### PR TITLE
JUnit imports

### DIFF
--- a/src/test/java/org/apache/commons/lang3/RandomUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/RandomUtilsTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.commons.lang3;
 
-import static junit.framework.TestCase.assertNotNull;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;


### PR DESCRIPTION
The `junit.framework` package has been deprecated, and should no longer
be used.

This patch fixes the one remaining import from it to statically import
`org.junit.Assert.assertNull` instead.