### PR TITLE
LANG-1266 Add alphabet converter

### DIFF
--- a/src/main/java/org/apache/commons/lang3/text/AlphabetConverter.java
+++ b/src/main/java/org/apache/commons/lang3/text/AlphabetConverter.java
@@ -1,0 +1,356 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.lang3.text;
+
+import java.io.UnsupportedEncodingException;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+/**
+ * Converts from one alphabet to another, with the possibility of leaving certain characters unencoded. 
+ *
+ * The target and do not encode languages must be in the Unicode BMP, but the source language does not.
+ * 
+ * The encoding will all be of a fixed length, except for the 'do not encode' chars, which will be of length 1
+ */
+public class AlphabetConverter {
+
+    private final Map<Integer, String> originalToEncoded;
+    private final Map<String, String> encodedToOriginal;
+    private final Map<Integer, String> doNotEncodeMap;
+    
+    private final int encodedLetterLength;
+
+    private AlphabetConverter(  Map<Integer, String> originalToEncoded,
+                                Map<String, String> encodedToOriginal,
+                                Map<Integer, String> doNotEncodeMap,
+                                int encodedLetterLength) {
+
+        this.originalToEncoded = originalToEncoded;
+        this.encodedToOriginal = encodedToOriginal;
+        this.doNotEncodeMap = doNotEncodeMap;
+        this.encodedLetterLength = encodedLetterLength;
+    }
+
+    /**
+     * Use this to recreate a new AlphabetConverter from the map received after calling getOriginalToEncoded()
+     * 
+     *  @param originalToEncoded a map returned from getOriginalToEncoded()
+     *  @return the reconstructed AlphabetConverter
+     *  @see AlphabetConverter#getOriginalToEncoded()
+     */
+    public static AlphabetConverter createConverterFromMap (Map<Integer, String> originalToEncoded) {
+        Map<String, String> encodedToOriginal = new LinkedHashMap<String,String>();
+        Map<Integer, String> doNotEncodeMap = new HashMap<Integer, String>();
+        
+        int encodedLetterLength = 1;
+        
+        for (Entry<Integer, String> e : originalToEncoded.entrySet()) {
+            String originalAsString = codePointToString(e.getKey());
+            encodedToOriginal.put(e.getValue(), originalAsString );
+            
+            if (e.getValue().equals(originalAsString)) {
+                doNotEncodeMap.put(e.getKey(), e.getValue());
+            }
+            
+            if (e.getValue().length() > encodedLetterLength) {
+                encodedLetterLength = e.getValue().length(); 
+            }
+        }
+
+        return new AlphabetConverter(originalToEncoded, encodedToOriginal, doNotEncodeMap, encodedLetterLength);
+    }
+
+    /**
+     * Creates an alphabet converter, for converting from the original alphabet, to the encoded alphabet, while leaving the characters in
+     * doNotEncode as they are (if possible) 
+     * 
+     *  @param original a Set of chars representing the original alphabet
+     *  @param encoding a Set of chars representing the alphabet to be used for encoding
+     *  @param doNotEncode a Set of chars to be encoded using the original alphabet - every char here must appear in both the previous params
+     *  @return the AlphabetConverter
+     *  @throws IllegalArgumentException if an AlphabetConverter cannot be constructed
+     */
+    public static AlphabetConverter createConverterFromChars (Set<Character> original, Set<Character> encoding, Set<Character> doNotEncode) {
+        return AlphabetConverter.createConverter(convertCharsToIntegers(original), convertCharsToIntegers(encoding), convertCharsToIntegers(doNotEncode));
+    }
+    
+    private static Set<Integer> convertCharsToIntegers(Set<Character> chars) {
+        Set<Integer> integers = new HashSet<Integer>();
+        
+        for (Character c : chars) {
+            integers.add((int)c);
+        }
+        
+        return integers;
+    }
+    
+    /**
+     * Creates an alphabet converter, for converting from the original alphabet, to the encoded alphabet, while leaving the characters in
+     * doNotEncode as they are (if possible) 
+     * 
+     *  @param original a Set of ints representing the original alphabet in codepoints
+     *  @param encoding a Set of ints representing the alphabet to be used for encoding, in codepoints
+     *  @param doNotEncode a Set of ints representing the chars to be encoded using the original alphabet - every char here must appear in both the previous params
+     *  @return the AlphabetConverter
+     *  @throws IllegalArgumentException if an AlphabetConverter cannot be constructed
+     */  
+    public static AlphabetConverter createConverter (Set<Integer> original, Set<Integer> encoding, Set<Integer> doNotEncode) {
+        
+        final Map<Integer, String> originalToEncoded = new LinkedHashMap<Integer, String>();
+        final Map<String, String> encodedToOriginal = new LinkedHashMap<String, String>();
+        final Map<Integer, String> doNotEncodeMap = new HashMap<Integer, String>();
+        
+        int encodedLetterLength;
+        
+        for (int i : doNotEncode) {
+            if (! original.contains(i)) {
+                throw new IllegalArgumentException("Can not use 'do not encode' list because original alphabet does not contain '" + codePointToString(i) + "'");
+            }
+            
+            if (! encoding.contains(i)) {
+                throw new IllegalArgumentException("Can not use 'do not encode' list because encoding alphabet does not contain '" + codePointToString(i) + "'");
+            }
+
+            doNotEncodeMap.put(i, codePointToString(i));
+        }
+        
+        if (encoding.size() >= original.size()) {
+            encodedLetterLength = 1;
+            
+            Iterator<Integer> it = encoding.iterator();
+            
+            for (int originalLetter : original) {
+                String originalLetterAsString = codePointToString(originalLetter);
+                
+                if (doNotEncodeMap.containsKey(originalLetter)) {
+                    originalToEncoded.put(originalLetter, originalLetterAsString);
+                    encodedToOriginal.put(originalLetterAsString, originalLetterAsString);
+                } else {
+                    Integer next = it.next();
+                    
+                    while (doNotEncode.contains(next)) {
+                        next = it.next();
+                    }
+                    
+                    String encodedLetter = codePointToString(next);
+                    
+                    originalToEncoded.put(originalLetter, encodedLetter);
+                    encodedToOriginal.put(encodedLetter, originalLetterAsString);
+                }
+            }
+            
+            return new AlphabetConverter(originalToEncoded, encodedToOriginal, doNotEncodeMap, encodedLetterLength);
+        
+        } else if (encoding.size() - doNotEncode.size() < 2) {
+            throw new IllegalArgumentException("Must have at least two encoding characters (not counting those in the 'do not encode' list), but has  " + (encoding.size() - doNotEncode.size()));
+        } else {
+            // we start with one which is our minimum, and because we do the first division outside the loop
+            int lettersSoFar = 1;
+            
+            // the first division takes into account that the doNotEncode letters can't be in the leftmost place
+            int lettersLeft = ( original.size() - doNotEncode.size() ) / (encoding.size() - doNotEncode.size());
+
+            while (lettersLeft / encoding.size() >= 1) {
+                lettersLeft = lettersLeft / encoding.size();
+                lettersSoFar++;
+            }
+
+            encodedLetterLength = lettersSoFar + 1;
+
+            AlphabetConverter ac = new AlphabetConverter(originalToEncoded, encodedToOriginal, doNotEncodeMap, encodedLetterLength);
+            
+            ac.addSingleEncoding(encodedLetterLength, "", encoding, original.iterator());
+            
+            return ac;
+        }
+    }
+
+    /**
+     * Decodes a given string
+     * 
+     * @param encoded a string that has been encoded using this AlphabetConverter
+     * @return the decoded string such that AlphabetConverter.encode() will return encoded 
+     * @throws UnsupportedEncodingException if unexpected characters that cannot be handled are encountered
+     */
+    public String decode (String encoded) throws UnsupportedEncodingException {
+        int j = 0;
+        
+        StringBuilder result = new StringBuilder();
+        
+        while (j < encoded.length()) {
+            Integer i = encoded.codePointAt(j);
+            
+            if (doNotEncodeMap.containsKey(i)) {
+                result.append(doNotEncodeMap.get(i));
+                j++; // because we do not encode in Unicode extended the length of each encoded char is 1
+            } else {
+                if (j + encodedLetterLength > encoded.length()) {
+                    throw new UnsupportedEncodingException("Unexpected end of string while decoding " + encoded);
+                } else {
+                    String nextGroup = encoded.substring(j, j + encodedLetterLength);
+                    String next = encodedToOriginal.get(nextGroup);
+                    
+                    if (next == null) {
+                        throw new UnsupportedEncodingException("Unexpected string without decoding (" + nextGroup + ") in " + encoded);
+                    } else {
+                        result.append(next);
+                        j += encodedLetterLength;
+                    }
+                }
+            }
+        }
+        
+        return result.toString();
+    }
+
+    /**
+     * Encodes a given string
+     * 
+     * @param original the string to be encoded
+     * @return the encoded string
+     * @throws UnsupportedEncodingException if chars that are not supported by this AlphabetConverter are encountered
+     */
+    public String encode (String original) throws UnsupportedEncodingException {
+        
+        if (original == null) {
+            return null;
+        }
+    
+        StringBuilder sb = new StringBuilder();
+
+        for (int i=0; i < original.length(); ) {
+            int codepoint = original.codePointAt(i);
+
+            String nextLetter = originalToEncoded.get(codepoint);
+            
+            if (nextLetter == null) {
+                throw new UnsupportedEncodingException("Couldn't find encoding for '" + codePointToString(codepoint) + "' in " + original);
+            }
+            
+            sb.append(nextLetter);
+            
+            i += Character.charCount(codepoint);
+        }
+        
+        return sb.toString();
+    }
+    
+    /**
+     * Recursive method used when creating encoder/decoder
+     */
+    private void addSingleEncoding(int level, String currentEncoding, Collection<Integer> encoding, Iterator<Integer> originals) {
+        
+        if (level > 0) {
+            for (int encodingLetter : encoding) {
+                if (originals.hasNext()) {
+                    
+                    // this skips the doNotEncode chars if they are in the leftmost place
+                    if (level != encodedLetterLength || ! doNotEncodeMap.containsKey(encodingLetter)) {
+                        addSingleEncoding(level - 1, currentEncoding + codePointToString(encodingLetter), encoding, originals);
+                    }
+                } else {
+                    return; // done encoding all the original alphabet
+                }
+            }
+        } else {
+            Integer next = originals.next();
+            
+            while (doNotEncodeMap.containsKey(next)) {
+                String originalLetterAsString = codePointToString(next);
+
+                originalToEncoded.put(next, originalLetterAsString);
+                encodedToOriginal.put(originalLetterAsString, originalLetterAsString);
+                
+                if (! originals.hasNext()) {
+                    return;
+                }
+                
+                next = originals.next();
+            }
+
+            String originalLetterAsString = codePointToString(next);
+
+            originalToEncoded.put(next, currentEncoding);
+            encodedToOriginal.put(currentEncoding, originalLetterAsString);
+        }
+    }
+
+    /**
+     * from http://www.oracle.com/us/technologies/java/supplementary-142654.html
+     */
+    private static String codePointToString(int i) {
+        if (Character.charCount(i) == 1) {
+            return String.valueOf((char) i);
+        } else {
+            return new String(Character.toChars(i));
+        }
+    }
+    
+    /**
+     * How many characters in the encoded alphabet are necessary for each character in the original alphabet
+     */
+    public int getEncodedCharLength() {
+        return encodedLetterLength;
+    }
+    
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        
+        for (Entry<Integer, String> i : originalToEncoded.entrySet()) {
+            sb.append(codePointToString(i.getKey())).append(" -> ").append(i.getValue()).append("\n");
+        }
+        
+        return sb.toString();
+    }
+
+    /**
+     * Get the mapping from integer code point of source language to encoded string. Use to reconstruct AlphabetConverter from serialized map
+     */
+    public Map<Integer, String> getOriginalToEncoded() {
+        return originalToEncoded;
+    }
+
+    /**
+     * Get the 'do not encode' chars
+     */
+    public Collection<String> getDoNotEncode() {
+        return doNotEncodeMap.values();
+    }
+    
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
+        }
+        if (obj instanceof AlphabetConverter == false) {
+            return false;
+        }
+        final AlphabetConverter other = (AlphabetConverter) obj;
+        return  doNotEncodeMap.equals(other.doNotEncodeMap) &&
+                originalToEncoded.equals(other.originalToEncoded) &&
+                encodedToOriginal.equals(other.encodedToOriginal) &&
+                encodedLetterLength == other.encodedLetterLength;
+    }
+}

