### PR TITLE
Ability to throw checked exceptions without declaring them

### DIFF
--- a/src/main/java/org/apache/commons/lang3/exception/ThrowUtils.java
+++ b/src/main/java/org/apache/commons/lang3/exception/ThrowUtils.java
@@ -1,0 +1,35 @@
+package org.apache.commons.lang3.exception;
+
+/**
+ * @author <a href="mailto:thegzak@gmail.com">Gregory Zak</a>
+ *
+ * <p>Utility class containing a method to allow checked exceptions to be rethrown without explicitly
+ * declaring them.</p>
+ *
+ */
+public final class ThrowUtils {
+
+    private ThrowUtils() {
+    }
+
+    /**
+     * <p>Any method with uninteresting checked exceptions in the body can simply be wrapped in a
+     * try/catch block, and the exceptions can then be freely rethrown from the catch block using
+     * {@code rethrow(t)}. If a method requires a return value, simply use {@code return rethrow(t)}
+     * in the catch block and compiler type inference will do the rest (no need to manually capture
+     * a return variable in the try block and return it after the catch block).</p>
+     *
+     * @param throwable The throwable to rethrow
+     * @param <R> Used only for compiler type inference
+     * @return Never returns, always throws
+     */
+    public static <R> R rethrow(Throwable throwable) {
+        return ThrowUtils.<R, RuntimeException>rethrow0(throwable);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <R, T extends Throwable> R rethrow0(Throwable throwable) throws T {
+        throw (T) throwable;
+    }
+
+}

--- a/src/test/java/org/apache/commons/lang3/exception/ThrowUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/exception/ThrowUtilsTest.java
@@ -1,0 +1,30 @@
+package org.apache.commons.lang3.exception;
+
+import org.junit.Test;
+
+import static org.apache.commons.lang3.exception.ThrowUtils.rethrow;
+
+/**
+ * @author <a href="mailto:thegzak@gmail.com">Gregory Zak</a>
+ */
+public class ThrowUtilsTest {
+
+    @Test(expected = Exception.class)
+    public void testVoid() {
+        rethrow(new Exception());
+    }
+
+    @Test(expected = Exception.class)
+    public void testReturning() {
+        Object obj = helper();
+    }
+
+    private static Object helper() {
+        try {
+            throw new Exception();
+        } catch (Exception e) {
+            return rethrow(e);
+        }
+    }
+
+}


### PR DESCRIPTION
One of Java's most controversial features is checked exceptions, and most other languages&mdash;including newer JVM-based languages (Scala, Clojure, etc.)&mdash;have dispensed with them. Check out this [fantastic interview with Anders Hejlsberg](http://www.artima.com/intv/handcuffs.html) (creator of C#) on why checked exceptions are a bad idea.

This utility gives users a way to dispense with checked exceptions even in Java, in a minimally intrusive fashion. By standardizing such a utility and giving it widespread adoption, hopefully the folks over at Oracle will eventually give in and drop the feature in a later release of Java. Luckily, it wouldn't be backwards incompatible to do so.