### PR TITLE
Apply checkstyle to test sources

### DIFF
--- a/checkstyle-suppressions.xml
+++ b/checkstyle-suppressions.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<!DOCTYPE suppressions PUBLIC "-//Puppy Crawl//DTD Suppressions 1.1//EN" "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+<suppressions>
+    <suppress checks="JavadocMethod" files=".*/test/.*"/>
+    <suppress checks="JavadocPackage" files=".*/test/.*"/>
+</suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -652,6 +652,8 @@
         <version>${checkstyle.plugin.version}</version>
         <configuration>
           <configLocation>${basedir}/checkstyle.xml</configLocation>
+          <suppressionsLocation>${basedir}/checkstyle-suppressions.xml</suppressionsLocation>
+          <includeTestSourceDirectory>true</includeTestSourceDirectory>
           <enableRulesSummary>false</enableRulesSummary>
         </configuration>
       </plugin>
@@ -666,6 +668,8 @@
         <version>${checkstyle.plugin.version}</version>
         <configuration>
           <configLocation>${basedir}/checkstyle.xml</configLocation>
+          <suppressionsLocation>${basedir}/checkstyle-suppressions.xml</suppressionsLocation>
+          <includeTestSourceDirectory>true</includeTestSourceDirectory>
           <enableRulesSummary>false</enableRulesSummary>
         </configuration>
         <reportSets>

--- a/src/test/java/org/apache/commons/lang3/ArrayUtilsInsertTest.java
+++ b/src/test/java/org/apache/commons/lang3/ArrayUtilsInsertTest.java
@@ -17,7 +17,10 @@
 
 package org.apache.commons.lang3;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
 
 import org.junit.Test;
 

--- a/src/test/java/org/apache/commons/lang3/CharSequenceUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/CharSequenceUtilsTest.java
@@ -16,12 +16,15 @@
  */
 package org.apache.commons.lang3;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
-
-import org.junit.Assert;
 
 import org.junit.Test;
 
