### PR TITLE
Use StringBuilders instead of StringBuffers for local variables

### DIFF
--- a/src/main/java/org/apache/commons/lang3/RandomStringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/RandomStringUtils.java
@@ -380,7 +380,7 @@ public class RandomStringUtils {
             }
         }
 
-        StringBuffer buffer = new StringBuffer(count);
+        StringBuilder builder = new StringBuilder(count);
         final int gap = end - start;
 
         while (count-- != 0) {
@@ -409,7 +409,7 @@ public class RandomStringUtils {
             if (letters && Character.isLetter(codePoint)
                     || numbers && Character.isDigit(codePoint)
                     || !letters && !numbers) {               
-                buffer.appendCodePoint(codePoint);
+                builder.appendCodePoint(codePoint);
                 
                 if (numberOfChars == 2) {
                     count--;
@@ -419,7 +419,7 @@ public class RandomStringUtils {
                 count++;
             }
         }
-        return buffer.toString();
+        return builder.toString();
     }
 
 

--- a/src/test/java/org/apache/commons/lang3/ArrayUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/ArrayUtilsTest.java
@@ -280,8 +280,8 @@ public class ArrayUtilsTest  {
         assertTrue(Arrays.equals(original1, cloned1));
         assertTrue(original1 != cloned1);
         
-        final StringBuffer buf = new StringBuffer("pick");
-        original1 = new Object[] {buf, "a", new String[] {"stick"}};
+        final StringBuilder builder = new StringBuilder("pick");
+        original1 = new Object[] {builder, "a", new String[] {"stick"}};
         cloned1 = ArrayUtils.clone(original1);
         assertTrue(Arrays.equals(original1, cloned1));
         assertTrue(original1 != cloned1);


### PR DESCRIPTION
Some old parts of the code, originally written before Java 5 was
available use StringBuffers in their local variables. Since local
variables pose no concurrency problems, they can safely be replaced
with non thread safe StringBuilders, for a slight performance gain.