### PR TITLE
Lang 1195: Enhance MethodUtils to allow invocation of private methods

### DIFF
--- a/src/main/java/org/apache/commons/lang3/reflect/MethodUtils.java
+++ b/src/main/java/org/apache/commons/lang3/reflect/MethodUtils.java
@@ -93,6 +93,29 @@ public class MethodUtils {
             IllegalAccessException, InvocationTargetException {
         return invokeMethod(object, methodName, ArrayUtils.EMPTY_OBJECT_ARRAY, null);
     }
+    
+    /**
+     * <p>Invokes a named method without parameters.</p>
+     *
+     * <p>This is a convenient wrapper for
+     * {@link #invokeMethod(Object object,String methodName, Object[] args, Class[] parameterTypes)}.
+     * </p>
+     *
+     * @param object invoke method on this object
+     * @param forceAccess force access to invoke method even if it's not accessible
+     * @param methodName get method with this name
+     * @return The value returned by the invoked method
+     *
+     * @throws NoSuchMethodException if there is no such accessible method
+     * @throws InvocationTargetException wraps an exception thrown by the method invoked
+     * @throws IllegalAccessException if the requested method is not accessible via reflection
+     *  
+     * @since 3.5
+     */
+    public static Object invokeMethod(final Object object, final boolean forceAccess, final String methodName) 
+    		throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
+        return invokeMethod(object, forceAccess, methodName, ArrayUtils.EMPTY_OBJECT_ARRAY, null);
+    }
 
     /**
      * <p>Invokes a named method whose parameter type matches the object type.</p>
@@ -123,7 +146,86 @@ public class MethodUtils {
         final Class<?>[] parameterTypes = ClassUtils.toClass(args);
         return invokeMethod(object, methodName, args, parameterTypes);
     }
+    
+    /**
+     * <p>Invokes a named method whose parameter type matches the object type.</p>
+     *
+     * <p>This method supports calls to methods taking primitive parameters 
+     * via passing in wrapping classes. So, for example, a {@code Boolean} object
+     * would match a {@code boolean} primitive.</p>
+     *
+     * <p>This is a convenient wrapper for
+     * {@link #invokeMethod(Object object,String methodName, Object[] args, Class[] parameterTypes)}.
+     * </p>
+     *
+     * @param object invoke method on this object
+     * @param methodName get method with this name
+     * @param args use these arguments - treat null as empty array
+     * @return The value returned by the invoked method
+     *
+     * @throws NoSuchMethodException if there is no such accessible method
+     * @throws InvocationTargetException wraps an exception thrown by the method invoked
+     * @throws IllegalAccessException if the requested method is not accessible via reflection
+     * 
+     * @since 3.5
+     */
+    public static Object invokeMethod(final Object object, final boolean forceAccess, final String methodName,
+            Object... args) throws NoSuchMethodException,
+            IllegalAccessException, InvocationTargetException {
+        args = ArrayUtils.nullToEmpty(args);
+        final Class<?>[] parameterTypes = ClassUtils.toClass(args);
+        return invokeMethod(object, forceAccess, methodName, args, parameterTypes);
+    }
 
+    /**
+     * <p>Invokes a named method whose parameter type matches the object type.</p>
+     *
+     * <p>This method supports calls to methods taking primitive parameters 
+     * via passing in wrapping classes. So, for example, a {@code Boolean} object
+     * would match a {@code boolean} primitive.</p>
+     *
+     * @param object invoke method on this object
+     * @param forceAccess force access to invoke method even if it's not accessible
+     * @param methodName get method with this name
+     * @param args use these arguments - treat null as empty array
+     * @param parameterTypes match these parameters - treat null as empty array
+     * @return The value returned by the invoked method
+     *
+     * @throws NoSuchMethodException if there is no such accessible method
+     * @throws InvocationTargetException wraps an exception thrown by the method invoked
+     * @throws IllegalAccessException if the requested method is not accessible via reflection
+     */
+    public static Object invokeMethod(final Object object, final boolean forceAccess, final String methodName,
+            Object[] args, Class<?>[] parameterTypes)
+            throws NoSuchMethodException, IllegalAccessException,
+            InvocationTargetException {
+        parameterTypes = ArrayUtils.nullToEmpty(parameterTypes);
+        args = ArrayUtils.nullToEmpty(args);
+        
+        final String messagePrefix;
+        final Method method;
+        if (forceAccess) {
+        	messagePrefix = "No such method: ";
+        	method = getMatchingMethod(object.getClass(),
+                    methodName, parameterTypes);
+        	if (method != null) {
+        		method.setAccessible(true);
+        	}
+        }  else {
+        	messagePrefix = "No such accessible method: ";
+        	method = getMatchingAccessibleMethod(object.getClass(),
+                    methodName, parameterTypes);
+        }
+        
+        if (method == null) {
+            throw new NoSuchMethodException(messagePrefix
+                    + methodName + "() on object: "
+                    + object.getClass().getName());
+        }
+        args = toVarArgs(method, args);
+        return method.invoke(object, args);
+    }
+    
     /**
      * <p>Invokes a named method whose parameter type matches the object type.</p>
      *
@@ -143,21 +245,11 @@ public class MethodUtils {
      * @throws InvocationTargetException wraps an exception thrown by the method invoked
      * @throws IllegalAccessException if the requested method is not accessible via reflection
      */
