### PR TITLE
Add escapeXml10 and escapeXml11

### DIFF
--- a/src/main/java/org/apache/commons/lang3/StringEscapeUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringEscapeUtils.java
@@ -24,9 +24,11 @@ import org.apache.commons.lang3.text.translate.CharSequenceTranslator;
 import org.apache.commons.lang3.text.translate.EntityArrays;
 import org.apache.commons.lang3.text.translate.JavaUnicodeEscaper;
 import org.apache.commons.lang3.text.translate.LookupTranslator;
+import org.apache.commons.lang3.text.translate.NumericEntityEscaper;
 import org.apache.commons.lang3.text.translate.NumericEntityUnescaper;
 import org.apache.commons.lang3.text.translate.OctalUnescaper;
 import org.apache.commons.lang3.text.translate.UnicodeUnescaper;
+import org.apache.commons.lang3.text.translate.UnicodeUnpairedSurrogateRemover;
 
 /**
  * <p>Escapes and unescapes {@code String}s for
@@ -116,6 +118,82 @@ public class StringEscapeUtils {
         new AggregateTranslator(
             new LookupTranslator(EntityArrays.BASIC_ESCAPE()),
             new LookupTranslator(EntityArrays.APOS_ESCAPE())
+        );
+    
+    /**
+     * Translator object for escaping XML 1.0.
+     * 
+     * While {@link #escapeXml10(String)} is the expected method of use, this
+     * object allows the XML escaping functionality to be used
+     * as the foundation for a custom translator.
+     */
+    public static final CharSequenceTranslator ESCAPE_XML10 =
+        new AggregateTranslator(
+            new LookupTranslator(EntityArrays.BASIC_ESCAPE()),
+            new LookupTranslator(EntityArrays.APOS_ESCAPE()),
+            new LookupTranslator(
+                    new String[][] {
+                            { "\u0000", "" },
+                            { "\u0001", "" },
+                            { "\u0002", "" },
+                            { "\u0003", "" },
+                            { "\u0004", "" },
+                            { "\u0005", "" },
+                            { "\u0006", "" },
+                            { "\u0007", "" },
+                            { "\u0008", "" },
+                            { "\u000b", "" },
+                            { "\u000c", "" },
+                            { "\u000e", "" },
+                            { "\u000f", "" },
+                            { "\u0010", "" },
+                            { "\u0011", "" },
+                            { "\u0012", "" },
+                            { "\u0013", "" },
+                            { "\u0014", "" },
+                            { "\u0015", "" },
+                            { "\u0016", "" },
+                            { "\u0017", "" },
+                            { "\u0018", "" },
+                            { "\u0019", "" },
+                            { "\u001a", "" },
+                            { "\u001b", "" },
+                            { "\u001c", "" },
+                            { "\u001d", "" },
+                            { "\u001e", "" },
+                            { "\u001f", "" },
+                            { "\ufffe", "" },
+                            { "\uffff", "" }
+                    }),
+            NumericEntityEscaper.between(0x7f, 0x84),
+            NumericEntityEscaper.between(0x86, 0x9f),
+            new UnicodeUnpairedSurrogateRemover()
+        );
+    
+    /**
+     * Translator object for escaping XML 1.1.
+     * 
+     * While {@link #escapeXml11(String)} is the expected method of use, this
+     * object allows the XML escaping functionality to be used
+     * as the foundation for a custom translator.
+     */
+    public static final CharSequenceTranslator ESCAPE_XML11 =
+        new AggregateTranslator(
+            new LookupTranslator(EntityArrays.BASIC_ESCAPE()),
+            new LookupTranslator(EntityArrays.APOS_ESCAPE()),
+            new LookupTranslator(
+                    new String[][] {
+                            { "\u0000", "" },
+                            { "\u000b", "&#11;" },
+                            { "\u000c", "&#12;" },
+                            { "\ufffe", "" },
+                            { "\uffff", "" }
+                    }),
+            NumericEntityEscaper.between(0x1, 0x8),
+            NumericEntityEscaper.between(0xe, 0x1f),
+            NumericEntityEscaper.between(0x7f, 0x84),
+            NumericEntityEscaper.between(0x86, 0x9f),
+            new UnicodeUnpairedSurrogateRemover()
         );
 
     /**
@@ -582,6 +660,66 @@ public class StringEscapeUtils {
      */
     public static final String escapeXml(final String input) {
         return ESCAPE_XML.translate(input);
+    }
+
+    /**
+     * <p>Escapes the characters in a {@code String} using XML entities.</p>
+     *
+     * <p>For example: <tt>"bread" & "butter"</tt> =>
+     * <tt>&amp;quot;bread&amp;quot; &amp;amp; &amp;quot;butter&amp;quot;</tt>.
+     * </p>
+     *
+     * <p>Note that XML 1.0 is a text-only format: it cannot represent control
+     * characters or unpaired Unicode surrogate codepoints, even after escaping.
+     * {@code escapeXml10} will remove characters that do not fit in the
+     * following ranges:</p>
+     * 
+     * <p>{@code #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]}</p>
+     * 
+     * <p>Though not strictly necessary, {@code escapeXml10} will escape
+     * characters in the following ranges:</p>
+     * 
+     * <p>{@code [#x7F-#x84] | [#x86-#x9F]}</p>
+     * 
+     * <p>The returned string can be inserted into a valid XML 1.0 or XML 1.1
+     * document. If you want to allow more non-text characters in an XML 1.1
+     * document, use {@link escapeXml11}.</p>
+     *
+     * @param input  the {@code String} to escape, may be null
+     * @return a new escaped {@code String}, {@code null} if null string input
+     * @see #unescapeXml(java.lang.String)
+     */
+    public static Object escapeXml10(final String input) {
+        return ESCAPE_XML10.translate(input);
+    }
+    
+    /**
+     * <p>Escapes the characters in a {@code String} using XML entities.</p>
+     *
+     * <p>For example: <tt>"bread" & "butter"</tt> =>
+     * <tt>&amp;quot;bread&amp;quot; &amp;amp; &amp;quot;butter&amp;quot;</tt>.
+     * </p>
+     *
+     * <p>XML 1.1 can represent certain control characters, but it cannot represent
+     * the null byte or unpaired Unicode surrogate codepoints, even after escaping.
+     * {@code escapeXml11} will remove characters that do not fit in the following
+     * ranges:</p>
+     * 
+     * <p>{@code [#x1-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]}</p>
+     * 
+     * <p>{@code escapeXml11} will escape characters in the following ranges:</p>
+     * 
+     * <p>{@code [#x1-#x8] | [#xB-#xC] | [#xE-#x1F] | [#x7F-#x84] | [#x86-#x9F]}</p>
+     * 
+     * <p>The returned string can be inserted into a valid XML 1.1 document. Do not
+     * use it for XML 1.0 documents.</p>
+     *
+     * @param input  the {@code String} to escape, may be null
+     * @return a new escaped {@code String}, {@code null} if null string input
+     * @see #unescapeXml(java.lang.String)
+     */
+    public static Object escapeXml11(final String input) {
+        return ESCAPE_XML11.translate(input);
     }
 
     //-----------------------------------------------------------------------