@@ -47,27 +50,27 @@ public class CharSequenceUtilsTest {
         //
         // null input
         //
-        Assert.assertEquals(null, CharSequenceUtils.subSequence(null, -1));
-        Assert.assertEquals(null, CharSequenceUtils.subSequence(null, 0));
-        Assert.assertEquals(null, CharSequenceUtils.subSequence(null, 1));
+        assertEquals(null, CharSequenceUtils.subSequence(null, -1));
+        assertEquals(null, CharSequenceUtils.subSequence(null, 0));
+        assertEquals(null, CharSequenceUtils.subSequence(null, 1));
         //
         // non-null input
         //
-        Assert.assertEquals(StringUtils.EMPTY, CharSequenceUtils.subSequence(StringUtils.EMPTY, 0));
-        Assert.assertEquals("012", CharSequenceUtils.subSequence("012", 0));
-        Assert.assertEquals("12", CharSequenceUtils.subSequence("012", 1));
-        Assert.assertEquals("2", CharSequenceUtils.subSequence("012", 2));
-        Assert.assertEquals(StringUtils.EMPTY, CharSequenceUtils.subSequence("012", 3));
+        assertEquals(StringUtils.EMPTY, CharSequenceUtils.subSequence(StringUtils.EMPTY, 0));
+        assertEquals("012", CharSequenceUtils.subSequence("012", 0));
+        assertEquals("12", CharSequenceUtils.subSequence("012", 1));
+        assertEquals("2", CharSequenceUtils.subSequence("012", 2));
+        assertEquals(StringUtils.EMPTY, CharSequenceUtils.subSequence("012", 3));
     }
 
     @Test(expected=IndexOutOfBoundsException.class)
     public void testSubSequenceNegativeStart() {
-        Assert.assertEquals(null, CharSequenceUtils.subSequence(StringUtils.EMPTY, -1));
+        assertEquals(null, CharSequenceUtils.subSequence(StringUtils.EMPTY, -1));
     }
 
     @Test(expected=IndexOutOfBoundsException.class)
     public void testSubSequenceTooLong() {
-        Assert.assertEquals(null, CharSequenceUtils.subSequence(StringUtils.EMPTY, 1));
+        assertEquals(null, CharSequenceUtils.subSequence(StringUtils.EMPTY, 1));
     }
 
     static class TestData{
@@ -142,15 +145,15 @@ public class CharSequenceUtilsTest {
             if (data.throwable != null) {
                 try {
                     invoke();
-                    Assert.fail(id + " Expected " + data.throwable);
+                    fail(id + " Expected " + data.throwable);
                 } catch (final Exception e) {
                     if (!e.getClass().equals(data.throwable)) {
-                        Assert.fail(id + " Expected " + data.throwable + " got " + e.getClass());
+                        fail(id + " Expected " + data.throwable + " got " + e.getClass());
                     }
                 }
             } else {
                 final boolean stringCheck = invoke();
-                Assert.assertEquals(id + " Failed test " + data, data.expected, stringCheck);                
+                assertEquals(id + " Failed test " + data, data.expected, stringCheck);
             }
         }
         

--- a/src/test/java/org/apache/commons/lang3/JavaVersionTest.java
+++ b/src/test/java/org/apache/commons/lang3/JavaVersionTest.java
@@ -21,7 +21,9 @@ package org.apache.commons.lang3;
 import org.junit.Test;
 
 import static org.apache.commons.lang3.JavaVersion.JAVA_RECENT;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.apache.commons.lang3.JavaVersion.JAVA_0_9;
 import static org.apache.commons.lang3.JavaVersion.JAVA_1_1;
 import static org.apache.commons.lang3.JavaVersion.JAVA_1_2;

--- a/src/test/java/org/apache/commons/lang3/StringUtilsStartsEndsWithTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringUtilsStartsEndsWithTest.java
@@ -17,7 +17,10 @@
 package org.apache.commons.lang3;
 
 import org.junit.Test;
-import static org.junit.Assert.*;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import org.apache.commons.lang3.text.StrBuilder;
 
 /**

--- a/src/test/java/org/apache/commons/lang3/StringUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringUtilsTest.java
@@ -16,7 +16,14 @@
  */
 package org.apache.commons.lang3;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Constructor;

--- a/src/test/java/org/apache/commons/lang3/builder/MultilineRecursiveToStringStyleTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/MultilineRecursiveToStringStyleTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.commons.lang3.builder;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/test/java/org/apache/commons/lang3/concurrent/BackgroundInitializerTest.java
+++ b/src/test/java/org/apache/commons/lang3/concurrent/BackgroundInitializerTest.java
@@ -18,7 +18,13 @@ package org.apache.commons.lang3.concurrent;
 
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;

--- a/src/test/java/org/apache/commons/lang3/exception/AbstractExceptionContextTest.java
+++ b/src/test/java/org/apache/commons/lang3/exception/AbstractExceptionContextTest.java
@@ -19,7 +19,8 @@ package org.apache.commons.lang3.exception;
 import org.junit.Test;
 import org.junit.Before;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.io.Serializable;
 import java.util.Arrays;

--- a/src/test/java/org/apache/commons/lang3/mutable/MutableBooleanTest.java
+++ b/src/test/java/org/apache/commons/lang3/mutable/MutableBooleanTest.java
@@ -18,7 +18,10 @@
 package org.apache.commons.lang3.mutable;
 
 import org.junit.Test;
-import static org.junit.Assert.*;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit tests.

--- a/src/test/java/org/apache/commons/lang3/mutable/MutableByteTest.java
+++ b/src/test/java/org/apache/commons/lang3/mutable/MutableByteTest.java
@@ -17,7 +17,10 @@
 package org.apache.commons.lang3.mutable;
 
 import org.junit.Test;
-import static org.junit.Assert.*;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit tests.

--- a/src/test/java/org/apache/commons/lang3/mutable/MutableDoubleTest.java
+++ b/src/test/java/org/apache/commons/lang3/mutable/MutableDoubleTest.java
@@ -17,7 +17,10 @@
 package org.apache.commons.lang3.mutable;
 
 import org.junit.Test;
-import static org.junit.Assert.*;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit tests.

--- a/src/test/java/org/apache/commons/lang3/mutable/MutableFloatTest.java
+++ b/src/test/java/org/apache/commons/lang3/mutable/MutableFloatTest.java
@@ -17,7 +17,10 @@
 package org.apache.commons.lang3.mutable;
 
 import org.junit.Test;
-import static org.junit.Assert.*;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit tests.

--- a/src/test/java/org/apache/commons/lang3/mutable/MutableIntTest.java
+++ b/src/test/java/org/apache/commons/lang3/mutable/MutableIntTest.java
@@ -17,7 +17,10 @@
 package org.apache.commons.lang3.mutable;
 
 import org.junit.Test;
-import static org.junit.Assert.*;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit tests.

--- a/src/test/java/org/apache/commons/lang3/mutable/MutableLongTest.java
+++ b/src/test/java/org/apache/commons/lang3/mutable/MutableLongTest.java
@@ -17,7 +17,10 @@
 package org.apache.commons.lang3.mutable;
 
 import org.junit.Test;
-import static org.junit.Assert.*;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit tests.

--- a/src/test/java/org/apache/commons/lang3/mutable/MutableObjectTest.java
+++ b/src/test/java/org/apache/commons/lang3/mutable/MutableObjectTest.java
@@ -16,8 +16,13 @@
  */
 package org.apache.commons.lang3.mutable;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
 import org.junit.Test;
-import static org.junit.Assert.*;
+
 
 /**
  * JUnit tests.

--- a/src/test/java/org/apache/commons/lang3/mutable/MutableShortTest.java
+++ b/src/test/java/org/apache/commons/lang3/mutable/MutableShortTest.java
@@ -17,7 +17,11 @@
 package org.apache.commons.lang3.mutable;
 
 import org.junit.Test;
-import static org.junit.Assert.*;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * JUnit tests.

--- a/src/test/java/org/apache/commons/lang3/reflect/FieldUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/reflect/FieldUtilsTest.java
@@ -17,7 +17,15 @@
 package org.apache.commons.lang3.reflect;
 
 import org.apache.commons.lang3.ArrayUtils;
-import org.apache.commons.lang3.reflect.testbed.*;
+
+import org.apache.commons.lang3.reflect.testbed.Ambig;
+import org.apache.commons.lang3.reflect.testbed.Annotated;
+import org.apache.commons.lang3.reflect.testbed.Foo;
+import org.apache.commons.lang3.reflect.testbed.PrivatelyShadowedChild;
+import org.apache.commons.lang3.reflect.testbed.PublicChild;
+import org.apache.commons.lang3.reflect.testbed.PubliclyShadowedChild;
+import org.apache.commons.lang3.reflect.testbed.StaticContainer;
+import org.apache.commons.lang3.reflect.testbed.StaticContainerChild;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -28,7 +36,13 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeNotNull;
 
 /**

--- a/src/test/java/org/apache/commons/lang3/reflect/MethodUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/reflect/MethodUtilsTest.java
@@ -103,39 +103,39 @@ public class MethodUtilsTest {
         public static void oneParameterStatic(final String s) {
             // empty
         }
-        
+
         @SuppressWarnings("unused")
         private void privateStuff() {
         }
 
         @SuppressWarnings("unused")
         private String privateStringStuff() {
-        	return "privateStringStuff()";
+            return "privateStringStuff()";
         }
-        
+
         @SuppressWarnings("unused")
         private String privateStringStuff(final int i) {
-        	return "privateStringStuff(int)";
+            return "privateStringStuff(int)";
         }
-        
+
         @SuppressWarnings("unused")
         private String privateStringStuff(final Integer i) {
-        	return "privateStringStuff(Integer)";
+            return "privateStringStuff(Integer)";
         }
-        
+
         @SuppressWarnings("unused")
         private String privateStringStuff(final double d) {
-        	return "privateStringStuff(double)";
+            return "privateStringStuff(double)";
         }
-        
+
         @SuppressWarnings("unused")
         private String privateStringStuff(final String s) {
-        	return "privateStringStuff(String)";
+            return "privateStringStuff(String)";
         }
-        
+
         @SuppressWarnings("unused")
         private String privateStringStuff(final Object s) {
-        	return "privateStringStuff(Object)";
+            return "privateStringStuff(Object)";
         }
 
 
@@ -760,12 +760,12 @@ public class MethodUtilsTest {
         final int[] actual = (int[])MethodUtils.invokeMethod(testBean, "unboxing", Integer.valueOf(1), Integer.valueOf(2));
         Assert.assertArrayEquals(new int[]{1, 2}, actual);
     }
-    
+
     @Test
     public void testInvokeMethodForceAccessNoArgs() throws Exception {
         Assert.assertEquals("privateStringStuff()", MethodUtils.invokeMethod(testBean, true, "privateStringStuff"));
     }
-    
+
     @Test
     public void testInvokeMethodForceAccessWithArgs() throws Exception {
         Assert.assertEquals("privateStringStuff(Integer)", MethodUtils.invokeMethod(testBean, true, "privateStringStuff", 5));
@@ -773,17 +773,17 @@ public class MethodUtilsTest {
         Assert.assertEquals("privateStringStuff(String)", MethodUtils.invokeMethod(testBean, true, "privateStringStuff", "Hi There"));
         Assert.assertEquals("privateStringStuff(Object)", MethodUtils.invokeMethod(testBean, true, "privateStringStuff", new Date()));
     }
-    
+
     @Test
     public void testDistance() throws Exception {
         final Method distanceMethod = MethodUtils.getMatchingMethod(MethodUtils.class, "distance", Class[].class, Class[].class);
         distanceMethod.setAccessible(true);
-        
+
         Assert.assertEquals(-1, distanceMethod.invoke(null, new Class[]{String.class}, new Class[]{Date.class}));
         Assert.assertEquals(0, distanceMethod.invoke(null, new Class[]{Date.class}, new Class[]{Date.class}));
         Assert.assertEquals(1, distanceMethod.invoke(null, new Class[]{Integer.class}, new Class[]{ClassUtils.wrapperToPrimitive(Integer.class)}));
         Assert.assertEquals(2, distanceMethod.invoke(null, new Class[]{Integer.class}, new Class[]{Object.class}));
-        
+
         distanceMethod.setAccessible(false);
     }
 }

--- a/src/test/java/org/apache/commons/lang3/text/CompositeFormatTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/CompositeFormatTest.java
@@ -18,7 +18,9 @@
 package org.apache.commons.lang3.text;
 
 import org.junit.Test;
-import static org.junit.Assert.*;
+
+import static org.junit.Assert.assertEquals;
+
 import java.text.FieldPosition;
 import java.text.Format;
 import java.text.ParsePosition;

--- a/src/test/java/org/apache/commons/lang3/text/ExtendedMessageFormatTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/ExtendedMessageFormatTest.java
@@ -18,7 +18,10 @@ package org.apache.commons.lang3.text;
 
 import org.junit.Test;
 import org.junit.Before;
-import static org.junit.Assert.*;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.text.DateFormat;
 import java.text.FieldPosition;

--- a/src/test/java/org/apache/commons/lang3/text/StrBuilderAppendInsertTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/StrBuilderAppendInsertTest.java
@@ -18,7 +18,9 @@
 package org.apache.commons.lang3.text;
 
 import org.junit.Test;
-import static org.junit.Assert.*;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import java.text.DecimalFormatSymbols;
 import java.util.Arrays;

--- a/src/test/java/org/apache/commons/lang3/text/StrBuilderTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/StrBuilderTest.java
@@ -18,7 +18,14 @@
 package org.apache.commons.lang3.text;
 
 import org.junit.Test;
-import static org.junit.Assert.*;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.io.Reader;

--- a/src/test/java/org/apache/commons/lang3/text/StrTokenizerTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/StrTokenizerTest.java
@@ -19,7 +19,11 @@ package org.apache.commons.lang3.text;
 
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/src/test/java/org/apache/commons/lang3/text/WordUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/WordUtilsTest.java
@@ -16,7 +16,10 @@
  */
 package org.apache.commons.lang3.text;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;

--- a/src/test/java/org/apache/commons/lang3/text/translate/OctalUnescaperTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/translate/OctalUnescaperTest.java
@@ -18,7 +18,7 @@
 package org.apache.commons.lang3.text.translate;
 
 import org.junit.Test;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Unit tests for {@link org.apache.commons.lang3.text.translate.OctalUnescaper}.

--- a/src/test/java/org/apache/commons/lang3/text/translate/UnicodeUnpairedSurrogateRemoverTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/translate/UnicodeUnpairedSurrogateRemoverTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.commons.lang3.text.translate;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import java.io.CharArrayWriter;
 import java.io.IOException;

--- a/src/test/java/org/apache/commons/lang3/time/DateUtilsFragmentTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/DateUtilsFragmentTest.java
@@ -18,7 +18,9 @@ package org.apache.commons.lang3.time;
 
 import org.junit.Test;
 import org.junit.Before;
-import static org.junit.Assert.*;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 import java.util.Calendar;
 import java.util.Date;
 

--- a/src/test/java/org/apache/commons/lang3/time/DateUtilsRoundingTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/DateUtilsRoundingTest.java
@@ -18,7 +18,10 @@ package org.apache.commons.lang3.time;
 
 import org.junit.Test;
 import org.junit.Before;
-import static org.junit.Assert.*;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;


### PR DESCRIPTION
This enforces the code style defined by the checkstyle checks to the test sources too.

This PR contains a series of patches that fix checkstyle violations, and a final patch the enables checkstyle checks on the test sources. In the cases where it would just add robustness and not improve the code's readability and maintainability (specifically - the javadoc checks), those checks are explicitly suppressed.