### PR TITLE
LANG-1316: Deprecate classes/methods moved to commons-text

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -80,6 +80,7 @@ The <action> type attribute can be add,update,fix,remove.
     <action issue="LANG-1312" type="fix" dev="pschumacher">LocaleUtils#toLocale does not support language followed by UN M.49 numeric-3 area code</action>
     <action issue="LANG-1265" type="fix" dev="pschumacher">Build failures when building with Java 9 EA</action>
     <action issue="LANG-1314" type="fix" dev="pschumacher" due-to="Allon Murienik">javadoc creation broken with Java 8</action>
+    <action issue="LANG-1316" type="update" dev="pschumacher">Deprecate classes/methods moved to commons-text</action>
   </release>
 
   <release version="3.5" date="2016-10-13" description="New features including Java 9 detection">

--- a/src/main/java/org/apache/commons/lang3/ObjectUtils.java
+++ b/src/main/java/org/apache/commons/lang3/ObjectUtils.java
@@ -42,6 +42,8 @@ import org.apache.commons.lang3.text.StrBuilder;
  * @since 1.0
  */
 //@Immutable
+@SuppressWarnings("deprecation") // deprecated class StrBuilder is imported
+// because it is part of the signature of deprecated methods
 public class ObjectUtils {
 
     /**
@@ -373,7 +375,9 @@ public class ObjectUtils {
      * @param builder  the builder to append to
      * @param object  the object to create a toString for
      * @since 3.2
+     * @deprecated as of 3.6, use one of the other {@code identityToString} methods instead
      */
+    @Deprecated
     public static void identityToString(final StrBuilder builder, final Object object) {
         if (object == null) {
             throw new NullPointerException("Cannot get the toString of a null identity");

--- a/src/main/java/org/apache/commons/lang3/StringEscapeUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringEscapeUtils.java
@@ -36,7 +36,11 @@ import org.apache.commons.lang3.text.translate.UnicodeUnpairedSurrogateRemover;
  *
  * <p>#ThreadSafe#</p>
  * @since 2.0
+ * @deprecated as of 3.6, use commons-text
+ * <a href="https://commons.apache.org/proper/commons-text/javadocs/api-release/org/apache/commons/text/StringEscapeUtils.html">
+ * StringEscapeUtils</a> instead
  */
+@Deprecated
 public class StringEscapeUtils {
 
     /* ESCAPE TRANSLATORS */

--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -7950,7 +7950,11 @@ public class StringUtils {
      * @throws IllegalArgumentException if either String input {@code null}
      * @since 3.0 Changed signature from getLevenshteinDistance(String, String) to
      * getLevenshteinDistance(CharSequence, CharSequence)
+     * @deprecated as of 3.6, use commons-text
+     * <a href="https://commons.apache.org/proper/commons-text/javadocs/api-release/org/apache/commons/text/similarity/LevenshteinDistance.html">
+     * LevenshteinDistance</a> instead
      */
+    @Deprecated
     public static int getLevenshteinDistance(CharSequence s, CharSequence t) {
         if (s == null || t == null) {
             throw new IllegalArgumentException("Strings must not be null");
@@ -8036,7 +8040,11 @@ public class StringUtils {
      * @param threshold the target threshold, must not be negative
      * @return result distance, or {@code -1} if the distance would be greater than the threshold
      * @throws IllegalArgumentException if either String input {@code null} or negative threshold
+     * @deprecated as of 3.6, use commons-text
+     * <a href="https://commons.apache.org/proper/commons-text/javadocs/api-release/org/apache/commons/text/similarity/LevenshteinDistance.html">
+     * LevenshteinDistance</a> instead
      */
+    @Deprecated
     public static int getLevenshteinDistance(CharSequence s, CharSequence t, final int threshold) {
         if (s == null || t == null) {
             throw new IllegalArgumentException("Strings must not be null");
@@ -8201,7 +8209,9 @@ public class StringUtils {
      * @return result distance
      * @throws IllegalArgumentException if either String input {@code null}
      * @since 3.3
-     * @deprecated as of 3.6, due to a misleading name, use {@link #getJaroWinklerSimilarity(CharSequence, CharSequence)} instead
+     * @deprecated as of 3.6, use commons-text
+     * <a href="https://commons.apache.org/proper/commons-text/javadocs/api-release/org/apache/commons/text/similarity/JaroWinklerDistance.html">
+     * JaroWinklerDistance</a> instead
      */
     @Deprecated
     public static double getJaroWinklerDistance(final CharSequence first, final CharSequence second) {
@@ -8252,7 +8262,11 @@ public class StringUtils {
      * @return result similarity
      * @throws IllegalArgumentException if either String input {@code null}
      * @since 3.6
+     * @deprecated as of 3.6, use commons-text
+     * <a href="https://commons.apache.org/proper/commons-text/javadocs/api-release/org/apache/commons/text/similarity/JaroWinklerDistance.html">
+     * JaroWinklerDistance</a> instead
      */
+    @Deprecated
     public static double getJaroWinklerSimilarity(final CharSequence first, final CharSequence second) {
         final double DEFAULT_SCALING_FACTOR = 0.1;
 
@@ -8351,7 +8365,11 @@ public class StringUtils {
      * @return result score
      * @throws IllegalArgumentException if either String input {@code null} or Locale input {@code null}
      * @since 3.4
+     * @deprecated as of 3.6, use commons-text
+     * <a href="https://commons.apache.org/proper/commons-text/javadocs/api-release/org/apache/commons/text/similarity/FuzzyScore.html">
+     * FuzzyScore</a> instead
      */
+    @Deprecated
     public static int getFuzzyDistance(final CharSequence term, final CharSequence query, final Locale locale) {
         if (term == null || query == null) {
             throw new IllegalArgumentException("Strings must not be null");

--- a/src/main/java/org/apache/commons/lang3/text/CompositeFormat.java
+++ b/src/main/java/org/apache/commons/lang3/text/CompositeFormat.java
@@ -25,7 +25,11 @@ import java.text.ParsePosition;
  * Formats using one formatter and parses using a different formatter. An
  * example of use for this would be a webapp where data is taken in one way and
  * stored in a database another way.
+ * @deprecated as of 3.6, use commons-text
+ * <a href="https://commons.apache.org/proper/commons-text/javadocs/api-release/org/apache/commons/text/CompositeFormat.html">
+ * CompositeFormat</a> instead
  */
+@Deprecated
 public class CompositeFormat extends Format {
 
     /**

--- a/src/main/java/org/apache/commons/lang3/text/ExtendedMessageFormat.java
+++ b/src/main/java/org/apache/commons/lang3/text/ExtendedMessageFormat.java
@@ -65,7 +65,11 @@ import org.apache.commons.lang3.Validate;
  * </ul>
  *
  * @since 2.4
+ * @deprecated as of 3.6, use commons-text
+ * <a href="https://commons.apache.org/proper/commons-text/javadocs/api-release/org/apache/commons/text/ExtendedMessageFormat.html">
+ * ExtendedMessageFormat</a> instead
  */
+@Deprecated
 public class ExtendedMessageFormat extends MessageFormat {
     private static final long serialVersionUID = -2362048321261811743L;
     private static final int HASH_SEED = 31;

--- a/src/main/java/org/apache/commons/lang3/text/FormatFactory.java
+++ b/src/main/java/org/apache/commons/lang3/text/FormatFactory.java
@@ -23,7 +23,11 @@ import java.util.Locale;
  * Format factory.
  * 
  * @since 2.4
+ * @deprecated as of 3.6, use commons-text
+ * <a href="https://commons.apache.org/proper/commons-text/javadocs/api-release/org/apache/commons/text/FormatFactory.html">
+ * FormatFactory</a> instead
  */
+@Deprecated
 public interface FormatFactory {
 
     /**

--- a/src/main/java/org/apache/commons/lang3/text/FormattableUtils.java
+++ b/src/main/java/org/apache/commons/lang3/text/FormattableUtils.java
@@ -33,7 +33,11 @@ import org.apache.commons.lang3.Validate;
  * and padding, and is not designed to allow generalised alternate formats.</p>
  * 
  * @since Lang 3.0
+ * @deprecated as of 3.6, use commons-text
+ * <a href="https://commons.apache.org/proper/commons-text/javadocs/api-release/org/apache/commons/text/FormattableUtils.html">
+ * FormattableUtils</a> instead
  */
+@Deprecated
 public class FormattableUtils {
 
     /**

--- a/src/main/java/org/apache/commons/lang3/text/StrBuilder.java
+++ b/src/main/java/org/apache/commons/lang3/text/StrBuilder.java
@@ -72,7 +72,11 @@ import org.apache.commons.lang3.builder.Builder;
  * the interface. 
  *
  * @since 2.2
+ * @deprecated as of 3.6, use commons-text
+ * <a href="https://commons.apache.org/proper/commons-text/javadocs/api-release/org/apache/commons/text/StrBuilder.html">
+ * StrBuilder</a> instead
  */
+@Deprecated
 public class StrBuilder implements CharSequence, Appendable, Serializable, Builder<String> {
 
     /**

--- a/src/main/java/org/apache/commons/lang3/text/StrLookup.java
+++ b/src/main/java/org/apache/commons/lang3/text/StrLookup.java
@@ -32,7 +32,11 @@ import java.util.Map;
  * key as a primary key, and looked up the value on demand from the database
  *
  * @since 2.2
+ * @deprecated as of 3.6, use commons-text
+ * <a href="https://commons.apache.org/proper/commons-text/javadocs/api-release/org/apache/commons/text/StrLookup.html">
+ * StrLookup</a> instead
  */
+@Deprecated
 public abstract class StrLookup<V> {
 
     /**

--- a/src/main/java/org/apache/commons/lang3/text/StrMatcher.java
+++ b/src/main/java/org/apache/commons/lang3/text/StrMatcher.java
@@ -28,7 +28,11 @@ import org.apache.commons.lang3.StringUtils;
  * If these do not suffice, you can subclass and implement your own matcher.
  *
  * @since 2.2
+ * @deprecated as of 3.6, use commons-text
+ * <a href="https://commons.apache.org/proper/commons-text/javadocs/api-release/org/apache/commons/text/StrMatcher.html">
+ * StrMatcher</a> instead
  */
+@Deprecated
 public abstract class StrMatcher {
 
     /**

--- a/src/main/java/org/apache/commons/lang3/text/StrSubstitutor.java
+++ b/src/main/java/org/apache/commons/lang3/text/StrSubstitutor.java
@@ -121,7 +121,11 @@ import org.apache.commons.lang3.StringUtils;
  * <p>This class is <b>not</b> thread safe.</p>
  *
  * @since 2.2
+ * @deprecated as of 3.6, use commons-text
+ * <a href="https://commons.apache.org/proper/commons-text/javadocs/api-release/org/apache/commons/text/StrSubstitutor.html">
+ * StrSubstitutor</a> instead
  */
+@Deprecated
 public class StrSubstitutor {
 
     /**

--- a/src/main/java/org/apache/commons/lang3/text/StrTokenizer.java
+++ b/src/main/java/org/apache/commons/lang3/text/StrTokenizer.java
@@ -83,7 +83,11 @@ import org.apache.commons.lang3.StringUtils;
  * </table>
  *
  * @since 2.2
+ * @deprecated as of 3.6, use commons-text
+ * <a href="https://commons.apache.org/proper/commons-text/javadocs/api-release/org/apache/commons/text/StrTokenizer.html">
+ * StrTokenizer</a> instead
  */
+@Deprecated
 public class StrTokenizer implements ListIterator<String>, Cloneable {
 
     private static final StrTokenizer CSV_TOKENIZER_PROTOTYPE;

--- a/src/main/java/org/apache/commons/lang3/text/translate/AggregateTranslator.java
+++ b/src/main/java/org/apache/commons/lang3/text/translate/AggregateTranslator.java
@@ -26,7 +26,11 @@ import org.apache.commons.lang3.ArrayUtils;
  * the first translator consumes codepoints from the input.
  * 
  * @since 3.0
+ * @deprecated as of 3.6, use commons-text
+ * <a href="https://commons.apache.org/proper/commons-text/javadocs/api-release/org/apache/commons/text/AggregateTranslator.html">
+ * AggregateTranslator</a> instead
  */
+@Deprecated
 public class AggregateTranslator extends CharSequenceTranslator {
 
     private final CharSequenceTranslator[] translators;

--- a/src/main/java/org/apache/commons/lang3/text/translate/CharSequenceTranslator.java
+++ b/src/main/java/org/apache/commons/lang3/text/translate/CharSequenceTranslator.java
@@ -27,7 +27,11 @@ import java.util.Locale;
  * is completely contextual, the API does not present two separate signatures.
  * 
  * @since 3.0
+ * @deprecated as of 3.6, use commons-text
+ * <a href="https://commons.apache.org/proper/commons-text/javadocs/api-release/org/apache/commons/text/translate/CharSequenceTranslator.html">
+ * CharSequenceTranslator</a> instead
  */
+@Deprecated
 public abstract class CharSequenceTranslator {
 
     static final char[] HEX_DIGITS = new char[] {'0','1','2','3','4','5','6','7','8','9','A','B','C','D','E','F'};

--- a/src/main/java/org/apache/commons/lang3/text/translate/CodePointTranslator.java
+++ b/src/main/java/org/apache/commons/lang3/text/translate/CodePointTranslator.java
@@ -24,7 +24,11 @@ import java.io.Writer;
  * will replace up to one character at a time.
  * 
  * @since 3.0
+ * @deprecated as of 3.6, use commons-text
+ * <a href="https://commons.apache.org/proper/commons-text/javadocs/api-release/org/apache/commons/text/translate/CodePointTranslator.html">
+ * CharSequenceTranslator</a> instead
  */
+@Deprecated
 public abstract class CodePointTranslator extends CharSequenceTranslator {
 
     /**

--- a/src/main/java/org/apache/commons/lang3/text/translate/EntityArrays.java
+++ b/src/main/java/org/apache/commons/lang3/text/translate/EntityArrays.java
@@ -22,7 +22,11 @@ package org.apache.commons.lang3.text.translate;
  * All arrays are of length [*][2].
  *
  * @since 3.0
+ * @deprecated as of 3.6, use commons-text
+ * <a href="https://commons.apache.org/proper/commons-text/javadocs/api-release/org/apache/commons/text/translate/CodePointTranslator.html">
+ * EntityArrays</a> instead
  */
+@Deprecated
 public class EntityArrays {
 
     /**

--- a/src/main/java/org/apache/commons/lang3/text/translate/JavaUnicodeEscaper.java
+++ b/src/main/java/org/apache/commons/lang3/text/translate/JavaUnicodeEscaper.java
@@ -20,7 +20,11 @@ package org.apache.commons.lang3.text.translate;
  * Translates codepoints to their Unicode escaped value suitable for Java source.
  * 
  * @since 3.2
+ * @deprecated as of 3.6, use commons-text
+ * <a href="https://commons.apache.org/proper/commons-text/javadocs/api-release/org/apache/commons/text/translate/UnicodeEscaper.html">
+ * UnicodeEscaper</a> instead
  */
+@Deprecated
 public class JavaUnicodeEscaper extends UnicodeEscaper {
 
     /**

--- a/src/main/java/org/apache/commons/lang3/text/translate/LookupTranslator.java
+++ b/src/main/java/org/apache/commons/lang3/text/translate/LookupTranslator.java
@@ -25,7 +25,11 @@ import java.util.HashSet;
  * Translates a value using a lookup table.
  *
  * @since 3.0
+ * @deprecated as of 3.6, use commons-text
+ * <a href="https://commons.apache.org/proper/commons-text/javadocs/api-release/org/apache/commons/text/translate/LookupTranslator.html">
+ * LookupTranslator</a> instead
  */
+@Deprecated
 public class LookupTranslator extends CharSequenceTranslator {
 
     private final HashMap<String, String> lookupMap;

--- a/src/main/java/org/apache/commons/lang3/text/translate/NumericEntityEscaper.java
+++ b/src/main/java/org/apache/commons/lang3/text/translate/NumericEntityEscaper.java
@@ -23,7 +23,11 @@ import java.io.Writer;
  * Translates codepoints to their XML numeric entity escaped value.
  *
  * @since 3.0
+ * @deprecated as of 3.6, use commons-text
+ * <a href="https://commons.apache.org/proper/commons-text/javadocs/api-release/org/apache/commons/text/translate/NumericEntityEscaper.html">
+ * NumericEntityEscaper</a> instead
  */
+@Deprecated
 public class NumericEntityEscaper extends CodePointTranslator {
 
     private final int below;

--- a/src/main/java/org/apache/commons/lang3/text/translate/NumericEntityUnescaper.java
+++ b/src/main/java/org/apache/commons/lang3/text/translate/NumericEntityUnescaper.java
@@ -28,7 +28,11 @@ import java.util.EnumSet;
  * Note that the semi-colon is optional.
  * 
  * @since 3.0
+ * @deprecated as of 3.6, use commons-text
+ * <a href="https://commons.apache.org/proper/commons-text/javadocs/api-release/org/apache/commons/text/translate/NumericEntityUnescaper.html">
+ * NumericEntityUnescaper</a> instead
  */
+@Deprecated
 public class NumericEntityUnescaper extends CharSequenceTranslator {
 
     public static enum OPTION { semiColonRequired, semiColonOptional, errorIfNoSemiColon }

--- a/src/main/java/org/apache/commons/lang3/text/translate/OctalUnescaper.java
+++ b/src/main/java/org/apache/commons/lang3/text/translate/OctalUnescaper.java
@@ -28,7 +28,11 @@ import java.io.Writer;
  * 1 to 377. This is because parsing Java is the main use case.
  * 
  * @since 3.0
+ * @deprecated as of 3.6, use commons-text
+ * <a href="https://commons.apache.org/proper/commons-text/javadocs/api-release/org/apache/commons/text/translate/OctalUnescaper.html">
+ * OctalUnescaper</a> instead
  */
+@Deprecated
 public class OctalUnescaper extends CharSequenceTranslator {
 
     /**

--- a/src/main/java/org/apache/commons/lang3/text/translate/UnicodeEscaper.java
+++ b/src/main/java/org/apache/commons/lang3/text/translate/UnicodeEscaper.java
@@ -23,7 +23,11 @@ import java.io.Writer;
  * Translates codepoints to their Unicode escaped value.
  *
  * @since 3.0
+ * @deprecated as of 3.6, use commons-text
+ * <a href="https://commons.apache.org/proper/commons-text/javadocs/api-release/org/apache/commons/text/translate/UnicodeEscaper.html">
+ * UnicodeEscaper</a> instead
  */
+@Deprecated
 public class UnicodeEscaper extends CodePointTranslator {
 
     private final int below;

--- a/src/main/java/org/apache/commons/lang3/text/translate/UnicodeUnescaper.java
+++ b/src/main/java/org/apache/commons/lang3/text/translate/UnicodeUnescaper.java
@@ -25,7 +25,11 @@ import java.io.Writer;
  * without the +.
  * 
  * @since 3.0
+ * @deprecated as of 3.6, use commons-text
+ * <a href="https://commons.apache.org/proper/commons-text/javadocs/api-release/org/apache/commons/text/translate/UnicodeUnescaper.html">
+ * UnicodeUnescaper</a> instead
  */
+@Deprecated
 public class UnicodeUnescaper extends CharSequenceTranslator {
 
     /**

--- a/src/main/java/org/apache/commons/lang3/text/translate/UnicodeUnpairedSurrogateRemover.java
+++ b/src/main/java/org/apache/commons/lang3/text/translate/UnicodeUnpairedSurrogateRemover.java
@@ -21,7 +21,12 @@ import java.io.Writer;
 
 /**
  * Helper subclass to CharSequenceTranslator to remove unpaired surrogates.
+ * 
+ * @deprecated as of 3.6, use commons-text
+ * <a href="https://commons.apache.org/proper/commons-text/javadocs/api-release/org/apache/commons/text/translate/UnicodeUnpairedSurrogateRemover.html">
+ * UnicodeUnpairedSurrogateRemover</a> instead
  */
+@Deprecated
 public class UnicodeUnpairedSurrogateRemover extends CodePointTranslator {
     /**
      * Implementation of translate that throws out unpaired surrogates. 

--- a/src/main/java/org/apache/commons/lang3/text/translate/package-info.java
+++ b/src/main/java/org/apache/commons/lang3/text/translate/package-info.java
@@ -20,5 +20,8 @@
  * <p>These classes are immutable, and therefore thread-safe.</p>
  *
  * @since 3.0
+ * @deprecated as of 3.6, use the commons-text
+ * <a href="https://commons.apache.org/proper/commons-text/javadocs/api-release/org/apache/commons/text/translate/package-summary.html">
+ * translate package</a> instead
  */
 package org.apache.commons.lang3.text.translate;

--- a/src/test/java/org/apache/commons/lang3/StringEscapeUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringEscapeUtilsTest.java
@@ -38,6 +38,7 @@ import org.junit.Test;
 /**
  * Unit tests for {@link StringEscapeUtils}.
  */
+@Deprecated
 public class StringEscapeUtilsTest {
     private final static String FOO = "foo";
 
@@ -314,7 +315,6 @@ public class StringEscapeUtilsTest {
     }
 
     @Test
-    @SuppressWarnings( "deprecation" ) // ESCAPE_XML has been replaced by ESCAPE_XML10 and ESCAPE_XML11 in 3.3
     public void testEscapeXml() throws Exception {
         assertEquals("&lt;abc&gt;", StringEscapeUtils.escapeXml("<abc>"));
         assertEquals("<abc>", StringEscapeUtils.unescapeXml("&lt;abc&gt;"));
@@ -399,7 +399,6 @@ public class StringEscapeUtilsTest {
      * @see <a href="https://issues.apache.org/jira/browse/LANG-728">LANG-728</a>
      */
     @Test
-    @SuppressWarnings( "deprecation" ) // ESCAPE_XML has been replaced by ESCAPE_XML10 and ESCAPE_XML11 in 3.3
     public void testEscapeXmlSupplementaryCharacters() {
         final CharSequenceTranslator escapeXml = 
             StringEscapeUtils.ESCAPE_XML.with( NumericEntityEscaper.between(0x7f, Integer.MAX_VALUE) );
@@ -412,7 +411,6 @@ public class StringEscapeUtilsTest {
     }
     
     @Test
-    @SuppressWarnings( "deprecation" ) // ESCAPE_XML has been replaced by ESCAPE_XML10 and ESCAPE_XML11 in 3.3
     public void testEscapeXmlAllCharacters() {
         // http://www.w3.org/TR/xml/#charsets says:
         // Char ::= #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF] /* any Unicode character,
@@ -604,7 +602,6 @@ public class StringEscapeUtilsTest {
      * Tests https://issues.apache.org/jira/browse/LANG-720
      */
     @Test
-    @SuppressWarnings( "deprecation" ) // escapeXml(String) has been replaced by escapeXml10(String) and escapeXml11(String) in 3.3
     public void testLang720() {
         final String input = "\ud842\udfb7" + "A";
         final String escaped = StringEscapeUtils.escapeXml(input);

--- a/src/test/java/org/apache/commons/lang3/StringUtilsStartsEndsWithTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringUtilsStartsEndsWithTest.java
@@ -21,7 +21,6 @@ import org.junit.Test;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import org.apache.commons.lang3.text.StrBuilder;
 
 /**
  * Unit tests {@link org.apache.commons.lang3.StringUtils} - StartsWith/EndsWith methods
@@ -98,7 +97,7 @@ public class StringUtilsStartsEndsWithTest {
         assertFalse(StringUtils.startsWithAny("ABCXYZ", null, "xyz", "abc"));
 
         assertTrue("StringUtils.startsWithAny(abcxyz, StringBuilder(xyz), StringBuffer(abc))", StringUtils.startsWithAny("abcxyz", new StringBuilder("xyz"), new StringBuffer("abc")));
-        assertTrue("StringUtils.startsWithAny( StrBuilder(abcxyz), StringBuilder(xyz), StringBuffer(abc))", StringUtils.startsWithAny( new StrBuilder("abcxyz"), new StringBuilder("xyz"), new StringBuffer("abc")));
+        assertTrue("StringUtils.startsWithAny(StringBuffer(abcxyz), StringBuilder(xyz), StringBuffer(abc))", StringUtils.startsWithAny(new StringBuffer("abcxyz"), new StringBuilder("xyz"), new StringBuffer("abc")));
     }
  
 
@@ -195,7 +194,7 @@ public class StringUtilsStartsEndsWithTest {
         assertTrue(StringUtils.endsWithAny("abcXYZ", ""));
 
         assertTrue("StringUtils.endsWithAny(abcxyz, StringBuilder(abc), StringBuffer(xyz))", StringUtils.endsWithAny("abcxyz", new StringBuilder("abc"), new StringBuffer("xyz")));
-        assertTrue("StringUtils.endsWithAny( StrBuilder(abcxyz), StringBuilder(abc), StringBuffer(xyz))", StringUtils.endsWithAny( new StrBuilder("abcxyz"), new StringBuilder("abc"), new StringBuffer("xyz")));
+        assertTrue("StringUtils.endsWithAny(StringBuffer(abcxyz), StringBuilder(abc), StringBuffer(xyz))", StringUtils.endsWithAny(new StringBuffer("abcxyz"), new StringBuilder("abc"), new StringBuffer("xyz")));
     }
 
 

--- a/src/test/java/org/apache/commons/lang3/reflect/TypeUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/reflect/TypeUtilsTest.java
@@ -33,7 +33,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeSet;
 
-import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.reflect.testbed.Foo;
 import org.apache.commons.lang3.reflect.testbed.GenericParent;
 import org.apache.commons.lang3.reflect.testbed.GenericTypeHolder;
@@ -455,12 +454,12 @@ public class TypeUtilsTest<B> {
 
         if (expected) {
             Assert.assertTrue("[" + i1 + ", " + i2 + "]: From "
-                    + StringEscapeUtils.escapeHtml4(String.valueOf(type2)) + " to "
-                    + StringEscapeUtils.escapeHtml4(String.valueOf(type1)), isAssignable);
+                    + String.valueOf(type2) + " to "
+                    + String.valueOf(type1), isAssignable);
         } else {
             Assert.assertFalse("[" + i1 + ", " + i2 + "]: From "
-                    + StringEscapeUtils.escapeHtml4(String.valueOf(type2)) + " to "
-                    + StringEscapeUtils.escapeHtml4(String.valueOf(type1)), isAssignable);
+                    + String.valueOf(type2) + " to "
+                    + String.valueOf(type1), isAssignable);
         }
     }
 

--- a/src/test/java/org/apache/commons/lang3/text/CompositeFormatTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/CompositeFormatTest.java
@@ -30,6 +30,7 @@ import java.util.Locale;
 /**
  * Unit tests for {@link org.apache.commons.lang3.text.CompositeFormat}.
  */
+@Deprecated
 public class CompositeFormatTest {
 
     /**

--- a/src/test/java/org/apache/commons/lang3/text/ExtendedMessageFormatTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/ExtendedMessageFormatTest.java
@@ -42,6 +42,7 @@ import java.util.Map;
  *
  * @since 2.4
  */
+@Deprecated
 public class ExtendedMessageFormatTest {
 
     private final Map<String, FormatFactory> registry = new HashMap<>();

--- a/src/test/java/org/apache/commons/lang3/text/FormattableUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/FormattableUtilsTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 /**
  * Unit tests {@link FormattableUtils}.
  */
+@Deprecated
 public class FormattableUtilsTest {
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/text/StrBuilderAppendInsertTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/StrBuilderAppendInsertTest.java
@@ -31,6 +31,7 @@ import java.util.Iterator;
 /**
  * Unit tests for {@link org.apache.commons.lang3.text.StrBuilder}.
  */
+@Deprecated
 public class StrBuilderAppendInsertTest {
 
     /** The system line separator. */

--- a/src/test/java/org/apache/commons/lang3/text/StrBuilderTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/StrBuilderTest.java
@@ -40,6 +40,7 @@ import org.apache.commons.lang3.ArrayUtils;
 /**
  * Unit tests for {@link org.apache.commons.lang3.text.StrBuilder}.
  */
+@Deprecated
 public class StrBuilderTest {
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/apache/commons/lang3/text/StrLookupTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/StrLookupTest.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 /**
  * Test class for StrLookup.
  */
+@Deprecated
 public class StrLookupTest  {
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/apache/commons/lang3/text/StrMatcherTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/StrMatcherTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 /**
  * Unit tests for {@link org.apache.commons.lang3.text.StrMatcher}.
  */
+@Deprecated
 public class StrMatcherTest  {
 
     private static final char[] BUFFER1 = "0,1\t2 3\n\r\f\u0000'\"".toCharArray();

--- a/src/test/java/org/apache/commons/lang3/text/StrSubstitutorTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/StrSubstitutorTest.java
@@ -36,6 +36,7 @@ import org.junit.Test;
 /**
  * Test class for StrSubstitutor.
  */
+@Deprecated
 public class StrSubstitutorTest {
 
     private Map<String, String> values;

--- a/src/test/java/org/apache/commons/lang3/text/StrTokenizerTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/StrTokenizerTest.java
@@ -35,6 +35,7 @@ import org.apache.commons.lang3.ArrayUtils;
 /**
  * Unit test for Tokenizer.
  */
+@Deprecated
 public class StrTokenizerTest {
 
     private static final String CSV_SIMPLE_FIXTURE = "A,b,c";

--- a/src/test/java/org/apache/commons/lang3/text/translate/EntityArraysTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/translate/EntityArraysTest.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 /**
  * Unit tests for {@link org.apache.commons.lang3.text.translate.EntityArrays}.
  */
+@Deprecated
 public class EntityArraysTest  {
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/text/translate/LookupTranslatorTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/translate/LookupTranslatorTest.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 /**
  * Unit tests for {@link org.apache.commons.lang3.text.translate.LookupTranslator}.
  */
+@Deprecated
 public class LookupTranslatorTest  {
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/text/translate/NumericEntityEscaperTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/translate/NumericEntityEscaperTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 /**
  * Unit tests for {@link org.apache.commons.lang3.text.translate.NumericEntityEscaper}.
  */
+@Deprecated
 public class NumericEntityEscaperTest  {
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/text/translate/NumericEntityUnescaperTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/translate/NumericEntityUnescaperTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 /**
  * Unit tests for {@link org.apache.commons.lang3.text.translate.NumericEntityUnescaper}.
  */
+@Deprecated
 public class NumericEntityUnescaperTest  {
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/text/translate/OctalUnescaperTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/translate/OctalUnescaperTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertEquals;
 /**
  * Unit tests for {@link org.apache.commons.lang3.text.translate.OctalUnescaper}.
  */
+@Deprecated
 public class OctalUnescaperTest {
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/text/translate/UnicodeEscaperTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/translate/UnicodeEscaperTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 /**
  * Unit tests for {@link org.apache.commons.lang3.text.translate.UnicodeEscaper}.
  */
+@Deprecated
 public class UnicodeEscaperTest  {
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/text/translate/UnicodeUnescaperTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/translate/UnicodeUnescaperTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 /**
  * Unit tests for {@link org.apache.commons.lang3.text.translate.UnicodeEscaper}.
  */
+@Deprecated
 public class UnicodeUnescaperTest {
 
     // Requested in LANG-507

--- a/src/test/java/org/apache/commons/lang3/text/translate/UnicodeUnpairedSurrogateRemoverTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/translate/UnicodeUnpairedSurrogateRemoverTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 /**
  * Unit tests for {@link org.apache.commons.lang3.text.translate.UnicodeUnpairedSurrogateRemover}.
  */
+@Deprecated
 public class UnicodeUnpairedSurrogateRemoverTest {
     final UnicodeUnpairedSurrogateRemover subject = new UnicodeUnpairedSurrogateRemover();
     final CharArrayWriter writer = new CharArrayWriter(); // nothing is ever written to it


### PR DESCRIPTION
* org.apache.commons.lang3.text.translate - every class
* org.apache.commons.lang3.text - every class beside WordUtils
* StringEscapeUtils - whole class
* StringUtils: getLevenshteinDistance, getFuzzyDistance and getJaroWinklerSimilarity methods
* ObjectUtils: identityToString(final StrBuilder builder, final Object object) method (StrBuilder was moved to commons-text)