### PR TITLE
Checkstyle for long literals

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -42,5 +42,6 @@ limitations under the License.
     <module name="JavadocMethod">
       <property name="allowUndeclaredRTE" value="true"/>
     </module>
+    <module name="UpperEll">
  </module>
 </module>


### PR DESCRIPTION
PR #248 corrected all the long literals to use the upper case L
notation.
This patch finishes the job as per the discussion there, and adds a
checktysle check to ensure no code that introduces long literals with
lowercase l are introduced.