### PR TITLE
LANG-1251: SerializationUtils.ClassLoaderAwareObjectInputStream should use static initializer to initialize primitiveTypes map.

### DIFF
--- a/src/main/java/org/apache/commons/lang3/SerializationUtils.java
+++ b/src/main/java/org/apache/commons/lang3/SerializationUtils.java
@@ -283,6 +283,19 @@ public class SerializationUtils {
      static class ClassLoaderAwareObjectInputStream extends ObjectInputStream {
         private static final Map<String, Class<?>> primitiveTypes = 
                 new HashMap<String, Class<?>>();
+
+        static {
+            primitiveTypes.put("byte", byte.class);
+            primitiveTypes.put("short", short.class);
+            primitiveTypes.put("int", int.class);
+            primitiveTypes.put("long", long.class);
+            primitiveTypes.put("float", float.class);
+            primitiveTypes.put("double", double.class);
+            primitiveTypes.put("boolean", boolean.class);
+            primitiveTypes.put("char", char.class);
+            primitiveTypes.put("void", void.class);
+        }
+
         private final ClassLoader classLoader;
         
         /**
@@ -295,16 +308,6 @@ public class SerializationUtils {
         public ClassLoaderAwareObjectInputStream(final InputStream in, final ClassLoader classLoader) throws IOException {
             super(in);
             this.classLoader = classLoader;
-
-            primitiveTypes.put("byte", byte.class);
-            primitiveTypes.put("short", short.class);
-            primitiveTypes.put("int", int.class);
-            primitiveTypes.put("long", long.class);
-            primitiveTypes.put("float", float.class);
-            primitiveTypes.put("double", double.class);
-            primitiveTypes.put("boolean", boolean.class);
-            primitiveTypes.put("char", char.class);
-            primitiveTypes.put("void", void.class);
         }
 
         /**


### PR DESCRIPTION
`SerializationUtils.ClassLoaderAwareObjectInputStream` should use static initializer to initialize `primitiveTypes` map because initializing the map in the constructor of `ClassLoaderAwareObjectInputStream` would break thread safety. `java.util.HashMap` is not thread safe.