### PR TITLE
[LANG-763] Reintroduce DateUtils.UTC_TIME_ZONE constant:

### DIFF
--- a/src/main/java/org/apache/commons/lang3/time/DateUtils.java
+++ b/src/main/java/org/apache/commons/lang3/time/DateUtils.java
@@ -24,6 +24,7 @@ import java.util.Date;
 import java.util.Iterator;
 import java.util.Locale;
 import java.util.NoSuchElementException;
+import java.util.TimeZone;
 
 /**
  * <p>A suite of utilities surrounding the use of the
@@ -44,6 +45,17 @@ import java.util.NoSuchElementException;
  * @version $Id$
  */
 public class DateUtils {
+
+    /**
+     * A reusable, immutable constant representing the UTC time zone.
+     * 
+     * Note that that two different TimeZone object instances representing the
+     * same time zone (for example this constant and a {@link TimeZone}
+     * retrieved by calling {@link TimeZone#getTimeZone(String)} with UTC
+     * parameter) don't necessarily object equals each other but
+     * {@link TimeZone#hasSameRules(TimeZone)} will return true for them.
+     */
+    public static final TimeZone UTC_TIME_ZONE = new ImmutableTimeZone(TimeZone.getTimeZone("UTC"));
 
     /**
      * Number of milliseconds in a standard second.

--- a/src/main/java/org/apache/commons/lang3/time/DelegatingTimeZone.java
+++ b/src/main/java/org/apache/commons/lang3/time/DelegatingTimeZone.java
@@ -1,0 +1,117 @@
+package org.apache.commons.lang3.time;
+
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
+
+import org.apache.commons.lang3.Validate;
+
+/**
+ * A {@link TimeZone} implementation that just delegates all non final method
+ * calls to an other {@link TimeZone} instance which was specified in the
+ * constructor.
+ * 
+ * Convenient base class for other {@link TimeZone} related classes.
+ * 
+ * Implementation detail: {@link TimeZone} has some final methods (
+ * {@link #getDisplayName()} and some of its variants) which of course can't be
+ * overridden but they all delegate to
+ * {@link #getDisplayName(boolean, int, Locale)} which is not final and so can
+ * be redefined.
+ */
+public class DelegatingTimeZone extends TimeZone {
+    private static final long serialVersionUID = 1910962594884138771L;
+
+    private final TimeZone delegate;
+
+    /**
+     * @param delegate
+     *            the non-null delegate, all method calls will be forwarded to
+     *            this object
+     */
+    public DelegatingTimeZone(TimeZone delegate) {
+        this.delegate = Validate.notNull(delegate);
+    }
+
+    @Override
+    public int hashCode() {
+        return delegate.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return delegate.equals(obj);
+    }
+
+    @Override
+    public int getOffset(long date) {
+        return delegate.getOffset(date);
+    }
+
+    @Override
+    public String toString() {
+        return delegate.toString();
+    }
+
+    @Override
+    public String getID() {
+        return delegate.getID();
+    }
+
+    @Override
+    public void setID(String ID) {
+        delegate.setID(ID);
+    }
+
+    @Override
+    public String getDisplayName(boolean daylight, int style, Locale locale) {
+        return delegate.getDisplayName(daylight, style, locale);
+    }
+
+    @Override
+    public int getDSTSavings() {
+        return delegate.getDSTSavings();
+    }
+
+    @Override
+    public boolean observesDaylightTime() {
+        return delegate.observesDaylightTime();
+    }
+
+    @Override
+    public boolean hasSameRules(TimeZone other) {
+        return delegate.hasSameRules(other);
+    }
+
+    @Override
+    public int getOffset(int era, int year, int month, int day, int dayOfWeek,
+            int milliseconds) {
+        return delegate.getOffset(era, year, month, day, dayOfWeek,
+                milliseconds);
+    }
+
+    @Override
+    public void setRawOffset(int offsetMillis) {
+        delegate.setRawOffset(offsetMillis);
+    }
+
+    @Override
+    public int getRawOffset() {
+        return delegate.getRawOffset();
+    }
+
+    @Override
+    public boolean useDaylightTime() {
+        return delegate.useDaylightTime();
+    }
+
+    @Override
+    public boolean inDaylightTime(Date date) {
+        return delegate.inDaylightTime(date);
+    }
+
+    @Override
+    public DelegatingTimeZone clone() {
+        return (DelegatingTimeZone) super.clone();
+    }
+}

--- a/src/main/java/org/apache/commons/lang3/time/ImmutableTimeZone.java
+++ b/src/main/java/org/apache/commons/lang3/time/ImmutableTimeZone.java
@@ -1,0 +1,35 @@
+package org.apache.commons.lang3.time;
+
+import java.util.TimeZone;
+
+/**
+ * An immutable {@link TimeZone} implementation which delegates all read only
+ * methods to the provided delegate and throws exception for all state modifying
+ * method calls.
+ */
+public class ImmutableTimeZone extends DelegatingTimeZone {
+    private static final long serialVersionUID = 2425068836232712021L;
+
+    /**
+     * @param delegate
+     *            the not-null wrapped timezone
+     */
+    public ImmutableTimeZone(TimeZone delegate) {
+        super(delegate);
+    }
+
+    @Override
+    public void setID(String ID) {
+        throw fail();
+    }
+
+    @Override
+    public void setRawOffset(int offsetMillis) {
+        throw fail();
+    }
+
+    private final RuntimeException fail() {
+        return new UnsupportedOperationException(
+                "This is an immutable TimeZone. State modifying methods are not supported.");
+    }
+}

--- a/src/test/java/org/apache/commons/lang3/time/DateUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/DateUtilsTest.java
@@ -39,6 +39,7 @@ import java.util.TimeZone;
 
 import junit.framework.AssertionFailedError;
 
+import org.apache.commons.lang3.JavaVersion;
 import org.apache.commons.lang3.SystemUtils;
 import org.junit.Before;
 import org.junit.Test;
@@ -1640,7 +1641,17 @@ public class DateUtilsTest {
         assertEquals("Expected UTC TZ with UTC id.", "UTC", DateUtils.UTC_TIME_ZONE.getID());
         assertEquals("Expected UTC TZ with no DST savings.", 0, DateUtils.UTC_TIME_ZONE.getDSTSavings());
         assertEquals("Expected UTC TZ with no offset.", 0, DateUtils.UTC_TIME_ZONE.getRawOffset());
-        assertFalse("Expected UTC TZ with no daylight time.", DateUtils.UTC_TIME_ZONE.observesDaylightTime());
+        if (SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_1_7)) {
+            assertFalse("Expected UTC TZ with no daylight time.", ((DelegatingTimeZone)DateUtils.UTC_TIME_ZONE).observesDaylightTime());
+        } else {
+            boolean failed = false;
+            try {
+                ((DelegatingTimeZone)DateUtils.UTC_TIME_ZONE).observesDaylightTime();
+            } catch (UnsupportedOperationException e) {
+                failed = true;
+            }
+            assertTrue("Expected observesDaylightTime() to throw an exception on a pre Java7 JVM.", failed);
+        }
 
         TimeZone refUtcTz = TimeZone.getTimeZone("UTC");
         assertTrue("Expected UTC TZ with same rules as reference UTZ TZ.", refUtcTz.hasSameRules(utcTz));

--- a/src/test/java/org/apache/commons/lang3/time/DateUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/DateUtilsTest.java
@@ -17,7 +17,6 @@
 package org.apache.commons.lang3.time;
 
 import static org.apache.commons.lang3.JavaVersion.JAVA_1_4;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -41,7 +40,6 @@ import java.util.TimeZone;
 import junit.framework.AssertionFailedError;
 
 import org.apache.commons.lang3.SystemUtils;
-
 import org.junit.Before;
 import org.junit.Test;
 
@@ -1625,7 +1623,41 @@ public class DateUtilsTest {
             Locale.setDefault(dflt);            
         }
     }
