### PR TITLE
Add tests for missed branches in DateUtils

### DIFF
--- a/src/test/java/org/apache/commons/lang3/time/DateUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/DateUtilsTest.java
@@ -170,8 +170,18 @@ public class DateUtilsTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testIsDameDay_DateNullNull() throws Exception {
+    public void testIsSameDay_DateNullNull() throws Exception {
         DateUtils.isSameDay((Date) null, (Date) null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testIsSameDay_DateNullNotNull() throws Exception {
+        DateUtils.isSameDay((Date) null, new Date());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testIsSameDay_DateNotNullNull() throws Exception {
+        DateUtils.isSameDay(new Date(), (Date) null);
     }
 
     //-----------------------------------------------------------------------
@@ -193,6 +203,16 @@ public class DateUtilsTest {
         DateUtils.isSameDay((Calendar) null, (Calendar) null);
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testIsSameDay_CalNullNotNull() throws Exception {
+        DateUtils.isSameDay((Calendar) null, Calendar.getInstance());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testIsSameDay_CalNotNullNull() throws Exception {
+        DateUtils.isSameDay(Calendar.getInstance(), (Calendar) null);
+    }
+
     //-----------------------------------------------------------------------
     @Test
     public void testIsSameInstant_Date() {
@@ -210,6 +230,16 @@ public class DateUtilsTest {
     @Test(expected = IllegalArgumentException.class)
     public void testIsSameInstant_DateNullNull() throws Exception {
         DateUtils.isSameInstant((Date) null, (Date) null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testIsSameInstant_DateNullNotNull() throws Exception {
+        DateUtils.isSameInstant((Date) null, new Date());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testIsSameInstant_DateNotNullNull() throws Exception {
+        DateUtils.isSameInstant(new Date(), (Date) null);
     }
 
     //-----------------------------------------------------------------------
@@ -230,6 +260,16 @@ public class DateUtilsTest {
     @Test(expected = IllegalArgumentException.class)
     public void testIsSameInstant_CalNullNull() throws Exception {
         DateUtils.isSameInstant((Calendar) null, (Calendar) null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testIsSameInstant_CalNullNotNull() throws Exception {
+        DateUtils.isSameInstant((Calendar) null, Calendar.getInstance());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testIsSameInstant_CalNotNullNull() throws Exception {
+        DateUtils.isSameInstant(Calendar.getInstance(), (Calendar) null);
     }
 
     //-----------------------------------------------------------------------
@@ -258,6 +298,16 @@ public class DateUtilsTest {
     @Test(expected = IllegalArgumentException.class)
     public void testIsSameLocalTime_CalNullNull() throws Exception {
         DateUtils.isSameLocalTime((Calendar) null, (Calendar) null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testIsSameLocalTime_CalNullNotNull() throws Exception {
+        DateUtils.isSameLocalTime((Calendar) null, Calendar.getInstance());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testIsSameLocalTime_CalNotNullNull() throws Exception {
+        DateUtils.isSameLocalTime(Calendar.getInstance(), (Calendar) null);
     }
 
     //-----------------------------------------------------------------------


### PR DESCRIPTION
Fixes a typo and adds tests for some missed branches in `DateUtils`.

The `isSame` methods require both dates to be non-`null`. Previously, breaking the check to allow one of the dates to be `null` didn't trigger a failing test.