--- a/src/test/java/org/apache/commons/lang3/text/AlphabetConverterTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/AlphabetConverterTest.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.lang3.text;
+
+import java.io.UnsupportedEncodingException;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link org.apache.commons.lang3.text.AlphabetConverter}.
+ */
+public class AlphabetConverterTest {
+
+    private static char[] lower_case_english = {' ','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z'};
+    private static char[] english_and_numbers = {'0','1','2','3','4','5','6','7','8','9','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z',' ' };
+    private static char[] lower_case_english_and_numbers = {'0','1','2','3','4','5','6','7','8','9','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z',' ' };
+    private static char[] numbers = {'0','1','2','3','4','5','6','7','8','9'};
+    private static char[] binary = {'0','1'};
+    private static char[] hebrew = {'_', ' ', '\u05e7','\u05e8','\u05d0','\u05d8','\u05d5','\u05df','\u05dd','\u05e4','\u05e9','\u05d3','\u05d2','\u05db','\u05e2','\u05d9','\u05d7','\u05dc','\u05da','\u05e3','\u05d6','\u05e1','\u05d1','\u05d4','\u05e0','\u05de','\u05e6','\u05ea','\u05e5'};
+    private static char[] empty = {};
+
+    private static int[] unicode = {32,35395,35397,36302,36291,35203,35201,35215,35219,35268,97,98,99,100,101,102,103,104,105,106,107,108,109,110,1001,1002,1003,1004,1005};
+    private static int[] lower_case_english_codepoints = {32,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122};
+    private static int[] doNotEncodePoints = {32,97,98,99}; // space, a, b, c
+    
+    private static Set<Character> makeSet(char[] chars) {
+        Set<Character> set = new HashSet<Character>();
+        
+        for (char c : chars) {
+            set.add(c);
+        }
+        
+        return set;
+    }
+
+    private static Set<Integer> makeCodePointSet(int[] ints) {
+        Set<Integer> set = new HashSet<Integer>();
+        
+        for (int i: ints) {
+            set.add(i);
+        }
+        
+        return set;
+    }
+
+    @Test
+    public void binaryTest() throws UnsupportedEncodingException {
+        test(numbers, binary, empty, "12345", "0");
+        test(lower_case_english, binary, empty, "abc", "a");
+    }
+
+    @Test
+    public void hebrewTest() throws UnsupportedEncodingException {
+        test(hebrew, binary, empty, "\u05d0", "\u05e2", "\u05d0\u05dc\u05e3_\u05d0\u05d5\u05d4\u05d1\u05dc_\u05d1\u05d9\u05ea_\u05d6\u05d4_\u05d1\u05d9\u05ea_\u05d2\u05d9\u05de\u05dc_\u05d6\u05d4_\u05db\u05de\u05dc_\u05d2\u05d3\u05d5\u05dc");
+        test(hebrew, numbers, empty, "\u05d0", "\u05e2", "\u05d0\u05dc\u05e3_\u05d0\u05d5\u05d4\u05d1\u05dc_\u05d1\u05d9\u05ea_\u05d6\u05d4_\u05d1\u05d9\u05ea_\u05d2\u05d9\u05de\u05dc_\u05d6\u05d4_\u05db\u05de\u05dc_\u05d2\u05d3\u05d5\u05dc");
+        test(numbers, hebrew, empty, "123456789", "1", "5");
+        test(lower_case_english, hebrew, empty, "this is a test");
+    }
+
+    @Test
+    public void doNotEncodeTest() throws UnsupportedEncodingException {
+        test(english_and_numbers, lower_case_english_and_numbers, lower_case_english, "1", "456", "abc", "ABC", "this will not be converted but THIS WILL");
+        test(english_and_numbers, lower_case_english_and_numbers, numbers, "1", "456", "abc", "ABC", "this will be converted but 12345 and this will be");
+    }
+    
+    /*
+     * Test constructor from code points
+     */
+    @Test
+    public void unicodeTest() throws UnsupportedEncodingException {
+        AlphabetConverter ac = AlphabetConverter.createConverter(makeCodePointSet(unicode), makeCodePointSet(lower_case_english_codepoints), makeCodePointSet(doNotEncodePoints));
+        
+        String original = "\u8a43\u8a45 \u8dce ab \u8dc3 c \u8983";
+        String encoded = ac.encode(original);
+        String decoded = ac.decode(encoded);
+        
+        Assert.assertEquals("Encoded '" + original + "' into '" + encoded + "', but decoded into '" + decoded + "'", original, decoded);
+    }
+    @Test(expected=IllegalArgumentException.class)
+    public void noEncodingLettersTest() {
+        AlphabetConverter.createConverterFromChars(makeSet(english_and_numbers), makeSet(numbers), makeSet(numbers));
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void onlyOneEncodingLettersTest() {
+        Set<Character> numbersPlusUnderscore = makeSet(numbers);
+        
+        numbersPlusUnderscore.add('_');
+        
+        AlphabetConverter.createConverterFromChars(makeSet(english_and_numbers), numbersPlusUnderscore, makeSet(numbers));
+    }
+
+    private void test(char[] originalChars, char[] encodingChars, char[] doNotEncodeChars, String... strings) throws UnsupportedEncodingException {
+        
+        // test AlphabetConverter creation
+        Set<Character> originals = makeSet(originalChars);
+        Set<Character> encodings = makeSet(encodingChars);
+        Set<Character> doNotEncode = makeSet(doNotEncodeChars);
+        
+        AlphabetConverter ac = AlphabetConverter.createConverterFromChars(originals, encodings, doNotEncode);
+        
+        AlphabetConverter reconstructedAlphabetConverter = AlphabetConverter.createConverterFromMap(ac.getOriginalToEncoded());
+        
+        Assert.assertEquals(ac, reconstructedAlphabetConverter);
+        Assert.assertEquals(ac.toString(), reconstructedAlphabetConverter.toString());
+        Assert.assertEquals(null, ac.encode(null)); // test null conversions
+        Assert.assertEquals("", ac.encode("")); // test empty conversion
+        
+        // test all the trial strings
+        for (String s : strings) {
+            String encoded = ac.encode(s);
+
+            // test that only encoding chars are used
+            for (int i = 0; i < encoded.length(); i++) {
+                Assert.assertTrue(encodings.contains(encoded.charAt(i)));
+            }
+            
+            String decoded = ac.decode(encoded);
+    
+            // test that only the original alphabet is used after decoding
+            for (int i = 0; i < decoded.length(); i++) {
+                Assert.assertTrue(originals.contains(decoded.charAt(i)));
+            }
+            
+            Assert.assertEquals("Encoded '" + s + "' into '" + encoded + "', but decoded into '" + decoded + "'", s, decoded);
+        }
+    }
+}


### PR DESCRIPTION
(as described in [the mailing list](http://mail-archives.apache.org/mod_mbox/commons-dev/201609.mbox/%3c289983494.3057706.1472720010277@mail.yahoo.com%3e))

This is a utility class I wrote for converting from one alphabet to another - for example, from unicode to latin, without using some of the chars in latin. The usage looks like this:

```
Set<Character> originals; // a, b, c, d
Set<Character> encoding; // 0, 1, d
Set<Character> doNotEncode; // d

AlphabetConverter ac = AlphabetConverter.createConverter(originals, encoding, doNotEncode);

ac.encode("a"); // 00
ac.encode("b"); // 01
ac.encode("c"); // 0d
ac.encode("d"); // d
ac.encode("abcd"); // 00010dd
```
Of course, 

`x.equals(ac.decode(ac.encode(x)))`

 should always be true.

The implementation provided makes the encodings of fixed length, other than the "do not encode" chars, which remain as they are (length one).

In addition, in order to make it easier to preserve the encoding scheme, I've added a human-readable toString implementation, and a constructor that can recreate an AlphabetConverter from the encoding map, such that:
```

AlphabetConverter ac;

ac.equals(AlphabetConverter.createConverterFromMap(ac.getOriginalToEncoded())); // always should be true

```