### PR TITLE
Add ThreadUtils

### DIFF
--- a/src/main/java/org/apache/commons/lang3/ThreadUtils.java
+++ b/src/main/java/org/apache/commons/lang3/ThreadUtils.java
@@ -1,0 +1,270 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.lang3;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * <p>
+ * Helpers for {@code java.lang.Thread} and {@code java.lang.ThreadGroup}.
+ * </p>
+ * <p>
+ * #ThreadSafe#
+ * </p>
+ *
+ * @see java.lang.Thread
+ * @see java.lang.ThreadGroup
+ * @since 3.4
+ * @version $Id$
+ */
+public class ThreadUtils {
+
+    private static final Thread[] EMPTY_THREAD_ARRAY = new Thread[0];
+
+    /**
+     * Return the thread with the specified id if they belong to a thread group with the specified group name
+     *
+     * @param threadId The thread id
+     * @param threadGroupName The thread group name
+     * @return The threads which belongs to a thread group with the specified group name and a thread name matching the specified id.
+     * An empty array is returned if no such thread exists
+     * @throws IllegalArgumentException if the specified id is zero or negative or the group name is null
+     * @throws  SecurityException
+     *          if the current thread cannot access the system thread group
+     *
+     * @throws  SecurityException  if the current thread cannot modify
+     *          thread groups from this thread's thread group up to the system thread group
+     */
+    public static Thread findThreadById(final long threadId, final String threadGroupName) {
+        final Thread thread = findThreadById(threadId);
+
+        if(thread == null) {
+            return null;
+        }
+
+        final Thread[] threads = findThreadsByName(thread.getName(), threadGroupName);
+        return threads.length==0?null:threads[0];
+    }
+
+    /**
+     * Return the threads with the specified name if they belong to a thread group with the specified group name
+     *
+     * @param threadName The thread name
+     * @param threadGroupName The thread group name
+     * @return The threads which belongs to a thread group with the specified group name and a thread name matching the specified name,
+     * An empty array is returned if no such thread exists
+     * @throws IllegalArgumentException if the specified thread name or group name is null
+     * @throws  SecurityException
+     *          if the current thread cannot access the system thread group
+     *
+     * @throws  SecurityException  if the current thread cannot modify
+     *          thread groups from this thread's thread group up to the system thread group
+     */
+    public static Thread[] findThreadsByName(final String threadName, final String threadGroupName) {
+        if (threadName == null) {
+            throw new IllegalArgumentException("The threadName must not be null");
+        }
+        if (threadGroupName == null) {
+            throw new IllegalArgumentException("The threadGroupName must not be null");
+        }
+        final ThreadGroup[] threadGroups = findThreadGroupsByName(threadGroupName);
+
+        if(threadGroups.length == 0) {
+            return EMPTY_THREAD_ARRAY;
+        }
+
+        final Thread[] threads = findThreadsByName(threadName);
+
+        if(threads.length == 0) {
+            return EMPTY_THREAD_ARRAY;
+        }
+
+        final List<Thread> matchedThreads = new ArrayList<Thread>();
+
+        for (int i = 0; i < threads.length; i++) {
+            final Thread thread = threads[i];
+
+            if(thread != null && ArrayUtils.contains(threadGroups, thread.getThreadGroup())) {
+                matchedThreads.add(thread);
+            }
+
+        }
+        return matchedThreads.toArray(new Thread[matchedThreads.size()]);
+    }
+
+    /**
+     * Return the thread groups with the specified group name
+     *
+     * @param threadGroupName The thread group name
+     * @return the thread groups with the specified group name or an empty array if no such thread group exists
+     * @throws IllegalArgumentException if group name is null
+     * @throws  SecurityException
+     *          if the current thread cannot access the system thread group
+     *
+     * @throws  SecurityException  if the current thread cannot modify
+     *          thread groups from this thread's thread group up to the system thread group
+     */
+    public static ThreadGroup[] findThreadGroupsByName(final String threadGroupName) {
+        if (threadGroupName == null) {
+            throw new IllegalArgumentException("The threadGroupName must not be null");
+        }
+        final ThreadGroup[] allThreadGroups = getAllThreadGroups();
+        final List<ThreadGroup> threadGroups = new ArrayList<ThreadGroup>();
+        for (int i = 0; i < allThreadGroups.length; i++) {
+            final ThreadGroup threadGroup = allThreadGroups[i];
+            if (threadGroup != null && threadGroupName.equals(threadGroup.getName())) {
+                threadGroups.add(threadGroup);
+            }
+        }
+        return threadGroups.toArray(new ThreadGroup[threadGroups.size()]);
+    }
+
+    /**
+     * Return all active thread groups including the system thread group (A thread group is active if it has been not destroyed)
+     *
+     * @return all thread groups including the system thread group
+     * @throws  SecurityException
+     *          if the current thread cannot access the system thread group
+     *
+     * @throws  SecurityException  if the current thread cannot modify
+     *          thread groups from this thread's thread group up to the system thread group
+     */
+    public static ThreadGroup[] getAllThreadGroups() {
+        final ThreadGroup rootThreadGroup = getSystemThreadGroup();
+        int estimatedThreadGroupCount = rootThreadGroup.activeGroupCount();
+        int threadGroupCount = 0;
+        ThreadGroup[] threadGroups;
+        do {
+            estimatedThreadGroupCount *= 2;
+            threadGroups = new ThreadGroup[estimatedThreadGroupCount];
+            threadGroupCount = rootThreadGroup.enumerate(threadGroups);
+        } while (threadGroupCount == estimatedThreadGroupCount);
+
+        final ThreadGroup[] allGroups = new ThreadGroup[threadGroupCount+1];
+        allGroups[0] = rootThreadGroup;
+        System.arraycopy(threadGroups, 0, allGroups, 1, threadGroupCount);
+        return allGroups;
+    }
+
+    /**
+     * Return the system thread group (sometimes also referred as "root thread group")
+     *
+     * @return the system thread group
+     * @throws  SecurityException  if the current thread cannot modify
+     *          thread groups from this thread's thread group up to the system thread group
+     */
+    public static ThreadGroup getSystemThreadGroup() {
+        ThreadGroup threadGroup = Thread.currentThread().getThreadGroup();
+        while(threadGroup.getParent() != null) {
+            threadGroup = threadGroup.getParent();
+        }
+        return threadGroup;
+    }
+
+    /**
+     * Return all active threads (A thread is active if it has been started and has not yet died)
+     *
+     * @return all active threads
+     * @throws  SecurityException
+     *          if the current thread cannot access the system thread group
+     *
+     * @throws  SecurityException  if the current thread cannot modify
+     *          thread groups from this thread's thread group up to the system thread group
+     */
+    public static Thread[] getAllThreads() {
+        final ThreadGroup rootThreadGroup = getSystemThreadGroup();
+        int estimatedThreadCount = rootThreadGroup.activeCount();
+        int threadCount = 0;
+        Thread[] threads;
+        do {
+            estimatedThreadCount *= 2;
+            threads = new Thread[estimatedThreadCount];
+            threadCount = rootThreadGroup.enumerate(threads);
+        } while (threadCount == estimatedThreadCount);
+
+        return Arrays.copyOf(threads, threadCount);
+    }
+
+    /**
+     * Return the threads with the specified name
+     *
+     * @param threadName The thread name
+     * @return The threads with the specified name or an empty array if no such thread exists
+     * @throws IllegalArgumentException if the specified name is null
+     * @throws  SecurityException
+     *          if the current thread cannot access the system thread group
+     *
+     * @throws  SecurityException  if the current thread cannot modify
+     *          thread groups from this thread's thread group up to the system thread group
+     */
+    public static Thread[] findThreadsByName(final String threadName) {
+        if (threadName == null) {
+            throw new IllegalArgumentException("The threadName must not be null");
+        }
+        final Thread[] allThreads = getAllThreads();
+        final List<Thread> threads = new ArrayList<Thread>();
+        for (int i = 0; i < allThreads.length; i++) {
+            final Thread thread = allThreads[i];
+            if (thread != null && threadName.equals(thread.getName())) {
+                threads.add(thread);
+            }
+        }
+        return threads.toArray(new Thread[threads.size()]);
+    }
+
+    /**
+     * Return the thread with the specified id
+     *
+     * @param threadId The thread id
+     * @return The thread with the specified id or {@code null} if no such thread exists
+     * @throws IllegalArgumentException if the specified id is zero or negative
+     * @throws  SecurityException
+     *          if the current thread cannot access the system thread group
+     *
+     * @throws  SecurityException  if the current thread cannot modify
+     *          thread groups from this thread's thread group up to the system thread group
+     */
+    public static Thread findThreadById(final long threadId) {
+        if (threadId <= 0) {
+            throw new IllegalArgumentException("The threadId must be greater than zero");
+        }
+        final Thread[] allThreads = getAllThreads();
+        for (int i = 0; i < allThreads.length; i++) {
+            final Thread thread = allThreads[i];
+            if (thread != null && threadId == thread.getId()) {
+                return thread;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * <p>
+     * ThreadUtils instances should NOT be constructed in standard programming. Instead, the class should be used as
+     * {@code ThreadUtils.getAllThreads()}
+     * </p>
+     * <p>
+     * This constructor is public to permit tools that require a JavaBean instance to operate
+     * </p>
+     */
+    public ThreadUtils() {
+        super();
+    }
+
+}

--- a/src/test/java/org/apache/commons/lang3/ThreadUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/ThreadUtilsTest.java
@@ -91,12 +91,12 @@ public class ThreadUtilsTest {
 
     @Test
     public void testNoThread() throws InterruptedException {
-        assertEquals(0, ThreadUtils.findThreadsByName("some_thread_which_does_not_exist_18762ZucTT").length);
+        assertEquals(0, ThreadUtils.findThreadsByName("some_thread_which_does_not_exist_18762ZucTT").size());
     }
 
     @Test
     public void testNoThreadGroup() throws InterruptedException {
-        assertEquals(0, ThreadUtils.findThreadGroupsByName("some_thread_group_which_does_not_exist_18762ZucTTII").length);
+        assertEquals(0, ThreadUtils.findThreadGroupsByName("some_thread_group_which_does_not_exist_18762ZucTTII").size());
     }
 
     @Test
@@ -109,12 +109,12 @@ public class ThreadUtilsTest {
 
     @Test
     public void testAtLeastOneThreadExists() throws InterruptedException {
-        assertTrue(ThreadUtils.getAllThreads().length > 0);
+        assertTrue(ThreadUtils.getAllThreads().size() > 0);
     }
 
     @Test
     public void testAtLeastOneThreadGroupExists() throws InterruptedException {
-        assertTrue(ThreadUtils.getAllThreadGroups().length > 0);
+        assertTrue(ThreadUtils.getAllThreadGroups().size() > 0);
     }
 
     @Test
@@ -125,7 +125,7 @@ public class ThreadUtilsTest {
         try {
             t1.start();
             alsot1.start();
-            assertEquals(2, ThreadUtils.findThreadsByName("thread1_XXOOLL__").length);
+            assertEquals(2, ThreadUtils.findThreadsByName("thread1_XXOOLL__").size());
         } finally {
             t1.interrupt();
             alsot1.interrupt();
@@ -142,7 +142,7 @@ public class ThreadUtilsTest {
         try {
             t1.start();
             t2.start();
-            assertEquals(1, ThreadUtils.findThreadsByName("thread2_XXOOLL__").length);
+            assertEquals(1, ThreadUtils.findThreadsByName("thread2_XXOOLL__").size());
         } finally {
             t1.interrupt();
             t2.interrupt();
@@ -194,13 +194,13 @@ public class ThreadUtilsTest {
         try {
             t1.start();
             t2.start();
-            assertEquals(1, ThreadUtils.findThreadsByName("thread1_XXOOPP__").length);
-            assertEquals(1, ThreadUtils.findThreadsByName("thread1_XXOOPP__","thread_group_DDZZ99__").length);
-            assertEquals(1, ThreadUtils.findThreadsByName("thread2_XXOOPP__","thread_group_DDZZ99__").length);
-            assertEquals(0, ThreadUtils.findThreadsByName("thread1_XXOOPP__","non_existent_thread_group_JJHHZZ__").length);
-            assertEquals(0, ThreadUtils.findThreadsByName("non_existent_thread_BBDDWW__","thread_group_DDZZ99__").length);
-            assertEquals(1, ThreadUtils.findThreadGroupsByName("thread_group_DDZZ99__").length);
-            assertEquals(0, ThreadUtils.findThreadGroupsByName("non_existent_thread_group_JJHHZZ__").length);
+            assertEquals(1, ThreadUtils.findThreadsByName("thread1_XXOOPP__").size());
+            assertEquals(1, ThreadUtils.findThreadsByName("thread1_XXOOPP__","thread_group_DDZZ99__").size());
+            assertEquals(1, ThreadUtils.findThreadsByName("thread2_XXOOPP__","thread_group_DDZZ99__").size());
+            assertEquals(0, ThreadUtils.findThreadsByName("thread1_XXOOPP__","non_existent_thread_group_JJHHZZ__").size());
+            assertEquals(0, ThreadUtils.findThreadsByName("non_existent_thread_BBDDWW__","thread_group_DDZZ99__").size());
+            assertEquals(1, ThreadUtils.findThreadGroupsByName("thread_group_DDZZ99__").size());
+            assertEquals(0, ThreadUtils.findThreadGroupsByName("non_existent_thread_group_JJHHZZ__").size());
             assertNotNull(ThreadUtils.findThreadById(t1.getId(),threadGroup));
         } finally {
             t1.interrupt();
@@ -222,17 +222,17 @@ public class ThreadUtilsTest {
         try {
             t1.start();
             t2.start();
-            assertEquals(1, ThreadUtils.findThreadsByName("thread1_XXOOPP__").length);
-            assertEquals(1, ThreadUtils.findThreadsByName("thread1_XXOOPP__",threadGroup).length);
-            assertEquals(1, ThreadUtils.findThreadsByName("thread2_XXOOPP__",threadGroup).length);
-            assertEquals(0, ThreadUtils.findThreadsByName("thread1_XXOOPP__",deadThreadGroup).length);
+            assertEquals(1, ThreadUtils.findThreadsByName("thread1_XXOOPP__").size());
+            assertEquals(1, ThreadUtils.findThreadsByName("thread1_XXOOPP__",threadGroup).size());
+            assertEquals(1, ThreadUtils.findThreadsByName("thread2_XXOOPP__",threadGroup).size());
+            assertEquals(0, ThreadUtils.findThreadsByName("thread1_XXOOPP__",deadThreadGroup).size());
         } finally {
             t1.interrupt();
             t2.interrupt();
             t1.join();
             t2.join();
             threadGroup.destroy();
-            assertEquals(0, ThreadUtils.findThreadsByName("thread2_XXOOPP__",threadGroup).length);
+            assertEquals(0, ThreadUtils.findThreadsByName("thread2_XXOOPP__",threadGroup).size());
         }
     }
 

--- a/src/test/java/org/apache/commons/lang3/ThreadUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/ThreadUtilsTest.java
@@ -1,0 +1,243 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.commons.lang3;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+import java.util.concurrent.CountDownLatch;
+
+import org.junit.Test;
+
+/**
+ * Unit tests {@link org.apache.commons.lang3.ThreadUtils}.
+ *
+ * @version $Id$
+ */
+public class ThreadUtilsTest {
+
+    @Test(expected=IllegalArgumentException.class)
+    public void testNullThreadName() throws InterruptedException {
+        ThreadUtils.findThreadsByName(null);
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void testNullThreadGroupName() throws InterruptedException {
+        ThreadUtils.findThreadGroupsByName(null);
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void testNullThreadThreadGroupName1() throws InterruptedException {
+        ThreadUtils.findThreadsByName(null, "tgname");
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void testNullThreadThreadGroupName2() throws InterruptedException {
+        ThreadUtils.findThreadsByName("tname", null);
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void testNullThreadThreadGroupName3() throws InterruptedException {
+        ThreadUtils.findThreadsByName(null, null);
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void testInvalidThreadId() throws InterruptedException {
+        ThreadUtils.findThreadById(-5L);
+    }
+
+    @Test
+    public void testNoThread() throws InterruptedException {
+        assertEquals(0, ThreadUtils.findThreadsByName("some_thread_which_does_not_exist_18762ZucTT").length);
+    }
+
+    @Test
+    public void testNoThreadGroup() throws InterruptedException {
+        assertEquals(0, ThreadUtils.findThreadGroupsByName("some_thread_group_which_does_not_exist_18762ZucTTII").length);
+    }
+
+    @Test
+    public void testSystemThreadGroupExists() throws InterruptedException {
+        ThreadGroup systemThreadGroup = ThreadUtils.getSystemThreadGroup();
+        assertNotNull(systemThreadGroup);
+        assertNull(systemThreadGroup.getParent());
+        assertEquals("system", systemThreadGroup.getName());
+    }
+
+    @Test
+    public void testAtLeastOneThreadExists() throws InterruptedException {
+        assertTrue(ThreadUtils.getAllThreads().length > 0);
+    }
+
+    @Test
+    public void testAtLeastOneThreadGroupExists() throws InterruptedException {
+        assertTrue(ThreadUtils.getAllThreadGroups().length > 0);
+    }
+
+    @Test
+    public void testThreadsSameName() throws InterruptedException {
+        Thread t1 = new TestThread("thread1_XXOOLL__");
+        Thread alsot1 = new TestThread("thread1_XXOOLL__");
+
+        try {
+            t1.start();
+            alsot1.start();
+            assertEquals(2, ThreadUtils.findThreadsByName("thread1_XXOOLL__").length);
+        } finally {
+            t1.interrupt();
+            alsot1.interrupt();
+            t1.join();
+            alsot1.join();
+        }
+    }
+
+    @Test
+    public void testThreads() throws InterruptedException {
+        Thread t1 = new TestThread("thread1_XXOOLL__");
+        Thread t2 = new TestThread("thread2_XXOOLL__");
+
+        try {
+            t1.start();
+            t2.start();
+            assertEquals(1, ThreadUtils.findThreadsByName("thread2_XXOOLL__").length);
+        } finally {
+            t1.interrupt();
+            t2.interrupt();
+            t1.join();
+            t2.join();
+        }
+    }
+
+    @Test
+    public void testThreadsById() throws InterruptedException {
+        Thread t1 = new TestThread("thread1_XXOOLL__");
+        Thread t2 = new TestThread("thread2_XXOOLL__");
+
+        try {
+            t1.start();
+            t2.start();
+            assertEquals(t1.getName(), ThreadUtils.findThreadById(t1.getId()).getName());
+            assertSame(t2, ThreadUtils.findThreadById(t2.getId()));
+        } finally {
+            t1.interrupt();
+            t2.interrupt();
+            t1.join();
+            t2.join();
+        }
+    }
+
+    @Test
+    public void testThreadGroups() throws InterruptedException {
+        ThreadGroup threadGroup = new ThreadGroup("thread_group_DDZZ99__");
+        Thread t1 = new TestThread(threadGroup, "thread1_XXOOPP__");
+        Thread t2 = new TestThread(threadGroup, "thread2_XXOOPP__");
+
+        try {
+            t1.start();
+            t2.start();
+            assertEquals(1, ThreadUtils.findThreadsByName("thread1_XXOOPP__").length);
+            assertEquals(1, ThreadUtils.findThreadsByName("thread1_XXOOPP__","thread_group_DDZZ99__").length);
+            assertEquals(1, ThreadUtils.findThreadsByName("thread2_XXOOPP__","thread_group_DDZZ99__").length);
+            assertEquals(0, ThreadUtils.findThreadsByName("thread1_XXOOPP__","non_existent_thread_group_JJHHZZ__").length);
+            assertEquals(0, ThreadUtils.findThreadsByName("non_existent_thread_BBDDWW__","thread_group_DDZZ99__").length);
+            assertEquals(1, ThreadUtils.findThreadGroupsByName("thread_group_DDZZ99__").length);
+            assertEquals(0, ThreadUtils.findThreadGroupsByName("non_existent_thread_group_JJHHZZ__").length);
+        } finally {
+            t1.interrupt();
+            t2.interrupt();
+            t1.join();
+            t2.join();
+            threadGroup.destroy();
+        }
+    }
+
+    @Test
+    public void testThreadGroupsById() throws InterruptedException {
+        ThreadGroup threadGroup = new ThreadGroup("thread_group_DDZZ99__");
+        Thread t1 = new TestThread(threadGroup, "thread1_XXOOPP__");
+        Thread t2 = new TestThread(threadGroup, "thread2_XXOOPP__");
+        long nonExistingId = t1.getId()+t2.getId();
+
+        try {
+            t1.start();
+            t2.start();
+            assertEquals(t1.getName(), ThreadUtils.findThreadById(t1.getId(),"thread_group_DDZZ99__").getName());
+            assertEquals(t2.getName(), ThreadUtils.findThreadById(t2.getId(),"thread_group_DDZZ99__").getName());
+            assertNull(ThreadUtils.findThreadById(nonExistingId,"non_existent_thread_group_JJHHZZ__"));
+            assertNull(ThreadUtils.findThreadById(nonExistingId,"thread_group_DDZZ99__"));
+        } finally {
+            t1.interrupt();
+            t2.interrupt();
+            t1.join();
+            t2.join();
+            threadGroup.destroy();
+        }
+    }
+
+    @Test
+    public void testConstructor() throws InterruptedException {
+        assertNotNull(new ThreadUtils());
+        final Constructor<?>[] cons = ThreadUtils.class.getDeclaredConstructors();
+        assertEquals(1, cons.length);
+        assertTrue(Modifier.isPublic(cons[0].getModifiers()));
+        assertTrue(Modifier.isPublic(ThreadUtils.class.getModifiers()));
+        assertFalse(Modifier.isFinal(ThreadUtils.class.getModifiers()));
+    }
+
+    private static class TestThread extends Thread {
+        private final CountDownLatch latch = new CountDownLatch(1);
+
+        public TestThread(String name) {
+            super(name);
+        }
+
+        public TestThread(ThreadGroup group, String name) {
+            super(group, name);
+        }
+
+        @Override
+        public synchronized void start() {
+            super.start();
+            try {
+                latch.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+
+        @Override
+        public void run() {
+            latch.countDown();
+            try {
+                synchronized(this){
+                    this.wait();
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add org.apache.commons.lang3.ThreadUtils which provide helper methods related to java.lang.Thread

* getSystemThreadGroup()
* getAllThreads()
* getAllThreadGroups()
* findThreadsByName(String threadName, String threadGroupName)
* findThreadsByName(String threadName) 
* findThreadGroupsByName(String threadGroupName)
* findThreadById(long threadId, String threadGroupName)
* findThreadById(long threadId)