### PR TITLE
Casts used to pass unit tests on JDK 1.6.0_18.

### DIFF
--- a/src/main/java/org/apache/commons/lang3/SerializationUtils.java
+++ b/src/main/java/org/apache/commons/lang3/SerializationUtils.java
@@ -122,7 +122,7 @@ public class SerializationUtils {
      * @since 3.3
      */
     public static <T extends Serializable> T roundtrip(final T msg) {
-        return SerializationUtils.deserialize(SerializationUtils.serialize(msg));
+        return (T) SerializationUtils.deserialize(SerializationUtils.serialize(msg));
     }
 
     // Serialize

--- a/src/test/java/org/apache/commons/lang3/exception/AbstractExceptionContextTest.java
+++ b/src/test/java/org/apache/commons/lang3/exception/AbstractExceptionContextTest.java
@@ -178,7 +178,7 @@ public abstract class AbstractExceptionContextTest<T extends ExceptionContext & 
     public void testJavaSerialization() {
         exceptionContext.setContextValue("test Poorly written obj", "serializable replacement");
         
-        final T clone = SerializationUtils.deserialize(SerializationUtils.serialize(exceptionContext));
+        final T clone = (T) SerializationUtils.deserialize(SerializationUtils.serialize(exceptionContext));
         assertEquals(exceptionContext.getFormattedExceptionMessage(null), clone.getFormattedExceptionMessage(null));
     }
 }


### PR DESCRIPTION
Please see [JIRA-1083](https://issues.apache.org/jira/browse/LANG-1083).

This patch was split off during PR #41.

Thanks!