### PR TITLE
Removing test redundant for org.apache.commons.lang3.builder.DefaultToStringStyleTest.testObjectArray

### DIFF
--- a/src/test/java/org/apache/commons/lang3/builder/RecursiveToStringStyleTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/RecursiveToStringStyleTest.java
@@ -99,7 +99,7 @@ public class RecursiveToStringStyleTest {
         assertEquals(baseStr + "[a=3,b=4]", new ToStringBuilder(base).append("a", 3L).append("b", 4L).toString());
     }
 
-    @Test
+    @Test @org.junit.Ignore
     public void testObjectArray() {
         Object[] array = new Object[] {null, base, new int[] {3, 6}};
         assertEquals(baseStr + "[{<null>,5,{3,6}}]", new ToStringBuilder(base).append(array).toString());


### PR DESCRIPTION
We are researchers working on identifying redundant tests in a test suite. Our analysis of finding redundant tests involve each test's dynamic code coverage and their potential fault-detection capability.

Through our analysis, we found that the tests org.apache.commons.lang3.builder.DefaultToStringStyleTest.testObjectArray, org.apache.commons.lang3.builder.RecursiveToStringStyleTest.testObjectArray are redundant with respect to one another. In this pull request, we are proposing to keep only the test org.apache.commons.lang3.builder.DefaultToStringStyleTest.testObjectArray while adding @Ignore annotations to the remaining test. However, as we believe these tests are identical, any one of them can be kept while skipping the remaining test.

If you do not believe any of these tests should be ignored, we would greatly appreciate it if you could follow up on this pull request and let us know your reasons.