### PR TITLE
Fix FastDateParser#getStrategy(char, int, Calendar) javadoc

### DIFF
--- a/src/main/java/org/apache/commons/lang3/time/FastDateParser.java
+++ b/src/main/java/org/apache/commons/lang3/time/FastDateParser.java
@@ -548,7 +548,7 @@ public class FastDateParser implements DateParser, Serializable {
 
     /**
      * Obtain a Strategy given a field from a SimpleDateFormat pattern
-     * @param formatField A sub-sequence of the SimpleDateFormat pattern
+     * @param f A sub-sequence of the SimpleDateFormat pattern
      * @param definingCalendar The calendar to obtain the short and long values
      * @return The Strategy that will handle parsing for the field
      */


### PR DESCRIPTION
The javadoc refers to a `formatField` parameter, which the method doesn't
have.
Reading the description and the method's code, this documentation
clearly refers to the `f` parameter.

This patch fixes the javadoc and aligns it with the method's parameters.