### PR TITLE
[LANG-1314] Fix javadoc creation on with Java 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,5 +21,8 @@ jdk:
   - oraclejdk7
   - oraclejdk8
 
+script:
+  - mvn test javadoc:javadoc -B
+
 after_success:
   - mvn clean apache-rat:check cobertura:cobertura coveralls:report

--- a/src/main/java/org/apache/commons/lang3/ArrayUtils.java
+++ b/src/main/java/org/apache/commons/lang3/ArrayUtils.java
@@ -8408,12 +8408,13 @@ public class ArrayUtils {
      * ArrayUtils.insert(index, array, null)     = cloned copy of 'array'
      * ArrayUtils.insert(index, null, values)    = null
      * </pre>
-     *  
+     *
+     * @param <T> The type of elements in {@code array} and {@code values}
      * @param index the position within {@code array} to insert the new values
      * @param array the array to insert the values into, may be {@code null}
      * @param values the new values to insert, may be {@code null}
      * @return The new array.
-     * @throws IndexOutOfBoundsException if {@code array} is provided 
+     * @throws IndexOutOfBoundsException if {@code array} is provided
      * and either {@code index < 0} or {@code index > array.length}
      * @since 3.6
      */

--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -313,7 +313,7 @@ public class StringUtils {
     /**
      * <p>Checks if a CharSequence is empty (""), null or whitespace only.</p>
      * 
-     * </p>Whitespace is defined by {@link Character#isWhitespace(char)}.</p>
+     * <p>Whitespace is defined by {@link Character#isWhitespace(char)}.</p>
      *
      * <pre>
      * StringUtils.isBlank(null)      = true
@@ -344,7 +344,7 @@ public class StringUtils {
     /**
      * <p>Checks if a CharSequence is not empty (""), not null and not whitespace only.</p>
      * 
-     * </p>Whitespace is defined by {@link Character#isWhitespace(char)}.</p>
+     * <p>Whitespace is defined by {@link Character#isWhitespace(char)}.</p>
      *
      * <pre>
      * StringUtils.isNotBlank(null)      = false
@@ -367,7 +367,7 @@ public class StringUtils {
     /**
      * <p>Checks if any of the CharSequences are empty ("") or null or whitespace only.</p>
      * 
-     * </p>Whitespace is defined by {@link Character#isWhitespace(char)}.</p>
+     * <p>Whitespace is defined by {@link Character#isWhitespace(char)}.</p>
      *
      * <pre>
      * StringUtils.isAnyBlank(null)             = true
@@ -400,7 +400,7 @@ public class StringUtils {
     /**
      * <p>Checks if any of the CharSequences are not empty (""), not null and not whitespace only.</p>
      * 
-     * </p>Whitespace is defined by {@link Character#isWhitespace(char)}.</p>
+     * <p>Whitespace is defined by {@link Character#isWhitespace(char)}.</p>
      *
      * <pre>
      * StringUtils.isAnyNotBlank(null)             = false
@@ -433,7 +433,7 @@ public class StringUtils {
     /**
      * <p>Checks if none of the CharSequences are empty (""), null or whitespace only.</p>
      * 
-     * </p>Whitespace is defined by {@link Character#isWhitespace(char)}.</p>
+     * <p>Whitespace is defined by {@link Character#isWhitespace(char)}.</p>
      *
      * <pre>
      * StringUtils.isNoneBlank(null)             = false
@@ -1943,7 +1943,7 @@ public class StringUtils {
     /**
      * <p>Check whether the given CharSequence contains any whitespace characters.</p>
      * 
-     * </p>Whitespace is defined by {@link Character#isWhitespace(char)}.</p>
+     * <p>Whitespace is defined by {@link Character#isWhitespace(char)}.</p>
      * 
      * @param seq the CharSequence to check (may be {@code null})
      * @return {@code true} if the CharSequence is not empty and
@@ -7089,7 +7089,7 @@ public class StringUtils {
     /**
      * <p>Checks if the CharSequence contains only whitespace.</p>
      * 
-     * </p>Whitespace is defined by {@link Character#isWhitespace(char)}.</p>
+     * <p>Whitespace is defined by {@link Character#isWhitespace(char)}.</p>
      *
      * <p>{@code null} will return {@code false}.
      * An empty CharSequence (length()=0) will return {@code true}.</p>
@@ -7238,7 +7238,7 @@ public class StringUtils {
      * <p>Returns either the passed in CharSequence, or if the CharSequence is
      * whitespace, empty ("") or {@code null}, the value of {@code defaultStr}.</p>
      * 
-     * </p>Whitespace is defined by {@link Character#isWhitespace(char)}.</p>
+     * <p>Whitespace is defined by {@link Character#isWhitespace(char)}.</p>
      *
      * <pre>
      * StringUtils.defaultIfBlank(null, "NULL")  = "NULL"

--- a/src/main/java/org/apache/commons/lang3/concurrent/Computable.java
+++ b/src/main/java/org/apache/commons/lang3/concurrent/Computable.java
@@ -18,7 +18,7 @@ package org.apache.commons.lang3.concurrent;
 
 /**
  * <p>Definition of an interface for a wrapper around a calculation that takes a single parameter and returns a result.</p>
- * <p/>
+ *
  * <p>This interface allows for wrapping a calculation into a class so that it maybe passed around an application.</p>
  *
  * @param <I> the type of the input to the calculation


### PR DESCRIPTION
Java 8's javadoc seems to be stricter than Java 7's, and the current head current fails to generate javadoc (`mvn javadoc:javadoc`) with Java 8.

This PR contains a series of fixes to the various classes' javadoc which are required for Java 8 (but would also improve the javadoc generated with earlier java versions) and then adds the `javadoc:javadoc` target to Travis CI so we can guarantee it won't break again.