### PR TITLE
Added a restart method for convenience

### DIFF
--- a/src/main/java/org/apache/commons/lang3/time/StopWatch.java
+++ b/src/main/java/org/apache/commons/lang3/time/StopWatch.java
@@ -223,6 +223,21 @@ public class StopWatch {
         }
         this.runningState = State.STOPPED;
     }
+    
+    /**
+     * <p>
+     * Restarts the stopwatch. Specifically puts the watch in a stop state, resets it, then starts it up again.
+     * </p>
+     * 
+     * <p>
+     * This method clears the internal values and starts the timer from scratch.
+     * </p>
+     */
+    public void restart() {
+        this.stop();
+        this.reset();
+        this.start();
+    }
 
     /**
      * <p>


### PR DESCRIPTION
The restart function will allow lazy people like me to simple call `stopwatch.restart()` instead of manually calling the `stop`, `restart` `start` methods one by one, or recreating the object itself.