-    
+
+    @Test
+    public void testUtcTzConstant() {
+        // sanity check
+        assertUtcTz(TimeZone.getTimeZone("UTC"));
+
+        assertUtcTz(DateUtils.UTC_TIME_ZONE);
+
+        TimeZone clone = (TimeZone) DateUtils.UTC_TIME_ZONE.clone();
+        assertEquals(DateUtils.UTC_TIME_ZONE.getClass(), clone.getClass());
+        assertUtcTz(clone);
+    }
+
+    private void assertUtcTz(TimeZone utcTz) {
+        assertEquals("Expected UTC TZ with UTC id.", "UTC", DateUtils.UTC_TIME_ZONE.getID());
+        assertEquals("Expected UTC TZ with no DST savings.", 0, DateUtils.UTC_TIME_ZONE.getDSTSavings());
+        assertEquals("Expected UTC TZ with no offset.", 0, DateUtils.UTC_TIME_ZONE.getRawOffset());
+        assertFalse("Expected UTC TZ with no daylight time.", DateUtils.UTC_TIME_ZONE.observesDaylightTime());
+
+        TimeZone refUtcTz = TimeZone.getTimeZone("UTC");
+        assertTrue("Expected UTC TZ with same rules as reference UTZ TZ.", refUtcTz.hasSameRules(utcTz));
+        assertEquals(utcTz, refUtcTz);
+        assertEquals(refUtcTz.hashCode(), utcTz.hashCode());
+    }
+
+    @Test(expected=UnsupportedOperationException.class)
+    public void testUtcTzConstantImmutable1() {
+        DateUtils.UTC_TIME_ZONE.setID("UTC");
+    }
+
+    @Test(expected=UnsupportedOperationException.class)
+    public void testUtcTzConstantImmutable2() {
+        DateUtils.UTC_TIME_ZONE.setRawOffset(0);
+    }
+
     /**
      * This checks that this is a 7 element iterator of Calendar objects
      * that are dates (no time), and exactly 1 day spaced after each other.


### PR DESCRIPTION
- add the reusable DelegatingTimeZone and ImmutableTimeZone classes
- add back the DateUtils.UTC_TIME_ZONE constant with some unit tests