### PR TITLE
LANG-1055: StrLookup.systemPropertiesLookup() not singleton.

### DIFF
--- a/src/test/java/org/apache/commons/lang3/text/StrLookupTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/StrLookupTest.java
@@ -54,6 +54,22 @@ public class StrLookupTest  {
     }
 
     @Test
+    public void testSystemPropertiesLookupNotSingleton() {
+        final String osName = "os.name";
+        final String originalOsName = System.getProperty(osName);
+
+        StrLookup properties1 = StrLookup.systemPropertiesLookup();
+        assertEquals(originalOsName, properties1.lookup(osName));
+
+        final String differentOsName = "HAL-9000";
+        System.setProperty(osName, differentOsName);
+        StrLookup properties2 = StrLookup.systemPropertiesLookup();
+
+        assertEquals(originalOsName, properties1.lookup(osName));
+        assertEquals(differentOsName, properties2.lookup(osName));
+    }
+
+    @Test
     public void testMapLookup() {
         final Map<String, Object> map = new HashMap<String, Object>();
         map.put("key", "value");


### PR DESCRIPTION
- Assuming StrLookup.systemPropertiesLookup() should not be a singleton.
- Assuming each lookup should have its own snap-shot of the system properties.

Please review the proposed changes.
Thank you!