### PR TITLE
Fix indexOfIgnoreCase javadoc and provide test for fixed example

### DIFF
--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -1327,7 +1327,7 @@ public class StringUtils {
      * StringUtils.indexOfIgnoreCase("aabaabaa", "B", 9)  = -1
      * StringUtils.indexOfIgnoreCase("aabaabaa", "B", -1) = 2
      * StringUtils.indexOfIgnoreCase("aabaabaa", "", 2)   = 2
-     * StringUtils.indexOfIgnoreCase("abc", "", 9)        = 3
+     * StringUtils.indexOfIgnoreCase("abc", "", 9)        = -1
      * </pre>
      *
      * @param str  the CharSequence to check, may be null

--- a/src/test/java/org/apache/commons/lang3/StringUtilsEqualsIndexOfTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringUtilsEqualsIndexOfTest.java
@@ -926,6 +926,7 @@ public class StringUtilsEqualsIndexOfTest  {
         assertEquals(5, StringUtils.indexOfIgnoreCase("aabaabaa", "", 5));
         assertEquals(-1, StringUtils.indexOfIgnoreCase("ab", "AAB", 0));
         assertEquals(-1, StringUtils.indexOfIgnoreCase("aab", "AAB", 1));
+        assertEquals(-1, StringUtils.indexOfIgnoreCase("abc", "", 9));
     }
 
     @Test


### PR DESCRIPTION
Now javadoc for StringUtils#indexOfIgnoreCase contains example
```
StringUtils.indexOfIgnoreCase("abc", "", 9) = 3
```
This result is very unintuitive and incorrect - with current code it will be -1. Provided test for this example and fixed example's result in javadoc.