### PR TITLE
Validate's String.format without arguments

### DIFF
--- a/src/main/java/org/apache/commons/lang3/Validate.java
+++ b/src/main/java/org/apache/commons/lang3/Validate.java
@@ -1052,7 +1052,7 @@ public class Validate {
     public static void inclusiveBetween(final long start, final long end, final long value, final String message) {
         // TODO when breaking BC, consider returning value
         if (value < start || value > end) {
-            throw new IllegalArgumentException(String.format(message));
+            throw new IllegalArgumentException(message);
         }
     }
 
@@ -1096,7 +1096,7 @@ public class Validate {
     public static void inclusiveBetween(final double start, final double end, final double value, final String message) {
         // TODO when breaking BC, consider returning value
         if (value < start || value > end) {
-            throw new IllegalArgumentException(String.format(message));
+            throw new IllegalArgumentException(message);
         }
     }
 
@@ -1190,7 +1190,7 @@ public class Validate {
     public static void exclusiveBetween(final long start, final long end, final long value, final String message) {
         // TODO when breaking BC, consider returning value
         if (value <= start || value >= end) {
-            throw new IllegalArgumentException(String.format(message));
+            throw new IllegalArgumentException(message);
         }
     }
 
@@ -1234,7 +1234,7 @@ public class Validate {
     public static void exclusiveBetween(final double start, final double end, final double value, final String message) {
         // TODO when breaking BC, consider returning value
         if (value <= start || value >= end) {
-            throw new IllegalArgumentException(String.format(message));
+            throw new IllegalArgumentException(message);
         }
     }
 


### PR DESCRIPTION
While calling `String.format("some string")` without any additional
arguments is not technically wrong, it's redundant, as it just
returns the same string.

Removing these calls and just using the string instead both cleans up
the code and offers a (very slight) performance gain.