### PR TITLE
fix StringUtils.ordinalIndexOf("aaaaaa", "aa", 2) == 3

### DIFF
--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -1020,7 +1020,7 @@ public class StringUtils {
             return lastIndex ? str.length() : 0;
         }
         int found = 0;
-        int index = lastIndex ? str.length() : INDEX_NOT_FOUND;
+        int index = lastIndex ? str.length() + searchStr.length() : 0 - searchStr.length();
         do {
             if (lastIndex) {
                 index = CharSequenceUtils.lastIndexOf(str, searchStr, index - searchStr.length());

--- a/src/test/java/org/apache/commons/lang3/StringUtilsEqualsIndexOfTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringUtilsEqualsIndexOfTest.java
@@ -16,18 +16,15 @@
  */
 package org.apache.commons.lang3;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-
-import java.util.Locale;
-
-import org.apache.commons.lang3.test.SystemDefaultsSwitch;
 import org.apache.commons.lang3.test.SystemDefaults;
+import org.apache.commons.lang3.test.SystemDefaultsSwitch;
 import org.hamcrest.core.IsNot;
 import org.junit.Rule;
 import org.junit.Test;
+
+import java.util.Locale;
+
+import static org.junit.Assert.*;
 
 /**
  * Unit tests {@link org.apache.commons.lang3.StringUtils} - Substring methods
@@ -1026,8 +1023,9 @@ public class StringUtilsEqualsIndexOfTest  {
         assertEquals(8, StringUtils.ordinalIndexOf("aaaaaaaaa", "a", 9));
         assertEquals(-1, StringUtils.ordinalIndexOf("aaaaaaaaa", "a", 10));
 
-        assertEquals(3, StringUtils.ordinalIndexOf("aaaaaa", "aa", 2));
-        assertEquals(-1, StringUtils.ordinalIndexOf("aaaaaa", "aa", 3));
+        assertEquals(2, StringUtils.ordinalIndexOf("aaaaaa", "aa", 2));
+        assertEquals(4, StringUtils.ordinalIndexOf("aaaaaa", "aa", 3));
+        assertEquals(-1, StringUtils.ordinalIndexOf("aaaaaa", "aa", 4));
     }
 
 }


### PR DESCRIPTION
fix StringUtils.ordinalIndexOf("aaaaaa", "aa", 2) == 3
to StringUtils.ordinalIndexOf("aaaaaa", "aa", 2) == 2

worked with Gyucheol Park, Wookju Ha and Sanghee Lee of coupang.