### PR TITLE
DiffBuilder: Add null check on fieldName when appending Object or Object[]

### DIFF
--- a/src/main/java/org/apache/commons/lang3/builder/DiffBuilder.java
+++ b/src/main/java/org/apache/commons/lang3/builder/DiffBuilder.java
@@ -835,7 +835,9 @@ public class DiffBuilder implements Builder<DiffResult> {
      */
     public DiffBuilder append(final String fieldName, final Object lhs,
             final Object rhs) {
-
+        if (fieldName == null) {
+            throw new IllegalArgumentException("Field name cannot be null");
+        }
         if (objectsTriviallyEqual) {
             return this;
         }
@@ -917,6 +919,9 @@ public class DiffBuilder implements Builder<DiffResult> {
      */
     public DiffBuilder append(final String fieldName, final Object[] lhs,
             final Object[] rhs) {
+        if (fieldName == null) {
+            throw new IllegalArgumentException("Field name cannot be null");
+        }
         if (objectsTriviallyEqual) {
             return this;
         }


### PR DESCRIPTION
The other append methods throw an IllegalArgumentException if fieldName is null. So, I added it here as well.