### PR TITLE
LANG-1218 EqualsBuilder.append is too large

### DIFF
--- a/src/main/java/org/apache/commons/lang3/builder/EqualsBuilder.java
+++ b/src/main/java/org/apache/commons/lang3/builder/EqualsBuilder.java
@@ -479,7 +479,22 @@ public class EqualsBuilder implements Builder<Boolean> {
         if (!lhsClass.isArray()) {
             // The simple case, not an array, just test the element
             isEquals = lhs.equals(rhs);
-        } else if (lhs.getClass() != rhs.getClass()) {
+        } else {
+            // factor out array case in order to keep method small enough
+            // to be inlined
+            appendArray(lhs, rhs);
+        }
+        return this;
+    }
+
+    /**
+     * <p>Test if an <code>Object</code> is equal to an array.</p>
+     *
+     * @param lhs  the left hand object, an array
+     * @param rhs  the right hand object
+     */
+    private void appendArray(final Object lhs, final Object rhs) {
+        if (lhs.getClass() != rhs.getClass()) {
             // Here when we compare different dimensions, for example: a boolean[][] to a boolean[]
             this.setEquals(false);
         }
@@ -505,7 +520,6 @@ public class EqualsBuilder implements Builder<Boolean> {
             // Not an array of primitives
             append((Object[]) lhs, (Object[]) rhs);
         }
-        return this;
     }
 
     /**


### PR DESCRIPTION
EqualsBuilder.append(Object, Object) is 327 bytes which is 2 bytes
above the default inline limit of 325 of HotSpot (MaxInlineSize). Micro
benchmarking has shown this can have a significant performance impact.
Currently EqualsBuilder can be two to three times slower than writing
the equals method "by hand". Once the method is small enough to be
inlined EqualsBuilder has more or less the same performance as writing
the equals method "by hand".

There are different ways to push the method under the the inline limit.
I decided to factor out the array handing of append(Object, Object)
into a method. This leaves the body of append(Object, Object) to do
what I presume is the common case, the non-array case.

Issue: LANG-1218
https://issues.apache.org/jira/browse/LANG-1218