### PR TITLE
LANG-1233: DiffBuilder add method to allow appending from a DiffResult

### DIFF
--- a/src/main/java/org/apache/commons/lang3/builder/DiffBuilder.java
+++ b/src/main/java/org/apache/commons/lang3/builder/DiffBuilder.java
@@ -981,6 +981,9 @@ public class DiffBuilder implements Builder<DiffResult> {
      * @param diffResult
      *            the {@code DiffResult} to append
      * @return this
+     * @throws IllegalArgumentException
+     *             if field name is {@code null}
+     * @since 3.5
      */
     public DiffBuilder append(final String fieldName,
             final DiffResult diffResult) {


### PR DESCRIPTION
Suppose one has a Diffable object where one of the properties is also diffable. For example, given a Person object with an address property, it might be useful to be able to perform a diff on the Person and identify specific differences within the address. You might want the diff result of a Person to show that "address.city" is different rather than just the entire address. This feature allows for that.

Creating a new pull request after the original was closed by mistake.

JIRA: https://issues.apache.org/jira/browse/LANG-1233
Previous Pull Request: https://github.com/apache/commons-lang/pull/122