### PR TITLE
Fix LANG-948

### DIFF
--- a/src/main/java/org/apache/commons/lang3/text/ExtendedMessageFormat.java
+++ b/src/main/java/org/apache/commons/lang3/text/ExtendedMessageFormat.java
@@ -157,7 +157,7 @@ public class ExtendedMessageFormat extends MessageFormat {
         while (pos.getIndex() < pattern.length()) {
             switch (c[pos.getIndex()]) {
             case QUOTE:
-                appendQuotedString(pattern, pos, stripCustom, false);
+                appendQuotedString(pattern, pos, stripCustom);
                 break;
             case START_FE:
                 fmtCount++;
@@ -384,7 +384,7 @@ public class ExtendedMessageFormat extends MessageFormat {
                 }
                 break;
             case QUOTE:
-                getQuotedString(pattern, pos, false);
+                getQuotedString(pattern, pos);
                 break;
             default:
                 break;
@@ -413,7 +413,7 @@ public class ExtendedMessageFormat extends MessageFormat {
             final char c = pattern.charAt(pos.getIndex());
             switch (c) {
             case QUOTE:
-                appendQuotedString(pattern, pos, sb, false);
+                appendQuotedString(pattern, pos, sb);
                 break;
             case START_FE:
                 depth++;
@@ -471,11 +471,10 @@ public class ExtendedMessageFormat extends MessageFormat {
      * @param pattern pattern to parse
      * @param pos current parse position
      * @param appendTo optional StringBuilder to append
-     * @param escapingOn whether to process escaped quotes
      * @return <code>appendTo</code>
      */
     private StringBuilder appendQuotedString(final String pattern, final ParsePosition pos,
-            final StringBuilder appendTo, final boolean escapingOn) {
+            final StringBuilder appendTo) {
         assert pattern.toCharArray()[pos.getIndex()] == QUOTE : 
             "Quoted string must start with quote character";
 
@@ -487,19 +486,8 @@ public class ExtendedMessageFormat extends MessageFormat {
 
         final int start = pos.getIndex();
         final char[] c = pattern.toCharArray();
-        if (escapingOn && c[start] == QUOTE) {
-            next(pos);
-            return appendTo == null ? null : appendTo.append(QUOTE);
-        }
         int lastHold = start;
         for (int i = pos.getIndex(); i < pattern.length(); i++) {
-            if (escapingOn && pattern.substring(i).startsWith(ESCAPED_QUOTE)) {
-                appendTo.append(c, lastHold, pos.getIndex() - lastHold).append(
-                        QUOTE);
-                pos.setIndex(i + ESCAPED_QUOTE.length());
-                lastHold = pos.getIndex();
-                continue;
-            }
             switch (c[pos.getIndex()]) {
             case QUOTE:
                 next(pos);
@@ -518,11 +506,9 @@ public class ExtendedMessageFormat extends MessageFormat {
      *
      * @param pattern pattern to parse
      * @param pos current parse position
-     * @param escapingOn whether to process escaped quotes
      */
-    private void getQuotedString(final String pattern, final ParsePosition pos,
-            final boolean escapingOn) {
-        appendQuotedString(pattern, pos, null, escapingOn);
+    private void getQuotedString(final String pattern, final ParsePosition pos) {
+        appendQuotedString(pattern, pos, null);
     }
 
     /**

--- a/src/main/java/org/apache/commons/lang3/text/ExtendedMessageFormat.java
+++ b/src/main/java/org/apache/commons/lang3/text/ExtendedMessageFormat.java
@@ -157,7 +157,7 @@ public class ExtendedMessageFormat extends MessageFormat {
         while (pos.getIndex() < pattern.length()) {
             switch (c[pos.getIndex()]) {
             case QUOTE:
-                appendQuotedString(pattern, pos, stripCustom, true);
+                appendQuotedString(pattern, pos, stripCustom, false);
                 break;
             case START_FE:
                 fmtCount++;
@@ -476,6 +476,12 @@ public class ExtendedMessageFormat extends MessageFormat {
      */
     private StringBuilder appendQuotedString(final String pattern, final ParsePosition pos,
             final StringBuilder appendTo, final boolean escapingOn) {
+        // handle quote character at the beginning of the string
+        if(appendTo != null) {
+            appendTo.append(QUOTE);
+        }
+        next(pos);
+
         final int start = pos.getIndex();
         final char[] c = pattern.toCharArray();
         if (escapingOn && c[start] == QUOTE) {

--- a/src/main/java/org/apache/commons/lang3/text/ExtendedMessageFormat.java
+++ b/src/main/java/org/apache/commons/lang3/text/ExtendedMessageFormat.java
@@ -476,6 +476,9 @@ public class ExtendedMessageFormat extends MessageFormat {
      */
     private StringBuilder appendQuotedString(final String pattern, final ParsePosition pos,
             final StringBuilder appendTo, final boolean escapingOn) {
+        assert pattern.toCharArray()[pos.getIndex()] == QUOTE : 
+            "Quoted string must start with quote character";
+
         // handle quote character at the beginning of the string
         if(appendTo != null) {
             appendTo.append(QUOTE);

--- a/src/test/java/org/apache/commons/lang3/text/ExtendedMessageFormatTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/ExtendedMessageFormatTest.java
@@ -90,6 +90,22 @@ public class ExtendedMessageFormatTest {
     }
 
     /**
+     * Test Bug LANG-948 - Exception while using ExtendedMessageFormat and escaping braces
+     */
+    @Test
+    public void testEscapedBraces_LANG_948() {
+        // message without placeholder because braces are escaped by quotes 
+        final String pattern = "Message without placeholders '{}'";
+        final ExtendedMessageFormat emf = new ExtendedMessageFormat(pattern, registry);
+        assertEquals("Message without placeholders {}", emf.format(new Object[] {"DUMMY"}));
+
+        // message with placeholder because quotes are escaped by quotes 
+        final String pattern2 = "Message with placeholder ''{0}''";
+        final ExtendedMessageFormat emf2 = new ExtendedMessageFormat(pattern2, registry);
+        assertEquals("Message with placeholder 'DUMMY'", emf2.format(new Object[] {"DUMMY"}));
+    }
+
+    /**
      * Test extended and built in formats.
      */
     @Test


### PR DESCRIPTION
Hi all!
This is fix for bug LANG-948.

Changes with explanations:
1) Method ```ExtendedMessageFormat.appendQuotedString()``` returned when finds first quote character. This is obviously wrong because quoted string start with quote character and method must consume whole quoted string. I added handling of first quote character at the beginning of method. Also, it doesn't make sense to handle escaped quotes because ```super.applyPattern(stripCustom.toString())``` will called below in ```applyPattern()```. Thus, last argument should be ```false``` when calling ```appendQuotedString()```.

2) Quoted string must start with quote character in ```appendQuotedString()```. And at this moment method is used this way. I added assertion to check and document this.

3) Thus, method ```appendQuotedString()``` is called with last argument always ```false```. It doesn't make sense to handle escaped quotes in ```appendQuotedString()``` because they will be handled in ```super.applyPattern()```. Thus, I deleted this parameter and code for handling escaped quotes.