### PR TITLE
LANG-1190: TypeUtils.isAssignable throws NullPointerException when fr…

### DIFF
--- a/src/main/java/org/apache/commons/lang3/reflect/TypeUtils.java
+++ b/src/main/java/org/apache/commons/lang3/reflect/TypeUtils.java
@@ -464,6 +464,10 @@ public class TypeUtils {
             final Type toTypeArg = unrollVariableAssignments(var, toTypeVarAssigns);
             final Type fromTypeArg = unrollVariableAssignments(var, fromTypeVarAssigns);
 
+            if (toTypeArg == null && fromTypeArg instanceof Class) {
+                continue;
+            }
+
             // parameters must either be absent from the subject type, within
             // the bounds of the wildcard type, or be an exact match to the
             // parameters of the target type.

--- a/src/test/java/org/apache/commons/lang3/reflect/TypeUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/reflect/TypeUtilsTest.java
@@ -25,6 +25,7 @@ import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
 import java.lang.reflect.WildcardType;
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
@@ -753,6 +754,22 @@ public class TypeUtilsTest<B> {
         Assert.assertTrue(TypeUtils.equals(t, TypeUtils.wrap(t).getType()));
 
         Assert.assertEquals(String.class, TypeUtils.wrap(String.class).getType());
+    }
+
+    public static class ClassWithSuperClassWithGenericType extends ArrayList<Object> {
+        private static final long serialVersionUID = 1L;
+
+        public static <U> Iterable<U> methodWithGenericReturnType() {
+            return null;
+        }
+    }
+
+    @Test
+    public void testLANG1190() throws Exception {
+        Type fromType = ClassWithSuperClassWithGenericType.class.getDeclaredMethod("methodWithGenericReturnType").getGenericReturnType();
+        Type failingToType = TypeUtils.wildcardType().withLowerBounds(ClassWithSuperClassWithGenericType.class).build();
+
+        Assert.assertTrue(TypeUtils.isAssignable(fromType, failingToType));
     }
 
     public Iterable<? extends Map<Integer, ? extends Collection<?>>> iterable;


### PR DESCRIPTION
…omType has type variables and toType generic superclass specifies type variable

Not sure if this is the right/best solution, so review carefully.