### PR TITLE
LANG-1265: Build failures when building with Java 9 EA

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -810,6 +810,17 @@
         </plugins>
       </build>
     </profile>
+
+    <profile>
+      <id>java9</id>
+      <activation>
+        <jdk>9</jdk>
+      </activation>
+      <properties>
+        <!-- LANG-1265: allow tests to access private fields/methods of java.base classes via reflection -->
+        <argLine>-Xmx512m --add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED</argLine>
+      </properties>
+    </profile>
   </profiles>
 
 </project>


### PR DESCRIPTION
Fix build on Java 9 Build 157 by adding a java-9 maven profile. This is activated by default on Java 9 and opens up java.base classes for reflection which makes all unit tests pass.