-    public static Object invokeMethod(final Object object, final String methodName,
+    public static Object invokeMethod(final Object object, final String methodName, 
             Object[] args, Class<?>[] parameterTypes)
             throws NoSuchMethodException, IllegalAccessException,
             InvocationTargetException {
-        parameterTypes = ArrayUtils.nullToEmpty(parameterTypes);
-        args = ArrayUtils.nullToEmpty(args);
-        final Method method = getMatchingAccessibleMethod(object.getClass(),
-                methodName, parameterTypes);
-        if (method == null) {
-            throw new NoSuchMethodException("No such accessible method: "
-                    + methodName + "() on object: "
-                    + object.getClass().getName());
-        }
-        args = toVarArgs(method, args);
-        return method.invoke(object, args);
+    	return invokeMethod(object, false, methodName, args, parameterTypes);
     }
 
     /**
@@ -603,6 +695,75 @@ public class MethodUtils {
             MemberUtils.setAccessibleWorkaround(bestMatch);
         }
         return bestMatch;
+    }
+    
+    /**
+     * <p>Retrieves a method whether or not it's accessible. If no such method
+     * can be found, return {@code null}.</p>
+     * @param cls The class that will be subjected to the method search
+     * @param methodName The method that we wish to call
+     * @param parameterTypes Argument class types
+     * @return The method
+     * 
+     * @since 3.5
+     */
+    public static Method getMatchingMethod(final Class<?> cls, final String methodName,
+            final Class<?>... parameterTypes) {
+    	Validate.notNull(cls, "Null class not allowed.");
+    	Validate.notEmpty(methodName, "Null or blank methodName not allowed.");
+    	
+    	// Address methods in superclasses
+    	Method[] methodArray = cls.getDeclaredMethods();
+    	List<Class<?>> superclassList = ClassUtils.getAllSuperclasses(cls);
+    	for (Class<?> klass: superclassList) {
+    		methodArray = ArrayUtils.addAll(methodArray, klass.getDeclaredMethods());
+    	}
+    	
+    	Method inexactMatch = null;
+    	for (Method method: methodArray) {
+    		if (methodName.equals(method.getName()) && 
+    				ArrayUtils.isEquals(parameterTypes, method.getParameterTypes())) {
+    			return method;
+    		} else if (methodName.equals(method.getName()) &&  
+    				ClassUtils.isAssignable(parameterTypes, method.getParameterTypes(), true)) {
+    			if (inexactMatch == null) {
+    				inexactMatch = method;
+    			} else if (distance(parameterTypes, method.getParameterTypes()) 
+    					< distance(parameterTypes, inexactMatch.getParameterTypes())) {
+    				inexactMatch = method;
+    			}
+    		}
+    		
+    	}
+    	return inexactMatch;
+    }
+    
+    /**
+     * <p>Returns the aggregate number of inheritance hops between assignable argument class types.  Returns -1
+     * if the arguments aren't assignable.  Fills a specific purpose for getMatchingMethod and is not generalized.</p>
+     * @param classArray
+     * @param toClassArray
+     * @return the aggregate number of inheritance hops between assignable argument class types.
+     */
+    private static int distance(Class<?>[] classArray, Class<?>[] toClassArray) {
+    	int answer=0;
+    	
+    	if (!ClassUtils.isAssignable(classArray, toClassArray, true)) {
+    		return -1;
+    	}
+    	for (int offset = 0; offset < classArray.length; offset++) {
+    		// Note InheritanceUtils.distance() uses different scoring system.
+    		if (classArray[offset].equals(toClassArray[offset])) {
+    			continue;
+    		} else if (ClassUtils.isAssignable(classArray[offset], toClassArray[offset], true) 
+    				&& !ClassUtils.isAssignable(classArray[offset], toClassArray[offset], false)) {
+    			answer++;
+    		} else {
+    			answer = answer+2;
+    		}
+    	}
+    	
+    	return answer;
     }
 
     /**

--- a/src/main/java/org/apache/commons/lang3/reflect/MethodUtils.java
+++ b/src/main/java/org/apache/commons/lang3/reflect/MethodUtils.java
@@ -204,12 +204,16 @@ public class MethodUtils {
         
         final String messagePrefix;
         final Method method;
+        boolean isOriginallyAccessible = false;
         if (forceAccess) {
         	messagePrefix = "No such method: ";
         	method = getMatchingMethod(object.getClass(),
                     methodName, parameterTypes);
         	if (method != null) {
-        		method.setAccessible(true);
+        	    isOriginallyAccessible = method.isAccessible();
+        	    if (!isOriginallyAccessible) {
+        	        method.setAccessible(true);
+        	    }
         	}
         }  else {
         	messagePrefix = "No such accessible method: ";
@@ -223,7 +227,12 @@ public class MethodUtils {
                     + object.getClass().getName());
         }
         args = toVarArgs(method, args);
-        return method.invoke(object, args);
+        Object result = method.invoke(object, args);
+        
+        if (forceAccess && method.isAccessible() != isOriginallyAccessible) {
+            method.setAccessible(isOriginallyAccessible);
+        }
+        return result;
     }
     
     /**

--- a/src/main/java/org/apache/commons/lang3/reflect/MethodUtils.java
+++ b/src/main/java/org/apache/commons/lang3/reflect/MethodUtils.java
@@ -98,7 +98,7 @@ public class MethodUtils {
      * <p>Invokes a named method without parameters.</p>
      *
      * <p>This is a convenient wrapper for
-     * {@link #invokeMethod(Object object,String methodName, Object[] args, Class[] parameterTypes)}.
+     * {@link #invokeMethod(Object object,boolean forceAccess,String methodName, Object[] args, Class[] parameterTypes)}.
      * </p>
      *
      * @param object invoke method on this object
@@ -155,7 +155,7 @@ public class MethodUtils {
      * would match a {@code boolean} primitive.</p>
      *
      * <p>This is a convenient wrapper for
-     * {@link #invokeMethod(Object object,String methodName, Object[] args, Class[] parameterTypes)}.
+     * {@link #invokeMethod(Object object,boolean forceAccess,String methodName, Object[] args, Class[] parameterTypes)}.
      * </p>
      *
      * @param object invoke method on this object

--- a/src/main/java/org/apache/commons/lang3/reflect/MethodUtils.java
+++ b/src/main/java/org/apache/commons/lang3/reflect/MethodUtils.java
@@ -29,7 +29,6 @@ import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 
 import org.apache.commons.lang3.ArrayUtils;
@@ -739,7 +738,7 @@ public class MethodUtils {
     	Method inexactMatch = null;
     	for (Method method: methodArray) {
     		if (methodName.equals(method.getName()) && 
-    				Objects.deepEquals(parameterTypes, method.getParameterTypes())) {
+    				ArrayUtils.isEquals(parameterTypes, method.getParameterTypes())) {
     			return method;
     		} else if (methodName.equals(method.getName()) &&  
     				ClassUtils.isAssignable(parameterTypes, method.getParameterTypes(), true)) {

--- a/src/main/java/org/apache/commons/lang3/reflect/MethodUtils.java
+++ b/src/main/java/org/apache/commons/lang3/reflect/MethodUtils.java
@@ -29,6 +29,7 @@ import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import org.apache.commons.lang3.ArrayUtils;
@@ -731,7 +732,7 @@ public class MethodUtils {
     	Method inexactMatch = null;
     	for (Method method: methodArray) {
     		if (methodName.equals(method.getName()) && 
-    				ArrayUtils.isEquals(parameterTypes, method.getParameterTypes())) {
+    				Objects.deepEquals(parameterTypes, method.getParameterTypes())) {
     			return method;
     		} else if (methodName.equals(method.getName()) &&  
     				ClassUtils.isAssignable(parameterTypes, method.getParameterTypes(), true)) {

--- a/src/test/java/org/apache/commons/lang3/reflect/MethodUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/reflect/MethodUtilsTest.java
@@ -32,12 +32,14 @@ import static org.junit.Assert.fail;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.ClassUtils;
 import org.apache.commons.lang3.ClassUtils.Interfaces;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.commons.lang3.mutable.Mutable;
@@ -757,5 +759,31 @@ public class MethodUtilsTest {
         TestBean testBean = new TestBean();
         int[] actual = (int[])MethodUtils.invokeMethod(testBean, "unboxing", Integer.valueOf(1), Integer.valueOf(2));
         Assert.assertArrayEquals(new int[]{1, 2}, actual);
+    }
+    
+    @Test
+    public void testInvokeMethodForceAccessNoArgs() throws Exception {
+        Assert.assertEquals("privateStringStuff()", MethodUtils.invokeMethod(testBean, true, "privateStringStuff"));
+    }
+    
+    @Test
+    public void testInvokeMethodForceAccessWithArgs() throws Exception {
+        Assert.assertEquals("privateStringStuff(Integer)", MethodUtils.invokeMethod(testBean, true, "privateStringStuff", 5));
+        Assert.assertEquals("privateStringStuff(double)", MethodUtils.invokeMethod(testBean, true, "privateStringStuff", 5.0d));
+        Assert.assertEquals("privateStringStuff(String)", MethodUtils.invokeMethod(testBean, true, "privateStringStuff", "Hi There"));
+        Assert.assertEquals("privateStringStuff(Object)", MethodUtils.invokeMethod(testBean, true, "privateStringStuff", new Date()));
+    }
+    
+    @Test
+    public void testDistance() throws Exception {
+        Method distanceMethod = MethodUtils.getMatchingMethod(MethodUtils.class, "distance", Class[].class, Class[].class);
+        distanceMethod.setAccessible(true);
+        
+        Assert.assertEquals(-1, distanceMethod.invoke(null, new Class[]{String.class}, new Class[]{Date.class}));
+        Assert.assertEquals(0, distanceMethod.invoke(null, new Class[]{Date.class}, new Class[]{Date.class}));
+        Assert.assertEquals(1, distanceMethod.invoke(null, new Class[]{Integer.class}, new Class[]{ClassUtils.wrapperToPrimitive(Integer.class)}));
+        Assert.assertEquals(2, distanceMethod.invoke(null, new Class[]{Integer.class}, new Class[]{Object.class}));
+        
+        distanceMethod.setAccessible(false);
     }
 }

--- a/src/test/java/org/apache/commons/lang3/reflect/MethodUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/reflect/MethodUtilsTest.java
@@ -101,9 +101,39 @@ public class MethodUtilsTest {
         public static void oneParameterStatic(final String s) {
             // empty
         }
-
+        
         @SuppressWarnings("unused")
         private void privateStuff() {
+        }
+
+        @SuppressWarnings("unused")
+        private String privateStringStuff() {
+        	return "privateStringStuff()";
+        }
+        
+        @SuppressWarnings("unused")
+        private String privateStringStuff(final int i) {
+        	return "privateStringStuff(int)";
+        }
+        
+        @SuppressWarnings("unused")
+        private String privateStringStuff(final Integer i) {
+        	return "privateStringStuff(Integer)";
+        }
+        
+        @SuppressWarnings("unused")
+        private String privateStringStuff(final double d) {
+        	return "privateStringStuff(double)";
+        }
+        
+        @SuppressWarnings("unused")
+        private String privateStringStuff(final String s) {
+        	return "privateStringStuff(String)";
+        }
+        
+        @SuppressWarnings("unused")
+        private String privateStringStuff(final Object s) {
+        	return "privateStringStuff(Object)";
         }
 
 

--- a/src/test/java/org/apache/commons/lang3/reflect/MethodUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/reflect/MethodUtilsTest.java
@@ -763,7 +763,10 @@ public class MethodUtilsTest {
     
     @Test
     public void testInvokeMethodForceAccessNoArgs() throws Exception {
+        Method privateStringStuffMethod = MethodUtils.getMatchingMethod(TestBean.class, "privateStringStuff");
+        Assert.assertFalse(privateStringStuffMethod.isAccessible());
         Assert.assertEquals("privateStringStuff()", MethodUtils.invokeMethod(testBean, true, "privateStringStuff"));
+        Assert.assertFalse(privateStringStuffMethod.isAccessible());
     }
     
     @Test


### PR DESCRIPTION
Currently, MethodUtils is restricted to finding and invoking accessible methods. Frequently, developers have a need to test 'private' methods. What I see is that they escalate access to 'protected' in order to more easily provide test coverage for these methods. From a design perspective, this is bad.

I propose to enhance MethodUtils so that it can easily invoke private methods. I'm not suggesting that developers should do this in production code, merely test code. Much as FieldUtils provides access to private fields via the 'forceAccess' overload on many of its methods. I've copied a utility like this around for years. It would be much more convenient to simply include it with Commons Lang. See [LANG-1195](https://issues.apache.org/jira/browse/LANG-1195) for details.

I made sure that I used space indentation and tried to adhere closely to your standards.  I've also signed the Contributor License Agreement.

Assuming you like the enhancement, I'm willing to contribute additional work if you see issues with what I've done.