### PR TITLE
LANG-1186 Fix NullPointerException in FastDateParser$TimeZoneStrategy

### DIFF
--- a/src/main/java/org/apache/commons/lang3/time/FastDateParser.java
+++ b/src/main/java/org/apache/commons/lang3/time/FastDateParser.java
@@ -853,6 +853,9 @@ public class FastDateParser implements DateParser, Serializable {
                 final TimeZone tz = TimeZone.getTimeZone(tzId);
                 for(int i= 1; i<zoneNames.length; ++i) {
                     String zoneName = zoneNames[i];
+                    if (zoneName == null) {
+                        break;
+                    }
                     if (tzNames.put(zoneName.toLowerCase(locale), tz) == null) {
                         simpleQuote(sb.append('|'), zoneName);
                     }

--- a/src/test/java/org/apache/commons/lang3/time/FastDateParser_TimeZoneStrategyTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/FastDateParser_TimeZoneStrategyTest.java
@@ -33,7 +33,9 @@ public class FastDateParser_TimeZoneStrategyTest {
             for(final String[] zone :  zones) {
                 for(int t = 1; t<zone.length; ++t) {
                     final String tzDisplay = zone[t];
-
+                    if (tzDisplay == null) {
+                        break;
+                    }
                     try {
                         parser.parse(tzDisplay);
                     }


### PR DESCRIPTION
Java 8u60 has a change where `DateFormatSymbols.getZoneStrings` returns arrays with 7 elements instead of 5 like it previously had. For some locales, the additional two elements are null.

Example from the unit tests:
```
Running org.apache.commons.lang3.time.FastDateParser_TimeZoneStrategyTest
Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.597 sec <<< FAILURE! - in org.apache.commons.lang3.time.FastDateParser_TimeZoneStrategyTest
testTimeZoneStrategyPattern(org.apache.commons.lang3.time.FastDateParser_TimeZoneStrategyTest)  Time elapsed: 0.597 sec  <<< ERROR!
java.lang.NullPointerException: null
	at org.apache.commons.lang3.time.FastDateParser$TimeZoneStrategy.<init>(FastDateParser.java:856)
	at org.apache.commons.lang3.time.FastDateParser.getLocaleSpecificStrategy(FastDateParser.java:647)
	at org.apache.commons.lang3.time.FastDateParser.getStrategy(FastDateParser.java:616)
	at org.apache.commons.lang3.time.FastDateParser.access$100(FastDateParser.java:74)
	at org.apache.commons.lang3.time.FastDateParser$StrategyParser.letterPattern(FastDateParser.java:230)
	at org.apache.commons.lang3.time.FastDateParser$StrategyParser.getNextStrategy(FastDateParser.java:214)
	at org.apache.commons.lang3.time.FastDateParser.init(FastDateParser.java:161)
	at org.apache.commons.lang3.time.FastDateParser.<init>(FastDateParser.java:147)
	at org.apache.commons.lang3.time.FastDateParser.<init>(FastDateParser.java:108)
	at org.apache.commons.lang3.time.FastDateParser_TimeZoneStrategyTest.testTimeZoneStrategyPattern(FastDateParser_TimeZoneStrategyTest.java:31)
```