### PR TITLE
LANG-1197: Prepare Java 9 detection

### DIFF
--- a/src/main/java/org/apache/commons/lang3/JavaVersion.java
+++ b/src/main/java/org/apache/commons/lang3/JavaVersion.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.lang3;
 
+import org.apache.commons.lang3.math.NumberUtils;
+
 /**
  * <p>An enum representing all the versions of the Java specification.
  * This is intended to mirror available values from the
@@ -72,11 +74,18 @@ public enum JavaVersion {
 
     /**
      * Java 1.9.
+     * 
+     * @deprecated As of release 3.5, replaced by {@link #JAVA_9}
      */
-    JAVA_1_9(1.9f, "1.9"),
+    JAVA_1_9(9.0f, "9"),
 
     /**
-     * Java 1.x, x &gt; 9. Mainly introduced to avoid to break when a new version of Java is used.
+     * Java 9
+     */
+    JAVA_9(9.0f, "9"),
+
+    /**
+     * The most recent java version. Mainly introduced to avoid to break when a new version of Java is used.
      */
     JAVA_RECENT(maxVersion(), Float.toString(maxVersion()));
 
@@ -156,8 +165,8 @@ public enum JavaVersion {
             return JAVA_1_7;
         } else if ("1.8".equals(nom)) {
             return JAVA_1_8;
-        } else if ("1.9".equals(nom)) {
-            return JAVA_1_9;
+        } else if ("9".equals(nom)) {
+            return JAVA_9;
         }
         if (nom == null) {
             return null;
@@ -187,33 +196,34 @@ public enum JavaVersion {
     }
 
     /**
-     * Gets the Java Version from the system or 2.0 if the {@code java.version} system property is not set.
+     * Gets the Java Version from the system or 99.0 if the {@code java.specification.version} system property is not set.
      * 
-     * @return the value of {@code java.version} system property or 2.0 if it is not set.
+     * @return the value of {@code java.specification.version} system property or 99.0 if it is not set.
      */
     private static float maxVersion() {
-        final float v = toFloatVersion(System.getProperty("java.version", "2.0"));
+        final float v = toFloatVersion(System.getProperty("java.specification.version", "99.0"));
         if (v > 0) {
             return v;
         }
-        return 2f;
+        return 99f;
     }
 
     /**
      * Parses a float value from a String.
      * 
      * @param value the String to parse.
-     * @return the float value represented by teh string or -1 if the given String can not be parsed.
+     * @return the float value represented by the string or -1 if the given String can not be parsed.
      */
     private static float toFloatVersion(final String value) {
-        final String[] toParse = value.split("\\.");
-        if (toParse.length >= 2) {
-            try {
-                return Float.parseFloat(toParse[0] + '.' + toParse[1]);
-            } catch (final NumberFormatException nfe) {
-                // no-op, let use default
+        final int defaultReturnValue = -1;
+        if (value.contains(".")) {
+            final String[] toParse = value.split("\\.");
+            if (toParse.length >= 2) {
+                return NumberUtils.toFloat(toParse[0] + '.' + toParse[1], defaultReturnValue);
             }
+        } else {
+            return NumberUtils.toFloat(value, defaultReturnValue);
         }
-        return -1;
+        return defaultReturnValue;
     }
 }

--- a/src/main/java/org/apache/commons/lang3/SystemUtils.java
+++ b/src/main/java/org/apache/commons/lang3/SystemUtils.java
@@ -953,8 +953,23 @@ public class SystemUtils {
      * </p>
      *
      * @since 3.4
+     * 
+     * @deprecated As of release 3.5, replaced by {@link #IS_JAVA_9}
      */
-    public static final boolean IS_JAVA_1_9 = getJavaVersionMatches("1.9");
+    @Deprecated
+    public static final boolean IS_JAVA_1_9 = getJavaVersionMatches("9");
+
+    /**
+     * <p>
+     * Is {@code true} if this is Java version 9 (also 9.x versions).
+     * </p>
+     * <p>
+     * The field will return {@code false} if {@link #JAVA_VERSION} is {@code null}.
+     * </p>
+     *
+     * @since 3.5
+     */
+    public static final boolean IS_JAVA_9 = getJavaVersionMatches("9");
 
     // Operating system checks
     // -----------------------------------------------------------------------

--- a/src/test/java/org/apache/commons/lang3/JavaVersionTest.java
+++ b/src/test/java/org/apache/commons/lang3/JavaVersionTest.java
@@ -32,6 +32,7 @@ import static org.apache.commons.lang3.JavaVersion.JAVA_1_6;
 import static org.apache.commons.lang3.JavaVersion.JAVA_1_7;
 import static org.apache.commons.lang3.JavaVersion.JAVA_1_8;
 import static org.apache.commons.lang3.JavaVersion.JAVA_1_9;
+import static org.apache.commons.lang3.JavaVersion.JAVA_9;
 import static org.apache.commons.lang3.JavaVersion.get;
 import static org.apache.commons.lang3.JavaVersion.getJavaVersion;
 
@@ -51,7 +52,7 @@ public class JavaVersionTest {
         assertEquals("1.6 failed", JAVA_1_6, get("1.6"));
         assertEquals("1.7 failed", JAVA_1_7, get("1.7"));
         assertEquals("1.8 failed", JAVA_1_8, get("1.8"));
-        assertEquals("1.9 failed", JAVA_1_9, get("1.9"));
+        assertEquals("9 failed", JAVA_9, get("9"));
         assertEquals("1.10 failed", JAVA_RECENT, get("1.10"));
         // assertNull("2.10 unexpectedly worked", get("2.10"));
         assertEquals("Wrapper method failed", get("1.5"), getJavaVersion("1.5"));

--- a/src/test/java/org/apache/commons/lang3/SystemUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/SystemUtilsTest.java
@@ -92,8 +92,9 @@ public class SystemUtilsTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void testIS_JAVA() {
-        final String javaVersion = System.getProperty("java.version");
+        final String javaVersion = System.getProperty("java.specification.name");
         if (javaVersion == null) {
             assertFalse(SystemUtils.IS_JAVA_1_1);
             assertFalse(SystemUtils.IS_JAVA_1_2);
@@ -104,6 +105,7 @@ public class SystemUtilsTest {
             assertFalse(SystemUtils.IS_JAVA_1_7);
             assertFalse(SystemUtils.IS_JAVA_1_8);
             assertFalse(SystemUtils.IS_JAVA_1_9);
+            assertFalse(SystemUtils.IS_JAVA_9);
         } else if (javaVersion.startsWith("1.1")) {
             assertTrue(SystemUtils.IS_JAVA_1_1);
             assertFalse(SystemUtils.IS_JAVA_1_2);
@@ -114,6 +116,7 @@ public class SystemUtilsTest {
             assertFalse(SystemUtils.IS_JAVA_1_7);
             assertFalse(SystemUtils.IS_JAVA_1_8);
             assertFalse(SystemUtils.IS_JAVA_1_9);
+            assertFalse(SystemUtils.IS_JAVA_9);
         } else if (javaVersion.startsWith("1.2")) {
             assertFalse(SystemUtils.IS_JAVA_1_1);
             assertTrue(SystemUtils.IS_JAVA_1_2);
@@ -124,6 +127,7 @@ public class SystemUtilsTest {
             assertFalse(SystemUtils.IS_JAVA_1_7);
             assertFalse(SystemUtils.IS_JAVA_1_8);
             assertFalse(SystemUtils.IS_JAVA_1_9);
+            assertFalse(SystemUtils.IS_JAVA_9);
         } else if (javaVersion.startsWith("1.3")) {
             assertFalse(SystemUtils.IS_JAVA_1_1);
             assertFalse(SystemUtils.IS_JAVA_1_2);
@@ -134,6 +138,7 @@ public class SystemUtilsTest {
             assertFalse(SystemUtils.IS_JAVA_1_7);
             assertFalse(SystemUtils.IS_JAVA_1_8);
             assertFalse(SystemUtils.IS_JAVA_1_9);
+            assertFalse(SystemUtils.IS_JAVA_9);
         } else if (javaVersion.startsWith("1.4")) {
             assertFalse(SystemUtils.IS_JAVA_1_1);
             assertFalse(SystemUtils.IS_JAVA_1_2);
@@ -144,6 +149,7 @@ public class SystemUtilsTest {
             assertFalse(SystemUtils.IS_JAVA_1_7);
             assertFalse(SystemUtils.IS_JAVA_1_8);
             assertFalse(SystemUtils.IS_JAVA_1_9);
+            assertFalse(SystemUtils.IS_JAVA_9);
         } else if (javaVersion.startsWith("1.5")) {
             assertFalse(SystemUtils.IS_JAVA_1_1);
             assertFalse(SystemUtils.IS_JAVA_1_2);
@@ -154,6 +160,7 @@ public class SystemUtilsTest {
             assertFalse(SystemUtils.IS_JAVA_1_7);
             assertFalse(SystemUtils.IS_JAVA_1_8);
             assertFalse(SystemUtils.IS_JAVA_1_9);
+            assertFalse(SystemUtils.IS_JAVA_9);
         } else if (javaVersion.startsWith("1.6")) {
             assertFalse(SystemUtils.IS_JAVA_1_1);
             assertFalse(SystemUtils.IS_JAVA_1_2);
@@ -164,6 +171,7 @@ public class SystemUtilsTest {
             assertFalse(SystemUtils.IS_JAVA_1_7);
             assertFalse(SystemUtils.IS_JAVA_1_8);
             assertFalse(SystemUtils.IS_JAVA_1_9);
+            assertFalse(SystemUtils.IS_JAVA_9);
         } else if (javaVersion.startsWith("1.7")) {
             assertFalse(SystemUtils.IS_JAVA_1_1);
             assertFalse(SystemUtils.IS_JAVA_1_2);
@@ -174,6 +182,7 @@ public class SystemUtilsTest {
             assertTrue(SystemUtils.IS_JAVA_1_7);
             assertFalse(SystemUtils.IS_JAVA_1_8);
             assertFalse(SystemUtils.IS_JAVA_1_9);
+            assertFalse(SystemUtils.IS_JAVA_9);
         } else if (javaVersion.startsWith("1.8")) {
             assertFalse(SystemUtils.IS_JAVA_1_1);
             assertFalse(SystemUtils.IS_JAVA_1_2);
@@ -184,7 +193,8 @@ public class SystemUtilsTest {
             assertFalse(SystemUtils.IS_JAVA_1_7);
             assertTrue(SystemUtils.IS_JAVA_1_8);
             assertFalse(SystemUtils.IS_JAVA_1_9);
-        } else if (javaVersion.startsWith("1.9")) {
+            assertFalse(SystemUtils.IS_JAVA_9);
+        } else if (javaVersion.startsWith("9")) {
             assertFalse(SystemUtils.IS_JAVA_1_1);
             assertFalse(SystemUtils.IS_JAVA_1_2);
             assertFalse(SystemUtils.IS_JAVA_1_3);
@@ -194,6 +204,7 @@ public class SystemUtilsTest {
             assertFalse(SystemUtils.IS_JAVA_1_7);
             assertFalse(SystemUtils.IS_JAVA_1_8);
             assertTrue(SystemUtils.IS_JAVA_1_9);
+            assertTrue(SystemUtils.IS_JAVA_9);
         } else {
             System.out.println("Can't test IS_JAVA value: "+javaVersion);
         }
@@ -262,6 +273,8 @@ public class SystemUtilsTest {
         assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.5"));
         assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.6"));
         assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.7"));
+        assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.8"));
+        assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "9"));
         javaVersion = "";
         assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.0"));
         assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.1"));
@@ -271,6 +284,8 @@ public class SystemUtilsTest {
         assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.5"));
         assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.6"));
         assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.7"));
+        assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.8"));
+        assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "9"));
         javaVersion = "1.0";
         assertTrue(SystemUtils.isJavaVersionMatch(javaVersion, "1.0"));
         assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.1"));
@@ -280,6 +295,8 @@ public class SystemUtilsTest {
         assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.5"));
         assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.6"));
         assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.7"));
+        assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.8"));
+        assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "9"));
         javaVersion = "1.1";
         assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.0"));
         assertTrue(SystemUtils.isJavaVersionMatch(javaVersion, "1.1"));
@@ -289,6 +306,8 @@ public class SystemUtilsTest {
         assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.5"));
         assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.6"));
         assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.7"));
+        assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.8"));
+        assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "9"));
         javaVersion = "1.2";
         assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.0"));
         assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.1"));
@@ -298,6 +317,8 @@ public class SystemUtilsTest {
         assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.5"));
         assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.6"));
         assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.7"));
+        assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.8"));
+        assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "9"));
         javaVersion = "1.3.0";
         assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.0"));
         assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.1"));
@@ -307,6 +328,8 @@ public class SystemUtilsTest {
         assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.5"));
         assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.6"));
         assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.7"));
+        assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.8"));
+        assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "9"));
         javaVersion = "1.3.1";
         assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.0"));
         assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.1"));
@@ -316,6 +339,8 @@ public class SystemUtilsTest {
         assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.5"));
         assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.6"));
         assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.7"));
+        assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.8"));
+        assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "9"));
         javaVersion = "1.4.0";
         assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.0"));
         assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.1"));
@@ -325,6 +350,8 @@ public class SystemUtilsTest {
         assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.5"));
         assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.6"));
         assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.7"));
+        assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.8"));
+        assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "9"));
         javaVersion = "1.4.1";
         assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.0"));
         assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.1"));
@@ -334,6 +361,8 @@ public class SystemUtilsTest {
         assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.5"));
         assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.6"));
         assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.7"));
+        assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.8"));
+        assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "9"));
         javaVersion = "1.4.2";
         assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.0"));
         assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.1"));
@@ -343,6 +372,8 @@ public class SystemUtilsTest {
         assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.5"));
         assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.6"));
         assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.7"));
+        assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.8"));
+        assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "9"));
         javaVersion = "1.5.0";
         assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.0"));
         assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.1"));
@@ -352,6 +383,8 @@ public class SystemUtilsTest {
         assertTrue(SystemUtils.isJavaVersionMatch(javaVersion, "1.5"));
         assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.6"));
         assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.7"));
+        assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.8"));
+        assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "9"));
         javaVersion = "1.6.0";
         assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.0"));
         assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.1"));
@@ -361,6 +394,8 @@ public class SystemUtilsTest {
         assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.5"));
         assertTrue(SystemUtils.isJavaVersionMatch(javaVersion, "1.6"));
         assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.7"));
+        assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.8"));
+        assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "9"));
         javaVersion = "1.7.0";
         assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.0"));
         assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.1"));
@@ -370,6 +405,30 @@ public class SystemUtilsTest {
         assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.5"));
         assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.6"));
         assertTrue(SystemUtils.isJavaVersionMatch(javaVersion, "1.7"));
+        assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.8"));
+        assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "9"));
+        javaVersion = "1.8.0";
+        assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.0"));
+        assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.1"));
+        assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.2"));
+        assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.3"));
+        assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.4"));
+        assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.5"));
+        assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.6"));
+        assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.7"));
+        assertTrue(SystemUtils.isJavaVersionMatch(javaVersion, "1.8"));
+        assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "9"));
+        javaVersion = "9";
+        assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.0"));
+        assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.1"));
+        assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.2"));
+        assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.3"));
+        assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.4"));
+        assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.5"));
+        assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.6"));
+        assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.7"));
+        assertFalse(SystemUtils.isJavaVersionMatch(javaVersion, "1.8"));
+        assertTrue(SystemUtils.isJavaVersionMatch(javaVersion, "9"));
     }
 
     @Test


### PR DESCRIPTION
Not complete: `JavaVersion` expects the `java.version` system property to return `1.x` but for java 9 it will return `9*`. Not sure how to handle this.