--- a/src/main/java/org/apache/commons/lang3/text/translate/UnicodeUnpairedSurrogateRemover.java
+++ b/src/main/java/org/apache/commons/lang3/text/translate/UnicodeUnpairedSurrogateRemover.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.lang3.text.translate;
+
+import java.io.IOException;
+import java.io.Writer;
+
+/**
+ * Helper subclass to CharSequenceTranslator to remove unpaired surrogates.
+ * 
+ * @version $Id$
+ */
+public class UnicodeUnpairedSurrogateRemover extends CodePointTranslator {
+    /**
+     * Implementation of translate that throws out unpaired surrogates. 
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean translate(int codepoint, Writer out) throws IOException {
+        if (codepoint >= Character.MIN_SURROGATE && codepoint <= Character.MAX_SURROGATE) {
+            // It's a surrogate. Write nothing and say we've translated.
+            return true;
+        } else {
+            // It's not a surrogate. Don't translate it.
+            return false;
+        }
+    }
+}

--- a/src/test/java/org/apache/commons/lang3/StringEscapeUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringEscapeUtilsTest.java
@@ -326,6 +326,38 @@ public class StringEscapeUtilsTest {
         }
         assertEquals("XML was unescaped incorrectly", "<abc>", sw.toString() );
     }
+    
+    @Test
+    public void testEscapeXml10() throws Exception {
+        assertEquals("a&lt;b&gt;c&quot;d&apos;e&amp;f", StringEscapeUtils.escapeXml10("a<b>c\"d'e&f"));
+        assertEquals("XML 1.0 should not escape \t \n \r",
+                "a\tb\rc\nd", StringEscapeUtils.escapeXml10("a\tb\rc\nd"));
+        assertEquals("XML 1.0 should omit most #x0-x8 | #xb | #xc | #xe-#x19",
+                "ab", StringEscapeUtils.escapeXml10("a\u0000\u0001\u0008\u000b\u000c\u000e\u001fb"));
+        assertEquals("XML 1.0 should omit #xd800-#xdfff",
+                "a\ud7ff  \ue000b", StringEscapeUtils.escapeXml10("a\ud7ff\ud800 \udfff \ue000b"));
+        assertEquals("XML 1.0 should omit #xfffe | #xffff",
+                "a\ufffdb", StringEscapeUtils.escapeXml10("a\ufffd\ufffe\uffffb"));
+        assertEquals("XML 1.0 should escape #x7f-#x84 | #x86 - #x9f, for XML 1.1 compatibility",
+                "a\u007e&#127;&#132;\u0085&#134;&#159;\u00a0b", StringEscapeUtils.escapeXml10("a\u007e\u007f\u0084\u0085\u0086\u009f\u00a0b"));
+    }
+    
+    @Test
+    public void testEscapeXml11() throws Exception {
+        assertEquals("a&lt;b&gt;c&quot;d&apos;e&amp;f", StringEscapeUtils.escapeXml11("a<b>c\"d'e&f"));
+        assertEquals("XML 1.1 should not escape \t \n \r",
+                "a\tb\rc\nd", StringEscapeUtils.escapeXml11("a\tb\rc\nd"));
+        assertEquals("XML 1.1 should omit #x0",
+                "ab", StringEscapeUtils.escapeXml11("a\u0000b"));
+        assertEquals("XML 1.1 should escape #x1-x8 | #xb | #xc | #xe-#x19",
+                "a&#1;&#8;&#11;&#12;&#14;&#31;b", StringEscapeUtils.escapeXml11("a\u0001\u0008\u000b\u000c\u000e\u001fb"));
+        assertEquals("XML 1.1 should escape #x7F-#x84 | #x86-#x9F",
+                "a\u007e&#127;&#132;\u0085&#134;&#159;\u00a0b", StringEscapeUtils.escapeXml11("a\u007e\u007f\u0084\u0085\u0086\u009f\u00a0b"));
+        assertEquals("XML 1.1 should omit #xd800-#xdfff",
+                "a\ud7ff  \ue000b", StringEscapeUtils.escapeXml11("a\ud7ff\ud800 \udfff \ue000b"));
+        assertEquals("XML 1.1 should omit #xfffe | #xffff",
+                "a\ufffdb", StringEscapeUtils.escapeXml11("a\ufffd\ufffe\uffffb"));
+    }
 
     /**
      * Tests Supplementary characters. 

--- a/src/test/java/org/apache/commons/lang3/text/translate/UnicodeUnpairedSurrogateRemoverTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/translate/UnicodeUnpairedSurrogateRemoverTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.lang3.text.translate;
+
+import static org.junit.Assert.*;
+
+import java.io.CharArrayWriter;
+import java.io.IOException;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link org.apache.commons.lang3.text.translate.UnicodeUnpairedSurrogateRemover}.
+ *
+ * @version $Id$
+ */
+public class UnicodeUnpairedSurrogateRemoverTest {
+    final UnicodeUnpairedSurrogateRemover subject = new UnicodeUnpairedSurrogateRemover();
+    final CharArrayWriter writer = new CharArrayWriter(); // nothing is ever written to it
+    
+    @Test
+    public void testValidCharacters() throws IOException {
+        assertEquals(false, subject.translate(0xd7ff, writer));
+        assertEquals(false, subject.translate(0xe000, writer));
+        assertEquals(0, writer.size());
+    }
+    
+    @Test
+    public void testInvalidCharacters() throws IOException {
+        assertEquals(true, subject.translate(0xd800, writer));
+        assertEquals(true, subject.translate(0xdfff, writer));
+        assertEquals(0, writer.size());
+    }
+}


### PR DESCRIPTION
These methods turn any String into valid XML, hacking off characters when necessary. See https://issues.apache.org/jira/browse/LANG-955
- `escapeXml10` outputs a string that can be included in an XML 1.0 or XML 1.1 document.
- `escapeXml11` outputs a string that can be included in an XML 1.1 document.

Neither method escapes or omits what http://www.w3.org/TR/REC-xml/#charsets calls "discouraged" characters. Rationale: any valid XML parser will still read them, even though they're icky.
