### PR TITLE
ReflectionToStringBuilder doesn't throw IllegalArgumentException when the constructor's object param is null

### DIFF
--- a/src/main/java/org/apache/commons/lang3/builder/ReflectionToStringBuilder.java
+++ b/src/main/java/org/apache/commons/lang3/builder/ReflectionToStringBuilder.java
@@ -362,6 +362,13 @@ public class ReflectionToStringBuilder extends ToStringBuilder {
     public static String toStringExclude(final Object object, final String... excludeFieldNames) {
         return new ReflectionToStringBuilder(object).setExcludeFieldNames(excludeFieldNames).toString();
     }
+    
+    private static Object checkNotNull(final Object obj) {
+        if (obj == null) {
+            throw new IllegalArgumentException("The Object passed in should not be null.");
+        }
+        return obj;
+    }
 
     /**
      * Whether or not to append static fields.
@@ -400,7 +407,7 @@ public class ReflectionToStringBuilder extends ToStringBuilder {
      *             if the Object passed in is <code>null</code>
      */
     public ReflectionToStringBuilder(final Object object) {
-        super(object);
+        super(checkNotNull(object));
     }
 
     /**
@@ -420,7 +427,7 @@ public class ReflectionToStringBuilder extends ToStringBuilder {
      *             if the Object passed in is <code>null</code>
      */
     public ReflectionToStringBuilder(final Object object, final ToStringStyle style) {
-        super(object, style);
+        super(checkNotNull(object), style);
     }
 
     /**
@@ -446,7 +453,7 @@ public class ReflectionToStringBuilder extends ToStringBuilder {
      *             if the Object passed in is <code>null</code>
      */
     public ReflectionToStringBuilder(final Object object, final ToStringStyle style, final StringBuffer buffer) {
-        super(object, style, buffer);
+        super(checkNotNull(object), style, buffer);
     }
 
     /**
@@ -471,7 +478,7 @@ public class ReflectionToStringBuilder extends ToStringBuilder {
     public <T> ReflectionToStringBuilder(
             final T object, final ToStringStyle style, final StringBuffer buffer,
             final Class<? super T> reflectUpToClass, final boolean outputTransients, final boolean outputStatics) {
-        super(object, style, buffer);
+        super(checkNotNull(object), style, buffer);
         this.setUpToClass(reflectUpToClass);
         this.setAppendTransients(outputTransients);
         this.setAppendStatics(outputStatics);

--- a/src/test/java/org/apache/commons/lang3/builder/ReflectionToStringBuilderTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/ReflectionToStringBuilderTest.java
@@ -1,0 +1,12 @@
+package org.apache.commons.lang3.builder;
+
+import org.junit.Test;
+
+public class ReflectionToStringBuilderTest {
+
+    @Test(expected=IllegalArgumentException.class)
+    public void testConstructorWithNullObject() {
+        new ReflectionToStringBuilder(null, ToStringStyle.DEFAULT_STYLE, new StringBuffer());
+    }
+
+}

--- a/src/test/java/org/apache/commons/lang3/builder/ToStringBuilderTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/ToStringBuilderTest.java
@@ -1041,7 +1041,7 @@ public class ToStringBuilderTest {
         static final int staticInt2 = 67890;
     }
 
-    @Test
+    @Test(expected=IllegalArgumentException.class)
     public void testReflectionNull() {
         assertEquals("<null>", ReflectionToStringBuilder.toString(null));
     }


### PR DESCRIPTION
As described in it's [javadoc](http://commons.apache.org/proper/commons-lang/javadocs/api-release/org/apache/commons/lang3/builder/ReflectionToStringBuilder.html#ReflectionToStringBuilder(java.lang.Object)), ReflectionToStringBuilder constructor will throw IllegalArgumentException if the Object to build a toStringfor is null, while in fact it won't.

I had create the Issue [LANG-1132](https://issues.apache.org/jira/browse/LANG-1132) for this.