### PR TITLE
Update ImmutablePair to be not final

### DIFF
--- a/src/main/java/org/apache/commons/lang3/tuple/ImmutablePair.java
+++ b/src/main/java/org/apache/commons/lang3/tuple/ImmutablePair.java
@@ -32,7 +32,7 @@ package org.apache.commons.lang3.tuple;
  * @since Lang 3.0
  * @version $Id$
  */
-public final class ImmutablePair<L, R> extends Pair<L, R> {
+public class ImmutablePair<L, R> extends Pair<L, R> {
 
     /** Serialization version */
     private static final long serialVersionUID = 4954918890077093841L;


### PR DESCRIPTION
The sibling class MutablePair is not final, and the JavaDoc for ImmutablePair also states it is not final: "The class is also not {@code final}, so a subclass could add undesirable behaviour".
