### PR TITLE
refactor FastDateParser

### DIFF
--- a/src/main/java/org/apache/commons/lang3/time/DateUtils.java
+++ b/src/main/java/org/apache/commons/lang3/time/DateUtils.java
@@ -368,18 +368,21 @@ public class DateUtils {
         final TimeZone tz = TimeZone.getDefault();
         final Locale lcl = locale==null ?Locale.getDefault() : locale;
         final ParsePosition pos = new ParsePosition(0);
+        final Calendar calendar = Calendar.getInstance(tz, lcl);
+        calendar.setLenient(lenient);
 
         for (final String parsePattern : parsePatterns) {
-            FastDateParser fdp = new FastDateParser(parsePattern, tz, lcl, null, lenient);
+            FastDateParser fdp = new FastDateParser(parsePattern, tz, lcl);
+            calendar.clear();
             try {
-                Date date = fdp.parse(str, pos);
-                if (pos.getIndex() == str.length()) {
-                    return date;
+                if (fdp.parse(str, pos, calendar) && pos.getIndex()==str.length()) {
+                    return calendar.getTime();
                 }
-                pos.setIndex(0);
             }
-            catch(IllegalArgumentException iae) {
+            catch(IllegalArgumentException ignore) {
+                // leniency is preventing calendar from being set
             }
+            pos.setIndex(0);
         }
         throw new ParseException("Unable to parse the date: " + str, -1);
     }

--- a/src/test/java/org/apache/commons/lang3/time/FastDateFormatTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/FastDateFormatTest.java
@@ -35,8 +35,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.apache.commons.lang3.test.SystemDefaultsSwitch;
 import org.apache.commons.lang3.test.SystemDefaults;
+import org.apache.commons.lang3.test.SystemDefaultsSwitch;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -230,7 +230,7 @@ public class FastDateFormatTest {
 
     @Test
     public void testParseSync() throws InterruptedException {
-        final String pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS Z";
+        final String pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS";
         final FastDateFormat formatter= FastDateFormat.getInstance(pattern);
         
         final long sdfTime= measureTime(formatter, new SimpleDateFormat(pattern) {

--- a/src/test/java/org/apache/commons/lang3/time/FastDateParserSDFTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/FastDateParserSDFTest.java
@@ -16,7 +16,10 @@
  */
 package org.apache.commons.lang3.time;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.text.ParseException;
 import java.text.ParsePosition;
@@ -193,8 +196,9 @@ public class FastDateParserSDFTest {
 
         ParsePosition sdfP = new ParsePosition(0);
         Date expectedTime = sdf.parse(formattedDate, sdfP);
+        final int sdferrorIndex = sdfP.getErrorIndex();
         if (valid) {
-            assertEquals("Expected SDF error index -1 ", -1, sdfP.getErrorIndex());
+            assertEquals("Expected SDF error index -1 ", -1, sdferrorIndex);
             final int endIndex = sdfP.getIndex();
             final int length = formattedDate.length();
             if (endIndex != length) {
@@ -216,15 +220,11 @@ public class FastDateParserSDFTest {
             final int endIndex = fdfP.getIndex();
             final int length = formattedDate.length();
             assertEquals("Expected FDF to parse full string " + fdfP, length, endIndex);
-            assertEquals(locale.toString()+" "+formattedDate +"\n",expectedTime, actualTime);            
+            assertEquals(locale.toString()+" "+formattedDate +"\n", expectedTime, actualTime);
         } else {
-            final int endIndex = fdfP.getIndex();
-            if (endIndex != -0) {
-                fail("Expected FDF parse to fail, but got " + fdfP);                
-            }
-            if (fdferrorIndex != -1) {
-                assertEquals("FDF error index should match SDF index (if it is set)", sdfP.getErrorIndex(), fdferrorIndex);
-            }
+            assertNotEquals("Test data error: expected FDF parse to fail, but got " + actualTime, -1, fdferrorIndex);
+            assertTrue("FDF error index ("+ fdferrorIndex + ") should approxiamate SDF index (" + sdferrorIndex + ")",
+                    sdferrorIndex - fdferrorIndex <= 4);
         }        
     }
 }

--- a/src/test/java/org/apache/commons/lang3/time/FastDateParserTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/FastDateParserTest.java
@@ -31,6 +31,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
 
+import org.apache.commons.lang3.LocaleUtils;
 import org.apache.commons.lang3.SerializationUtils;
 import org.junit.Assert;
 import org.junit.Test;
@@ -325,7 +326,8 @@ public class FastDateParserTest {
         if (eraBC) {
             cal.set(Calendar.ERA, GregorianCalendar.BC);
         }
-        for(final Locale locale : Locale.getAvailableLocales()) {
+
+        for(final Locale locale : Locale.getAvailableLocales() ) {
             // ja_JP_JP cannot handle dates before 1868 properly
             if (eraBC && locale.equals(FastDateParser.JAPANESE_IMPERIAL)) {
                 continue;
@@ -337,6 +339,28 @@ public class FastDateParserTest {
                 checkParse(locale, cal, sdf, fdf);
             } catch(final ParseException ex) {
                 Assert.fail("Locale "+locale+ " failed with "+format+" era "+(eraBC?"BC":"AD")+"\n" + trimMessage(ex.toString()));
+            }
+        }
+    }
+    
+    @Test
+    public void testJpLocales() {
+
+        final Calendar cal= Calendar.getInstance(GMT);
+        cal.clear();
+        cal.set(2003, Calendar.FEBRUARY, 10);
+        cal.set(Calendar.ERA, GregorianCalendar.BC);
+
+        final Locale locale = LocaleUtils.toLocale("zh"); {
+            // ja_JP_JP cannot handle dates before 1868 properly
+
+            final SimpleDateFormat sdf = new SimpleDateFormat(LONG_FORMAT, locale);
+            final DateParser fdf = getInstance(LONG_FORMAT, locale);
+
+            try {
+                checkParse(locale, cal, sdf, fdf);
+            } catch(final ParseException ex) {
+                Assert.fail("Locale "+locale+ " failed with "+LONG_FORMAT+"\n" + trimMessage(ex.toString()));
             }
         }
     }
@@ -441,7 +465,7 @@ public class FastDateParserTest {
             final DateParser fdp = getInstance(format, NEW_YORK, Locale.US);
             dfdp = fdp.parse(date);
             if (shouldFail) {
-                Assert.fail("Expected FDF failure, but got " + dfdp + " for ["+format+","+date+"] using "+((FastDateParser)fdp).getParsePattern());
+                Assert.fail("Expected FDF failure, but got " + dfdp + " for ["+format+","+date+"]");
             }
         } catch (final Exception e) {
             f = e;

--- a/src/test/java/org/apache/commons/lang3/time/FastDateParser_MoreOrLessTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/FastDateParser_MoreOrLessTest.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.lang3.time;
+
+import java.text.ParseException;
+import java.text.ParsePosition;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class FastDateParser_MoreOrLessTest {
+
+    private static final TimeZone NEW_YORK = TimeZone.getTimeZone("America/New_York");
+    
+    @Test
+    public void testInputHasPrecedingCharacters() throws ParseException {
+        FastDateParser parser = new FastDateParser("MM/dd", TimeZone.getDefault(), Locale.getDefault());
+        ParsePosition parsePosition = new ParsePosition(0);
+        Date date = parser.parse("A 3/23/61", parsePosition);
+        Assert.assertNull(date);
+        Assert.assertEquals(0, parsePosition.getIndex());      
+        Assert.assertEquals(0, parsePosition.getErrorIndex());        
+    }
+
+    @Test
+    public void testInputHasWhitespace() throws ParseException {
+        FastDateParser parser = new FastDateParser("M/d/y", TimeZone.getDefault(), Locale.getDefault());
+        //SimpleDateFormat parser = new SimpleDateFormat("M/d/y");
+        ParsePosition parsePosition = new ParsePosition(0);
+        Date date = parser.parse(" 3/ 23/ 1961", parsePosition);
+        Assert.assertEquals(12, parsePosition.getIndex());
+
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTime(date);
+        Assert.assertEquals(1961, calendar.get(Calendar.YEAR));
+        Assert.assertEquals(2, calendar.get(Calendar.MONTH));
+        Assert.assertEquals(23, calendar.get(Calendar.DATE));       
+    }
+
+    @Test
+    public void testInputHasMoreCharacters() throws ParseException {
+        FastDateParser parser = new FastDateParser("MM/dd", TimeZone.getDefault(), Locale.getDefault());
+        ParsePosition parsePosition = new ParsePosition(0);
+        Date date = parser.parse("3/23/61", parsePosition);
+        Assert.assertEquals(4, parsePosition.getIndex());
+
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTime(date);
+        Assert.assertEquals(2, calendar.get(Calendar.MONTH));
+        Assert.assertEquals(23, calendar.get(Calendar.DATE));       
+    }
+    
+    @Test
+    public void testInputHasWrongCharacters() {
+        FastDateParser parser = new FastDateParser("MM-dd-yyy", TimeZone.getDefault(), Locale.getDefault());
+        ParsePosition parsePosition = new ParsePosition(0);
+        Assert.assertNull(parser.parse("03/23/1961", parsePosition));
+        Assert.assertEquals(2, parsePosition.getErrorIndex());
+    }
+    
+    @Test
+    public void testInputHasLessCharacters() {
+        FastDateParser parser = new FastDateParser("MM/dd/yyy", TimeZone.getDefault(), Locale.getDefault());
+        ParsePosition parsePosition = new ParsePosition(0);
+        Assert.assertNull(parser.parse("03/23", parsePosition));
+        Assert.assertEquals(5, parsePosition.getErrorIndex());
+    }
+    
+    @Test
+    public void testInputHasWrongTimeZone() {
+        FastDateParser parser = new FastDateParser("mm:ss z", NEW_YORK, Locale.US);
+        
+        String input = "11:23 Pacific Standard Time";
+        ParsePosition parsePosition = new ParsePosition(0);
+        Assert.assertNotNull(parser.parse(input, parsePosition));
+        Assert.assertEquals(input.length(), parsePosition.getIndex());
+        
+        parsePosition.setIndex(0);
+        Assert.assertNull(parser.parse( "11:23 Pacific Standard ", parsePosition));
+        Assert.assertEquals(6, parsePosition.getErrorIndex());
+    }
+    
+    @Test
+    public void testInputHasWrongDay() throws ParseException {
+        FastDateParser parser = new FastDateParser("EEEE, MM/dd/yyy", NEW_YORK, Locale.US);
+        String input = "Thursday, 03/23/61";
+        ParsePosition parsePosition = new ParsePosition(0);
+        Assert.assertNotNull(parser.parse(input, parsePosition));
+        Assert.assertEquals(input.length(), parsePosition.getIndex());
+        
+        parsePosition.setIndex(0);
+        Assert.assertNull(parser.parse( "Thorsday, 03/23/61", parsePosition));
+        Assert.assertEquals(0, parsePosition.getErrorIndex());
+    }
+}


### PR DESCRIPTION
use hashmap for performance
    break down regular expressions to per-format, allowing
ParsePosition to get set
    add parse with Calendar input, allowing client to set leniency
and/or replace display names