### PR TITLE
Fix non-critical typos in comments and JavaDoc

### DIFF
--- a/src/main/java/org/apache/commons/lang3/Conversion.java
+++ b/src/main/java/org/apache/commons/lang3/Conversion.java
@@ -578,7 +578,7 @@ public class Conversion {
             return dstInit;
         }
         if ((nInts - 1) * 32 + dstPos >= 64) {
-            throw new IllegalArgumentException("(nInts-1)*32+dstPos is greather or equal to than 64");
+            throw new IllegalArgumentException("(nInts-1)*32+dstPos is greater or equal to than 64");
         }
         long out = dstInit;
         for (int i = 0; i < nInts; i++) {
@@ -613,7 +613,7 @@ public class Conversion {
             return dstInit;
         }
         if ((nShorts - 1) * 16 + dstPos >= 64) {
-            throw new IllegalArgumentException("(nShorts-1)*16+dstPos is greather or equal to than 64");
+            throw new IllegalArgumentException("(nShorts-1)*16+dstPos is greater or equal to than 64");
         }
         long out = dstInit;
         for (int i = 0; i < nShorts; i++) {
@@ -648,7 +648,7 @@ public class Conversion {
             return dstInit;
         }
         if ((nShorts - 1) * 16 + dstPos >= 32) {
-            throw new IllegalArgumentException("(nShorts-1)*16+dstPos is greather or equal to than 32");
+            throw new IllegalArgumentException("(nShorts-1)*16+dstPos is greater or equal to than 32");
         }
         int out = dstInit;
         for (int i = 0; i < nShorts; i++) {
@@ -683,7 +683,7 @@ public class Conversion {
             return dstInit;
         }
         if ((nBytes - 1) * 8 + dstPos >= 64) {
-            throw new IllegalArgumentException("(nBytes-1)*8+dstPos is greather or equal to than 64");
+            throw new IllegalArgumentException("(nBytes-1)*8+dstPos is greater or equal to than 64");
         }
         long out = dstInit;
         for (int i = 0; i < nBytes; i++) {
@@ -718,7 +718,7 @@ public class Conversion {
             return dstInit;
         }
         if ((nBytes - 1) * 8 + dstPos >= 32) {
-            throw new IllegalArgumentException("(nBytes-1)*8+dstPos is greather or equal to than 32");
+            throw new IllegalArgumentException("(nBytes-1)*8+dstPos is greater or equal to than 32");
         }
         int out = dstInit;
         for (int i = 0; i < nBytes; i++) {
@@ -753,7 +753,7 @@ public class Conversion {
             return dstInit;
         }
         if ((nBytes - 1) * 8 + dstPos >= 16) {
-            throw new IllegalArgumentException("(nBytes-1)*8+dstPos is greather or equal to than 16");
+            throw new IllegalArgumentException("(nBytes-1)*8+dstPos is greater or equal to than 16");
         }
         short out = dstInit;
         for (int i = 0; i < nBytes; i++) {
@@ -786,7 +786,7 @@ public class Conversion {
             return dstInit;
         }
         if ((nHex - 1) * 4 + dstPos >= 64) {
-            throw new IllegalArgumentException("(nHexs-1)*4+dstPos is greather or equal to than 64");
+            throw new IllegalArgumentException("(nHexs-1)*4+dstPos is greater or equal to than 64");
         }
         long out = dstInit;
         for (int i = 0; i < nHex; i++) {
@@ -818,7 +818,7 @@ public class Conversion {
             return dstInit;
         }
         if ((nHex - 1) * 4 + dstPos >= 32) {
-            throw new IllegalArgumentException("(nHexs-1)*4+dstPos is greather or equal to than 32");
+            throw new IllegalArgumentException("(nHexs-1)*4+dstPos is greater or equal to than 32");
         }
         int out = dstInit;
         for (int i = 0; i < nHex; i++) {
@@ -851,7 +851,7 @@ public class Conversion {
             return dstInit;
         }
         if ((nHex - 1) * 4 + dstPos >= 16) {
-            throw new IllegalArgumentException("(nHexs-1)*4+dstPos is greather or equal to than 16");
+            throw new IllegalArgumentException("(nHexs-1)*4+dstPos is greater or equal to than 16");
         }
         short out = dstInit;
         for (int i = 0; i < nHex; i++) {
@@ -884,7 +884,7 @@ public class Conversion {
             return dstInit;
         }
         if ((nHex - 1) * 4 + dstPos >= 8) {
-            throw new IllegalArgumentException("(nHexs-1)*4+dstPos is greather or equal to than 8");
+            throw new IllegalArgumentException("(nHexs-1)*4+dstPos is greater or equal to than 8");
         }
         byte out = dstInit;
         for (int i = 0; i < nHex; i++) {
@@ -919,7 +919,7 @@ public class Conversion {
             return dstInit;
         }
         if (nBools - 1 + dstPos >= 64) {
-            throw new IllegalArgumentException("nBools-1+dstPos is greather or equal to than 64");
+            throw new IllegalArgumentException("nBools-1+dstPos is greater or equal to than 64");
         }
         long out = dstInit;
         for (int i = 0; i < nBools; i++) {
@@ -954,7 +954,7 @@ public class Conversion {
             return dstInit;
         }
         if (nBools - 1 + dstPos >= 32) {
-            throw new IllegalArgumentException("nBools-1+dstPos is greather or equal to than 32");
+            throw new IllegalArgumentException("nBools-1+dstPos is greater or equal to than 32");
         }
         int out = dstInit;
         for (int i = 0; i < nBools; i++) {
@@ -989,7 +989,7 @@ public class Conversion {
             return dstInit;
         }
         if (nBools - 1 + dstPos >= 16) {
-            throw new IllegalArgumentException("nBools-1+dstPos is greather or equal to than 16");
+            throw new IllegalArgumentException("nBools-1+dstPos is greater or equal to than 16");
         }
         short out = dstInit;
         for (int i = 0; i < nBools; i++) {
@@ -1024,7 +1024,7 @@ public class Conversion {
             return dstInit;
         }
         if (nBools - 1 + dstPos >= 8) {
-            throw new IllegalArgumentException("nBools-1+dstPos is greather or equal to than 8");
+            throw new IllegalArgumentException("nBools-1+dstPos is greater or equal to than 8");
         }
         byte out = dstInit;
         for (int i = 0; i < nBools; i++) {
@@ -1059,7 +1059,7 @@ public class Conversion {
             return dst;
         }
         if ((nInts - 1) * 32 + srcPos >= 64) {
-            throw new IllegalArgumentException("(nInts-1)*32+srcPos is greather or equal to than 64");
+            throw new IllegalArgumentException("(nInts-1)*32+srcPos is greater or equal to than 64");
         }
         for (int i = 0; i < nInts; i++) {
             final int shift = i * 32 + srcPos;
@@ -1091,7 +1091,7 @@ public class Conversion {
             return dst;
         }
         if ((nShorts - 1) * 16 + srcPos >= 64) {
-            throw new IllegalArgumentException("(nShorts-1)*16+srcPos is greather or equal to than 64");
+            throw new IllegalArgumentException("(nShorts-1)*16+srcPos is greater or equal to than 64");
         }
         for (int i = 0; i < nShorts; i++) {
             final int shift = i * 16 + srcPos;
@@ -1123,7 +1123,7 @@ public class Conversion {
             return dst;
         }
         if ((nShorts - 1) * 16 + srcPos >= 32) {
-            throw new IllegalArgumentException("(nShorts-1)*16+srcPos is greather or equal to than 32");
+            throw new IllegalArgumentException("(nShorts-1)*16+srcPos is greater or equal to than 32");
         }
         for (int i = 0; i < nShorts; i++) {
             final int shift = i * 16 + srcPos;
@@ -1155,7 +1155,7 @@ public class Conversion {
             return dst;
         }
         if ((nBytes - 1) * 8 + srcPos >= 64) {
-            throw new IllegalArgumentException("(nBytes-1)*8+srcPos is greather or equal to than 64");
+            throw new IllegalArgumentException("(nBytes-1)*8+srcPos is greater or equal to than 64");
         }
         for (int i = 0; i < nBytes; i++) {
             final int shift = i * 8 + srcPos;
@@ -1187,7 +1187,7 @@ public class Conversion {
             return dst;
         }
         if ((nBytes - 1) * 8 + srcPos >= 32) {
-            throw new IllegalArgumentException("(nBytes-1)*8+srcPos is greather or equal to than 32");
+            throw new IllegalArgumentException("(nBytes-1)*8+srcPos is greater or equal to than 32");
         }
         for (int i = 0; i < nBytes; i++) {
             final int shift = i * 8 + srcPos;
@@ -1219,7 +1219,7 @@ public class Conversion {
             return dst;
         }
         if ((nBytes - 1) * 8 + srcPos >= 16) {
-            throw new IllegalArgumentException("(nBytes-1)*8+srcPos is greather or equal to than 16");
+            throw new IllegalArgumentException("(nBytes-1)*8+srcPos is greater or equal to than 16");
         }
         for (int i = 0; i < nBytes; i++) {
             final int shift = i * 8 + srcPos;
@@ -1250,7 +1250,7 @@ public class Conversion {
             return dstInit;
         }
         if ((nHexs - 1) * 4 + srcPos >= 64) {
-            throw new IllegalArgumentException("(nHexs-1)*4+srcPos is greather or equal to than 64");
+            throw new IllegalArgumentException("(nHexs-1)*4+srcPos is greater or equal to than 64");
         }
         final StringBuilder sb = new StringBuilder(dstInit);
         int append = sb.length();
@@ -1289,7 +1289,7 @@ public class Conversion {
             return dstInit;
         }
         if ((nHexs - 1) * 4 + srcPos >= 32) {
-            throw new IllegalArgumentException("(nHexs-1)*4+srcPos is greather or equal to than 32");
+            throw new IllegalArgumentException("(nHexs-1)*4+srcPos is greater or equal to than 32");
         }
         final StringBuilder sb = new StringBuilder(dstInit);
         int append = sb.length();
@@ -1328,7 +1328,7 @@ public class Conversion {
             return dstInit;
         }
         if ((nHexs - 1) * 4 + srcPos >= 16) {
-            throw new IllegalArgumentException("(nHexs-1)*4+srcPos is greather or equal to than 16");
+            throw new IllegalArgumentException("(nHexs-1)*4+srcPos is greater or equal to than 16");
         }
         final StringBuilder sb = new StringBuilder(dstInit);
         int append = sb.length();
@@ -1367,7 +1367,7 @@ public class Conversion {
             return dstInit;
         }
         if ((nHexs - 1) * 4 + srcPos >= 8) {
-            throw new IllegalArgumentException("(nHexs-1)*4+srcPos is greather or equal to than 8");
+            throw new IllegalArgumentException("(nHexs-1)*4+srcPos is greater or equal to than 8");
         }
         final StringBuilder sb = new StringBuilder(dstInit);
         int append = sb.length();
@@ -1407,7 +1407,7 @@ public class Conversion {
             return dst;
         }
         if (nBools - 1 + srcPos >= 64) {
-            throw new IllegalArgumentException("nBools-1+srcPos is greather or equal to than 64");
+            throw new IllegalArgumentException("nBools-1+srcPos is greater or equal to than 64");
         }
         for (int i = 0; i < nBools; i++) {
             final int shift = i + srcPos;
@@ -1439,7 +1439,7 @@ public class Conversion {
             return dst;
         }
         if (nBools - 1 + srcPos >= 32) {
-            throw new IllegalArgumentException("nBools-1+srcPos is greather or equal to than 32");
+            throw new IllegalArgumentException("nBools-1+srcPos is greater or equal to than 32");
         }
         for (int i = 0; i < nBools; i++) {
             final int shift = i + srcPos;
@@ -1471,7 +1471,7 @@ public class Conversion {
             return dst;
         }
         if (nBools - 1 + srcPos >= 16) {
-            throw new IllegalArgumentException("nBools-1+srcPos is greather or equal to than 16");
+            throw new IllegalArgumentException("nBools-1+srcPos is greater or equal to than 16");
         }
         assert (nBools - 1) < 16 - srcPos;
         for (int i = 0; i < nBools; i++) {
@@ -1504,7 +1504,7 @@ public class Conversion {
             return dst;
         }
         if (nBools - 1 + srcPos >= 8) {
-            throw new IllegalArgumentException("nBools-1+srcPos is greather or equal to than 8");
+            throw new IllegalArgumentException("nBools-1+srcPos is greater or equal to than 8");
         }
         for (int i = 0; i < nBools; i++) {
             final int shift = i + srcPos;
@@ -1534,7 +1534,7 @@ public class Conversion {
             return dst;
         }
         if (nBytes > 16) {
-            throw new IllegalArgumentException("nBytes is greather than 16");
+            throw new IllegalArgumentException("nBytes is greater than 16");
         }
         longToByteArray(src.getMostSignificantBits(), 0, dst, dstPos, nBytes > 8 ? 8 : nBytes);
         if (nBytes >= 8) {

--- a/src/main/java/org/apache/commons/lang3/SerializationUtils.java
+++ b/src/main/java/org/apache/commons/lang3/SerializationUtils.java
@@ -107,7 +107,7 @@ public class SerializationUtils {
      *           the type of the object involved
      * @param msg
      *            the object to roundtrip
-     * @return the serialized and deseralized object
+     * @return the serialized and deserialized object
      * @since 3.3
      */
     @SuppressWarnings("unchecked") // OK, because we serialized a type `T`

--- a/src/main/java/org/apache/commons/lang3/concurrent/ConcurrentRuntimeException.java
+++ b/src/main/java/org/apache/commons/lang3/concurrent/ConcurrentRuntimeException.java
@@ -22,7 +22,7 @@ package org.apache.commons.lang3.concurrent;
  * accessing data of background tasks.
  * </p>
  * <p>
- * This class is an analogon of the {@link ConcurrentException} exception class.
+ * This class is an analogue of the {@link ConcurrentException} exception class.
  * However, it is a runtime exception and thus does not need explicit catch
  * clauses. Some methods of {@link ConcurrentUtils} throw {@code
  * ConcurrentRuntimeException} exceptions rather than

--- a/src/main/java/org/apache/commons/lang3/concurrent/package-info.java
+++ b/src/main/java/org/apache/commons/lang3/concurrent/package-info.java
@@ -191,7 +191,7 @@
  * </pre>
  *
  * <p> Related to <code>BackgroundInitializer</code> is the {@link org.apache.commons.lang3.concurrent.MultiBackgroundInitializer} class.
- * As the name implies, this class can handle multiplie initializations in parallel.
+ * As the name implies, this class can handle multiple initializations in parallel.
  * The basic usage scenario is that a <code>MultiBackgroundInitializer</code> instance is created.
  * Then an arbitrary number of <code>BackgroundInitializer</code> objects is added using the {@link org.apache.commons.lang3.concurrent.MultiBackgroundInitializer#addInitializer(String, BackgroundInitializer)} method.
  * When adding an initializer a string has to be provided which is later used to obtain the result for this initializer.

--- a/src/main/java/org/apache/commons/lang3/exception/ExceptionUtils.java
+++ b/src/main/java/org/apache/commons/lang3/exception/ExceptionUtils.java
@@ -735,7 +735,7 @@ public class ExceptionUtils {
      * code through a method re-declaring the desired checked exception, or
      * catch Exception and use the instanceof operator. Either of these
      * techniques are required when interacting with non-java jvm code such as
-     * Jyton, Scala, or Groovy, since these languages do not consider any
+     * Jython, Scala, or Groovy, since these languages do not consider any
      * exceptions as checked.
      *
      * @param throwable

--- a/src/main/java/org/apache/commons/lang3/text/StrSubstitutor.java
+++ b/src/main/java/org/apache/commons/lang3/text/StrSubstitutor.java
@@ -187,7 +187,7 @@ public class StrSubstitutor {
 
     /**
      * Replaces all the occurrences of variables in the given source object with
-     * their matching values from the map. This method allows to specifiy a
+     * their matching values from the map. This method allows to specify a
      * custom variable prefix and suffix
      *
      * @param <V> the type of the values in the map

--- a/src/main/java/org/apache/commons/lang3/text/translate/NumericEntityUnescaper.java
+++ b/src/main/java/org/apache/commons/lang3/text/translate/NumericEntityUnescaper.java
@@ -124,9 +124,9 @@ public class NumericEntityUnescaper extends CharSequenceTranslator {
             }
 
             if(entityValue > 0xFFFF) {
-                final char[] chrs = Character.toChars(entityValue);
-                out.write(chrs[0]);
-                out.write(chrs[1]);
+                final char[] chars = Character.toChars(entityValue);
+                out.write(chars[0]);
+                out.write(chars[1]);
             } else {
                 out.write(entityValue);
             }

--- a/src/test/java/org/apache/commons/lang3/CharUtilsPerfRun.java
+++ b/src/test/java/org/apache/commons/lang3/CharUtilsPerfRun.java
@@ -29,7 +29,7 @@ Now: Thu Mar 18 14:29:48 PST 2004
 Sun Microsystems Inc. Java(TM) 2 Runtime Environment, Standard Edition 1.3.1_10-b03
 Sun Microsystems Inc. Java HotSpot(TM) Client VM 1.3.1_10-b03
 Windows XP 5.1 x86 pentium i486 i386
-Do nohting: 0 milliseconds.
+Do nothing: 0 milliseconds.
 run_CharUtils_isAsciiNumeric: 4,545 milliseconds.
 run_inlined_CharUtils_isAsciiNumeric: 3,417 milliseconds.
 run_inlined_CharUtils_isAsciiNumeric: 85,679 milliseconds.
@@ -39,7 +39,7 @@ Now: Thu Mar 18 14:24:51 PST 2004
 Sun Microsystems Inc. Java(TM) 2 Runtime Environment, Standard Edition 1.4.2_04-b05
 Sun Microsystems Inc. Java HotSpot(TM) Client VM 1.4.2_04-b05
 Windows XP 5.1 x86 pentium i486 i386
-Do nohting: 0 milliseconds.
+Do nothing: 0 milliseconds.
 run_CharUtils_isAsciiNumeric: 2,578 milliseconds.
 run_inlined_CharUtils_isAsciiNumeric: 2,477 milliseconds.
 run_inlined_CharUtils_isAsciiNumeric: 114,429 milliseconds.
@@ -48,7 +48,7 @@ Now: Thu Mar 18 14:27:55 PST 2004
 Sun Microsystems Inc. Java(TM) 2 Runtime Environment, Standard Edition 1.4.2_04-b05
 Sun Microsystems Inc. Java HotSpot(TM) Server VM 1.4.2_04-b05
 Windows XP 5.1 x86 pentium i486 i386
-Do nohting: 0 milliseconds.
+Do nothing: 0 milliseconds.
 run_CharUtils_isAsciiNumeric: 630 milliseconds.
 run_inlined_CharUtils_isAsciiNumeric: 709 milliseconds.
 run_inlined_CharUtils_isAsciiNumeric: 84,420 milliseconds.
@@ -100,7 +100,7 @@ public class CharUtilsPerfRun {
         this.printSysInfo();
         long start;
         start = System.currentTimeMillis();
-        this.printlnTotal("Do nohting", start);
+        this.printlnTotal("Do nothing", start);
         //System.out.println("Warming up...");
         run_CharUtils_isAsciiNumeric(WARM_UP);
         //System.out.println("Measuring...");

--- a/src/test/java/org/apache/commons/lang3/LocaleUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/LocaleUtilsTest.java
@@ -131,7 +131,7 @@ public class LocaleUtilsTest  {
         assertValidToLocale("fr");
         assertValidToLocale("de");
         assertValidToLocale("zh");
-        // Valid format but lang doesnt exist, should make instance anyway
+        // Valid format but lang doesn't exist, should make instance anyway
         assertValidToLocale("qq");
         // LANG-941: JDK 8 introduced the empty locale as one of the default locales
         assertValidToLocale("");
@@ -170,7 +170,7 @@ public class LocaleUtilsTest  {
     @Test
     public void testToLocale_2Part() {
         assertValidToLocale("us_EN", "us", "EN");
-        //valid though doesnt exist
+        //valid though doesn't exist
         assertValidToLocale("us_ZH", "us", "ZH");
         
         try {
@@ -400,7 +400,7 @@ public class LocaleUtilsTest  {
         final List<Locale> list2 = LocaleUtils.languagesByCountry(country);
         assertNotNull(list);
         assertSame(list, list2);
-        //search through langauges
+        //search through languages
         for (final String language : languages) {
             final Iterator<Locale> iterator = list.iterator();
             boolean found = false;
@@ -417,7 +417,7 @@ public class LocaleUtilsTest  {
                 }
             }
             if (!found) {
-                fail("Cound not find language: " + language
+                fail("Could not find language: " + language
                         + " for country: " + country);
             }
         }
@@ -451,8 +451,8 @@ public class LocaleUtilsTest  {
         final List<Locale> list2 = LocaleUtils.countriesByLanguage(language);
         assertNotNull(list);
         assertSame(list, list2);
-        //search through langauges
-        for (final String countrie : countries) {
+        //search through languages
+        for (final String country : countries) {
             final Iterator<Locale> iterator = list.iterator();
             boolean found = false;
             // see if it was returned by the set
@@ -462,13 +462,13 @@ public class LocaleUtilsTest  {
                 assertTrue(locale.getVariant() == null
                         || locale.getVariant().isEmpty());
                 assertEquals(language, locale.getLanguage());
-                if (countrie.equals(locale.getCountry())) {
+                if (country.equals(locale.getCountry())) {
                     found = true;
                     break;
                 }
             }
             if (!found) {
-                fail("Cound not find language: " + countrie
+                fail("Could not find language: " + country
                         + " for country: " + language);
             }
         }
@@ -566,7 +566,7 @@ public class LocaleUtilsTest  {
                 }
                 if (suff >= 0) { // we have a suffix
                     try {
-                        LocaleUtils.toLocale(str); // shouuld cause IAE
+                        LocaleUtils.toLocale(str); // should cause IAE
                         System.out.println("Should not have parsed: " + str);
                         failures++;
                         continue; // try next Locale

--- a/src/test/java/org/apache/commons/lang3/ObjectUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/ObjectUtilsTest.java
@@ -339,7 +339,7 @@ public class ObjectUtilsTest {
         final Calendar calendar = Calendar.getInstance();
         final Date nonNullComparable1 = calendar.getTime();
         final Date nonNullComparable2 = calendar.getTime();
-        final String[] nullAray = null;
+        final String[] nullArray = null;
         
         calendar.set( Calendar.YEAR, calendar.get( Calendar.YEAR ) -1 );
         final Date minComparable = calendar.getTime();
@@ -347,7 +347,7 @@ public class ObjectUtilsTest {
         assertNotSame( nonNullComparable1, nonNullComparable2 );
         
         assertNull(ObjectUtils.max( (String) null ) );
-        assertNull(ObjectUtils.max( nullAray ) );
+        assertNull(ObjectUtils.max( nullArray ) );
         assertSame( nonNullComparable1, ObjectUtils.max( null, nonNullComparable1 ) );
         assertSame( nonNullComparable1, ObjectUtils.max( nonNullComparable1, null ) );
         assertSame( nonNullComparable1, ObjectUtils.max( null, nonNullComparable1, null ) );
@@ -365,7 +365,7 @@ public class ObjectUtilsTest {
         final Calendar calendar = Calendar.getInstance();
         final Date nonNullComparable1 = calendar.getTime();
         final Date nonNullComparable2 = calendar.getTime();
-        final String[] nullAray = null;
+        final String[] nullArray = null;
         
         calendar.set( Calendar.YEAR, calendar.get( Calendar.YEAR ) -1 );
         final Date minComparable = calendar.getTime();
@@ -373,7 +373,7 @@ public class ObjectUtilsTest {
         assertNotSame( nonNullComparable1, nonNullComparable2 );
         
         assertNull(ObjectUtils.min( (String) null ) );
-        assertNull(ObjectUtils.min( nullAray ) );
+        assertNull(ObjectUtils.min( nullArray ) );
         assertSame( nonNullComparable1, ObjectUtils.min( null, nonNullComparable1 ) );
         assertSame( nonNullComparable1, ObjectUtils.min( nonNullComparable1, null ) );
         assertSame( nonNullComparable1, ObjectUtils.min( null, nonNullComparable1, null ) );

--- a/src/test/java/org/apache/commons/lang3/SystemUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/SystemUtilsTest.java
@@ -59,7 +59,7 @@ public class SystemUtilsTest {
     }
 
     /**
-     * Assums no security manager exists.
+     * Assumes no security manager exists.
      */
     @Test
     public void testGetJavaHome() {
@@ -69,7 +69,7 @@ public class SystemUtilsTest {
     }
 
     /**
-     * Assums no security manager exists.
+     * Assumes no security manager exists.
      */
     @Test
     public void testGetJavaIoTmpDir() {
@@ -79,7 +79,7 @@ public class SystemUtilsTest {
     }
 
     /**
-     * Assums no security manager exists.
+     * Assumes no security manager exists.
      */
     @Test
     public void testGetUserDir() {
@@ -89,7 +89,7 @@ public class SystemUtilsTest {
     }
 
     /**
-     * Assums no security manager exists.
+     * Assumes no security manager exists.
      */
     @Test
     public void testGetUserHome() {

--- a/src/test/java/org/apache/commons/lang3/concurrent/ThresholdCircuitBreakerTest.java
+++ b/src/test/java/org/apache/commons/lang3/concurrent/ThresholdCircuitBreakerTest.java
@@ -51,7 +51,7 @@ public class ThresholdCircuitBreakerTest {
     public void testThresholdCircuitBreakingException() {
         final ThresholdCircuitBreaker circuit = new ThresholdCircuitBreaker(threshold);
         circuit.incrementAndCheckState(9L);
-        assertTrue("The circuit was spposed to be open after increment above the threshold", circuit.incrementAndCheckState(2L));
+        assertTrue("The circuit was supposed to be open after increment above the threshold", circuit.incrementAndCheckState(2L));
     }
 
     /**

--- a/src/test/java/org/apache/commons/lang3/exception/ExceptionUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/exception/ExceptionUtilsTest.java
@@ -367,7 +367,7 @@ public class ExceptionUtilsTest {
     public void testPrintRootCauseStackTrace_Throwable() throws Exception {
         ExceptionUtils.printRootCauseStackTrace(null);
         // could pipe system.err to a known stream, but not much point as
-        // internally this method calls stram method anyway
+        // internally this method calls stream method anyway
     }
     
     @Test

--- a/src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java
@@ -1399,7 +1399,7 @@ public class NumberUtilsTest {
 
     @Test
     public void testIsNumberLANG1252() {
-        //Check idiosyncries between java 1.6 and 1.7,1.8 redarding leading + signs
+        //Check idiosyncrasies between java 1.6 and 1.7,1.8 regarding leading + signs
         if (SystemUtils.IS_JAVA_1_6) {
             compareIsNumberWithCreateNumber("+2", false);
         } else {

--- a/src/test/java/org/apache/commons/lang3/text/StrLookupTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/StrLookupTest.java
@@ -40,7 +40,7 @@ public class StrLookupTest  {
     }
 
     @Test
-    public void testSystemProperiesLookup() {
+    public void testSystemPropertiesLookup() {
         assertEquals(System.getProperty("os.name"), StrLookup.systemPropertiesLookup().lookup("os.name"));
         assertEquals(null, StrLookup.systemPropertiesLookup().lookup(""));
         assertEquals(null, StrLookup.systemPropertiesLookup().lookup("other"));

--- a/src/test/java/org/apache/commons/lang3/text/StrSubstitutorTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/StrSubstitutorTest.java
@@ -318,7 +318,7 @@ public class StrSubstitutorTest {
         assertEquals(
                 "Wrong result (3)",
                 "The fox jumps over the lazy dog.",
-                sub.replace("The ${unknown.animal.${unknown.species:-1}:-fox} jumps over the ${unknow.target:-lazy dog}."));
+                sub.replace("The ${unknown.animal.${unknown.species:-1}:-fox} jumps over the ${unknown.target:-lazy dog}."));
     }
 
     /**

--- a/src/test/java/org/apache/commons/lang3/time/DateFormatUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/DateFormatUtilsTest.java
@@ -203,7 +203,7 @@ public class DateFormatUtilsTest {
         // test JDK
         java.text.SimpleDateFormat sdf = new java.text.SimpleDateFormat(pattern, locale);
         sdf.setTimeZone(timeZone);
-// There's nothing we can do if the JDK fails, so just going to pring a warning in this case
+// There's nothing we can do if the JDK fails, so just going to print a warning in this case
 //        assertEquals(expected, sdf.format( date ) );
         if( ! expected.equals( sdf.format( date ) ) ) {
             System.out.println("WARNING: JDK test failed - testLang312()");

--- a/src/test/java/org/apache/commons/lang3/time/FastDateParserSDFTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/FastDateParserSDFTest.java
@@ -223,7 +223,7 @@ public class FastDateParserSDFTest {
             assertEquals(locale.toString()+" "+formattedDate +"\n", expectedTime, actualTime);
         } else {
             assertNotEquals("Test data error: expected FDF parse to fail, but got " + actualTime, -1, fdferrorIndex);
-            assertTrue("FDF error index ("+ fdferrorIndex + ") should approxiamate SDF index (" + sdferrorIndex + ")",
+            assertTrue("FDF error index ("+ fdferrorIndex + ") should approximate SDF index (" + sdferrorIndex + ")",
                     sdferrorIndex - fdferrorIndex <= 4);
         }        
     }


### PR DESCRIPTION
fix typos in several local variables.

Please, look closely at changes in those files:
- org/apache/commons/lang3/text/StrSubstitutorTest.java ([Anchor](https://github.com/apache/commons-lang/compare/master...Abrasha:fix/non-critical-typos?expand=1#diff-8b41a3f8f69fbfc88251e619307f01ff))
- org/apache/commons/lang3/exception/ExceptionUtils.java ([Anchor](https://github.com/apache/commons-lang/compare/master...Abrasha:fix/non-critical-typos?expand=1#diff-40d839797a9b13ac5aa8d881e7e9f2d6))