### PR TITLE
StringUtils#repeat(char,int) has arguments in in reverse order in javadoc examples

### DIFF
--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -5048,9 +5048,9 @@ public class StringUtils {
      * to a given length.</p>
      *
      * <pre>
-     * StringUtils.repeat(0, 'e')  = ""
-     * StringUtils.repeat(3, 'e')  = "eee"
-     * StringUtils.repeat(-2, 'e') = ""
+     * StringUtils.repeat('e', 0)  = ""
+     * StringUtils.repeat('e', 3)  = "eee"
+     * StringUtils.repeat('e', -2) = ""
      * </pre>
      *
      * <p>Note: this method doesn't not support padding with


### PR DESCRIPTION
In StringUtils#repeat(char,int) the javadoc examples have the arguments specified as int,char which is backwards.
