### PR TITLE
 LANG-1118: Fix StringUtils.repeat(char, int)

### DIFF
--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -5233,6 +5233,9 @@ public class StringUtils {
      * @see #repeat(String, int)
      */
     public static String repeat(final char ch, final int repeat) {
+        if (repeat <= 0) {
+            return EMPTY;
+        }
         final char[] buf = new char[repeat];
         for (int i = repeat - 1; i >= 0; i--) {
             buf[i] = ch;

--- a/src/test/java/org/apache/commons/lang3/StringUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringUtilsTest.java
@@ -1375,6 +1375,13 @@ public class StringUtilsTest {
     }
 
     @Test
+    public void testRepeat_CharInt() {
+        assertEquals("zzz", StringUtils.repeat('z', 3));
+        assertEquals("", StringUtils.repeat('z', 0));
+        assertEquals("", StringUtils.repeat('z', -2));
+    }
+
+    @Test
     public void testChop() {
 
         final String[][] chopCases = {

--- a/src/test/java/org/apache/commons/lang3/StringUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringUtilsTest.java
@@ -1353,6 +1353,7 @@ public class StringUtilsTest {
         assertEquals("", StringUtils.repeat("ab", 0));
         assertEquals("", StringUtils.repeat("", 3));
         assertEquals("aaa", StringUtils.repeat("a", 3));
+        assertEquals("", StringUtils.repeat("a", -2));
         assertEquals("ababab", StringUtils.repeat("ab", 3));
         assertEquals("abcabcabc", StringUtils.repeat("abc", 3));
         final String str = StringUtils.repeat("a", 10000);  // bigger than pad limit


### PR DESCRIPTION
_Close PR #68. Recreated due to rebase on master._

Now doing what is said in JavaDoc comment :
when passing a negative repeat value to the *StringUtils.repeat(char, int)* function, it returns an empty String instead of throwing a _NegativeArraySizeException_.