### PR TITLE
Adding .gitignore to commons-lang

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,9 @@ target
 maven-eclipse.xml
 build.properties
 site-content
+
+# IntelliJ IDEA fies
+.idea
+.iws
+*.iml
+*.ipr


### PR DESCRIPTION
Added .gitignore to the project in order to make working with git easier, and avoid accidentally commiting files that should not be commited.

These patches currently introduce two sets of ignored files:
First patch: Maven's build products (the target folder)
Second patch: IntelliJ IDEA's files

I'll happily add other files (e.g., Eclipse's file, other IDEs) if you wish.
