### PR TITLE
LANG-1236: Add StopWatch#getTime with String Format Argument

### DIFF
--- a/src/main/java/org/apache/commons/lang3/time/StopWatch.java
+++ b/src/main/java/org/apache/commons/lang3/time/StopWatch.java
@@ -358,6 +358,44 @@ public class StopWatch {
 
     /**
      * <p>
+     * Get the time on the stopwatch as a formatted string.
+     * </p>
+     * 
+     * <p>
+     * This is either the time between the start and the moment this method is called, or the amount of time between
+     * start and stop. The format string follows the same conventions as {@code DurationFormatUtils}. Numbers are
+     * left padded with zeros.
+     * </p>
+     * 
+     * @param format the way in which to format the elapsed time, not null
+     * @return the time as a formatted string
+     * @see org.apache.commons.lang3.time.DurationFormatUtils
+     */
+    public String getTime(final String format) {
+        return DurationFormatUtils.formatDuration(getTime(), format);
+    }
+
+    /**
+     * <p>
+     * Get the time on the stopwatch as a formatted string.
+     * </p>
+     * 
+     * <p>
+     * This is either the time between the start and the moment this method is called, or the amount of time between
+     * start and stop. The format string follows the same conventions as {@code DurationFormatUtils}.
+     * </p>
+     * 
+     * @param format the way in which to format the elapsed time, not null
+     * @param padWithZeros whether to pad the left hand side of numbers with 0's
+     * @return the time as a formatted string
+     * @see org.apache.commons.lang3.time.DurationFormatUtils
+     */
+    public String getTime(final String format, final boolean padWithZeros) {
+        return DurationFormatUtils.formatDuration(getTime(), format, padWithZeros);
+    }
+
+    /**
+     * <p>
      * Get the time on the stopwatch in nanoseconds.
      * </p>
      * 

--- a/src/main/java/org/apache/commons/lang3/time/StopWatch.java
+++ b/src/main/java/org/apache/commons/lang3/time/StopWatch.java
@@ -17,6 +17,8 @@
 
 package org.apache.commons.lang3.time;
 
+import java.util.concurrent.TimeUnit;
+
 /**
  * <p>
  * <code>StopWatch</code> provides a convenient API for timings.
@@ -334,6 +336,26 @@ public class StopWatch {
     public long getTime() {
         return getNanoTime() / NANO_2_MILLIS;
     }
+
+    /**
+     * <p>
+     * Get the time on the stopwatch in the specified TimeUnit.
+     * </p>
+     * 
+     * <p>
+     * This is either the time between the start and the moment this method is called, or the amount of time between
+     * start and stop. The resulting time will be expressed in the desired TimeUnit with any remainder rounded down.
+     * For example, if the specified unit is {@code TimeUnit.HOURS} and the stopwatch time is 59 minutes, then the
+     * result returned will be {@code 0}.
+     * </p>
+     * 
+     * @param timeUnit the unit of time, not null
+     * @return the time in the specified TimeUnit, rounded down
+     */
+    public long getTime(final TimeUnit timeUnit) {
+        return timeUnit.convert(getNanoTime(), TimeUnit.NANOSECONDS);
+    }
+
     /**
      * <p>
      * Get the time on the stopwatch in nanoseconds.


### PR DESCRIPTION
I wasn't sure if this kind of thing should be a part of the getTime method or if toString should be overloaded to take a format argument. Either way seems okay to me. I put it on getTime, but if there are disagreements about that, I would be okay with putting it in toString instead.