### PR TITLE
[LANG-903] Trunk - ToStringStyle typos and XML implementation

### DIFF
--- a/src/main/java/org/apache/commons/lang3/builder/ToStringStyle.java
+++ b/src/main/java/org/apache/commons/lang3/builder/ToStringStyle.java
@@ -118,7 +118,7 @@ public abstract class ToStringStyle implements Serializable {
     public static final ToStringStyle SHORT_PREFIX_STYLE = new ShortPrefixToStringStyle();
 
     /**
-     * The simple toString style. Using the Using the <code>Person</code>
+     * The simple toString style. Using the <code>Person</code>
      * example from {@link ToStringBuilder}, the output would look like this:
      *
      * <pre>
@@ -2205,6 +2205,8 @@ public abstract class ToStringStyle implements Serializable {
         }
 
     }
+
+    //----------------------------------------------------------------------------
 
     /**
      * <p><code>ToStringStyle</code> that does not print out the


### PR DESCRIPTION
Fixes a comment typo and adds separator between two subclasses.

Brings the XMLToStringStyle implementation back from the grave (commons-lang v1.1).