### PR TITLE
Fix typo in API docs

### DIFF
--- a/src/main/java/org/apache/commons/lang3/time/DateUtils.java
+++ b/src/main/java/org/apache/commons/lang3/time/DateUtils.java
@@ -613,7 +613,7 @@ public class DateUtils {
 
     //-----------------------------------------------------------------------
     /**
-     * Sets the miliseconds field to a date returning a new object.
+     * Sets the milliseconds field to a date returning a new object.
      * The original {@code Date} is unchanged.
      *
      * @param date  the date, not null


### PR DESCRIPTION
`miliseconds` => `milliseconds`.