### PR TITLE
Remove redundant casts

### DIFF
--- a/src/main/java/org/apache/commons/lang3/exception/ExceptionUtils.java
+++ b/src/main/java/org/apache/commons/lang3/exception/ExceptionUtils.java
@@ -183,7 +183,7 @@ public class ExceptionUtils {
      */
     public static Throwable getRootCause(final Throwable throwable) {
         final List<Throwable> list = getThrowableList(throwable);
-        return list.size() < 2 ? null : (Throwable)list.get(list.size() - 1);
+        return list.size() < 2 ? null : list.get(list.size() - 1);
     }
 
     /**

--- a/src/main/java/org/apache/commons/lang3/reflect/TypeUtils.java
+++ b/src/main/java/org/apache/commons/lang3/reflect/TypeUtils.java
@@ -1687,7 +1687,7 @@ public class TypeUtils {
     public static String toLongString(final TypeVariable<?> var) {
         Validate.notNull(var, "var is null");
         final StringBuilder buf = new StringBuilder();
-        final GenericDeclaration d = ((TypeVariable<?>) var).getGenericDeclaration();
+        final GenericDeclaration d = var.getGenericDeclaration();
         if (d instanceof Class<?>) {
             Class<?> c = (Class<?>) d;
             while (true) {

--- a/src/main/java/org/apache/commons/lang3/text/StrSubstitutor.java
+++ b/src/main/java/org/apache/commons/lang3/text/StrSubstitutor.java
@@ -241,7 +241,7 @@ public class StrSubstitutor {
      * and the escaping character.
      */
     public StrSubstitutor() {
-        this((StrLookup<?>) null, DEFAULT_PREFIX, DEFAULT_SUFFIX, DEFAULT_ESCAPE);
+        this(null, DEFAULT_PREFIX, DEFAULT_SUFFIX, DEFAULT_ESCAPE);
     }
 
     /**

--- a/src/test/java/org/apache/commons/lang3/ArrayUtilsAddTest.java
+++ b/src/test/java/org/apache/commons/lang3/ArrayUtilsAddTest.java
@@ -51,10 +51,10 @@ public class ArrayUtilsAddTest {
     @Test
     public void testAddObjectArrayBoolean() {
         boolean[] newArray;
-        newArray = ArrayUtils.add((boolean[])null, false);
+        newArray = ArrayUtils.add(null, false);
         assertTrue(Arrays.equals(new boolean[]{false}, newArray));
         assertEquals(Boolean.TYPE, newArray.getClass().getComponentType());
-        newArray = ArrayUtils.add((boolean[])null, true);
+        newArray = ArrayUtils.add(null, true);
         assertTrue(Arrays.equals(new boolean[]{true}, newArray));
         assertEquals(Boolean.TYPE, newArray.getClass().getComponentType());
         final boolean[] array1 = new boolean[]{true, false, true};
@@ -249,7 +249,7 @@ public class ArrayUtilsAddTest {
 
     @Test
     public void testAddObjectArrayToObjectArray() {
-        assertNull(ArrayUtils.addAll((Object[]) null, (Object[]) null));
+        assertNull(ArrayUtils.addAll(null, (Object[]) null));
         Object[] newArray;
         final String[] stringArray1 = new String[]{"a", "b", "c"};
         final String[] stringArray2 = new String[]{"1", "2", "3"};
@@ -586,7 +586,7 @@ public class ArrayUtilsAddTest {
         double[] doubleArray = ArrayUtils.add( new double[] { 1.1 }, 0, 2.2);
         assertTrue( Arrays.equals( new double[] { 2.2, 1.1 }, doubleArray ) );
         try {
-          doubleArray = ArrayUtils.add( (double[]) null, -1, 2.2);
+          doubleArray = ArrayUtils.add(null, -1, 2.2);
         } catch(final IndexOutOfBoundsException e) {
             assertEquals("Index: -1, Length: 0", e.getMessage());
         }

--- a/src/test/java/org/apache/commons/lang3/ArrayUtilsInsertTest.java
+++ b/src/test/java/org/apache/commons/lang3/ArrayUtilsInsertTest.java
@@ -323,7 +323,7 @@ public class ArrayUtilsInsertTest {
         
         assertNull(ArrayUtils.insert(42, null, array));    
         assertArrayEquals(new String[0], ArrayUtils.insert(0, new String[0], (String[]) null));
-        assertNull(ArrayUtils.insert(42, (String[]) null, (String[]) null));
+        assertNull(ArrayUtils.insert(42, null, (String[]) null));
         
         try {
             ArrayUtils.insert(-1, array, array);

--- a/src/test/java/org/apache/commons/lang3/ArrayUtilsRemoveTest.java
+++ b/src/test/java/org/apache/commons/lang3/ArrayUtilsRemoveTest.java
@@ -311,7 +311,7 @@ public class ArrayUtilsRemoveTest {
     @Test
     public void testRemoveElementObjectArray() {
         Object[] array;
-        array = ArrayUtils.removeElement((Object[]) null, "a");
+        array = ArrayUtils.removeElement(null, "a");
         assertNull(array);
         array = ArrayUtils.removeElement(ArrayUtils.EMPTY_OBJECT_ARRAY, "a");
         assertTrue(Arrays.equals(ArrayUtils.EMPTY_OBJECT_ARRAY, array));
@@ -330,7 +330,7 @@ public class ArrayUtilsRemoveTest {
     @Test
     public void testRemoveElementBooleanArray() {
         boolean[] array;
-        array = ArrayUtils.removeElement((boolean[]) null, true);
+        array = ArrayUtils.removeElement(null, true);
         assertNull(array);
         array = ArrayUtils.removeElement(ArrayUtils.EMPTY_BOOLEAN_ARRAY, true);
         assertTrue(Arrays.equals(ArrayUtils.EMPTY_BOOLEAN_ARRAY, array));
@@ -388,7 +388,7 @@ public class ArrayUtilsRemoveTest {
     @SuppressWarnings("cast")
     public void testRemoveElementDoubleArray() {
         double[] array;
-        array = ArrayUtils.removeElement((double[]) null, (double) 1);
+        array = ArrayUtils.removeElement(null, (double) 1);
         assertNull(array);
         array = ArrayUtils.removeElement(ArrayUtils.EMPTY_DOUBLE_ARRAY, (double) 1);
         assertTrue(Arrays.equals(ArrayUtils.EMPTY_DOUBLE_ARRAY, array));

--- a/src/test/java/org/apache/commons/lang3/ArrayUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/ArrayUtilsTest.java
@@ -3842,10 +3842,10 @@ public class ArrayUtilsTest  {
         array = new double[0];
         assertEquals(-1, ArrayUtils.indexOf(array, (double) 0, (double) 0));
         array = new double[] { 0, 1, 2, 3, 0 };
-        assertEquals(0, ArrayUtils.indexOf(array, (double) 0, (double) 0.3));
-        assertEquals(2, ArrayUtils.indexOf(array, (double) 2.2, (double) 0.35));
-        assertEquals(3, ArrayUtils.indexOf(array, (double) 4.15, (double) 2.0));
-        assertEquals(1, ArrayUtils.indexOf(array, (double) 1.00001324, (double) 0.0001));
+        assertEquals(0, ArrayUtils.indexOf(array, (double) 0, 0.3));
+        assertEquals(2, ArrayUtils.indexOf(array, 2.2, 0.35));
+        assertEquals(3, ArrayUtils.indexOf(array, 4.15, 2.0));
+        assertEquals(1, ArrayUtils.indexOf(array, 1.00001324, 0.0001));
     }
 
     @SuppressWarnings("cast")
@@ -3872,14 +3872,14 @@ public class ArrayUtilsTest  {
         array = new double[0];
         assertEquals(-1, ArrayUtils.indexOf(array, (double) 0, 2, (double) 0));
         array = new double[] { 0, 1, 2, 3, 0 };
-        assertEquals(-1, ArrayUtils.indexOf(array, (double) 0, 99, (double) 0.3));
-        assertEquals(0, ArrayUtils.indexOf(array, (double) 0, 0, (double) 0.3));
-        assertEquals(4, ArrayUtils.indexOf(array, (double) 0, 3, (double) 0.3));
-        assertEquals(2, ArrayUtils.indexOf(array, (double) 2.2, 0, (double) 0.35));
-        assertEquals(3, ArrayUtils.indexOf(array, (double) 4.15, 0, (double) 2.0));
-        assertEquals(1, ArrayUtils.indexOf(array, (double) 1.00001324, 0, (double) 0.0001));
-        assertEquals(3, ArrayUtils.indexOf(array, (double) 4.15, -1, (double) 2.0));
-        assertEquals(1, ArrayUtils.indexOf(array, (double) 1.00001324, -300, (double) 0.0001));
+        assertEquals(-1, ArrayUtils.indexOf(array, (double) 0, 99, 0.3));
+        assertEquals(0, ArrayUtils.indexOf(array, (double) 0, 0, 0.3));
+        assertEquals(4, ArrayUtils.indexOf(array, (double) 0, 3, 0.3));
+        assertEquals(2, ArrayUtils.indexOf(array, 2.2, 0, 0.35));
+        assertEquals(3, ArrayUtils.indexOf(array, 4.15, 0, 2.0));
+        assertEquals(1, ArrayUtils.indexOf(array, 1.00001324, 0, 0.0001));
+        assertEquals(3, ArrayUtils.indexOf(array, 4.15, -1, 2.0));
+        assertEquals(1, ArrayUtils.indexOf(array, 1.00001324, -300, 0.0001));
     }
 
     @SuppressWarnings("cast")
@@ -3905,10 +3905,10 @@ public class ArrayUtilsTest  {
         array = new double[0];
         assertEquals(-1, ArrayUtils.lastIndexOf(array, (double) 0, (double) 0));
         array = new double[] { 0, 1, 2, 3, 0 };
-        assertEquals(4, ArrayUtils.lastIndexOf(array, (double) 0, (double) 0.3));
-        assertEquals(2, ArrayUtils.lastIndexOf(array, (double) 2.2, (double) 0.35));
-        assertEquals(3, ArrayUtils.lastIndexOf(array, (double) 4.15, (double) 2.0));
-        assertEquals(1, ArrayUtils.lastIndexOf(array, (double) 1.00001324, (double) 0.0001));
+        assertEquals(4, ArrayUtils.lastIndexOf(array, (double) 0, 0.3));
+        assertEquals(2, ArrayUtils.lastIndexOf(array, 2.2, 0.35));
+        assertEquals(3, ArrayUtils.lastIndexOf(array, 4.15, 2.0));
+        assertEquals(1, ArrayUtils.lastIndexOf(array, 1.00001324, 0.0001));
     }
 
     @SuppressWarnings("cast")
@@ -3938,12 +3938,12 @@ public class ArrayUtilsTest  {
         array = new double[] { (double) 3 };
         assertEquals(-1, ArrayUtils.lastIndexOf(array, (double) 1, 0, (double) 0));
         array = new double[] { 0, 1, 2, 3, 0 };
-        assertEquals(4, ArrayUtils.lastIndexOf(array, (double) 0, 99, (double) 0.3));
-        assertEquals(0, ArrayUtils.lastIndexOf(array, (double) 0, 3, (double) 0.3));
-        assertEquals(2, ArrayUtils.lastIndexOf(array, (double) 2.2, 3, (double) 0.35));
-        assertEquals(3, ArrayUtils.lastIndexOf(array, (double) 4.15, array.length, (double) 2.0));
-        assertEquals(1, ArrayUtils.lastIndexOf(array, (double) 1.00001324, array.length, (double) 0.0001));
-        assertEquals(-1, ArrayUtils.lastIndexOf(array, (double) 4.15, -200, (double) 2.0));
+        assertEquals(4, ArrayUtils.lastIndexOf(array, (double) 0, 99, 0.3));
+        assertEquals(0, ArrayUtils.lastIndexOf(array, (double) 0, 3, 0.3));
+        assertEquals(2, ArrayUtils.lastIndexOf(array, 2.2, 3, 0.35));
+        assertEquals(3, ArrayUtils.lastIndexOf(array, 4.15, array.length, 2.0));
+        assertEquals(1, ArrayUtils.lastIndexOf(array, 1.00001324, array.length, 0.0001));
+        assertEquals(-1, ArrayUtils.lastIndexOf(array, 4.15, -200, 2.0));
     }
 
     @SuppressWarnings("cast")
@@ -3965,10 +3965,10 @@ public class ArrayUtilsTest  {
         double[] array = null;
         assertFalse(ArrayUtils.contains(array, (double) 1, (double) 0));
         array = new double[] { 0, 1, 2, 3, 0 };
-        assertFalse(ArrayUtils.contains(array, (double) 4.0, (double) 0.33));
-        assertFalse(ArrayUtils.contains(array, (double) 2.5, (double) 0.49));
-        assertTrue(ArrayUtils.contains(array, (double) 2.5, (double) 0.50));
-        assertTrue(ArrayUtils.contains(array, (double) 2.5, (double) 0.51));
+        assertFalse(ArrayUtils.contains(array, 4.0, 0.33));
+        assertFalse(ArrayUtils.contains(array, 2.5, 0.49));
+        assertTrue(ArrayUtils.contains(array, 2.5, 0.50));
+        assertTrue(ArrayUtils.contains(array, 2.5, 0.51));
     }
     
     //-----------------------------------------------------------------------
@@ -4740,49 +4740,49 @@ public class ArrayUtilsTest  {
         
         final Object[] emptyObjectArray = new Object[0];
         final Object[] notEmptyObjectArray = new Object[] {"aValue"};
-        assertEquals(0, ArrayUtils.getLength((Object[]) null));
+        assertEquals(0, ArrayUtils.getLength(null));
         assertEquals(0, ArrayUtils.getLength(emptyObjectArray));
         assertEquals(1, ArrayUtils.getLength(notEmptyObjectArray));
  
         final int[] emptyIntArray = new int[] {};
         final int[] notEmptyIntArray = new int[] { 1 };
-        assertEquals(0, ArrayUtils.getLength((int[]) null));
+        assertEquals(0, ArrayUtils.getLength(null));
         assertEquals(0, ArrayUtils.getLength(emptyIntArray));
         assertEquals(1, ArrayUtils.getLength(notEmptyIntArray));
 
         final short[] emptyShortArray = new short[] {};
         final short[] notEmptyShortArray = new short[] { 1 };
-        assertEquals(0, ArrayUtils.getLength((short[]) null));
+        assertEquals(0, ArrayUtils.getLength(null));
         assertEquals(0, ArrayUtils.getLength(emptyShortArray));
         assertEquals(1, ArrayUtils.getLength(notEmptyShortArray));
 
         final char[] emptyCharArray = new char[] {};
         final char[] notEmptyCharArray = new char[] { 1 };
-        assertEquals(0, ArrayUtils.getLength((char[]) null));
+        assertEquals(0, ArrayUtils.getLength(null));
         assertEquals(0, ArrayUtils.getLength(emptyCharArray));
         assertEquals(1, ArrayUtils.getLength(notEmptyCharArray));
 
         final byte[] emptyByteArray = new byte[] {};
         final byte[] notEmptyByteArray = new byte[] { 1 };
-        assertEquals(0, ArrayUtils.getLength((byte[]) null));
+        assertEquals(0, ArrayUtils.getLength(null));
         assertEquals(0, ArrayUtils.getLength(emptyByteArray));
         assertEquals(1, ArrayUtils.getLength(notEmptyByteArray));
 
         final double[] emptyDoubleArray = new double[] {};
         final double[] notEmptyDoubleArray = new double[] { 1.0 };
-        assertEquals(0, ArrayUtils.getLength((double[]) null));
+        assertEquals(0, ArrayUtils.getLength(null));
         assertEquals(0, ArrayUtils.getLength(emptyDoubleArray));
         assertEquals(1, ArrayUtils.getLength(notEmptyDoubleArray));
 
         final float[] emptyFloatArray = new float[] {};
         final float[] notEmptyFloatArray = new float[] { 1.0F };
-        assertEquals(0, ArrayUtils.getLength((float[]) null));
+        assertEquals(0, ArrayUtils.getLength(null));
         assertEquals(0, ArrayUtils.getLength(emptyFloatArray));
         assertEquals(1, ArrayUtils.getLength(notEmptyFloatArray));
 
         final boolean[] emptyBooleanArray = new boolean[] {};
         final boolean[] notEmptyBooleanArray = new boolean[] { true };
-        assertEquals(0, ArrayUtils.getLength((boolean[]) null));
+        assertEquals(0, ArrayUtils.getLength(null));
         assertEquals(0, ArrayUtils.getLength(emptyBooleanArray));
         assertEquals(1, ArrayUtils.getLength(notEmptyBooleanArray));
         
@@ -4957,11 +4957,11 @@ public class ArrayUtilsTest  {
     @Test
     public void testCreatePrimitiveArray() {
         Assert.assertNull(ArrayUtils.toPrimitive((Object[])null));
-        Assert.assertArrayEquals(new int[]{}, (int[]) ArrayUtils.toPrimitive(new Integer[]{}));
-        Assert.assertArrayEquals(new short[]{2}, (short[]) ArrayUtils.toPrimitive(new Short[]{2}));
-        Assert.assertArrayEquals(new long[]{2, 3}, (long[]) ArrayUtils.toPrimitive(new Long[]{2L, 3L}));
-        Assert.assertArrayEquals(new float[]{3.14f}, (float[]) ArrayUtils.toPrimitive(new Float[]{3.14f}), 0.1f);
-        Assert.assertArrayEquals(new double[]{2.718}, (double[]) ArrayUtils.toPrimitive(new Double[]{2.718}), 0.1);
+        Assert.assertArrayEquals(new int[]{}, ArrayUtils.toPrimitive(new Integer[]{}));
+        Assert.assertArrayEquals(new short[]{2}, ArrayUtils.toPrimitive(new Short[]{2}));
+        Assert.assertArrayEquals(new long[]{2, 3}, ArrayUtils.toPrimitive(new Long[]{2L, 3L}));
+        Assert.assertArrayEquals(new float[]{3.14f}, ArrayUtils.toPrimitive(new Float[]{3.14f}), 0.1f);
+        Assert.assertArrayEquals(new double[]{2.718}, ArrayUtils.toPrimitive(new Double[]{2.718}), 0.1);
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/BooleanUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/BooleanUtilsTest.java
@@ -56,14 +56,14 @@ public class BooleanUtilsTest {
     public void test_isTrue_Boolean() {
         assertTrue(BooleanUtils.isTrue(Boolean.TRUE));
         assertFalse(BooleanUtils.isTrue(Boolean.FALSE));
-        assertFalse(BooleanUtils.isTrue((Boolean) null));
+        assertFalse(BooleanUtils.isTrue(null));
     }
 
     @Test
     public void test_isNotTrue_Boolean() {
         assertFalse(BooleanUtils.isNotTrue(Boolean.TRUE));
         assertTrue(BooleanUtils.isNotTrue(Boolean.FALSE));
-        assertTrue(BooleanUtils.isNotTrue((Boolean) null));
+        assertTrue(BooleanUtils.isNotTrue(null));
     }
 
     //-----------------------------------------------------------------------
@@ -71,14 +71,14 @@ public class BooleanUtilsTest {
     public void test_isFalse_Boolean() {
         assertFalse(BooleanUtils.isFalse(Boolean.TRUE));
         assertTrue(BooleanUtils.isFalse(Boolean.FALSE));
-        assertFalse(BooleanUtils.isFalse((Boolean) null));
+        assertFalse(BooleanUtils.isFalse(null));
     }
 
     @Test
     public void test_isNotFalse_Boolean() {
         assertTrue(BooleanUtils.isNotFalse(Boolean.TRUE));
         assertFalse(BooleanUtils.isNotFalse(Boolean.FALSE));
-        assertTrue(BooleanUtils.isNotFalse((Boolean) null));
+        assertTrue(BooleanUtils.isNotFalse(null));
     }
 
     //-----------------------------------------------------------------------
@@ -95,8 +95,8 @@ public class BooleanUtilsTest {
         assertTrue(BooleanUtils.toBooleanDefaultIfNull(Boolean.TRUE, false));
         assertFalse(BooleanUtils.toBooleanDefaultIfNull(Boolean.FALSE, true));
         assertFalse(BooleanUtils.toBooleanDefaultIfNull(Boolean.FALSE, false));
-        assertTrue(BooleanUtils.toBooleanDefaultIfNull((Boolean) null, true));
-        assertFalse(BooleanUtils.toBooleanDefaultIfNull((Boolean) null, false));
+        assertTrue(BooleanUtils.toBooleanDefaultIfNull(null, true));
+        assertFalse(BooleanUtils.toBooleanDefaultIfNull(null, false));
     }
 
     //-----------------------------------------------------------------------
@@ -140,8 +140,8 @@ public class BooleanUtilsTest {
         final Integer six = Integer.valueOf(6);
         final Integer seven = Integer.valueOf(7);
 
-        assertTrue(BooleanUtils.toBoolean((Integer) null, null, seven));
-        assertFalse(BooleanUtils.toBoolean((Integer) null, six, null));
+        assertTrue(BooleanUtils.toBoolean(null, null, seven));
+        assertFalse(BooleanUtils.toBoolean(null, six, null));
 
         assertTrue(BooleanUtils.toBoolean(Integer.valueOf(6), six, seven));
         assertFalse(BooleanUtils.toBoolean(Integer.valueOf(7), six, seven));
@@ -176,9 +176,9 @@ public class BooleanUtilsTest {
         final Integer seven = Integer.valueOf(7);
         final Integer eight = Integer.valueOf(8);
 
-        assertSame(Boolean.TRUE, BooleanUtils.toBooleanObject((Integer) null, null, seven, eight));
-        assertSame(Boolean.FALSE, BooleanUtils.toBooleanObject((Integer) null, six, null, eight));
-        assertSame(null, BooleanUtils.toBooleanObject((Integer) null, six, seven, null));
+        assertSame(Boolean.TRUE, BooleanUtils.toBooleanObject(null, null, seven, eight));
+        assertSame(Boolean.FALSE, BooleanUtils.toBooleanObject(null, six, null, eight));
+        assertSame(null, BooleanUtils.toBooleanObject(null, six, seven, null));
 
         assertEquals(Boolean.TRUE, BooleanUtils.toBooleanObject(Integer.valueOf(6), six, seven, eight));
         assertEquals(Boolean.FALSE, BooleanUtils.toBooleanObject(Integer.valueOf(7), six, seven, eight));
@@ -212,7 +212,7 @@ public class BooleanUtilsTest {
     public void test_toIntegerObject_Boolean() {
         assertEquals(Integer.valueOf(1), BooleanUtils.toIntegerObject(Boolean.TRUE));
         assertEquals(Integer.valueOf(0), BooleanUtils.toIntegerObject(Boolean.FALSE));
-        assertEquals(null, BooleanUtils.toIntegerObject((Boolean) null));
+        assertEquals(null, BooleanUtils.toIntegerObject(null));
     }
     
     //-----------------------------------------------------------------------
@@ -244,8 +244,8 @@ public class BooleanUtilsTest {
         final Integer eight = Integer.valueOf(8);
         assertEquals(six, BooleanUtils.toIntegerObject(Boolean.TRUE, six, seven, eight));
         assertEquals(seven, BooleanUtils.toIntegerObject(Boolean.FALSE, six, seven, eight));
-        assertEquals(eight, BooleanUtils.toIntegerObject((Boolean) null, six, seven, eight));
-        assertEquals(null, BooleanUtils.toIntegerObject((Boolean) null, six, seven, null));
+        assertEquals(eight, BooleanUtils.toIntegerObject(null, six, seven, eight));
+        assertEquals(null, BooleanUtils.toIntegerObject(null, six, seven, null));
     }
     
     //-----------------------------------------------------------------------
@@ -288,9 +288,9 @@ public class BooleanUtilsTest {
     
     @Test
     public void test_toBooleanObject_String_String_String_String() {
-        assertSame(Boolean.TRUE, BooleanUtils.toBooleanObject((String) null, null, "N", "U"));
-        assertSame(Boolean.FALSE, BooleanUtils.toBooleanObject((String) null, "Y", null, "U"));
-        assertSame(null, BooleanUtils.toBooleanObject((String) null, "Y", "N", null));
+        assertSame(Boolean.TRUE, BooleanUtils.toBooleanObject(null, null, "N", "U"));
+        assertSame(Boolean.FALSE, BooleanUtils.toBooleanObject(null, "Y", null, "U"));
+        assertSame(null, BooleanUtils.toBooleanObject(null, "Y", "N", null));
 
         assertEquals(Boolean.TRUE, BooleanUtils.toBooleanObject("Y", "Y", "N", "U"));
         assertEquals(Boolean.FALSE, BooleanUtils.toBooleanObject("N", "Y", "N", "U"));
@@ -299,7 +299,7 @@ public class BooleanUtilsTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void test_toBooleanObject_String_String_String_String_nullValue() {
-        BooleanUtils.toBooleanObject((String) null, "Y", "N", "U");
+        BooleanUtils.toBooleanObject(null, "Y", "N", "U");
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -357,8 +357,8 @@ public class BooleanUtilsTest {
 
     @Test
     public void test_toBoolean_String_String_String() {
-        assertTrue(BooleanUtils.toBoolean((String) null, null, "N"));
-        assertFalse(BooleanUtils.toBoolean((String) null, "Y", null));
+        assertTrue(BooleanUtils.toBoolean(null, null, "N"));
+        assertFalse(BooleanUtils.toBoolean(null, "Y", null));
         assertTrue(BooleanUtils.toBoolean("Y", "Y", "N"));
         assertTrue(BooleanUtils.toBoolean("Y", new String("Y"), new String("N")));
         assertFalse(BooleanUtils.toBoolean("N", "Y", "N"));
@@ -381,28 +381,28 @@ public class BooleanUtilsTest {
     //-----------------------------------------------------------------------
     @Test
     public void test_toStringTrueFalse_Boolean() {
-        assertEquals(null, BooleanUtils.toStringTrueFalse((Boolean) null));
+        assertEquals(null, BooleanUtils.toStringTrueFalse(null));
         assertEquals("true", BooleanUtils.toStringTrueFalse(Boolean.TRUE));
         assertEquals("false", BooleanUtils.toStringTrueFalse(Boolean.FALSE));
     }
     
     @Test
     public void test_toStringOnOff_Boolean() {
-        assertEquals(null, BooleanUtils.toStringOnOff((Boolean) null));
+        assertEquals(null, BooleanUtils.toStringOnOff(null));
         assertEquals("on", BooleanUtils.toStringOnOff(Boolean.TRUE));
         assertEquals("off", BooleanUtils.toStringOnOff(Boolean.FALSE));
     }
     
     @Test
     public void test_toStringYesNo_Boolean() {
-        assertEquals(null, BooleanUtils.toStringYesNo((Boolean) null));
+        assertEquals(null, BooleanUtils.toStringYesNo(null));
         assertEquals("yes", BooleanUtils.toStringYesNo(Boolean.TRUE));
         assertEquals("no", BooleanUtils.toStringYesNo(Boolean.FALSE));
     }
     
     @Test
     public void test_toString_Boolean_String_String_String() {
-        assertEquals("U", BooleanUtils.toString((Boolean) null, "Y", "N", "U"));
+        assertEquals("U", BooleanUtils.toString(null, "Y", "N", "U"));
         assertEquals("Y", BooleanUtils.toString(Boolean.TRUE, "Y", "N", "U"));
         assertEquals("N", BooleanUtils.toString(Boolean.FALSE, "Y", "N", "U"));
     }

--- a/src/test/java/org/apache/commons/lang3/ClassUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/ClassUtilsTest.java
@@ -137,7 +137,7 @@ public class ClassUtilsTest  {
     public void test_getSimpleName_Class() {
         assertEquals("ClassUtils", ClassUtils.getSimpleName(ClassUtils.class));
         assertEquals("Entry", ClassUtils.getSimpleName(Map.Entry.class));
-        assertEquals("", ClassUtils.getSimpleName((Class<?>) null));
+        assertEquals("", ClassUtils.getSimpleName(null));
 
         // LANG-535
         assertEquals("String[]", ClassUtils.getSimpleName(String[].class));
@@ -380,7 +380,7 @@ public class ClassUtilsTest  {
         assertTrue(ClassUtils.isAssignable(array0, array0));
 //        assertTrue(ClassUtils.isAssignable(array0, null)); 
         assertTrue(ClassUtils.isAssignable(array0, (Class<?>[]) null)); // explicit cast to avoid warning
-        assertTrue(ClassUtils.isAssignable((Class[]) null, (Class[]) null));
+        assertTrue(ClassUtils.isAssignable((Class[]) null, null));
 
         assertFalse(ClassUtils.isAssignable(array1, array1s));
         assertTrue(ClassUtils.isAssignable(array1s, array1s));
@@ -410,7 +410,7 @@ public class ClassUtilsTest  {
         assertTrue(ClassUtils.isAssignable(null, array0, true));
         assertTrue(ClassUtils.isAssignable(array0, array0, true));
         assertTrue(ClassUtils.isAssignable(array0, null, true));
-        assertTrue(ClassUtils.isAssignable((Class[]) null, (Class[]) null, true));
+        assertTrue(ClassUtils.isAssignable((Class[]) null, null, true));
 
         assertFalse(ClassUtils.isAssignable(array1, array1s, true));
         assertTrue(ClassUtils.isAssignable(array1s, array1s, true));
@@ -438,7 +438,7 @@ public class ClassUtilsTest  {
         assertTrue(ClassUtils.isAssignable(null, array0, false));
         assertTrue(ClassUtils.isAssignable(array0, array0, false));
         assertTrue(ClassUtils.isAssignable(array0, null, false));
-        assertTrue(ClassUtils.isAssignable((Class[]) null, (Class[]) null, false));
+        assertTrue(ClassUtils.isAssignable((Class[]) null, null, false));
 
         assertFalse(ClassUtils.isAssignable(array1, array1s, false));
         assertTrue(ClassUtils.isAssignable(array1s, array1s, false));

--- a/src/test/java/org/apache/commons/lang3/EnumUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/EnumUtilsTest.java
@@ -76,7 +76,7 @@ public class EnumUtilsTest {
 
     @Test(expected=NullPointerException.class)
     public void test_isEnum_nullClass() {
-        EnumUtils.isValidEnum((Class<Traffic>) null, "PURPLE");
+        EnumUtils.isValidEnum(null, "PURPLE");
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/LocaleUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/LocaleUtilsTest.java
@@ -125,7 +125,7 @@ public class LocaleUtilsTest  {
      */
     @Test
     public void testToLocale_1Part() {
-        assertNull(LocaleUtils.toLocale((String) null));
+        assertNull(LocaleUtils.toLocale(null));
         
         assertValidToLocale("us");
         assertValidToLocale("fr");

--- a/src/test/java/org/apache/commons/lang3/ObjectUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/ObjectUtilsTest.java
@@ -80,7 +80,7 @@ public class ObjectUtilsTest {
         assertNull(ObjectUtils.firstNonNull(new Object[0]));
         
         // Cast to Object in line below ensures compiler doesn't complain of unchecked generic array creation
-        assertNull(ObjectUtils.firstNonNull((Object) null, (Object) null));
+        assertNull(ObjectUtils.firstNonNull(null, null));
         
 //        assertSame("123", ObjectUtils.firstNonNull(null, ObjectUtils.NULL, "123", "456"));
 //        assertSame("456", ObjectUtils.firstNonNull(ObjectUtils.NULL, "456", "123", null));
@@ -313,13 +313,13 @@ public class ObjectUtilsTest {
 
     @Test
     public void testToString_Object() {
-        assertEquals("", ObjectUtils.toString((Object) null) );
+        assertEquals("", ObjectUtils.toString(null) );
         assertEquals(Boolean.TRUE.toString(), ObjectUtils.toString(Boolean.TRUE) );
     }
 
     @Test
     public void testToString_ObjectString() {
-        assertEquals(BAR, ObjectUtils.toString((Object) null, BAR) );
+        assertEquals(BAR, ObjectUtils.toString(null, BAR) );
         assertEquals(Boolean.TRUE.toString(), ObjectUtils.toString(Boolean.TRUE, BAR) );
     }
 
@@ -355,7 +355,7 @@ public class ObjectUtilsTest {
         assertSame( nonNullComparable1, ObjectUtils.max( minComparable, nonNullComparable1 ) );
         assertSame( nonNullComparable1, ObjectUtils.max( null, minComparable, null, nonNullComparable1 ) );
 
-        assertNull( ObjectUtils.max((String)null, (String)null) );
+        assertNull( ObjectUtils.max(null, null) );
     }
 
     @Test
@@ -381,7 +381,7 @@ public class ObjectUtilsTest {
         assertSame( minComparable, ObjectUtils.min( minComparable, nonNullComparable1 ) );
         assertSame( minComparable, ObjectUtils.min( null, nonNullComparable1, null, minComparable ) );
 
-        assertNull( ObjectUtils.min((String)null, (String)null) );
+        assertNull( ObjectUtils.min(null, null) );
     }
 
     /**

--- a/src/test/java/org/apache/commons/lang3/RangeTest.java
+++ b/src/test/java/org/apache/commons/lang3/RangeTest.java
@@ -53,7 +53,7 @@ public class RangeTest {
         byteRange2 = Range.between((byte) 0, (byte) 5);
         byteRange3 = Range.between((byte) 0, (byte) 10);
 
-        intRange = Range.between((int) 10, (int) 20);
+        intRange = Range.between(10, 20);
         longRange = Range.between((long) 10, (long) 20);
         floatRange = Range.between((float) 10, (float) 20);
         doubleRange = Range.between((double) 10, (double) 20);

--- a/src/test/java/org/apache/commons/lang3/StringUtilsStartsEndsWithTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringUtilsStartsEndsWithTest.java
@@ -38,8 +38,8 @@ public class StringUtilsStartsEndsWithTest {
      */
     @Test
     public void testStartsWith() {
-        assertTrue("startsWith(null, null)", StringUtils.startsWith(null, (String)null));
-        assertFalse("startsWith(FOOBAR, null)", StringUtils.startsWith(FOOBAR, (String)null));
+        assertTrue("startsWith(null, null)", StringUtils.startsWith(null, null));
+        assertFalse("startsWith(FOOBAR, null)", StringUtils.startsWith(FOOBAR, null));
         assertFalse("startsWith(null, FOO)",    StringUtils.startsWith(null, FOO));
         assertTrue("startsWith(FOOBAR, \"\")",  StringUtils.startsWith(FOOBAR, ""));
 
@@ -62,8 +62,8 @@ public class StringUtilsStartsEndsWithTest {
      */
     @Test
     public void testStartsWithIgnoreCase() {
-        assertTrue("startsWithIgnoreCase(null, null)",    StringUtils.startsWithIgnoreCase(null, (String)null));
-        assertFalse("startsWithIgnoreCase(FOOBAR, null)", StringUtils.startsWithIgnoreCase(FOOBAR, (String)null));
+        assertTrue("startsWithIgnoreCase(null, null)",    StringUtils.startsWithIgnoreCase(null, null));
+        assertFalse("startsWithIgnoreCase(FOOBAR, null)", StringUtils.startsWithIgnoreCase(FOOBAR, null));
         assertFalse("startsWithIgnoreCase(null, FOO)",    StringUtils.startsWithIgnoreCase(null, FOO));
         assertTrue("startsWithIgnoreCase(FOOBAR, \"\")",  StringUtils.startsWithIgnoreCase(FOOBAR, ""));
 
@@ -104,8 +104,8 @@ public class StringUtilsStartsEndsWithTest {
      */
     @Test
     public void testEndsWith() {
-        assertTrue("endsWith(null, null)",    StringUtils.endsWith(null, (String)null));
-        assertFalse("endsWith(FOOBAR, null)", StringUtils.endsWith(FOOBAR, (String)null));
+        assertTrue("endsWith(null, null)",    StringUtils.endsWith(null, null));
+        assertFalse("endsWith(FOOBAR, null)", StringUtils.endsWith(FOOBAR, null));
         assertFalse("endsWith(null, FOO)",    StringUtils.endsWith(null, FOO));
         assertTrue("endsWith(FOOBAR, \"\")",  StringUtils.endsWith(FOOBAR, ""));
 
@@ -135,8 +135,8 @@ public class StringUtilsStartsEndsWithTest {
      */
     @Test
     public void testEndsWithIgnoreCase() {
-        assertTrue("endsWithIgnoreCase(null, null)",    StringUtils.endsWithIgnoreCase(null, (String)null));
-        assertFalse("endsWithIgnoreCase(FOOBAR, null)", StringUtils.endsWithIgnoreCase(FOOBAR, (String)null));
+        assertTrue("endsWithIgnoreCase(null, null)",    StringUtils.endsWithIgnoreCase(null, null));
+        assertFalse("endsWithIgnoreCase(FOOBAR, null)", StringUtils.endsWithIgnoreCase(FOOBAR, null));
         assertFalse("endsWithIgnoreCase(null, FOO)",    StringUtils.endsWithIgnoreCase(null, FOO));
         assertTrue("endsWithIgnoreCase(FOOBAR, \"\")",  StringUtils.endsWithIgnoreCase(FOOBAR, ""));
 

--- a/src/test/java/org/apache/commons/lang3/builder/CompareToBuilderTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/CompareToBuilderTest.java
@@ -270,7 +270,7 @@ public class CompareToBuilderTest {
         assertTrue(new CompareToBuilder().append(o2, o1).toComparison() > 0);
         
         assertTrue(new CompareToBuilder().append(o1, null).toComparison() > 0);
-        assertTrue(new CompareToBuilder().append((Object) null, (Object) null).toComparison() == 0);
+        assertTrue(new CompareToBuilder().append((Object) null, null).toComparison() == 0);
         assertTrue(new CompareToBuilder().append(null, o1).toComparison() < 0);
     }
     
@@ -285,7 +285,7 @@ public class CompareToBuilderTest {
         assertTrue(new CompareToBuilder().append(o2, o1).build().intValue() > 0);
         
         assertTrue(new CompareToBuilder().append(o1, null).build().intValue() > 0);
-        assertEquals(Integer.valueOf(0), new CompareToBuilder().append((Object) null, (Object) null).build());
+        assertEquals(Integer.valueOf(0), new CompareToBuilder().append((Object) null, null).build());
         assertTrue(new CompareToBuilder().append(null, o1).build().intValue() < 0);
     }
 
@@ -310,7 +310,7 @@ public class CompareToBuilderTest {
         assertTrue(new CompareToBuilder().append(o2, o1, String.CASE_INSENSITIVE_ORDER).toComparison() > 0);
         
         assertTrue(new CompareToBuilder().append(o1, null, String.CASE_INSENSITIVE_ORDER).toComparison() > 0);
-        assertTrue(new CompareToBuilder().append((Object) null, (Object) null, String.CASE_INSENSITIVE_ORDER).toComparison() == 0);
+        assertTrue(new CompareToBuilder().append(null, null, String.CASE_INSENSITIVE_ORDER).toComparison() == 0);
         assertTrue(new CompareToBuilder().append(null, o1, String.CASE_INSENSITIVE_ORDER).toComparison() < 0);
     }
     
@@ -325,7 +325,7 @@ public class CompareToBuilderTest {
         assertTrue(new CompareToBuilder().append(o2, o1, null).toComparison() > 0);
         
         assertTrue(new CompareToBuilder().append(o1, null, null).toComparison() > 0);
-        assertTrue(new CompareToBuilder().append((Object) null, (Object) null, null).toComparison() == 0);
+        assertTrue(new CompareToBuilder().append(null, null, null).toComparison() == 0);
         assertTrue(new CompareToBuilder().append(null, o1, null).toComparison() < 0);
     }
 
@@ -469,7 +469,7 @@ public class CompareToBuilderTest {
         assertTrue(new CompareToBuilder().append(obj2, obj1).toComparison() < 0);
 
         assertTrue(new CompareToBuilder().append(obj1, null).toComparison() > 0);
-        assertTrue(new CompareToBuilder().append((Object[]) null, (Object[]) null).toComparison() == 0);
+        assertTrue(new CompareToBuilder().append((Object[]) null, null).toComparison() == 0);
         assertTrue(new CompareToBuilder().append(null, obj1).toComparison() < 0);
     }
 
@@ -496,7 +496,7 @@ public class CompareToBuilderTest {
         assertTrue(new CompareToBuilder().append(obj2, obj1).toComparison() < 0);
 
         assertTrue(new CompareToBuilder().append(obj1, null).toComparison() > 0);
-        assertTrue(new CompareToBuilder().append((long[]) null, (long[]) null).toComparison() == 0);
+        assertTrue(new CompareToBuilder().append((long[]) null, null).toComparison() == 0);
         assertTrue(new CompareToBuilder().append(null, obj1).toComparison() < 0);
     }
 
@@ -523,7 +523,7 @@ public class CompareToBuilderTest {
         assertTrue(new CompareToBuilder().append(obj2, obj1).toComparison() < 0);
 
         assertTrue(new CompareToBuilder().append(obj1, null).toComparison() > 0);
-        assertTrue(new CompareToBuilder().append((int[]) null, (int[]) null).toComparison() == 0);
+        assertTrue(new CompareToBuilder().append((int[]) null, null).toComparison() == 0);
         assertTrue(new CompareToBuilder().append(null, obj1).toComparison() < 0);
     }
 
@@ -550,7 +550,7 @@ public class CompareToBuilderTest {
         assertTrue(new CompareToBuilder().append(obj2, obj1).toComparison() < 0);
 
         assertTrue(new CompareToBuilder().append(obj1, null).toComparison() > 0);
-        assertTrue(new CompareToBuilder().append((short[]) null, (short[]) null).toComparison() == 0);
+        assertTrue(new CompareToBuilder().append((short[]) null, null).toComparison() == 0);
         assertTrue(new CompareToBuilder().append(null, obj1).toComparison() < 0);
     }
 
@@ -577,7 +577,7 @@ public class CompareToBuilderTest {
         assertTrue(new CompareToBuilder().append(obj2, obj1).toComparison() < 0);
 
         assertTrue(new CompareToBuilder().append(obj1, null).toComparison() > 0);
-        assertTrue(new CompareToBuilder().append((char[]) null, (char[]) null).toComparison() == 0);
+        assertTrue(new CompareToBuilder().append((char[]) null, null).toComparison() == 0);
         assertTrue(new CompareToBuilder().append(null, obj1).toComparison() < 0);
     }
 
@@ -604,7 +604,7 @@ public class CompareToBuilderTest {
         assertTrue(new CompareToBuilder().append(obj2, obj1).toComparison() < 0);
 
         assertTrue(new CompareToBuilder().append(obj1, null).toComparison() > 0);
-        assertTrue(new CompareToBuilder().append((byte[]) null, (byte[]) null).toComparison() == 0);
+        assertTrue(new CompareToBuilder().append((byte[]) null, null).toComparison() == 0);
         assertTrue(new CompareToBuilder().append(null, obj1).toComparison() < 0);
     }
 
@@ -631,7 +631,7 @@ public class CompareToBuilderTest {
         assertTrue(new CompareToBuilder().append(obj2, obj1).toComparison() < 0);
 
         assertTrue(new CompareToBuilder().append(obj1, null).toComparison() > 0);
-        assertTrue(new CompareToBuilder().append((double[]) null, (double[]) null).toComparison() == 0);
+        assertTrue(new CompareToBuilder().append((double[]) null, null).toComparison() == 0);
         assertTrue(new CompareToBuilder().append(null, obj1).toComparison() < 0);
     }
 
@@ -658,7 +658,7 @@ public class CompareToBuilderTest {
         assertTrue(new CompareToBuilder().append(obj2, obj1).toComparison() < 0);
 
         assertTrue(new CompareToBuilder().append(obj1, null).toComparison() > 0);
-        assertTrue(new CompareToBuilder().append((float[]) null, (float[]) null).toComparison() == 0);
+        assertTrue(new CompareToBuilder().append((float[]) null, null).toComparison() == 0);
         assertTrue(new CompareToBuilder().append(null, obj1).toComparison() < 0);
     }
 
@@ -685,7 +685,7 @@ public class CompareToBuilderTest {
         assertTrue(new CompareToBuilder().append(obj2, obj1).toComparison() < 0);
 
         assertTrue(new CompareToBuilder().append(obj1, null).toComparison() > 0);
-        assertTrue(new CompareToBuilder().append((boolean[]) null, (boolean[]) null).toComparison() == 0);
+        assertTrue(new CompareToBuilder().append((boolean[]) null, null).toComparison() == 0);
         assertTrue(new CompareToBuilder().append(null, obj1).toComparison() < 0);
     }
 

--- a/src/test/java/org/apache/commons/lang3/builder/DiffBuilderTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/DiffBuilderTest.java
@@ -397,15 +397,15 @@ public class DiffBuilderTest {
     @Test
     public void testByteArrayEqualAsObject() throws Exception {
         final DiffResult list = new DiffBuilder("String1", "String2", SHORT_STYLE)
-            .append("foo", (Object) new boolean[] {false}, (Object) new boolean[] {false})
-            .append("foo", (Object) new byte[] {0x01}, (Object) new byte[] {0x01})
-            .append("foo", (Object) new char[] {'a'}, (Object) new char[] {'a'})
-            .append("foo", (Object) new double[] {1.0}, (Object) new double[] {1.0})
-            .append("foo", (Object) new float[] {1.0F}, (Object) new float[] {1.0F})
-            .append("foo", (Object) new int[] {1}, (Object) new int[] {1})
-            .append("foo", (Object) new long[] {1L}, (Object) new long[] {1L})
-            .append("foo", (Object) new short[] {1}, (Object) new short[] {1})
-            .append("foo", (Object) new Object[] {1, "two"}, (Object) new Object[] {1, "two"})
+            .append("foo", new boolean[] {false}, new boolean[] {false})
+            .append("foo", new byte[] {0x01}, new byte[] {0x01})
+            .append("foo", new char[] {'a'}, new char[] {'a'})
+            .append("foo", new double[] {1.0}, new double[] {1.0})
+            .append("foo", new float[] {1.0F}, new float[] {1.0F})
+            .append("foo", new int[] {1}, new int[] {1})
+            .append("foo", new long[] {1L}, new long[] {1L})
+            .append("foo", new short[] {1}, new short[] {1})
+            .append("foo", new Object[] {1, "two"}, new Object[] {1, "two"})
             .build();
 
         assertEquals(0, list.getNumberOfDiffs());

--- a/src/test/java/org/apache/commons/lang3/builder/EqualsBuilderTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/EqualsBuilderTest.java
@@ -221,7 +221,7 @@ public class EqualsBuilderTest {
 
         assertTrue(!EqualsBuilder.reflectionEquals(o1, null));
         assertTrue(!EqualsBuilder.reflectionEquals(null, o2));
-        assertTrue(EqualsBuilder.reflectionEquals((Object) null, (Object) null));
+        assertTrue(EqualsBuilder.reflectionEquals(null, null));
     }
     
     @Test
@@ -348,7 +348,7 @@ public class EqualsBuilderTest {
         assertTrue(!EqualsBuilder.reflectionEquals(to2, null, testTransients));
         assertTrue(!EqualsBuilder.reflectionEquals(null, to, testTransients));
         assertTrue(!EqualsBuilder.reflectionEquals(null, to2, testTransients));
-        assertTrue(EqualsBuilder.reflectionEquals((Object) null, (Object) null, testTransients));
+        assertTrue(EqualsBuilder.reflectionEquals(null, null, testTransients));
     }
 
     @Test
@@ -374,7 +374,7 @@ public class EqualsBuilderTest {
         
         assertTrue(!new EqualsBuilder().append(o1, null).isEquals());
         assertTrue(!new EqualsBuilder().append(null, o2).isEquals());
-        assertTrue(new EqualsBuilder().append((Object) null, (Object) null).isEquals());
+        assertTrue(new EqualsBuilder().append((Object) null, null).isEquals());
     }
     
     @Test
@@ -390,7 +390,7 @@ public class EqualsBuilderTest {
         
         assertEquals(Boolean.FALSE, new EqualsBuilder().append(o1, null).build());
         assertEquals(Boolean.FALSE, new EqualsBuilder().append(null, o2).build());
-        assertEquals(Boolean.TRUE, new EqualsBuilder().append((Object) null, (Object) null).build());
+        assertEquals(Boolean.TRUE, new EqualsBuilder().append((Object) null, null).build());
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/builder/HashCodeBuilderTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/HashCodeBuilderTest.java
@@ -207,16 +207,16 @@ public class HashCodeBuilderTest {
     @Test
     @SuppressWarnings("cast") // cast is not really needed, keep for consistency
     public void testLong() {
-        assertEquals(17 * 37, new HashCodeBuilder(17, 37).append((long) 0L).toHashCode());
+        assertEquals(17 * 37, new HashCodeBuilder(17, 37).append(0L).toHashCode());
         assertEquals(17 * 37 + (int) (123456789L ^ 123456789L >> 32), new HashCodeBuilder(17, 37).append(
-                (long) 123456789L).toHashCode());
+                123456789L).toHashCode());
     }
 
     @Test
     @SuppressWarnings("cast") // cast is not really needed, keep for consistency
     public void testInt() {
-        assertEquals(17 * 37, new HashCodeBuilder(17, 37).append((int) 0).toHashCode());
-        assertEquals(17 * 37 + 123456, new HashCodeBuilder(17, 37).append((int) 123456).toHashCode());
+        assertEquals(17 * 37, new HashCodeBuilder(17, 37).append(0).toHashCode());
+        assertEquals(17 * 37 + 123456, new HashCodeBuilder(17, 37).append(123456).toHashCode());
     }
 
     @Test
@@ -240,7 +240,7 @@ public class HashCodeBuilderTest {
     @Test
     @SuppressWarnings("cast") // cast is not really needed, keep for consistency
     public void testDouble() {
-        assertEquals(17 * 37, new HashCodeBuilder(17, 37).append((double) 0d).toHashCode());
+        assertEquals(17 * 37, new HashCodeBuilder(17, 37).append(0d).toHashCode());
         final double d = 1234567.89;
         final long l = Double.doubleToLongBits(d);
         assertEquals(17 * 37 + (int) (l ^ l >> 32), new HashCodeBuilder(17, 37).append(d).toHashCode());
@@ -249,7 +249,7 @@ public class HashCodeBuilderTest {
     @Test
     @SuppressWarnings("cast") // cast is not really needed, keep for consistency
     public void testFloat() {
-        assertEquals(17 * 37, new HashCodeBuilder(17, 37).append((float) 0f).toHashCode());
+        assertEquals(17 * 37, new HashCodeBuilder(17, 37).append(0f).toHashCode());
         final float f = 1234.89f;
         final int i = Float.floatToIntBits(f);
         assertEquals(17 * 37 + i, new HashCodeBuilder(17, 37).append(f).toHashCode());

--- a/src/test/java/org/apache/commons/lang3/builder/ToStringBuilderTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/ToStringBuilderTest.java
@@ -660,9 +660,9 @@ public class ToStringBuilderTest {
     @SuppressWarnings("cast") // cast is not really needed, keep for consistency
     @Test
     public void testInt() {
-        assertEquals(baseStr + "[3]", new ToStringBuilder(base).append((int) 3).toString());
-        assertEquals(baseStr + "[a=3]", new ToStringBuilder(base).append("a", (int) 3).toString());
-        assertEquals(baseStr + "[a=3,b=4]", new ToStringBuilder(base).append("a", (int) 3).append("b", (int) 4).toString());
+        assertEquals(baseStr + "[3]", new ToStringBuilder(base).append(3).toString());
+        assertEquals(baseStr + "[a=3]", new ToStringBuilder(base).append("a", 3).toString());
+        assertEquals(baseStr + "[a=3,b=4]", new ToStringBuilder(base).append("a", 3).append("b", 4).toString());
     }
 
     @Test
@@ -689,9 +689,9 @@ public class ToStringBuilderTest {
     @SuppressWarnings("cast")
     @Test
     public void testDouble() {
-        assertEquals(baseStr + "[3.2]", new ToStringBuilder(base).append((double) 3.2).toString());
-        assertEquals(baseStr + "[a=3.2]", new ToStringBuilder(base).append("a", (double) 3.2).toString());
-        assertEquals(baseStr + "[a=3.2,b=4.3]", new ToStringBuilder(base).append("a", (double) 3.2).append("b", (double) 4.3).toString());
+        assertEquals(baseStr + "[3.2]", new ToStringBuilder(base).append(3.2).toString());
+        assertEquals(baseStr + "[a=3.2]", new ToStringBuilder(base).append("a", 3.2).toString());
+        assertEquals(baseStr + "[a=3.2,b=4.3]", new ToStringBuilder(base).append("a", 3.2).append("b", 4.3).toString());
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/exception/AbstractExceptionContextTest.java
+++ b/src/test/java/org/apache/commons/lang3/exception/AbstractExceptionContextTest.java
@@ -181,7 +181,7 @@ public abstract class AbstractExceptionContextTest<T extends ExceptionContext & 
         exceptionContext.setContextValue("test Poorly written obj", "serializable replacement");
         
         @SuppressWarnings("unchecked")
-        final T clone = (T) SerializationUtils.deserialize(SerializationUtils.serialize(exceptionContext));
+        final T clone = SerializationUtils.deserialize(SerializationUtils.serialize(exceptionContext));
         assertEquals(exceptionContext.getFormattedExceptionMessage(null), clone.getFormattedExceptionMessage(null));
     }
 }

--- a/src/test/java/org/apache/commons/lang3/exception/ExceptionUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/exception/ExceptionUtilsTest.java
@@ -119,8 +119,8 @@ public class ExceptionUtilsTest {
         assertSame(nested, ExceptionUtils.getCause(withCause));
         assertSame(null, ExceptionUtils.getCause(jdkNoCause));
         assertSame(cyclicCause.getCause(), ExceptionUtils.getCause(cyclicCause));
-        assertSame(((ExceptionWithCause) cyclicCause.getCause()).getCause(), ExceptionUtils.getCause(cyclicCause.getCause()));
-        assertSame(cyclicCause.getCause(), ExceptionUtils.getCause(((ExceptionWithCause) cyclicCause.getCause()).getCause()));
+        assertSame(cyclicCause.getCause().getCause(), ExceptionUtils.getCause(cyclicCause.getCause()));
+        assertSame(cyclicCause.getCause(), ExceptionUtils.getCause(cyclicCause.getCause().getCause()));
         assertSame(withoutCause, ExceptionUtils.getCause(notVisibleException));
     }
 
@@ -151,7 +151,7 @@ public class ExceptionUtilsTest {
         assertSame(withoutCause, ExceptionUtils.getRootCause(nested));
         assertSame(withoutCause, ExceptionUtils.getRootCause(withCause));
         assertSame(null, ExceptionUtils.getRootCause(jdkNoCause));
-        assertSame(((ExceptionWithCause) cyclicCause.getCause()).getCause(), ExceptionUtils.getRootCause(cyclicCause));
+        assertSame(cyclicCause.getCause().getCause(), ExceptionUtils.getRootCause(cyclicCause));
     }
 
     //-----------------------------------------------------------------------
@@ -208,7 +208,7 @@ public class ExceptionUtilsTest {
         assertEquals(3, throwables.length);
         assertSame(cyclicCause, throwables[0]);
         assertSame(cyclicCause.getCause(), throwables[1]);
-        assertSame(((ExceptionWithCause) cyclicCause.getCause()).getCause(), throwables[2]);
+        assertSame(cyclicCause.getCause().getCause(), throwables[2]);
     }
 
     //-----------------------------------------------------------------------
@@ -255,7 +255,7 @@ public class ExceptionUtilsTest {
         assertEquals(3, throwables.size());
         assertSame(cyclicCause, throwables.get(0));
         assertSame(cyclicCause.getCause(), throwables.get(1));
-        assertSame(((ExceptionWithCause) cyclicCause.getCause()).getCause(), throwables.get(2));
+        assertSame(cyclicCause.getCause().getCause(), throwables.get(2));
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/apache/commons/lang3/mutable/MutableIntTest.java
+++ b/src/test/java/org/apache/commons/lang3/mutable/MutableIntTest.java
@@ -150,7 +150,7 @@ public class MutableIntTest {
 
     @Test
     public void testIncrementAndGet() {
-        final MutableInt mutNum = new MutableInt((int) 1);
+        final MutableInt mutNum = new MutableInt(1);
         final int result = mutNum.incrementAndGet();
 
         assertEquals(2, result);
@@ -160,7 +160,7 @@ public class MutableIntTest {
 
     @Test
     public void testGetAndIncrement() {
-        final MutableInt mutNum = new MutableInt((int) 1);
+        final MutableInt mutNum = new MutableInt(1);
         final int result = mutNum.getAndIncrement();
 
         assertEquals(1, result);
@@ -179,7 +179,7 @@ public class MutableIntTest {
 
     @Test
     public void testDecrementAndGet() {
-        final MutableInt mutNum = new MutableInt((int) 1);
+        final MutableInt mutNum = new MutableInt(1);
         final int result = mutNum.decrementAndGet();
 
         assertEquals(0, result);
@@ -189,7 +189,7 @@ public class MutableIntTest {
 
     @Test
     public void testGetAndDecrement() {
-        final MutableInt mutNum = new MutableInt((int) 1);
+        final MutableInt mutNum = new MutableInt(1);
         final int result = mutNum.getAndDecrement();
 
         assertEquals(1, result);
@@ -217,38 +217,38 @@ public class MutableIntTest {
 
     @Test
     public void testGetAndAddValuePrimitive() {
-        final MutableInt mutableInteger = new MutableInt((int)0);
-        final int result = mutableInteger.getAndAdd((int) 1);
+        final MutableInt mutableInteger = new MutableInt(0);
+        final int result = mutableInteger.getAndAdd(1);
 
-        assertEquals((int) 0, result);
-        assertEquals((int) 1, mutableInteger.intValue());
+        assertEquals(0, result);
+        assertEquals(1, mutableInteger.intValue());
     }
 
     @Test
     public void testGetAndAddValueObject() {
-        final MutableInt mutableInteger = new MutableInt((int)0);
-        final int result = mutableInteger.getAndAdd(Integer.valueOf((int) 1));
+        final MutableInt mutableInteger = new MutableInt(0);
+        final int result = mutableInteger.getAndAdd(Integer.valueOf(1));
 
-        assertEquals((int) 0, result);
-        assertEquals((int) 1, mutableInteger.intValue());
+        assertEquals(0, result);
+        assertEquals(1, mutableInteger.intValue());
     }
 
     @Test
     public void testAddAndGetValuePrimitive() {
-        final MutableInt mutableInteger = new MutableInt((int)0);
-        final int result = mutableInteger.addAndGet((int) 1);
+        final MutableInt mutableInteger = new MutableInt(0);
+        final int result = mutableInteger.addAndGet(1);
 
-        assertEquals((int) 1, result);
-        assertEquals((int) 1, mutableInteger.intValue());
+        assertEquals(1, result);
+        assertEquals(1, mutableInteger.intValue());
     }
 
     @Test
     public void testAddAndGetValueObject() {
-        final MutableInt mutableInteger = new MutableInt((int)0);
-        final int result = mutableInteger.addAndGet(Integer.valueOf((int) 1));
+        final MutableInt mutableInteger = new MutableInt(0);
+        final int result = mutableInteger.addAndGet(Integer.valueOf(1));
 
-        assertEquals((int) 1, result);
-        assertEquals((int) 1, mutableInteger.intValue());
+        assertEquals(1, result);
+        assertEquals(1, mutableInteger.intValue());
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/reflect/MethodUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/reflect/MethodUtilsTest.java
@@ -345,7 +345,7 @@ public class MethodUtilsTest {
         assertEquals("foo()", MethodUtils.invokeMethod(testBean, "foo",
                 (Object[]) null));
         assertEquals("foo()", MethodUtils.invokeMethod(testBean, "foo",
-                (Object[]) null, (Class<?>[]) null));
+                null, null));
         assertEquals("foo(String)", MethodUtils.invokeMethod(testBean, "foo",
                 ""));
         assertEquals("foo(Object)", MethodUtils.invokeMethod(testBean, "foo",
@@ -385,7 +385,7 @@ public class MethodUtilsTest {
         assertEquals("foo()", MethodUtils.invokeExactMethod(testBean, "foo",
                 (Object[]) null));
         assertEquals("foo()", MethodUtils.invokeExactMethod(testBean, "foo",
-                (Object[]) null, (Class<?>[]) null));
+                null, null));
         assertEquals("foo(String)", MethodUtils.invokeExactMethod(testBean,
                 "foo", ""));
         assertEquals("foo(Object)", MethodUtils.invokeExactMethod(testBean,
@@ -422,7 +422,7 @@ public class MethodUtilsTest {
         assertEquals("bar()", MethodUtils.invokeStaticMethod(TestBean.class,
                 "bar", (Object[]) null));
         assertEquals("bar()", MethodUtils.invokeStaticMethod(TestBean.class,
-                "bar", (Object[]) null, (Class<?>[]) null));
+                "bar", null, null));
         assertEquals("bar(String)", MethodUtils.invokeStaticMethod(
                 TestBean.class, "bar", ""));
         assertEquals("bar(Object)", MethodUtils.invokeStaticMethod(
@@ -465,7 +465,7 @@ public class MethodUtilsTest {
         assertEquals("bar()", MethodUtils.invokeExactStaticMethod(TestBean.class,
                 "bar", (Object[]) null));
         assertEquals("bar()", MethodUtils.invokeExactStaticMethod(TestBean.class,
-                "bar", (Object[]) null, (Class<?>[]) null));
+                "bar", null, null));
         assertEquals("bar(String)", MethodUtils.invokeExactStaticMethod(
                 TestBean.class, "bar", ""));
         assertEquals("bar(Object)", MethodUtils.invokeExactStaticMethod(

--- a/src/test/java/org/apache/commons/lang3/text/StrBuilderAppendInsertTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/StrBuilderAppendInsertTest.java
@@ -1374,7 +1374,7 @@ public class StrBuilderAppendInsertTest {
             // expected
         }
 
-        sb.insert(0, (char[]) null, 0, 0);
+        sb.insert(0, null, 0, 0);
         assertEquals("barbaz", sb.toString());
 
         sb.insert(0, new char[0], 0, 0);
@@ -1599,7 +1599,7 @@ public class StrBuilderAppendInsertTest {
         sb.insert(0, (char[]) null);
         assertEquals("nullfoonullbarbaz", sb.toString());
 
-        sb.insert(0, (char[]) null, 0, 0);
+        sb.insert(0, null, 0, 0);
         assertEquals("nullnullfoonullbarbaz", sb.toString());
     }
 }

--- a/src/test/java/org/apache/commons/lang3/text/StrBuilderTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/StrBuilderTest.java
@@ -63,7 +63,7 @@ public class StrBuilderTest {
         assertEquals(0, sb4.length());
         assertEquals(0, sb4.size());
 
-        final StrBuilder sb5 = new StrBuilder((String) null);
+        final StrBuilder sb5 = new StrBuilder(null);
         assertEquals(32, sb5.capacity());
         assertEquals(0, sb5.length());
         assertEquals(0, sb5.size());
@@ -184,7 +184,7 @@ public class StrBuilderTest {
         sb.setNewLineText("");
         assertEquals("", sb.getNewLineText());
 
-        sb.setNewLineText((String) null);
+        sb.setNewLineText(null);
         assertEquals(null, sb.getNewLineText());
     }
 
@@ -203,7 +203,7 @@ public class StrBuilderTest {
         sb.setNullText("NULL");
         assertEquals("NULL", sb.getNullText());
 
-        sb.setNullText((String) null);
+        sb.setNullText(null);
         assertEquals(null, sb.getNullText());
     }
 
@@ -745,7 +745,7 @@ public class StrBuilderTest {
         assertEquals("aaabc", sb.toString());
         sb.replace(0, 3, "");
         assertEquals("bc", sb.toString());
-        sb.replace(1, 2, (String) null);
+        sb.replace(1, 2, null);
         assertEquals("b", sb.toString());
         sb.replace(1, 1000, "text");
         assertEquals("btext", sb.toString());
@@ -941,7 +941,7 @@ public class StrBuilderTest {
     @Test
     public void testReplace_StrMatcher_String_int_int_int_VaryMatcher() {
         StrBuilder sb = new StrBuilder("abcbccba");
-        sb.replace((StrMatcher) null, "x", 0, sb.length(), -1);
+        sb.replace(null, "x", 0, sb.length(), -1);
         assertEquals("abcbccba", sb.toString());
         
         sb.replace(StrMatcher.charMatcher('a'), "x", 0, sb.length(), -1);

--- a/src/test/java/org/apache/commons/lang3/text/StrMatcherTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/StrMatcherTest.java
@@ -197,7 +197,7 @@ public class StrMatcherTest  {
         assertEquals(0, matcher.isMatch(BUFFER2, 4));
         assertEquals(0, matcher.isMatch(BUFFER2, 5));
         assertSame(StrMatcher.noneMatcher(), StrMatcher.stringMatcher(""));
-        assertSame(StrMatcher.noneMatcher(), StrMatcher.stringMatcher((String) null));
+        assertSame(StrMatcher.noneMatcher(), StrMatcher.stringMatcher(null));
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/apache/commons/lang3/text/StrSubstitutorTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/StrSubstitutorTest.java
@@ -477,7 +477,7 @@ public class StrSubstitutorTest {
         sub.setVariablePrefix("<<");
         assertTrue(sub.getVariablePrefixMatcher() instanceof StrMatcher.StringMatcher);
         try {
-            sub.setVariablePrefix((String) null);
+            sub.setVariablePrefix(null);
             fail();
         } catch (final IllegalArgumentException ex) {
             // expected
@@ -488,7 +488,7 @@ public class StrSubstitutorTest {
         sub.setVariablePrefixMatcher(matcher);
         assertSame(matcher, sub.getVariablePrefixMatcher());
         try {
-            sub.setVariablePrefixMatcher((StrMatcher) null);
+            sub.setVariablePrefixMatcher(null);
             fail();
         } catch (final IllegalArgumentException ex) {
             // expected
@@ -509,7 +509,7 @@ public class StrSubstitutorTest {
         sub.setVariableSuffix("<<");
         assertTrue(sub.getVariableSuffixMatcher() instanceof StrMatcher.StringMatcher);
         try {
-            sub.setVariableSuffix((String) null);
+            sub.setVariableSuffix(null);
             fail();
         } catch (final IllegalArgumentException ex) {
             // expected
@@ -520,7 +520,7 @@ public class StrSubstitutorTest {
         sub.setVariableSuffixMatcher(matcher);
         assertSame(matcher, sub.getVariableSuffixMatcher());
         try {
-            sub.setVariableSuffixMatcher((StrMatcher) null);
+            sub.setVariableSuffixMatcher(null);
             fail();
         } catch (final IllegalArgumentException ex) {
             // expected
@@ -540,13 +540,13 @@ public class StrSubstitutorTest {
 
         sub.setValueDelimiter("||");
         assertTrue(sub.getValueDelimiterMatcher() instanceof StrMatcher.StringMatcher);
-        sub.setValueDelimiter((String) null);
+        sub.setValueDelimiter(null);
         assertNull(sub.getValueDelimiterMatcher());
 
         final StrMatcher matcher = StrMatcher.commaMatcher();
         sub.setValueDelimiterMatcher(matcher);
         assertSame(matcher, sub.getValueDelimiterMatcher());
-        sub.setValueDelimiterMatcher((StrMatcher) null);
+        sub.setValueDelimiterMatcher(null);
         assertNull(sub.getValueDelimiterMatcher());
     }
 

--- a/src/test/java/org/apache/commons/lang3/time/DateUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/DateUtilsTest.java
@@ -171,17 +171,17 @@ public class DateUtilsTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testIsSameDay_DateNullNull() throws Exception {
-        DateUtils.isSameDay((Date) null, (Date) null);
+        DateUtils.isSameDay((Date) null, null);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testIsSameDay_DateNullNotNull() throws Exception {
-        DateUtils.isSameDay((Date) null, new Date());
+        DateUtils.isSameDay(null, new Date());
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testIsSameDay_DateNotNullNull() throws Exception {
-        DateUtils.isSameDay(new Date(), (Date) null);
+        DateUtils.isSameDay(new Date(), null);
     }
 
     //-----------------------------------------------------------------------
@@ -200,17 +200,17 @@ public class DateUtilsTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testIsSameDay_CalNullNull() throws Exception {
-        DateUtils.isSameDay((Calendar) null, (Calendar) null);
+        DateUtils.isSameDay((Calendar) null, null);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testIsSameDay_CalNullNotNull() throws Exception {
-        DateUtils.isSameDay((Calendar) null, Calendar.getInstance());
+        DateUtils.isSameDay(null, Calendar.getInstance());
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testIsSameDay_CalNotNullNull() throws Exception {
-        DateUtils.isSameDay(Calendar.getInstance(), (Calendar) null);
+        DateUtils.isSameDay(Calendar.getInstance(), null);
     }
 
     //-----------------------------------------------------------------------
@@ -229,17 +229,17 @@ public class DateUtilsTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testIsSameInstant_DateNullNull() throws Exception {
-        DateUtils.isSameInstant((Date) null, (Date) null);
+        DateUtils.isSameInstant((Date) null, null);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testIsSameInstant_DateNullNotNull() throws Exception {
-        DateUtils.isSameInstant((Date) null, new Date());
+        DateUtils.isSameInstant(null, new Date());
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testIsSameInstant_DateNotNullNull() throws Exception {
-        DateUtils.isSameInstant(new Date(), (Date) null);
+        DateUtils.isSameInstant(new Date(), null);
     }
 
     //-----------------------------------------------------------------------
@@ -259,17 +259,17 @@ public class DateUtilsTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testIsSameInstant_CalNullNull() throws Exception {
-        DateUtils.isSameInstant((Calendar) null, (Calendar) null);
+        DateUtils.isSameInstant((Calendar) null, null);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testIsSameInstant_CalNullNotNull() throws Exception {
-        DateUtils.isSameInstant((Calendar) null, Calendar.getInstance());
+        DateUtils.isSameInstant(null, Calendar.getInstance());
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testIsSameInstant_CalNotNullNull() throws Exception {
-        DateUtils.isSameInstant(Calendar.getInstance(), (Calendar) null);
+        DateUtils.isSameInstant(Calendar.getInstance(), null);
     }
 
     //-----------------------------------------------------------------------
@@ -297,17 +297,17 @@ public class DateUtilsTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testIsSameLocalTime_CalNullNull() throws Exception {
-        DateUtils.isSameLocalTime((Calendar) null, (Calendar) null);
+        DateUtils.isSameLocalTime(null, null);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testIsSameLocalTime_CalNullNotNull() throws Exception {
-        DateUtils.isSameLocalTime((Calendar) null, Calendar.getInstance());
+        DateUtils.isSameLocalTime(null, Calendar.getInstance());
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testIsSameLocalTime_CalNotNullNull() throws Exception {
-        DateUtils.isSameLocalTime(Calendar.getInstance(), (Calendar) null);
+        DateUtils.isSameLocalTime(Calendar.getInstance(), null);
     }
 
     //-----------------------------------------------------------------------


### PR DESCRIPTION
Remove redundant casts throughout the codebase to make it cleaner and
easier to read.