### PR TITLE
LANG-1274: StrSubstitutor should state its thread safety

### DIFF
--- a/src/main/java/org/apache/commons/lang3/text/StrSubstitutor.java
+++ b/src/main/java/org/apache/commons/lang3/text/StrSubstitutor.java
@@ -118,6 +118,7 @@ import org.apache.commons.lang3.StringUtils;
  * names, but it has to be enabled explicitly by setting the
  * {@link #setEnableSubstitutionInVariables(boolean) enableSubstitutionInVariables}
  * property to <b>true</b>.
+ * <p>This class is <b>not</b> thread safe.</p>
  *
  * @since 2.2
  */


### PR DESCRIPTION
Add paragraph to class javadoc stating that StrSubstitutor is not thread safe.