### PR TITLE
Fix/different annotations test

### DIFF
--- a/src/test/java/org/apache/commons/lang3/AnnotationUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/AnnotationUtilsTest.java
@@ -350,7 +350,8 @@ public class AnnotationUtilsTest {
         NestAnnotation nest();
         NestAnnotation[] nests();
     }
-
+    
+    @Retention(RUNTIME)
     public @interface NestAnnotation {
         String string();
         String[] strings();


### PR DESCRIPTION
```
@Test
public void testAnnotationsOfDifferingTypes() {
    assertFalse(AnnotationUtils.equals(field1.getAnnotation(TestAnnotation.class), field4.getAnnotation(NestAnnotation.class)));
    assertFalse(AnnotationUtils.equals(field4.getAnnotation(NestAnnotation.class), field1.getAnnotation(TestAnnotation.class)));
}
```

This test is successful, but checks a different behaviour than expected.

`field4.getAnnotation(NestAnnotation.class)` is expected to return an annotation of type `NestAnnotation`, but actually it returns `null` because the Retention of annotation is set to default.

As a result, test did not cover quite important case.

See discussion: [#217](https://github.com/apache/commons-lang/pull/217)