### PR TITLE
Fix bug with stripping spaces on last line in WordUtils.wrap()

### DIFF
--- a/src/main/java/org/apache/commons/lang3/text/WordUtils.java
+++ b/src/main/java/org/apache/commons/lang3/text/WordUtils.java
@@ -183,10 +183,14 @@ public class WordUtils {
         int offset = 0;
         final StringBuilder wrappedLine = new StringBuilder(inputLineLength + 32);
         
-        while (inputLineLength - offset > wrapLength) {
+        while (offset < inputLineLength) {
             if (str.charAt(offset) == ' ') {
                 offset++;
                 continue;
+            }
+            // only last line without leading spaces is left
+            if(inputLineLength - offset <= wrapLength) {
+                break;
             }
             int spaceToWrapAt = str.lastIndexOf(' ', wrapLength + offset);
 

--- a/src/test/java/org/apache/commons/lang3/text/WordUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/WordUtilsTest.java
@@ -71,6 +71,12 @@ public class WordUtilsTest {
         expected = "Click here," + systemNewLine + "http://commons.apache.org," + systemNewLine 
             + "to jump to the" + systemNewLine + "commons website";
         assertEquals(expected, WordUtils.wrap(input, 20));
+        
+        // leading spaces on a new line are stripped
+        // trailing spaces are not stripped
+        input = "word1             word2                        word3";
+        expected = "word1  " + systemNewLine + "word2  " + systemNewLine + "word3";
+        assertEquals(expected, WordUtils.wrap(input, 7));
     }
     
     @Test


### PR DESCRIPTION
In _WordUtils.wpap()_ leading white spaces on new lines are stripped from the result. But there is a bug if there are multiple white spaces on the last line. For example:

``` java
input = "word1             word2                        word3";
System.out.println(WordUtils.wrap(input, 7));
```

The result will

```
word1  
word2  
  word3
```

Expected result is

```
word1  
word2  
word3
```

I propose fix contained in this pull request.
