### PR TITLE
Update DateUtils.java

### DIFF
--- a/src/main/java/org/apache/commons/lang3/time/DateUtils.java
+++ b/src/main/java/org/apache/commons/lang3/time/DateUtils.java
@@ -390,7 +390,9 @@ public class DateUtils {
             String str2 = str;
             // LANG-530 - need to make sure 'ZZ' output doesn't hit SimpleDateFormat as it will ParseException
             if (parsePattern.endsWith("ZZ")) {
-                str2 = str.replaceAll("([-+][0-9][0-9]):([0-9][0-9])$", "$1$2"); 
+                str2 = str.replaceAll("([-+][0-9][0-9]):([0-9][0-9])$", "$1$2");
+                // LANG-1116 'Z' is also a supported timezone.
+                str2 = str2.replaceAll("Z$", "+0000");
             }
 
             final Date date = parser.parse(str2, pos);

--- a/src/test/java/org/apache/commons/lang3/time/DateUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/DateUtilsTest.java
@@ -1199,11 +1199,15 @@ public class DateUtilsTest {
     // http://issues.apache.org/jira/browse/LANG-530
     @Test
     public void testLang530() throws ParseException {
-        final Date d = new Date();
-        final String isoDateStr = DateFormatUtils.ISO_DATETIME_TIME_ZONE_FORMAT.format(d);
-        final Date d2 = DateUtils.parseDate(isoDateStr, new String[] { DateFormatUtils.ISO_DATETIME_TIME_ZONE_FORMAT.getPattern() });
-        // the format loses milliseconds so have to reintroduce them
-        assertEquals("Date not equal to itself ISO formatted and parsed", d.getTime(), d2.getTime() + d.getTime() % 1000); 
+        for (final String timezoneId : TimeZone.getAvailableIDs()) {
+            final TimeZone timezone = TimeZone.getTimeZone(timezoneId);
+            final Calendar calendar = new GregorianCalendar(timezone);
+
+            final String isoDateStr = DateFormatUtils.ISO_DATETIME_TIME_ZONE_FORMAT.format(calendar);
+            final Date d2 = DateUtils.parseDate(isoDateStr, new String[] { DateFormatUtils.ISO_DATETIME_TIME_ZONE_FORMAT.getPattern() });
+            // the format loses milliseconds so have to reintroduce them
+            assertEquals("Date not equal to itself ISO formatted and parsed", calendar.getTimeInMillis(), d2.getTime() + calendar.getTimeInMillis() % 1000); 
+        }
     }
     
     /**


### PR DESCRIPTION
'Z' is the UTC timezone and machines running in this timezone fail the testLang530 test.