### PR TITLE
Removing test redundant for org.apache.commons.lang3.StringUtilsTest.testIsNotEmpty

### DIFF
--- a/src/test/java/org/apache/commons/lang3/StringUtilsTrimEmptyTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringUtilsTrimEmptyTest.java
@@ -40,7 +40,7 @@ public class StringUtilsTrimEmptyTest  {
         assertFalse(StringUtils.isEmpty("  foo  "));
     }
 
-    @Test
+    @Test @org.junit.Ignore
     public void testIsNotEmpty() {
         assertFalse(StringUtils.isNotEmpty(null));
         assertFalse(StringUtils.isNotEmpty(""));


### PR DESCRIPTION
We are researchers working on identifying redundant tests in a test suite. Our analysis of finding redundant tests involve each test's dynamic code coverage and their potential fault-detection capability.

Through our analysis, we found that the tests org.apache.commons.lang3.StringUtilsTest.testIsNotEmpty, org.apache.commons.lang3.StringUtilsTrimEmptyTest.testIsNotEmpty are redundant with respect to one another. In this pull request, we are proposing to keep only the test org.apache.commons.lang3.StringUtilsTest.testIsNotEmpty while adding @Ignore annotations to the remaining test. However, as we believe these tests are identical, any one of them can be kept while skipping the remaining test.

If you do not believe any of these tests should be ignored, we would greatly appreciate it if you could follow up on this pull request and let us know your reasons.