### PR TITLE
ObjectUtilsTest: collapse empty catch blocks

### DIFF
--- a/src/test/java/org/apache/commons/lang3/ObjectUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/ObjectUtilsTest.java
@@ -301,15 +301,13 @@ public class ObjectUtilsTest {
         try {
             ObjectUtils.identityToString((Appendable)null, "tmp");
             fail("NullPointerException expected");
-        } catch(final NullPointerException npe) {
-        } catch (final IOException ex) {
+        } catch(final NullPointerException | IOException npe) {
         }
-        
+
         try {
             ObjectUtils.identityToString((Appendable)(new StringBuilder()), null);
             fail("NullPointerException expected");
-        } catch(final NullPointerException npe) {
-        } catch (final IOException ex) {
+        } catch(final NullPointerException | IOException npe) {
         }
     }
 


### PR DESCRIPTION
This patch employs Java 7's syntax to catch multiple exceptions in
the same block with the `|` operator to make `ObjectUtilsTest`'s code
cleaner and easier to read.