### PR TITLE
[LANG-1250] SerializationUtils::deserialize has unnecessary code and a comment for that

### DIFF
--- a/src/main/java/org/apache/commons/lang3/SerializationUtils.java
+++ b/src/main/java/org/apache/commons/lang3/SerializationUtils.java
@@ -219,12 +219,10 @@ public class SerializationUtils {
         try {
             // stream closed in the finally
             in = new ObjectInputStream(inputStream);
-            @SuppressWarnings("unchecked") // may fail with CCE if serialised form is incorrect
+            @SuppressWarnings("unchecked")
             final T obj = (T) in.readObject();
             return obj;
 
-        } catch (final ClassCastException ex) {
-            throw new SerializationException(ex);
         } catch (final ClassNotFoundException ex) {
             throw new SerializationException(ex);
         } catch (final IOException ex) {


### PR DESCRIPTION
There is no real CCE possible, even the javadoc say so. Github's blame showed the code and javadoc is written by two indiviual person in two different years, so that may be the cause.