### PR TITLE
Fix JsonToStringStyleTest.NestingPerson javadoc

### DIFF
--- a/src/test/java/org/apache/commons/lang3/builder/JsonToStringStyleTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/JsonToStringStyleTest.java
@@ -359,7 +359,7 @@ public class JsonToStringStyleTest {
     }
     
     /**
-     * An object with nested object structures used to test {@link JsonToStringStyle}.
+     * An object with nested object structures used to test {@link ToStringStyle.JsonToStringStyle}.
      * 
      */
     static class NestingPerson {


### PR DESCRIPTION
A `{@link}` javadoc can only reference a resolvable class name. The
`{@link}` tag in `NestingPerson`'s javadoc is thus broken, as it directly
references `JsonToStringStyle` without qualifying it with the enclosing
`ToStringStyle` class.

This patch adds the enclosing class to the javadoc, thus "unbreaking"
the reference.