### PR TITLE
LANG-1263 Add possibility to retrieve the current JavaVersion

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -46,6 +46,7 @@ The <action> type attribute can be add,update,fix,remove.
   <body>
 
   <release version="3.5" date="tba" description="New features including Java 9 detection">
+    <action issue="LANG-1263" type="add" dev="britter">Add possibility to retrieve the current JavaVersion</action>
     <action issue="LANG-1197" type="update" dev="pschumacher" >Prepare Java 9 detection</action>
     <action issue="LANG-1252" type="fix" dev="chtompki" due-to="Rob Tompkins">Rename NumberUtils.isNumber, isCreatable to better reflect createNumber. Also, accommodated for "+" symbol as prefix in isCreatable and isNumber.</action>
     <action issue="LANG-1262" type="update" dev="pschumacher" due-to="Ruslan Cheremin">CompareToBuilder.append(Object, Object, Comparator) method is too big to be inlined</action>

--- a/src/main/java/org/apache/commons/lang3/JavaVersion.java
+++ b/src/main/java/org/apache/commons/lang3/JavaVersion.java
@@ -132,20 +132,6 @@ public enum JavaVersion {
      * @return the corresponding enumeration constant or <b>null</b> if the
      * version is unknown
      */
-    // helper for static importing
-    static JavaVersion getJavaVersion(final String nom) {
-        return get(nom);
-    }
-
-    /**
-     * Transforms the given string with a Java version number to the
-     * corresponding constant of this enumeration class. This method is used
-     * internally.
-     *
-     * @param nom the Java version as string
-     * @return the corresponding enumeration constant or <b>null</b> if the
-     * version is unknown
-     */
     static JavaVersion get(final String nom) {
         if ("0.9".equals(nom)) {
             return JAVA_0_9;

--- a/src/main/java/org/apache/commons/lang3/JavaVersion.java
+++ b/src/main/java/org/apache/commons/lang3/JavaVersion.java
@@ -69,23 +69,31 @@ public enum JavaVersion {
 
     /**
      * Java 1.8.
+     *
+     * @since 3.4
      */
     JAVA_1_8(1.8f, "1.8"),
 
     /**
      * Java 1.9.
-     * 
+     *
+     * @since 3.4
      * @deprecated As of release 3.5, replaced by {@link #JAVA_9}
      */
     JAVA_1_9(9.0f, "9"),
 
     /**
      * Java 9
+     *
+     * @since 3.5
      */
     JAVA_9(9.0f, "9"),
 
     /**
      * The most recent java version. Mainly introduced to avoid to break when a new version of Java is used.
+     * Java 1.x, x &gt; 9. Mainly introduced to avoid to break when a new version of Java is used.
+     *
+     * @since 3.4
      */
     JAVA_RECENT(maxVersion(), Float.toString(maxVersion()));
 

--- a/src/main/java/org/apache/commons/lang3/JavaVersion.java
+++ b/src/main/java/org/apache/commons/lang3/JavaVersion.java
@@ -98,6 +98,19 @@ public enum JavaVersion {
     JAVA_RECENT(maxVersion(), Float.toString(maxVersion()));
 
     /**
+     * JavaVersion representing the value of the {@code java.specification.version} system property.
+     *
+     * <p>
+     * Note that this is not an enum constant since it has to be calculated at runtime. For this reason
+     * this value can't be retrieved using {@link #valueOf(String)}.
+     * </p>
+     *
+     * @since 3.5
+     * @see SystemUtils#JAVA_SPECIFICATION_VERSION
+     */
+    public static JavaVersion CURRENT = get(SystemUtils.JAVA_SPECIFICATION_VERSION);
+
+    /**
      * The float value.
      */
     private final float value;

--- a/src/test/java/org/apache/commons/lang3/JavaVersionTest.java
+++ b/src/test/java/org/apache/commons/lang3/JavaVersionTest.java
@@ -21,7 +21,9 @@ package org.apache.commons.lang3;
 import org.junit.Test;
 
 import static org.apache.commons.lang3.JavaVersion.JAVA_RECENT;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.apache.commons.lang3.JavaVersion.JAVA_0_9;
 import static org.apache.commons.lang3.JavaVersion.JAVA_1_1;
 import static org.apache.commons.lang3.JavaVersion.JAVA_1_2;

--- a/src/test/java/org/apache/commons/lang3/JavaVersionTest.java
+++ b/src/test/java/org/apache/commons/lang3/JavaVersionTest.java
@@ -36,6 +36,7 @@ import static org.apache.commons.lang3.JavaVersion.JAVA_1_8;
 import static org.apache.commons.lang3.JavaVersion.JAVA_1_9;
 import static org.apache.commons.lang3.JavaVersion.JAVA_9;
 import static org.apache.commons.lang3.JavaVersion.get;
+import static org.junit.Assert.fail;
 
 /**
  * Unit tests {@link org.apache.commons.lang3.JavaVersion}.
@@ -73,4 +74,28 @@ public class JavaVersionTest {
         assertEquals("1.2", JAVA_1_2.toString());
     }
 
+    @Test
+    public void testCurrent() throws Exception {
+        if (SystemUtils.JAVA_SPECIFICATION_VERSION.equals("1.1")) {
+            assertEquals(JAVA_1_1, JavaVersion.CURRENT);
+        } else if (SystemUtils.JAVA_SPECIFICATION_VERSION.equals("1.2")) {
+            assertEquals(JAVA_1_2, JavaVersion.CURRENT);
+        } else if (SystemUtils.JAVA_SPECIFICATION_VERSION.equals("1.3")) {
+            assertEquals(JAVA_1_3, JavaVersion.CURRENT);
+        } else if (SystemUtils.JAVA_SPECIFICATION_VERSION.equals("1.4")) {
+            assertEquals(JAVA_1_4, JavaVersion.CURRENT);
+        } else if (SystemUtils.JAVA_SPECIFICATION_VERSION.equals("1.5")) {
+            assertEquals(JAVA_1_5, JavaVersion.CURRENT);
+        } else if (SystemUtils.JAVA_SPECIFICATION_VERSION.equals("1.6")) {
+            assertEquals(JAVA_1_6, JavaVersion.CURRENT);
+        } else if (SystemUtils.JAVA_SPECIFICATION_VERSION.equals("1.7")) {
+            assertEquals(JAVA_1_7, JavaVersion.CURRENT);
+        } else if (SystemUtils.JAVA_SPECIFICATION_VERSION.equals("1.8")) {
+            assertEquals(JAVA_1_8, JavaVersion.CURRENT);
+        } else if (SystemUtils.JAVA_SPECIFICATION_VERSION.equals("9.0.0")) {
+            assertEquals(JAVA_1_9, JavaVersion.CURRENT);
+        } else {
+            fail("Unkown java.specification.version: " + SystemUtils.JAVA_SPECIFICATION_VERSION);
+        }
+    }
 }

--- a/src/test/java/org/apache/commons/lang3/JavaVersionTest.java
+++ b/src/test/java/org/apache/commons/lang3/JavaVersionTest.java
@@ -76,23 +76,23 @@ public class JavaVersionTest {
 
     @Test
     public void testCurrent() throws Exception {
-        if (SystemUtils.JAVA_SPECIFICATION_VERSION.equals("1.1")) {
+        if (SystemUtils.IS_JAVA_1_1) {
             assertEquals(JAVA_1_1, JavaVersion.CURRENT);
-        } else if (SystemUtils.JAVA_SPECIFICATION_VERSION.equals("1.2")) {
+        } else if (SystemUtils.IS_JAVA_1_2) {
             assertEquals(JAVA_1_2, JavaVersion.CURRENT);
-        } else if (SystemUtils.JAVA_SPECIFICATION_VERSION.equals("1.3")) {
+        } else if (SystemUtils.IS_JAVA_1_3) {
             assertEquals(JAVA_1_3, JavaVersion.CURRENT);
-        } else if (SystemUtils.JAVA_SPECIFICATION_VERSION.equals("1.4")) {
+        } else if (SystemUtils.IS_JAVA_1_4) {
             assertEquals(JAVA_1_4, JavaVersion.CURRENT);
-        } else if (SystemUtils.JAVA_SPECIFICATION_VERSION.equals("1.5")) {
+        } else if (SystemUtils.IS_JAVA_1_5) {
             assertEquals(JAVA_1_5, JavaVersion.CURRENT);
-        } else if (SystemUtils.JAVA_SPECIFICATION_VERSION.equals("1.6")) {
+        } else if (SystemUtils.IS_JAVA_1_6) {
             assertEquals(JAVA_1_6, JavaVersion.CURRENT);
-        } else if (SystemUtils.JAVA_SPECIFICATION_VERSION.equals("1.7")) {
+        } else if (SystemUtils.IS_JAVA_1_7) {
             assertEquals(JAVA_1_7, JavaVersion.CURRENT);
-        } else if (SystemUtils.JAVA_SPECIFICATION_VERSION.equals("1.8")) {
+        } else if (SystemUtils.IS_JAVA_1_8) {
             assertEquals(JAVA_1_8, JavaVersion.CURRENT);
-        } else if (SystemUtils.JAVA_SPECIFICATION_VERSION.equals("9.0.0")) {
+        } else if (SystemUtils.IS_JAVA_1_9) {
             assertEquals(JAVA_1_9, JavaVersion.CURRENT);
         } else {
             fail("Unkown java.specification.version: " + SystemUtils.JAVA_SPECIFICATION_VERSION);

--- a/src/test/java/org/apache/commons/lang3/JavaVersionTest.java
+++ b/src/test/java/org/apache/commons/lang3/JavaVersionTest.java
@@ -34,7 +34,6 @@ import static org.apache.commons.lang3.JavaVersion.JAVA_1_8;
 import static org.apache.commons.lang3.JavaVersion.JAVA_1_9;
 import static org.apache.commons.lang3.JavaVersion.JAVA_9;
 import static org.apache.commons.lang3.JavaVersion.get;
-import static org.apache.commons.lang3.JavaVersion.getJavaVersion;
 
 /**
  * Unit tests {@link org.apache.commons.lang3.JavaVersion}.
@@ -55,7 +54,6 @@ public class JavaVersionTest {
         assertEquals("9 failed", JAVA_9, get("9"));
         assertEquals("1.10 failed", JAVA_RECENT, get("1.10"));
         // assertNull("2.10 unexpectedly worked", get("2.10"));
-        assertEquals("Wrapper method failed", get("1.5"), getJavaVersion("1.5"));
     }
 
     @Test


### PR DESCRIPTION
Added a constant `CURRENT` to the `JavaVersion` enum which represents the JavaVersion for the `java.specification.version` system property. This allows for checks like this:

```java
if(JavaVersion.CURRENT.atLeast(JAVA_1_6) {
  // do something only possible in Java 1.6+
}
```