### PR TITLE
#LAN-1114 fixes bug in TypeUtils.equals(WildcardType, Type)

### DIFF
--- a/src/main/java/org/apache/commons/lang3/reflect/TypeUtils.java
+++ b/src/main/java/org/apache/commons/lang3/reflect/TypeUtils.java
@@ -1626,7 +1626,7 @@ public class TypeUtils {
             return equals(getImplicitLowerBounds(w), getImplicitLowerBounds(other))
                 && equals(getImplicitUpperBounds(w), getImplicitUpperBounds(other));
         }
-        return true;
+        return false;
     }
 
     /**

--- a/src/test/java/org/apache/commons/lang3/reflect/TypeUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/reflect/TypeUtilsTest.java
@@ -97,6 +97,8 @@ public class TypeUtilsTest<B> {
 
     public static Comparable<Long> longComparable;
 
+    public static Comparable<?> wildcardComparable;
+
     public static URI uri;
 
     public void dummyMethod(final List list0, final List<Object> list1, final List<?> list2,
@@ -720,6 +722,15 @@ public class TypeUtilsTest<B> {
        final WildcardType lowerTypeVariable = TypeUtils.wildcardType().withLowerBounds(iterableT0).build();
        Assert.assertEquals(String.format("? super %s", iterableT0.getName()), TypeUtils.toString(lowerTypeVariable));
        Assert.assertEquals(String.format("? super %s", iterableT0.getName()), lowerTypeVariable.toString());
+    }
+
+    @Test
+    public void testLang1114() throws Exception {
+        final Type nonWildcardType = getClass().getDeclaredField("wildcardComparable").getGenericType();
+        final Type wildcardType = ((ParameterizedType)nonWildcardType).getActualTypeArguments()[0];
+
+        Assert.assertFalse(TypeUtils.equals(wildcardType, nonWildcardType));
+        Assert.assertFalse(TypeUtils.equals(nonWildcardType, wildcardType));
     }
 
     @Test


### PR DESCRIPTION
fixes bug in TypeUtils.equals(WildcardType, Type) where it was incorrectly returning true when the second argument was not a Wildcard type.