### PR TITLE
Reimplemented normalize space

### DIFF
--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -7442,12 +7442,34 @@ public class StringUtils {
      *
      * @since 3.0
      */
-    public static String normalizeSpace(final String str) {
-        if (str == null) {
-            return null;
-        }
-        return WHITESPACE_PATTERN.matcher(trim(str)).replaceAll(SPACE);
-    }
+		public static String normalizeSpace(final String str) {
+			if (org.apache.commons.lang3.StringUtils.isEmpty(str)) {
+				return str;
+			}
+			final int size = str.length();
+			final char[] newChars = new char[size];
+			int count = 0;
+			int whitespacesCount = 0;
+			boolean startWhitespaces = true;
+			for (int i = 0; i < size; i++) {
+				char actualChar = str.charAt(i);
+				boolean isWhitespace = Character.isWhitespace(actualChar);
+				if (!isWhitespace) {
+					startWhitespaces = false;
+					newChars[count++] = (actualChar == 160 ? 32 : actualChar);
+					whitespacesCount = 0;
+				} else {
+					if (whitespacesCount == 0 && !startWhitespaces) {
+						newChars[count++] = SPACE.charAt(0);
+					}
+					whitespacesCount++;
+				}
+			}
+			if (startWhitespaces) {
+				return EMPTY;
+			}
+			return new String(newChars, 0, count - (whitespacesCount > 0 ? 1 : 0));
+		}
 
     /**
      * <p>Check if a CharSequence ends with any of an array of specified strings.</p>


### PR DESCRIPTION
Hi.
I reimplemented normalize space method of String utils, because regexp is much more rich operation than array traversing and I use this normalization often.
Here is benchmark created using google caliper.

 0% Scenario{vm=java, trial=0, benchmark=ApacheNormalize, length=0} 1553.39 ns; σ=142.64 ns @ 10 trials
13% Scenario{vm=java, trial=0, benchmark=NewNormalize, length=0} 114.80 ns; σ=1.00 ns @ 3 trials
25% Scenario{vm=java, trial=0, benchmark=ApacheNormalize, length=10} 1513.44 ns; σ=133.58 ns @ 10 trials
38% Scenario{vm=java, trial=0, benchmark=NewNormalize, length=10} 114.49 ns; σ=1.05 ns @ 3 trials
50% Scenario{vm=java, trial=0, benchmark=ApacheNormalize, length=100} 1545.23 ns; σ=107.97 ns @ 10 trials
63% Scenario{vm=java, trial=0, benchmark=NewNormalize, length=100} 114.28 ns; σ=0.65 ns @ 3 trials
75% Scenario{vm=java, trial=0, benchmark=ApacheNormalize, length=1000} 1550.35 ns; σ=138.57 ns @ 10 trials
88% Scenario{vm=java, trial=0, benchmark=NewNormalize, length=1000} 115.16 ns; σ=1.14 ns @ 3 trials

```
  benchmark length   ns linear runtime
```

ApacheNormalize      0 1553 ==============================
ApacheNormalize     10 1513 =============================
ApacheNormalize    100 1545 =============================
ApacheNormalize   1000 1550 =============================
   NewNormalize      0  115 ==
   NewNormalize     10  114 ==
   NewNormalize    100  114 ==
   NewNormalize   1000  115 ==

vm: java
trial: 0
