### PR TITLE
site: Nav, javadoc now says GIT latest as opposed to SVN latest

### DIFF
--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -38,7 +38,7 @@
             <item name="Proposal"             href="/proposal.html"/>
             <item name="Developer guide"      href="/developerguide.html"/>
             <item name="Source Repository"    href="/source-repository.html"/>
-            <item name="Javadoc (SVN latest)" href="apidocs/index.html"/>
+            <item name="Javadoc (GIT latest)" href="apidocs/index.html"/>
         </menu>
 
     </body>


### PR DESCRIPTION
@britter any thoughts on taking this without a jira?