### PR TITLE
Add checkstyle to the CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ jdk:
   - oraclejdk8
 
 script:
-  - mvn test javadoc:javadoc -B
+  - mvn test checkstyle:check javadoc:javadoc -B
 
 after_success:
   - mvn clean apache-rat:check cobertura:cobertura coveralls:report

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -36,9 +36,6 @@ limitations under the License.
     <module name="RedundantImport"/>
     <module name="UnusedImports"/>
     <module name="NeedBraces"/>
-    <module name="RedundantThrows">
-      <property name="allowUnchecked" value="true"/>
-    </module>
     <module name="JavadocMethod">
       <property name="allowUndeclaredRTE" value="true"/>
     </module>

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -38,6 +38,7 @@ limitations under the License.
     <module name="NeedBraces"/>
     <module name="JavadocMethod">
       <property name="allowUndeclaredRTE" value="true"/>
+      <property name="scope" value="public" />
     </module>
     <module name="UpperEll" />
  </module>

--- a/pom.xml
+++ b/pom.xml
@@ -576,6 +576,7 @@
 
     <!-- Override clirr version to be able to build the site on Java 8 -->
     <commons.clirr.version>2.8</commons.clirr.version>
+    <checkstyle.plugin.version>2.17</checkstyle.plugin.version>
   </properties>
 
 
@@ -646,6 +647,14 @@
           </ignorePathsToDelete>
         </configuration>
       </plugin>
+      <plugin>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>${checkstyle.plugin.version}</version>
+        <configuration>
+          <configLocation>${basedir}/checkstyle.xml</configLocation>
+          <enableRulesSummary>false</enableRulesSummary>
+        </configuration>
+      </plugin>
     </plugins>
 
   </build>
@@ -654,7 +663,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>2.17</version>
+        <version>${checkstyle.plugin.version}</version>
         <configuration>
           <configLocation>${basedir}/checkstyle.xml</configLocation>
           <enableRulesSummary>false</enableRulesSummary>

--- a/pom.xml
+++ b/pom.xml
@@ -654,7 +654,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>2.15</version>
+        <version>2.17</version>
         <configuration>
           <configLocation>${basedir}/checkstyle.xml</configLocation>
           <enableRulesSummary>false</enableRulesSummary>

--- a/src/main/java/org/apache/commons/lang3/concurrent/annotation/package-info.java
+++ b/src/main/java/org/apache/commons/lang3/concurrent/annotation/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * <p>Provides annotations to document classes' thread safety</p>
+ *
+ * @since 3.6
+ */
+package org.apache.commons.lang3.concurrent.annotation;

--- a/src/main/java/org/apache/commons/lang3/exception/ExceptionUtils.java
+++ b/src/main/java/org/apache/commons/lang3/exception/ExceptionUtils.java
@@ -29,7 +29,6 @@ import java.util.StringTokenizer;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.ClassUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.SystemUtils;
 
 /**
  * <p>Provides utilities for manipulating and examining 

--- a/src/main/java/org/apache/commons/lang3/time/DateUtils.java
+++ b/src/main/java/org/apache/commons/lang3/time/DateUtils.java
@@ -675,9 +675,9 @@ public class DateUtils {
      * @throws NullPointerException if {@code date} or {@code tz} is null
      */
     public static Calendar toCalendar(final Date date, final TimeZone tz) {
-    	final Calendar c = Calendar.getInstance(tz);
-    	c.setTime(date);
-    	return c;
+        final Calendar c = Calendar.getInstance(tz);
+        c.setTime(date);
+        return c;
     }
     
     //-----------------------------------------------------------------------


### PR DESCRIPTION
The Apache Commons Lang project uses checktyle to enforce its coding style, but this is only done as part of the reporting phase, when the site is generated. Thus, using checkstyle becomes somewhat of an opt-in procedure, depending on the vigilance of the developers to check the report, instead of being an actual enforcement against violating the codestyle, as evident by the fact that the current checkstyle report contains several hundred(!) such violations.

This PR contains a series of patches to fix the existing checkstyle violations and a final patch that adds checkstyle to Travis CI, making it a gating check instead of an opt-in practice.