### PR TITLE
(doc) Use the full alphabet for the well-known example text.

### DIFF
--- a/src/main/java/org/apache/commons/lang3/text/StrSubstitutor.java
+++ b/src/main/java/org/apache/commons/lang3/text/StrSubstitutor.java
@@ -52,13 +52,13 @@ import org.apache.commons.lang3.StringUtils;
  * Map valuesMap = HashMap();
  * valuesMap.put(&quot;animal&quot;, &quot;quick brown fox&quot;);
  * valuesMap.put(&quot;target&quot;, &quot;lazy dog&quot;);
- * String templateString = &quot;The ${animal} jumped over the ${target}.&quot;;
+ * String templateString = &quot;The ${animal} jumps over the ${target}.&quot;;
  * StrSubstitutor sub = new StrSubstitutor(valuesMap);
  * String resolvedString = sub.replace(templateString);
  * </pre>
  * yielding:
  * <pre>
- *      The quick brown fox jumped over the lazy dog.
+ *      The quick brown fox jumps over the lazy dog.
  * </pre>
  * <p>
  * Also, this class allows to set a default value for unresolved variables.
@@ -72,13 +72,13 @@ import org.apache.commons.lang3.StringUtils;
  * Map valuesMap = HashMap();
  * valuesMap.put(&quot;animal&quot;, &quot;quick brown fox&quot;);
  * valuesMap.put(&quot;target&quot;, &quot;lazy dog&quot;);
- * String templateString = &quot;The ${animal} jumped over the ${target}. ${undefined.number:-1234567890}.&quot;;
+ * String templateString = &quot;The ${animal} jumps over the ${target}. ${undefined.number:-1234567890}.&quot;;
  * StrSubstitutor sub = new StrSubstitutor(valuesMap);
  * String resolvedString = sub.replace(templateString);
  * </pre>
  * yielding:
  * <pre>
- *      The quick brown fox jumped over the lazy dog. 1234567890.
+ *      The quick brown fox jumps over the lazy dog. 1234567890.
  * </pre>
  * <p>
  * In addition to this usage pattern there are some static convenience methods that

--- a/src/test/java/org/apache/commons/lang3/StringUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringUtilsTest.java
@@ -2940,7 +2940,7 @@ public class StringUtilsTest {
      */
     @Test
     public void testToString() throws UnsupportedEncodingException {
-        final String expectedString = "The quick brown fox jumped over the lazy dog.";
+        final String expectedString = "The quick brown fox jumps over the lazy dog.";
         byte[] expectedBytes = expectedString.getBytes(Charset.defaultCharset());
         // sanity check start
         assertArrayEquals(expectedBytes, expectedString.getBytes());
@@ -3087,7 +3087,7 @@ public class StringUtilsTest {
      */
     @Test
     public void testToEncodedString() {
-        final String expectedString = "The quick brown fox jumped over the lazy dog.";
+        final String expectedString = "The quick brown fox jumps over the lazy dog.";
         String encoding = SystemUtils.FILE_ENCODING;
         byte[] expectedBytes = expectedString.getBytes(Charset.defaultCharset());
         // sanity check start


### PR DESCRIPTION
This change adds the missing `s` character to complete the `[a-z]` namespace.

Since the commit only affects Javadoc and test code, I refrained from creating a Jira issue. If I should create one, please leave a comment.

I have signed the ICLA via email.

Signed-off-by: Tobias Gesellchen <tobias@gesellix.de>
