### PR TITLE
Lang 1255: Add DateUtils.toCalendar(Date, TimeZone) and 4 unit tests

### DIFF
--- a/src/main/java/org/apache/commons/lang3/time/DateUtils.java
+++ b/src/main/java/org/apache/commons/lang3/time/DateUtils.java
@@ -668,6 +668,19 @@ public class DateUtils {
     
     //-----------------------------------------------------------------------
     /**
+     * Converts a {@code Date} of a given {@code TimeZone} into a {@code Calendar}
+     * @param date the date to convert to a Calendar
+     * @param timeZone the time zone of the @{code date}
+     * @return
+     */
+    public static Calendar toCalendar(final Date date, final TimeZone tz) {
+    	final Calendar c = Calendar.getInstance(tz);
+    	c.setTime(date);
+    	return c;
+    }
+    
+    //-----------------------------------------------------------------------
+    /**
      * <p>Rounds a date, leaving the field specified as the most
      * significant field.</p>
      *

--- a/src/main/java/org/apache/commons/lang3/time/DateUtils.java
+++ b/src/main/java/org/apache/commons/lang3/time/DateUtils.java
@@ -670,8 +670,9 @@ public class DateUtils {
     /**
      * Converts a {@code Date} of a given {@code TimeZone} into a {@code Calendar}
      * @param date the date to convert to a Calendar
-     * @param timeZone the time zone of the @{code date}
-     * @return
+     * @param tz the time zone of the @{code date}
+     * @return the created Calendar
+     * @throws NullPointerException if {@code date} or {@code tz} is null
      */
     public static Calendar toCalendar(final Date date, final TimeZone tz) {
     	final Calendar c = Calendar.getInstance(tz);

--- a/src/test/java/org/apache/commons/lang3/time/DateUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/DateUtilsTest.java
@@ -695,56 +695,29 @@ public class DateUtilsTest {
     }
     
     //-----------------------------------------------------------------------
-    @Test
-    public void testToCalendarWithDateNotNull() {
-        assertEquals("Convert Date and TimeZone to a Calendar, but failed to get the Date back", date1, DateUtils.toCalendar(date1, zone).getTime());
-    }
-    
-    //-----------------------------------------------------------------------
-    @Test
+    @Test(expected=NullPointerException.class)
     public void testToCalendarWithDateNull() {
-        try {
-            DateUtils.toCalendar(null, zone);
-            fail("Expected NullPointerException to be thrown when Date is null");
-        } catch(final NullPointerException npe) {
-            // expected
-        }
+        DateUtils.toCalendar(null, zone);
     }
     
     //-----------------------------------------------------------------------
-    @Test
-    public void testToCalendarWithTimeZoneNotNull() {
-    	assertEquals("Convert Date and TimeZone to a Calendar, but failed to get the TimeZone back", zone, DateUtils.toCalendar(date1, zone).getTimeZone());
-    }
-    
-    //-----------------------------------------------------------------------
-    @Test
+    @Test(expected=NullPointerException.class)
     public void testToCalendarWithTimeZoneNull() {
-        try {
-            DateUtils.toCalendar(date1, null);
-            fail("Expected NullPointerException to be thrown when TimeZone is null");
-        } catch(final NullPointerException npe) {
-            // expected
-        }
+        DateUtils.toCalendar(date1, null);
     }
     
     //-----------------------------------------------------------------------
     @Test
     public void testToCalendarWithDateAndTimeZoneNotNull() {
-    	Calendar c = DateUtils.toCalendar(date2, defaultZone);
-    	assertEquals("Convert Date and TimeZone to a Calendar, but failed to get the Date back", date2, c.getTime());
-    	assertEquals("Convert Date and TimeZone to a Calendar, but failed to get the TimeZone back", defaultZone, c.getTimeZone());
+        Calendar c = DateUtils.toCalendar(date2, defaultZone);
+        assertEquals("Convert Date and TimeZone to a Calendar, but failed to get the Date back", date2, c.getTime());
+        assertEquals("Convert Date and TimeZone to a Calendar, but failed to get the TimeZone back", defaultZone, c.getTimeZone());
     }
     
     //-----------------------------------------------------------------------
-    @Test
+    @Test(expected=NullPointerException.class)
     public void testToCalendarWithDateAndTimeZoneNull() {
-    	try {
-    		DateUtils.toCalendar(null, null);
-            fail("Expected NullPointerException to be thrown when both Date and TimeZone are null");
-        } catch(final NullPointerException npe) {
-            // expected
-        }
+        DateUtils.toCalendar(null, null);
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/apache/commons/lang3/time/DateUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/DateUtilsTest.java
@@ -693,6 +693,43 @@ public class DateUtilsTest {
             // expected
         }
     }
+    
+    //-----------------------------------------------------------------------
+    @Test
+    public void testToCalendarWithDate() {
+        assertEquals("Convert Date and TimeZone to a Calendar, but failed to get the Date back", date1, DateUtils.toCalendar(date1, zone).getTime());
+        try {
+            DateUtils.toCalendar(null, zone);
+            fail("Expected NullPointerException to be thrown");
+        } catch(final NullPointerException npe) {
+            // expected
+        }
+    }
+    
+    //-----------------------------------------------------------------------
+    @Test
+    public void testToCalendarWithTimeZone() {
+    	assertEquals("Convert Date and TimeZone to a Calendar, but failed to get the TimeZone back", zone, DateUtils.toCalendar(date1, zone).getTimeZone());
+        try {
+            DateUtils.toCalendar(date1, null);
+            fail("Expected NullPointerException to be thrown");
+        } catch(final NullPointerException npe) {
+            // expected
+        }
+    }
+    
+  //-----------------------------------------------------------------------
+    @Test
+    public void testToCalendarWithDateAndTimeZone() {
+        try {
+        	Calendar c = DateUtils.toCalendar(date2, defaultZone);
+        	assertEquals("Convert Date and TimeZone to a Calendar, but failed to get the Date back", date2, c.getTime());
+        	assertEquals("Convert Date and TimeZone to a Calendar, but failed to get the TimeZone back", defaultZone, c.getTimeZone());
+        	// expected
+        } catch(final NullPointerException npe) {
+        	fail("Expected NullPointerException to be thrown");
+        }
+    }
 
     //-----------------------------------------------------------------------
     /**

--- a/src/test/java/org/apache/commons/lang3/time/DateUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/DateUtilsTest.java
@@ -696,11 +696,16 @@ public class DateUtilsTest {
     
     //-----------------------------------------------------------------------
     @Test
-    public void testToCalendarWithDate() {
+    public void testToCalendarWithDateNotNull() {
         assertEquals("Convert Date and TimeZone to a Calendar, but failed to get the Date back", date1, DateUtils.toCalendar(date1, zone).getTime());
+    }
+    
+    //-----------------------------------------------------------------------
+    @Test
+    public void testToCalendarWithDateNull() {
         try {
             DateUtils.toCalendar(null, zone);
-            fail("Expected NullPointerException to be thrown");
+            fail("Expected NullPointerException to be thrown when Date is null");
         } catch(final NullPointerException npe) {
             // expected
         }
@@ -708,26 +713,37 @@ public class DateUtilsTest {
     
     //-----------------------------------------------------------------------
     @Test
-    public void testToCalendarWithTimeZone() {
+    public void testToCalendarWithTimeZoneNotNull() {
     	assertEquals("Convert Date and TimeZone to a Calendar, but failed to get the TimeZone back", zone, DateUtils.toCalendar(date1, zone).getTimeZone());
+    }
+    
+    //-----------------------------------------------------------------------
+    @Test
+    public void testToCalendarWithTimeZoneNull() {
         try {
             DateUtils.toCalendar(date1, null);
-            fail("Expected NullPointerException to be thrown");
+            fail("Expected NullPointerException to be thrown when TimeZone is null");
         } catch(final NullPointerException npe) {
             // expected
         }
     }
     
-  //-----------------------------------------------------------------------
+    //-----------------------------------------------------------------------
     @Test
-    public void testToCalendarWithDateAndTimeZone() {
-        try {
-        	Calendar c = DateUtils.toCalendar(date2, defaultZone);
-        	assertEquals("Convert Date and TimeZone to a Calendar, but failed to get the Date back", date2, c.getTime());
-        	assertEquals("Convert Date and TimeZone to a Calendar, but failed to get the TimeZone back", defaultZone, c.getTimeZone());
-        	// expected
+    public void testToCalendarWithDateAndTimeZoneNotNull() {
+    	Calendar c = DateUtils.toCalendar(date2, defaultZone);
+    	assertEquals("Convert Date and TimeZone to a Calendar, but failed to get the Date back", date2, c.getTime());
+    	assertEquals("Convert Date and TimeZone to a Calendar, but failed to get the TimeZone back", defaultZone, c.getTimeZone());
+    }
+    
+    //-----------------------------------------------------------------------
+    @Test
+    public void testToCalendarWithDateAndTimeZoneNull() {
+    	try {
+    		DateUtils.toCalendar(null, null);
+            fail("Expected NullPointerException to be thrown when both Date and TimeZone are null");
         } catch(final NullPointerException npe) {
-        	fail("Expected NullPointerException to be thrown");
+            // expected
         }
     }
 


### PR DESCRIPTION
Added new toCalendar method in DateUtils with 4 unit tests as proposed in LANG-1255.

Link: https://issues.apache.org/jira/browse/LANG-1255