### PR TITLE
Update src/main/java/org/apache/commons/lang3/SystemUtils.java

### DIFF
--- a/src/main/java/org/apache/commons/lang3/SystemUtils.java
+++ b/src/main/java/org/apache/commons/lang3/SystemUtils.java
@@ -1225,6 +1225,18 @@ public class SystemUtils {
 
     /**
      * <p>
+     * Is {@code true} if this is Windows 8.
+     * </p>
+     * <p>
+     * The field will return {@code false} if {@code OS_NAME} is {@code null}.
+     * </p>
+     *
+     * @since 3.0
+     */
+    public static final boolean IS_OS_WINDOWS_8 = getOSMatches(OS_NAME_WINDOWS_PREFIX, "6.2");
+
+    /**
+     * <p>
      * Gets the Java home directory as a {@code File}.
      * </p>
      *


### PR DESCRIPTION
Updated SystemUtils to account for Windows 8.

Windows 8 RTM is released, soon to be going out to consumers. Many people are already using it.

The current version is 6.2.9200.16384 (RTM) and the string returned by the java property is "Windows 8" in accordance with 7 and other versions.
