### PR TITLE
LANG-1230 Remove unnecessary synchronization

### DIFF
--- a/src/main/java/org/apache/commons/lang3/builder/EqualsBuilder.java
+++ b/src/main/java/org/apache/commons/lang3/builder/EqualsBuilder.java
@@ -171,14 +171,12 @@ public class EqualsBuilder implements Builder<Boolean> {
      * @param lhs <code>this</code> object to register
      * @param rhs the other object to register
      */
-    static void register(final Object lhs, final Object rhs) {
-        synchronized (EqualsBuilder.class) {
-            if (getRegistry() == null) {
-                REGISTRY.set(new HashSet<Pair<IDKey, IDKey>>());
-            }
+    private static void register(final Object lhs, final Object rhs) {
+        Set<Pair<IDKey, IDKey>> registry = getRegistry();
+        if (registry == null) {
+            registry = new HashSet<Pair<IDKey, IDKey>>();
+            REGISTRY.set(registry);
         }
-
-        final Set<Pair<IDKey, IDKey>> registry = getRegistry();
         final Pair<IDKey, IDKey> pair = getRegisterPair(lhs, rhs);
         registry.add(pair);
     }
@@ -195,17 +193,13 @@ public class EqualsBuilder implements Builder<Boolean> {
      * @param rhs the other object to unregister
      * @since 3.0
      */
-    static void unregister(final Object lhs, final Object rhs) {
+    private static void unregister(final Object lhs, final Object rhs) {
         Set<Pair<IDKey, IDKey>> registry = getRegistry();
         if (registry != null) {
             final Pair<IDKey, IDKey> pair = getRegisterPair(lhs, rhs);
             registry.remove(pair);
-            synchronized (EqualsBuilder.class) {
-                //read again
-                registry = getRegistry();
-                if (registry != null && registry.isEmpty()) {
-                    REGISTRY.remove();
-                }
+            if (registry.isEmpty()) {
+                REGISTRY.remove();
             }
         }
     }

--- a/src/main/java/org/apache/commons/lang3/builder/HashCodeBuilder.java
+++ b/src/main/java/org/apache/commons/lang3/builder/HashCodeBuilder.java
@@ -497,13 +497,13 @@ public class HashCodeBuilder implements Builder<Integer> {
      * @param value
      *            The object to register.
      */
-    static void register(final Object value) {
-        synchronized (HashCodeBuilder.class) {
-            if (getRegistry() == null) {
-                REGISTRY.set(new HashSet<IDKey>());
-            }
+    private static void register(final Object value) {
+        Set<IDKey> registry = getRegistry();
+        if (registry == null) {
+            registry = new HashSet<IDKey>();
+            REGISTRY.set(registry);
         }
-        getRegistry().add(new IDKey(value));
+        registry.add(new IDKey(value));
     }
 
     /**
@@ -518,16 +518,12 @@ public class HashCodeBuilder implements Builder<Integer> {
      *            The object to unregister.
      * @since 2.3
      */
-    static void unregister(final Object value) {
+    private static void unregister(final Object value) {
         Set<IDKey> registry = getRegistry();
         if (registry != null) {
             registry.remove(new IDKey(value));
-            synchronized (HashCodeBuilder.class) {
-                //read again
-                registry = getRegistry();
-                if (registry != null && registry.isEmpty()) {
-                    REGISTRY.remove();
-                }
+            if (registry.isEmpty()) {
+                REGISTRY.remove();
             }
         }
     }


### PR DESCRIPTION
The synchronization in HashCodeBuilder and EqualsBuilder is not needed
and can safely be removed.

Issue: LANG-1230
https://issues.apache.org/jira/browse/LANG-1230