### PR TITLE
Findbugs in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ jdk:
   - oraclejdk8
 
 script:
-  - mvn test apache-rat:check clirr:check checkstyle:check javadoc:javadoc -B
+  - mvn test apache-rat:check clirr:check checkstyle:check findbugs:check javadoc:javadoc -B
 
 after_success:
   - mvn clean cobertura:cobertura coveralls:report

--- a/findbugs-exclude-filter.xml
+++ b/findbugs-exclude-filter.xml
@@ -150,6 +150,13 @@
     <Bug pattern="SF_SWITCH_NO_DEFAULT" />
   </Match>
 
+  <!-- Reason: The fallthrough on the swich stateme is intentional -->
+  <Match>
+    <Class name="org.apache.commons.lang3.time.FastDatePrinter"/>
+    <Method name="appendFullDigits" params="java.lang.Appendable, int, int"/>
+    <Bug pattern="SF_SWITCH_FALLTHROUGH" />
+  </Match>
+
   <!-- Reason: Internal class that is used only as a key for an internal FormatCache. For this reason we can
    be sure, that equals will never be called with null or types other than MultipartKey.
   -->

--- a/findbugs-exclude-filter.xml
+++ b/findbugs-exclude-filter.xml
@@ -58,7 +58,11 @@
   <!-- Reason: Optimization to use == -->
   <Match>
     <Class name="org.apache.commons.lang3.StringUtils" />
-    <Method name="indexOfDifference"/>
+    <Or>
+      <Method name="indexOfDifference"/>
+      <Method name="compare" params="java.lang.String,java.lang.String,boolean"/>
+      <Method name="compareIgnoreCase" params="java.lang.String,java.lang.String,boolean"/>
+    </Or>
     <Bug pattern="ES_COMPARING_PARAMETER_STRING_WITH_EQ" />
   </Match>
 

--- a/findbugs-exclude-filter.xml
+++ b/findbugs-exclude-filter.xml
@@ -150,6 +150,14 @@
     <Bug pattern="SF_SWITCH_NO_DEFAULT" />
   </Match>
 
+  <!-- Reason: FindBugs cannot correctly recognize default branches in switch statements without break statements.
+   See, e.g., the report at https://sourceforge.net/p/findbugs/bugs/1298 -->
+  <Match>
+    <Class name="org.apache.commons.lang3.time.FastDatePrinter"/>
+    <Method name="appendFullDigits" params="java.lang.Appendable, int, int"/>
+    <Bug pattern="SF_SWITCH_NO_DEFAULT" />
+  </Match>
+
   <!-- Reason: The fallthrough on the swich stateme is intentional -->
   <Match>
     <Class name="org.apache.commons.lang3.time.FastDatePrinter"/>

--- a/findbugs-exclude-filter.xml
+++ b/findbugs-exclude-filter.xml
@@ -139,9 +139,14 @@
     <Method name="insertFormats" />
     <Bug pattern="SF_SWITCH_NO_DEFAULT" />
   </Match>
+  <!-- Reason: FindBugs does not correctly recognize default branches in switch statements without break statements.
+   See, e.g., the report at https://sourceforge.net/p/findbugs/bugs/1298 -->
   <Match>
     <Class name="org.apache.commons.lang3.time.FastDateParser"/>
-    <Method name="getStrategy" />
+    <Or>
+      <Method name="getStrategy" />
+      <Method name="simpleQuote" params="java.lang.StringBuilder, java.lang.String"/>
+    </Or>
     <Bug pattern="SF_SWITCH_NO_DEFAULT" />
   </Match>
 

--- a/pom.xml
+++ b/pom.xml
@@ -660,6 +660,15 @@
           <enableRulesSummary>false</enableRulesSummary>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>findbugs-maven-plugin</artifactId>
+        <!-- Use version from parent pom as that is adjusted according to the Java version used to run Maven -->
+        <version>${commons.findbugs.version}</version>
+        <configuration>
+          <excludeFilterFile>${basedir}/findbugs-exclude-filter.xml</excludeFilterFile>
+        </configuration>
+      </plugin>
     </plugins>
 
   </build>

--- a/src/main/java/org/apache/commons/lang3/time/FastDateParser.java
+++ b/src/main/java/org/apache/commons/lang3/time/FastDateParser.java
@@ -863,6 +863,8 @@ public class FastDateParser implements DateParser, Serializable {
                     case 5: // offset 5 starts additional names, probably standard time
                         tzInfo = standard;
                         break;
+                    default:
+                        break;
                     }
                     if (zoneNames[i] != null) {
                         final String key = zoneNames[i].toLowerCase(locale);


### PR DESCRIPTION
This PR adds FindBugs to Travis CI so it can be used to automatically evaluate new patches instead of having to do so retroactively.

It contains a series of patches that either fix existing FindBugs errors or excludes them (either because the violation is intentional or because FindBugs cannot properly assess the code) - individual commit messages explain individual decisions.
At the end of that series of patches is a patch that adds the `findbugs:check` goal to Travis CI, so it would now be applied on any new PR.