### PR TITLE
Removing test redundant for org.apache.commons.lang3.ClassUtilsTest.testWrapperToPrimitiveNoWrapper

### DIFF
--- a/src/test/java/org/apache/commons/lang3/ClassUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/ClassUtilsTest.java
@@ -934,7 +934,7 @@ public class ClassUtilsTest  {
         assertNull("Wrong result for non wrapper class", ClassUtils.wrapperToPrimitive(String.class));
     }
 
-    @Test
+    @Test @org.junit.Ignore
     public void testWrapperToPrimitiveNull() {
         assertNull("Wrong result for null class", ClassUtils.wrapperToPrimitive(null));
     }


### PR DESCRIPTION
We are researchers working on identifying redundant tests in a test suite. Our analysis of finding redundant tests involve each test's dynamic code coverage and their potential fault-detection capability.

Through our analysis, we found that the tests org.apache.commons.lang3.ClassUtilsTest.testWrapperToPrimitiveNoWrapper, org.apache.commons.lang3.ClassUtilsTest.testWrapperToPrimitiveNull are redundant with respect to one another. In this pull request, we are proposing to keep only the test org.apache.commons.lang3.ClassUtilsTest.testWrapperToPrimitiveNoWrapper while adding @Ignore annotations to the remaining test. However, as we believe these tests are identical, any one of them can be kept while skipping the remaining test.

If you do not believe any of these tests should be ignored, we would greatly appreciate it if you could follow up on this pull request and let us know your reasons.