### PR TITLE
Eliminate redundant calculation of isDecimalPoint.

### DIFF
--- a/src/main/java/org/apache/commons/lang3/math/NumberUtils.java
+++ b/src/main/java/org/apache/commons/lang3/math/NumberUtils.java
@@ -1524,7 +1524,7 @@ public class NumberUtils {
         int decimalPoints = 0;
         for (int i = beginIdx; i < str.length(); i++) {
             final boolean isDecimalPoint = str.charAt(i) == '.';
-            if (str.charAt(i) == '.') {
+            if (isDecimalPoint) {
                 decimalPoints++;
             }
             if (decimalPoints > 1) {


### PR DESCRIPTION
There was a redundant check of ```str.charAt(i) == '.'```.

I eliminated the second check in favor of using the already defined ```isDecimalPoint```.