### PR TITLE
LANG-1268: Add methods for comparing numbers/compareables against eac…

### DIFF
--- a/src/main/java/org/apache/commons/lang3/Validate.java
+++ b/src/main/java/org/apache/commons/lang3/Validate.java
@@ -49,6 +49,16 @@ public class Validate {
         "The validated value is not a number";
     private static final String DEFAULT_FINITE_EX_MESSAGE =
         "The value is invalid: %f";
+    private static final String DEFAULT_GREATER_EX_MESSAGE =
+        "The value %s is not greater than %s";
+    private static final String DEFAULT_GREATER_OR_EQUAL_EX_MESSAGE =
+        "The value %s is not greater than or equal to %s";
+    private static final String DEFAULT_SMALLER_EX_MESSAGE =
+        "The value %s is not less than %s";
+    private static final String DEFAULT_SMALLER_OR_EQUAL_EX_MESSAGE =
+        "The value %s is not less than or equal to %s";
+    private static final String DEFAULT_NOT_EQUAL_EX_MESSAGE =
+        "The value %s is equal to %s";
     private static final String DEFAULT_EXCLUSIVE_BETWEEN_EX_MESSAGE =
         "The value %s is not in the specified exclusive range of %s to %s";
     private static final String DEFAULT_INCLUSIVE_BETWEEN_EX_MESSAGE =
@@ -958,6 +968,240 @@ public class Validate {
      */
     public static void finite(final double value, final String message, final Object... values) {
         if (Double.isNaN(value) || Double.isInfinite(value)) {
+            throw new IllegalArgumentException(String.format(message, values));
+        }
+    }
+
+    // greater
+    //---------------------------------------------------------------------------------
+
+    /**
+     * <p>Validates that the specified argument is strictly greater than a given
+     * reference; otherwise throwing an exception.</p>
+     *
+     * <pre>Validate.greater(myObject, refObject);</pre>
+     *
+     * <p>The message of the exception is &quot;The value {@code value} is not
+     * greater than {@code min}&quot;.</p>
+     *
+     * @param <T>  the type of the argument object
+     * @param value  the object to validate
+     * @param min  the reference value
+     * @throws IllegalArgumentException if {@code value} is lessThan than or equal to {@code min}
+     * @see #greater(java.lang.Object, java.lang.Comparable, java.lang.String, java.lang.Object...) 
+     * 
+     * @since 3.5
+     */
+    public static <T> void greater(final Comparable<T> value, final T min) {
+        greater(value, min, DEFAULT_GREATER_EX_MESSAGE, value, min);
+    }
+
+    /**
+     * <p>Validates that the specified argument is strictly greater than a given
+     * reference; otherwise throwing an exception with the specified message.</p>
+     *
+     * <pre>Validate.greater(myObject, refObject, "The value must be greater than the reference");</pre>
+     *
+     * @param <T>  the type of the argument object
+     * @param value  the object to validate
+     * @param min  the reference value
+     * @param message  the {@link String#format(String, Object...)} exception message if invalid, not null
+     * @param values  the optional values for the formatted exception message
+     * @throws IllegalArgumentException if {@code value} is lessThan than or equal to {@code min}
+     * @see #greater(java.lang.Object, java.lang.Comparable) 
+     * 
+     * @since 3.5
+     */
+    public static <T> void greater(final Comparable<T> value, final T min, final String message, final Object... values) {
+        if (value.compareTo(min) <= 0) {
+            throw new IllegalArgumentException(String.format(message, values));
+        }
+    }
+
+    // greaterOrEqual
+    //---------------------------------------------------------------------------------
+
+    /**
+     * <p>Validates that the specified argument is greater than, or equal to, a
+     * given reference; otherwise throwing an exception.</p>
+     *
+     * <pre>Validate.greaterOrEqual(myObject, refObject);</pre>
+     *
+     * <p>The message of the exception is &quot;The value {@code value} is not
+     * greater than or equal to {@code min}&quot;.</p>
+     *
+     * @param <T>  the type of the argument object
+     * @param value  the object to validate
+     * @param min  the reference value
+     * @throws IllegalArgumentException if {@code value} is lessThan than {@code min}
+     * @see #greaterOrEqual(java.lang.Object, java.lang.Comparable, java.lang.String, java.lang.Object...) 
+     * 
+     * @since 3.5
+     */
+    public static <T> void greaterOrEqual(final Comparable<T> value, final T min) {
+        greaterOrEqual(value, min, DEFAULT_GREATER_OR_EQUAL_EX_MESSAGE, value, min);
+    }
+
+    /**
+     * <p>Validates that the specified argument is greater than, or equal to, a
+     * given reference; otherwise throwing an exception.</p>
+     *
+     * <pre>Validate.greaterOrEqual(myObject, refObject, "The value must be greater than the reference");</pre>
+     *
+     * @param <T>  the type of the argument object
+     * @param value  the object to validate
+     * @param min  the reference value
+     * @param message  the {@link String#format(String, Object...)} exception message if invalid, not null
+     * @param values  the optional values for the formatted exception message
+     * @throws IllegalArgumentException if {@code value} is lessThan than {@code min}
+     * @see #greaterOrEqual(java.lang.Object, java.lang.Comparable) 
+     * 
+     * @since 3.5
+     */
+    public static <T> void greaterOrEqual(final Comparable<T> value, final T min, final String message, final Object... values) {
+        if (value.compareTo(min) < 0) {
+            throw new IllegalArgumentException(String.format(message, values));
+        }
+    }
+
+    // lessThan
+    //---------------------------------------------------------------------------------
+
+    /**
+     * <p>Validates that the specified argument is strictly lessThan than a given
+     * reference; otherwise throwing an exception.</p>
+     *
+     * <pre>Validate.lessThan(myObject, refObject);</pre>
+     *
+     * <p>The message of the exception is &quot;The value {@code value} is not
+     * lessThan than {@code max}&quot;.</p>
+     *
+     * @param <T>  the type of the argument object
+     * @param value  the object to validate
+     * @param max  the reference value
+     * @throws IllegalArgumentException if {@code value} is greater than or equal to {@code max}
+     * @see #lessThan(java.lang.Object, java.lang.Comparable, java.lang.String, java.lang.Object...) 
+     * 
+     * @since 3.5
+     */
+    public static <T> void lessThan(final Comparable<T> value, final T max) {
+        lessThan(value, max, DEFAULT_SMALLER_EX_MESSAGE, value, max);
+    }
+
+    /**
+     * <p>Validates that the specified argument is strictly lessThan than a given
+     * reference; otherwise throwing an exception with the specified message.</p>
+     *
+     * <pre>Validate.lessThan(myObject, refObject, "The value must be greater than the reference");</pre>
+     *
+     * @param <T>  the type of the argument object
+     * @param value  the object to validate
+     * @param max  the reference value
+     * @param message  the {@link String#format(String, Object...)} exception message if invalid, not null
+     * @param values  the optional values for the formatted exception message
+     * @throws IllegalArgumentException if {@code value} is greater than or equal to {@code max}
+     * @see #lessThan(java.lang.Object, java.lang.Comparable) 
+     * 
+     * @since 3.5
+     */
+    public static <T> void lessThan(final Comparable<T> value, final T max, final String message, final Object... values) {
+        if (value.compareTo(max) >= 0) {
+            throw new IllegalArgumentException(String.format(message, values));
+        }
+    }
+
+    // lessThanOrEqual
+    //---------------------------------------------------------------------------------
+
+    /**
+     * <p>Validates that the specified argument is lessThan than, or equal to, a
+     * given reference; otherwise throwing an exception.</p>
+     *
+     * <pre>Validate.lessThanOrEqual(myObject, refObject);</pre>
+     *
+     * <p>The message of the exception is &quot;The value {@code value} is not
+     * lessThan than or equal to {@code max}&quot;.</p>
+     *
+     * @param <T>  the type of the argument object
+     * @param value  the object to validate
+     * @param max  the reference value
+     * @throws IllegalArgumentException if {@code value} is greater than {@code max}
+     * @see #lessThanOrEqual(java.lang.Object, java.lang.Comparable, java.lang.String, java.lang.Object...) 
+     * 
+     * @since 3.5
+     */
+    public static <T> void lessThanOrEqual(final Comparable<T> value, final T max) {
+        lessThanOrEqual(value, max, DEFAULT_SMALLER_OR_EQUAL_EX_MESSAGE, value, max);
+    }
+
+    /**
+     * <p>Validates that the specified argument is lessThan than, or equal to, a
+     * given reference; otherwise throwing an exception with the specified message.</p>
+     *
+     * <pre>Validate.lessThanOrEqual(myObject, refObject, "The value must be greater than the reference");</pre>
+     *
+     * @param <T>  the type of the argument object
+     * @param value  the object to validate
+     * @param max  the reference value
+     * @param message  the {@link String#format(String, Object...)} exception message if invalid, not null
+     * @param values  the optional values for the formatted exception message
+     * @throws IllegalArgumentException if {@code value} is greater than {@code max}
+     * @see #lessThanOrEqual(java.lang.Object, java.lang.Comparable) 
+     * 
+     * @since 3.5
+     */
+    public static <T> void lessThanOrEqual(final Comparable<T> value, final T max, final String message, final Object... values) {
+        if (value.compareTo(max) > 0) {
+            throw new IllegalArgumentException(String.format(message, values));
+        }
+    }
+
+    // different
+    //---------------------------------------------------------------------------------
+
+    /**
+     * <p>Validates that the specified argument is different from a given value
+     * (reference); otherwise throwing an exception.</p>
+     *
+     * <p>Two objects are considered different if
+     * {@code value.equals(reference) == false}</p>
+     *
+     * <pre>Validate.different(myObject, refObject);</pre>
+     *
+     * <p>The message of the exception is &quot;The value {@code value} is
+     * invalid&quot;.</p>
+     *
+     * @param <T>  the type of the argument object
+     * @param value  the object to validate
+     * @param reference  the reference value
+     * @throws IllegalArgumentException if {@code value} is equal to {@code reference}
+     *
+     * @since 3.5
+     */
+    public static <T> void notEqual(final T value, final T reference) {
+        notEqual(value, reference, DEFAULT_NOT_EQUAL_EX_MESSAGE, value, reference);
+    }
+
+    /**
+     * <p>Validates that the specified argument is different from a given value
+     * (reference); otherwise throwing an exception with the specified message.</p>
+     *
+     * <p>Two objects are considered different if
+     * {@code value.equals(reference) == false}</p>
+     *
+     * <pre>Validate.different(myObject, refObject, "The value is invalid");</pre>
+     *
+     * @param <T>  the type of the argument object
+     * @param value  the object to validate
+     * @param reference  the reference value
+     * @param message  the {@link String#format(String, Object...)} exception message if invalid, not null
+     * @param values  the optional values for the formatted exception message
+     * @throws IllegalArgumentException if {@code value} is equal to {@code reference}
+     *
+     * @since 3.5
+     */
+    public static <T> void notEqual(final T value, final T reference, final String message, final Object... values) {
+        if (value.equals(reference)) {
             throw new IllegalArgumentException(String.format(message, values));
         }
     }

--- a/src/test/java/org/apache/commons/lang3/ValidateTest.java
+++ b/src/test/java/org/apache/commons/lang3/ValidateTest.java
@@ -913,6 +913,573 @@ public class ValidateTest  {
     //-----------------------------------------------------------------------
 
     @Test
+    public void testGreaterObject1() {
+        Validate.greater("c", "b");
+        try {
+            Validate.greater("b", "b");
+            fail("Expecting IllegalArgumentException");
+        } catch (final IllegalArgumentException ex) {
+            assertEquals("The value b is not greater than b", ex.getMessage());
+        }
+        try {
+            Validate.greater("a", "b");
+            fail("Expecting IllegalArgumentException");
+        } catch (final IllegalArgumentException ex) {
+            assertEquals("The value a is not greater than b", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void testGreaterObject2() {
+        Validate.greater("c", "b", "MSG");
+        try {
+            Validate.greater("b", "b", "MSG");
+            fail("Expecting IllegalArgumentException");
+        } catch (final IllegalArgumentException ex) {
+            assertEquals("MSG", ex.getMessage());
+        }
+        try {
+            Validate.greater("a", "b", "MSG");
+            fail("Expecting IllegalArgumentException");
+        } catch (final IllegalArgumentException ex) {
+            assertEquals("MSG", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void testGreaterLong1() {
+        Validate.greater(1, 0);
+        try {
+            Validate.greater(0, 0);
+            fail("Expecting IllegalArgumentException");
+        } catch (final IllegalArgumentException ex) {
+            assertEquals("The value 0 is not greater than 0", ex.getMessage());
+        }
+        try {
+            Validate.greater(-1, 0);
+            fail("Expecting IllegalArgumentException");
+        } catch (final IllegalArgumentException ex) {
+            assertEquals("The value -1 is not greater than 0", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void testGreaterLong2() {
+        Validate.greater(1, 0, "MSG");
+        try {
+            Validate.greater(0, 0, "MSG");
+            fail("Expecting IllegalArgumentException");
+        } catch (final IllegalArgumentException ex) {
+            assertEquals("MSG", ex.getMessage());
+        }
+        try {
+            Validate.greater(-1, 0, "MSG");
+            fail("Expecting IllegalArgumentException");
+        } catch (final IllegalArgumentException ex) {
+            assertEquals("MSG", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void testGreaterDouble1() {
+        Validate.greater(1.0, 0.0);
+        Validate.greater(Double.POSITIVE_INFINITY, 0.0);
+        Validate.greater(Double.NaN, 0.0);
+        try {
+            Validate.greater(0.0, 0.0);
+            fail("Expecting IllegalArgumentException");
+        } catch (final IllegalArgumentException ex) {
+            assertEquals("The value 0.0 is not greater than 0.0", ex.getMessage());
+        }
+        try {
+            Validate.greater(-1.0, 0.0);
+            fail("Expecting IllegalArgumentException");
+        } catch (final IllegalArgumentException ex) {
+            assertEquals("The value -1.0 is not greater than 0.0", ex.getMessage());
+        }
+        try {
+            Validate.greater(Double.NEGATIVE_INFINITY, 0.0);
+            fail("Expecting IllegalArgumentException");
+        } catch (final IllegalArgumentException ex) {
+            assertEquals("The value -Infinity is not greater than 0.0", ex.getMessage());
+        }
+        try {
+            Validate.greater(0.0, Double.NaN);
+            fail("Expecting IllegalArgumentException");
+        } catch (final IllegalArgumentException ex) {
+            assertEquals("The value 0.0 is not greater than NaN", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void testGreaterDouble2() {
+        Validate.greater(1.0, 0.0, "MSG");
+        Validate.greater(Double.POSITIVE_INFINITY, 0.0, "MSG");
+        Validate.greater(Double.NaN, 0.0, "MSG");
+        try {
+            Validate.greater(0.0, 0.0, "MSG");
+            fail("Expecting IllegalArgumentException");
+        } catch (final IllegalArgumentException ex) {
+            assertEquals("MSG", ex.getMessage());
+        }
+        try {
+            Validate.greater(-1.0, 0.0, "MSG");
+            fail("Expecting IllegalArgumentException");
+        } catch (final IllegalArgumentException ex) {
+            assertEquals("MSG", ex.getMessage());
+        }
+        try {
+            Validate.greater(Double.NEGATIVE_INFINITY, 0.0, "MSG");
+            fail("Expecting IllegalArgumentException");
+        } catch (final IllegalArgumentException ex) {
+            assertEquals("MSG", ex.getMessage());
+        }
+        try {
+            Validate.greater(0.0, Double.NaN, "MSG");
+            fail("Expecting IllegalArgumentException");
+        } catch (final IllegalArgumentException ex) {
+            assertEquals("MSG", ex.getMessage());
+        }
+    }
+
+    //-----------------------------------------------------------------------
+    //-----------------------------------------------------------------------
+
+    @Test
+    public void testGreaterOrEqualObject1() {
+        Validate.greaterOrEqual("c", "b");
+        Validate.greaterOrEqual("b", "b");
+        try {
+            Validate.greaterOrEqual("a", "b");
+            fail("Expecting IllegalArgumentException");
+        } catch (final IllegalArgumentException ex) {
+            assertEquals("The value a is not greater than or equal to b", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void testGreaterOrEqualObject2() {
+        Validate.greaterOrEqual("c", "b", "MSG");
+        Validate.greaterOrEqual("b", "b", "MSG");
+        try {
+            Validate.greaterOrEqual("a", "b", "MSG");
+            fail("Expecting IllegalArgumentException");
+        } catch (final IllegalArgumentException ex) {
+            assertEquals("MSG", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void testGreaterOrEqualLong1() {
+        Validate.greaterOrEqual(1, 0);
+        Validate.greaterOrEqual(0, 0);
+        try {
+            Validate.greaterOrEqual(-1, 0);
+            fail("Expecting IllegalArgumentException");
+        } catch (final IllegalArgumentException ex) {
+            assertEquals("The value -1 is not greater than or equal to 0", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void testGreaterOrEqualLong2() {
+        Validate.greaterOrEqual(1, 0, "MSG");
+        Validate.greaterOrEqual(0, 0, "MSG");
+        try {
+            Validate.greaterOrEqual(-1, 0, "MSG");
+            fail("Expecting IllegalArgumentException");
+        } catch (final IllegalArgumentException ex) {
+            assertEquals("MSG", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void testGreaterOrEqualDouble1() {
+        Validate.greaterOrEqual(1.0, 0.0);
+        Validate.greaterOrEqual(Double.POSITIVE_INFINITY, 0.0);
+        Validate.greaterOrEqual(0.0, 0.0);
+        Validate.greaterOrEqual(Double.NaN, 0.0);
+        Validate.greaterOrEqual(Double.NaN, Double.NaN);
+
+        try {
+            Validate.greaterOrEqual(-1.0, 0.0);
+            fail("Expecting IllegalArgumentException");
+        } catch (final IllegalArgumentException ex) {
+            assertEquals("The value -1.0 is not greater than or equal to 0.0", ex.getMessage());
+        }
+        try {
+            Validate.greaterOrEqual(Double.NEGATIVE_INFINITY, 0.0);
+            fail("Expecting IllegalArgumentException");
+        } catch (final IllegalArgumentException ex) {
+            assertEquals("The value -Infinity is not greater than or equal to 0.0", ex.getMessage());
+        }
+        try {
+            Validate.greaterOrEqual(0.0, Double.NaN);
+            fail("Expecting IllegalArgumentException");
+        } catch (final IllegalArgumentException ex) {
+            assertEquals("The value 0.0 is not greater than or equal to NaN", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void testGreaterOrEqualDouble2() {
+        Validate.greaterOrEqual(1.0, 0.0, "MSG");
+        Validate.greaterOrEqual(Double.POSITIVE_INFINITY, 0.0, "MSG");
+        Validate.greaterOrEqual(0.0, 0.0, "MSG");
+        Validate.greaterOrEqual(Double.NaN, 0.0, "MSG");
+        Validate.greaterOrEqual(Double.NaN, Double.NaN, "MSG");
+
+        try {
+            Validate.greaterOrEqual(-1.0, 0.0, "MSG");
+            fail("Expecting IllegalArgumentException");
+        } catch (final IllegalArgumentException ex) {
+            assertEquals("MSG", ex.getMessage());
+        }
+        try {
+            Validate.greaterOrEqual(Double.NEGATIVE_INFINITY, 0.0, "MSG");
+            fail("Expecting IllegalArgumentException");
+        } catch (final IllegalArgumentException ex) {
+            assertEquals("MSG", ex.getMessage());
+        }
+        try {
+            Validate.greaterOrEqual(0.0, Double.NaN, "MSG");
+            fail("Expecting IllegalArgumentException");
+        } catch (final IllegalArgumentException ex) {
+            assertEquals("MSG", ex.getMessage());
+        }
+    }
+
+    //-----------------------------------------------------------------------
+    //-----------------------------------------------------------------------
+
+    @Test
+    public void testLessThanObject1() {
+        Validate.lessThan("a", "b");
+        try {
+            Validate.lessThan("b", "b");
+            fail("Expecting IllegalArgumentException");
+        } catch (final IllegalArgumentException ex) {
+            assertEquals("The value b is not less than b", ex.getMessage());
+        }
+        try {
+            Validate.lessThan("c", "b");
+            fail("Expecting IllegalArgumentException");
+        } catch (final IllegalArgumentException ex) {
+            assertEquals("The value c is not less than b", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void testLessThanObject2() {
+        Validate.lessThan("a", "b", "MSG");
+        try {
+            Validate.lessThan("b", "b", "MSG");
+            fail("Expecting IllegalArgumentException");
+        } catch (final IllegalArgumentException ex) {
+            assertEquals("MSG", ex.getMessage());
+        }
+        try {
+            Validate.lessThan("c", "b", "MSG");
+            fail("Expecting IllegalArgumentException");
+        } catch (final IllegalArgumentException ex) {
+            assertEquals("MSG", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void testLessThanLong1() {
+        Validate.lessThan(-1, 0);
+        try {
+            Validate.lessThan(0, 0);
+            fail("Expecting IllegalArgumentException");
+        } catch (final IllegalArgumentException ex) {
+            assertEquals("The value 0 is not less than 0", ex.getMessage());
+        }
+        try {
+            Validate.lessThan(1, 0);
+            fail("Expecting IllegalArgumentException");
+        } catch (final IllegalArgumentException ex) {
+            assertEquals("The value 1 is not less than 0", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void testLessThanLong2() {
+        Validate.lessThan(-1, 0, "MSG");
+        try {
+            Validate.lessThan(0, 0, "MSG");
+            fail("Expecting IllegalArgumentException");
+        } catch (final IllegalArgumentException ex) {
+            assertEquals("MSG", ex.getMessage());
+        }
+        try {
+            Validate.lessThan(1, 0, "MSG");
+            fail("Expecting IllegalArgumentException");
+        } catch (final IllegalArgumentException ex) {
+            assertEquals("MSG", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void testLessThanDouble1() {
+        Validate.lessThan(-1.0, 0.0);
+        Validate.lessThan(Double.NEGATIVE_INFINITY, 0.0);
+        Validate.lessThan(0.0, Double.NaN);
+
+        try {
+            Validate.lessThan(0.0, 0.0);
+            fail("Expecting IllegalArgumentException");
+        } catch (final IllegalArgumentException ex) {
+            assertEquals("The value 0.0 is not less than 0.0", ex.getMessage());
+        }
+        try {
+            Validate.lessThan(1.0, 0.0);
+            fail("Expecting IllegalArgumentException");
+        } catch (final IllegalArgumentException ex) {
+            assertEquals("The value 1.0 is not less than 0.0", ex.getMessage());
+        }
+        try {
+            Validate.lessThan(Double.POSITIVE_INFINITY, 0.0);
+            fail("Expecting IllegalArgumentException");
+        } catch (final IllegalArgumentException ex) {
+            assertEquals("The value Infinity is not less than 0.0", ex.getMessage());
+        }
+        try {
+            Validate.lessThan(Double.NaN, 0.0);
+            fail("Expecting IllegalArgumentException");
+        } catch (final IllegalArgumentException ex) {
+            assertEquals("The value NaN is not less than 0.0", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void testLessThanDouble2() {
+        Validate.lessThan(-1.0, 0.0, "MSG");
+        Validate.lessThan(Double.NEGATIVE_INFINITY, 0.0, "MSG");
+        Validate.lessThan(0.0, Double.NaN, "MSG");
+
+        try {
+            Validate.lessThan(0.0, 0.0, "MSG");
+            fail("Expecting IllegalArgumentException");
+        } catch (final IllegalArgumentException ex) {
+            assertEquals("MSG", ex.getMessage());
+        }
+        try {
+            Validate.lessThan(1.0, 0.0, "MSG");
+            fail("Expecting IllegalArgumentException");
+        } catch (final IllegalArgumentException ex) {
+            assertEquals("MSG", ex.getMessage());
+        }
+        try {
+            Validate.lessThan(Double.POSITIVE_INFINITY, 0.0, "MSG");
+            fail("Expecting IllegalArgumentException");
+        } catch (final IllegalArgumentException ex) {
+            assertEquals("MSG", ex.getMessage());
+        }
+        try {
+            Validate.lessThan(Double.NaN, 0.0, "MSG");
+            fail("Expecting IllegalArgumentException");
+        } catch (final IllegalArgumentException ex) {
+            assertEquals("MSG", ex.getMessage());
+        }
+    }
+
+    //-----------------------------------------------------------------------
+    //-----------------------------------------------------------------------
+
+    @Test
+    public void testLessThanOrEqualObject1() {
+        Validate.lessThanOrEqual("a", "b");
+        Validate.lessThanOrEqual("b", "b");
+        try {
+            Validate.lessThanOrEqual("c", "b");
+            fail("Expecting IllegalArgumentException");
+        } catch (final IllegalArgumentException ex) {
+            assertEquals("The value c is not less than or equal to b", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void testLessThanOrEqualObject2() {
+        Validate.lessThanOrEqual("a", "b", "MSG");
+        Validate.lessThanOrEqual("b", "b", "MSG");
+        try {
+            Validate.lessThanOrEqual("c", "b", "MSG");
+            fail("Expecting IllegalArgumentException");
+        } catch (final IllegalArgumentException ex) {
+            assertEquals("MSG", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void testLessThanOrEqualLong1() {
+        Validate.lessThanOrEqual(-1, 0);
+        Validate.lessThanOrEqual(0, 0);
+        try {
+            Validate.lessThanOrEqual(1, 0);
+            fail("Expecting IllegalArgumentException");
+        } catch (final IllegalArgumentException ex) {
+            assertEquals("The value 1 is not less than or equal to 0", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void testLessThanOrEqualLong2() {
+        Validate.lessThanOrEqual(-1, 0, "MSG");
+        Validate.lessThanOrEqual(0, 0, "MSG");
+        try {
+            Validate.lessThanOrEqual(1, 0, "MSG");
+            fail("Expecting IllegalArgumentException");
+        } catch (final IllegalArgumentException ex) {
+            assertEquals("MSG", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void testLessThanOrEqualDouble1() {
+        Validate.lessThanOrEqual(-1.0, 0.0);
+        Validate.lessThanOrEqual(Double.NEGATIVE_INFINITY, 0.0);
+        Validate.lessThanOrEqual(0.0, 0.0);
+        Validate.lessThanOrEqual(0.0, Double.NaN);
+
+        try {
+            Validate.lessThanOrEqual(1.0, 0.0);
+            fail("Expecting IllegalArgumentException");
+        } catch (final IllegalArgumentException ex) {
+            assertEquals("The value 1.0 is not less than or equal to 0.0", ex.getMessage());
+        }
+        try {
+            Validate.lessThanOrEqual(Double.POSITIVE_INFINITY, 0.0);
+            fail("Expecting IllegalArgumentException");
+        } catch (final IllegalArgumentException ex) {
+            assertEquals("The value Infinity is not less than or equal to 0.0", ex.getMessage());
+        }
+        try {
+            Validate.lessThanOrEqual(Double.NaN, 0.0);
+            fail("Expecting IllegalArgumentException");
+        } catch (final IllegalArgumentException ex) {
+            assertEquals("The value NaN is not less than or equal to 0.0", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void testLessThanOrEqualDouble2() {
+        Validate.lessThanOrEqual(-1.0, 0.0, "MSG");
+        Validate.lessThanOrEqual(Double.NEGATIVE_INFINITY, 0.0, "MSG");
+        Validate.lessThanOrEqual(0.0, 0.0, "MSG");
+        Validate.lessThanOrEqual(0.0, Double.NaN, "MSG");
+
+        try {
+            Validate.lessThanOrEqual(1.0, 0.0, "MSG");
+            fail("Expecting IllegalArgumentException");
+        } catch (final IllegalArgumentException ex) {
+            assertEquals("MSG", ex.getMessage());
+        }
+        try {
+            Validate.lessThanOrEqual(Double.POSITIVE_INFINITY, 0.0, "MSG");
+            fail("Expecting IllegalArgumentException");
+        } catch (final IllegalArgumentException ex) {
+            assertEquals("MSG", ex.getMessage());
+        }
+        try {
+            Validate.lessThanOrEqual(Double.NaN, 0.0, "MSG");
+            fail("Expecting IllegalArgumentException");
+        } catch (final IllegalArgumentException ex) {
+            assertEquals("MSG", ex.getMessage());
+        }
+    }
+
+    //-----------------------------------------------------------------------
+    //-----------------------------------------------------------------------
+
+    @Test
+    public void testNotEqual1() {
+        Validate.notEqual("b", "a");
+        try {
+            Validate.notEqual("a", "a");
+            fail("Expecting IllegalArgumentException");
+        } catch (final IllegalArgumentException ex) {
+            assertEquals("The value a is equal to a", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void testNotEqual2() {
+        Validate.notEqual("b", "a", "MSG");
+        try {
+            Validate.notEqual("a", "a", "MSG");
+            fail("Expecting IllegalArgumentException");
+        } catch (final IllegalArgumentException ex) {
+            assertEquals("MSG", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void testDifferentLong1() {
+        Validate.notEqual(1, 0);
+        try {
+            Validate.notEqual(0, 0);
+            fail("Expecting IllegalArgumentException");
+        } catch (final IllegalArgumentException ex) {
+            assertEquals("The value 0 is equal to 0", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void testDifferentLong2() {
+        Validate.notEqual(1, 0, "MSG");
+        try {
+            Validate.notEqual(0, 0, "MSG");
+            fail("Expecting IllegalArgumentException");
+        } catch (final IllegalArgumentException ex) {
+            assertEquals("MSG", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void testDifferentDouble1() {
+        Validate.notEqual(1.0, 0.0);
+        Validate.notEqual(Double.NaN, 0.0);
+        Validate.notEqual(1.0, Double.NaN);
+        Validate.notEqual(Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY);
+        try {
+            Validate.notEqual(0, 0);
+            fail("Expecting IllegalArgumentException");
+        } catch (final IllegalArgumentException ex) {
+            assertEquals("The value 0 is equal to 0", ex.getMessage());
+        }
+        try {
+            Validate.notEqual(Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY);
+            fail("Expecting IllegalArgumentException");
+        } catch (final IllegalArgumentException ex) {
+            assertEquals("The value Infinity is equal to Infinity", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void testDifferentDouble2() {
+        Validate.notEqual(1.0, 0.0, "MSG");
+        Validate.notEqual(Double.NaN, 0.0, "MSG");
+        Validate.notEqual(1.0, Double.NaN, "MSG");
+        Validate.notEqual(Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, "MSG");
+        try {
+            Validate.notEqual(0, 0, "MSG");
+            fail("Expecting IllegalArgumentException");
+        } catch (final IllegalArgumentException ex) {
+            assertEquals("MSG", ex.getMessage());
+        }
+        try {
+            Validate.notEqual(Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY, "MSG");
+            fail("Expecting IllegalArgumentException");
+        } catch (final IllegalArgumentException ex) {
+            assertEquals("MSG", ex.getMessage());
+        }
+    }
+
+    //-----------------------------------------------------------------------
+    //-----------------------------------------------------------------------
+
+    @Test
     public void testInclusiveBetween()
     {
         Validate.inclusiveBetween("a", "c", "b");


### PR DESCRIPTION
…h others to Validate

It's not a completely satisfying solution, because double `compareTo` is not 100% compatible with the comparison performed by the Java language numerical comparison operators: https://www.tutorialspoint.com/java/lang/double_compareto.htm 

So `Double.NaN` and `0.0d`/`-0.0d` for these new methods would be different than the handling for the existing methods of this class with primitive double parameters.
