### PR TITLE
LANG-1018: Fix precision loss on NumberUtils.createNumber(String)

### DIFF
--- a/src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java
@@ -242,6 +242,10 @@ public class NumberUtilsTest {
         final Number bigNum = NumberUtils.createNumber("-1.1E-700F");
         assertNotNull(bigNum);
         assertEquals(BigDecimal.class, bigNum.getClass());
+        
+        // LANG-1018
+        assertEquals("createNumber(String) LANG-1018 failed",
+                Double.valueOf("-160952.54"), NumberUtils.createNumber("-160952.54"));
     }
     
     @Test


### PR DESCRIPTION
**Warning: This patch will break backwards compatibility.**

This patch is designed to fix the loss of precision when using NumberUtils.createNumber(String). However, the fix is not 100% backwards compatible with the currently released commons-lang 3.4. To fix the loss of precision, values that were previously returning Floats are now returning Doubles. Some explicit casts may break as a result.

```java
// Works in 3.4, but causes ClassCastException in patch.
Float f = (Float) NumberUtils.createNumber("-160952.54");
System.out.println(f); // prints "-160952.55"

// Works with patch.
Double d = (Double) NumberUtils.createNumber("-160952.54");
System.out.println(d); // prints "-160952.54"
```