### PR TITLE
Use String#contains where possible

### DIFF
--- a/src/test/java/org/apache/commons/lang3/builder/ReflectionToStringBuilderExcludeTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/ReflectionToStringBuilderExcludeTest.java
@@ -120,8 +120,8 @@ public class ReflectionToStringBuilderExcludeTest {
     }
 
     private void validateNonSecretField(final String toString) {
-        Assert.assertTrue(toString.indexOf(NOT_SECRET_FIELD) > ArrayUtils.INDEX_NOT_FOUND);
-        Assert.assertTrue(toString.indexOf(NOT_SECRET_VALUE) > ArrayUtils.INDEX_NOT_FOUND);
+        Assert.assertTrue(toString.contains(NOT_SECRET_FIELD));
+        Assert.assertTrue(toString.contains(NOT_SECRET_VALUE));
     }
 
     private void validateSecretFieldAbsent(final String toString) {

--- a/src/test/java/org/apache/commons/lang3/exception/AbstractExceptionContextTest.java
+++ b/src/test/java/org/apache/commons/lang3/exception/AbstractExceptionContextTest.java
@@ -63,13 +63,13 @@ public abstract class AbstractExceptionContextTest<T extends ExceptionContext & 
     @Test
     public void testAddContextValue() {
         final String message = exceptionContext.getFormattedExceptionMessage(TEST_MESSAGE);
-        assertTrue(message.indexOf(TEST_MESSAGE) >= 0);
-        assertTrue(message.indexOf("test1") >= 0);
-        assertTrue(message.indexOf("test2") >= 0);
-        assertTrue(message.indexOf("test Date") >= 0);
-        assertTrue(message.indexOf("test Nbr") >= 0);
-        assertTrue(message.indexOf("some value") >= 0);
-        assertTrue(message.indexOf("5") >= 0);
+        assertTrue(message.contains(TEST_MESSAGE));
+        assertTrue(message.contains("test1"));
+        assertTrue(message.contains("test2"));
+        assertTrue(message.contains("test Date"));
+        assertTrue(message.contains("test Nbr"));
+        assertTrue(message.contains("some value"));
+        assertTrue(message.contains("5"));
 
         assertTrue(exceptionContext.getFirstContextValue("test1") == null);
         assertTrue(exceptionContext.getFirstContextValue("test2").equals("some value"));
@@ -85,7 +85,7 @@ public abstract class AbstractExceptionContextTest<T extends ExceptionContext & 
         assertTrue(exceptionContext.getContextLabels().contains("test2"));
 
         final String contextMessage = exceptionContext.getFormattedExceptionMessage(null);
-        assertTrue(contextMessage.indexOf(TEST_MESSAGE) == -1);
+        assertTrue(!contextMessage.contains(TEST_MESSAGE));
     }
 
     @Test
@@ -94,9 +94,9 @@ public abstract class AbstractExceptionContextTest<T extends ExceptionContext & 
         exceptionContext.setContextValue("test3", "3");
 
         final String message = exceptionContext.getFormattedExceptionMessage(TEST_MESSAGE);
-        assertTrue(message.indexOf(TEST_MESSAGE) >= 0);
-        assertTrue(message.indexOf("test Poorly written obj") >= 0);
-        assertTrue(message.indexOf("Crap") >= 0);
+        assertTrue(message.contains(TEST_MESSAGE));
+        assertTrue(message.contains("test Poorly written obj"));
+        assertTrue(message.contains("Crap"));
 
         assertTrue(exceptionContext.getFirstContextValue("crap") == null);
         assertTrue(exceptionContext.getFirstContextValue("test Poorly written obj") instanceof ObjectWithFaultyToString);
@@ -118,7 +118,7 @@ public abstract class AbstractExceptionContextTest<T extends ExceptionContext & 
         assertEquals(6, exceptionContext.getContextLabels().size());
 
         final String contextMessage = exceptionContext.getFormattedExceptionMessage(null);
-        assertTrue(contextMessage.indexOf(TEST_MESSAGE) == -1);
+        assertTrue(!contextMessage.contains(TEST_MESSAGE));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/exception/ContextedExceptionTest.java
+++ b/src/test/java/org/apache/commons/lang3/exception/ContextedExceptionTest.java
@@ -41,7 +41,7 @@ public class ContextedExceptionTest extends AbstractExceptionContextTest<Context
         exceptionContext = new ContextedException();
         final String message = exceptionContext.getMessage();
         final String trace = ExceptionUtils.getStackTrace(exceptionContext);
-        assertTrue(trace.indexOf("ContextedException")>=0);
+        assertTrue(trace.contains("ContextedException"));
         assertTrue(StringUtils.isEmpty(message));
     }
 
@@ -51,7 +51,7 @@ public class ContextedExceptionTest extends AbstractExceptionContextTest<Context
         assertEquals(TEST_MESSAGE, exceptionContext.getMessage());
         
         final String trace = ExceptionUtils.getStackTrace(exceptionContext);
-        assertTrue(trace.indexOf(TEST_MESSAGE)>=0);
+        assertTrue(trace.contains(TEST_MESSAGE));
     }
 
     @Test
@@ -59,9 +59,9 @@ public class ContextedExceptionTest extends AbstractExceptionContextTest<Context
         exceptionContext = new ContextedException(new Exception(TEST_MESSAGE));
         final String message = exceptionContext.getMessage();
         final String trace = ExceptionUtils.getStackTrace(exceptionContext);
-        assertTrue(trace.indexOf("ContextedException")>=0);
-        assertTrue(trace.indexOf(TEST_MESSAGE)>=0);
-        assertTrue(message.indexOf(TEST_MESSAGE)>=0);
+        assertTrue(trace.contains("ContextedException"));
+        assertTrue(trace.contains(TEST_MESSAGE));
+        assertTrue(message.contains(TEST_MESSAGE));
     }
 
     @Test
@@ -69,10 +69,10 @@ public class ContextedExceptionTest extends AbstractExceptionContextTest<Context
         exceptionContext = new ContextedException(TEST_MESSAGE_2, new Exception(TEST_MESSAGE));
         final String message = exceptionContext.getMessage();
         final String trace = ExceptionUtils.getStackTrace(exceptionContext);
-        assertTrue(trace.indexOf("ContextedException")>=0);
-        assertTrue(trace.indexOf(TEST_MESSAGE)>=0);
-        assertTrue(trace.indexOf(TEST_MESSAGE_2)>=0);
-        assertTrue(message.indexOf(TEST_MESSAGE_2)>=0);
+        assertTrue(trace.contains("ContextedException"));
+        assertTrue(trace.contains(TEST_MESSAGE));
+        assertTrue(trace.contains(TEST_MESSAGE_2));
+        assertTrue(message.contains(TEST_MESSAGE_2));
     }
     
     @Test
@@ -80,10 +80,10 @@ public class ContextedExceptionTest extends AbstractExceptionContextTest<Context
         exceptionContext = new ContextedException(TEST_MESSAGE_2, new Exception(TEST_MESSAGE), new DefaultExceptionContext());
         final String message = exceptionContext.getMessage();
         final String trace = ExceptionUtils.getStackTrace(exceptionContext);
-        assertTrue(trace.indexOf("ContextedException")>=0);
-        assertTrue(trace.indexOf(TEST_MESSAGE)>=0);
-        assertTrue(trace.indexOf(TEST_MESSAGE_2)>=0);
-        assertTrue(message.indexOf(TEST_MESSAGE_2)>=0);
+        assertTrue(trace.contains("ContextedException"));
+        assertTrue(trace.contains(TEST_MESSAGE));
+        assertTrue(trace.contains(TEST_MESSAGE_2));
+        assertTrue(message.contains(TEST_MESSAGE_2));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/exception/ContextedRuntimeExceptionTest.java
+++ b/src/test/java/org/apache/commons/lang3/exception/ContextedRuntimeExceptionTest.java
@@ -43,7 +43,7 @@ public class ContextedRuntimeExceptionTest extends AbstractExceptionContextTest<
         exceptionContext = new ContextedRuntimeException();
         final String message = exceptionContext.getMessage();
         final String trace = ExceptionUtils.getStackTrace(exceptionContext);
-        assertTrue(trace.indexOf("ContextedException")>=0);
+        assertTrue(trace.contains("ContextedException"));
         assertTrue(StringUtils.isEmpty(message));
     }
 
@@ -53,7 +53,7 @@ public class ContextedRuntimeExceptionTest extends AbstractExceptionContextTest<
         assertEquals(TEST_MESSAGE, exceptionContext.getMessage());
         
         final String trace = ExceptionUtils.getStackTrace(exceptionContext);
-        assertTrue(trace.indexOf(TEST_MESSAGE)>=0);
+        assertTrue(trace.contains(TEST_MESSAGE));
     }
 
     @Test
@@ -61,9 +61,9 @@ public class ContextedRuntimeExceptionTest extends AbstractExceptionContextTest<
         exceptionContext = new ContextedRuntimeException(new Exception(TEST_MESSAGE));
         final String message = exceptionContext.getMessage();
         final String trace = ExceptionUtils.getStackTrace(exceptionContext);
-        assertTrue(trace.indexOf("ContextedException")>=0);
-        assertTrue(trace.indexOf(TEST_MESSAGE)>=0);
-        assertTrue(message.indexOf(TEST_MESSAGE)>=0);
+        assertTrue(trace.contains("ContextedException"));
+        assertTrue(trace.contains(TEST_MESSAGE));
+        assertTrue(message.contains(TEST_MESSAGE));
     }
 
     @Test
@@ -71,10 +71,10 @@ public class ContextedRuntimeExceptionTest extends AbstractExceptionContextTest<
         exceptionContext = new ContextedRuntimeException(TEST_MESSAGE_2, new Exception(TEST_MESSAGE));
         final String message = exceptionContext.getMessage();
         final String trace = ExceptionUtils.getStackTrace(exceptionContext);
-        assertTrue(trace.indexOf("ContextedException")>=0);
-        assertTrue(trace.indexOf(TEST_MESSAGE)>=0);
-        assertTrue(trace.indexOf(TEST_MESSAGE_2)>=0);
-        assertTrue(message.indexOf(TEST_MESSAGE_2)>=0);
+        assertTrue(trace.contains("ContextedException"));
+        assertTrue(trace.contains(TEST_MESSAGE));
+        assertTrue(trace.contains(TEST_MESSAGE_2));
+        assertTrue(message.contains(TEST_MESSAGE_2));
     }
     
     @Test
@@ -84,10 +84,10 @@ public class ContextedRuntimeExceptionTest extends AbstractExceptionContextTest<
         new DefaultExceptionContext() {private static final long serialVersionUID = 1L;});
         final String message = exceptionContext.getMessage();
         final String trace = ExceptionUtils.getStackTrace(exceptionContext);
-        assertTrue(trace.indexOf("ContextedException")>=0);
-        assertTrue(trace.indexOf(TEST_MESSAGE)>=0);
-        assertTrue(trace.indexOf(TEST_MESSAGE_2)>=0);
-        assertTrue(message.indexOf(TEST_MESSAGE_2)>=0);
+        assertTrue(trace.contains("ContextedException"));
+        assertTrue(trace.contains(TEST_MESSAGE));
+        assertTrue(trace.contains(TEST_MESSAGE_2));
+        assertTrue(message.contains(TEST_MESSAGE_2));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/exception/ExceptionUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/exception/ExceptionUtilsTest.java
@@ -388,12 +388,12 @@ public class ExceptionUtilsTest {
         final Throwable cause = createExceptionWithCause();
         ExceptionUtils.printRootCauseStackTrace(cause, new PrintStream(out));
         String stackTrace = out.toString();
-        assertTrue(stackTrace.indexOf(ExceptionUtils.WRAPPED_MARKER) != -1);
+        assertTrue(stackTrace.contains(ExceptionUtils.WRAPPED_MARKER));
         
         out = new ByteArrayOutputStream(1024);
         ExceptionUtils.printRootCauseStackTrace(withoutCause, new PrintStream(out));
         stackTrace = out.toString();
-        assertTrue(stackTrace.indexOf(ExceptionUtils.WRAPPED_MARKER) == -1);
+        assertTrue(!stackTrace.contains(ExceptionUtils.WRAPPED_MARKER));
     }
 
     @Test
@@ -414,12 +414,12 @@ public class ExceptionUtilsTest {
         final Throwable cause = createExceptionWithCause();
         ExceptionUtils.printRootCauseStackTrace(cause, new PrintWriter(writer));
         String stackTrace = writer.toString();
-        assertTrue(stackTrace.indexOf(ExceptionUtils.WRAPPED_MARKER) != -1);
+        assertTrue(stackTrace.contains(ExceptionUtils.WRAPPED_MARKER));
         
         writer = new StringWriter(1024);
         ExceptionUtils.printRootCauseStackTrace(withoutCause, new PrintWriter(writer));
         stackTrace = writer.toString();
-        assertTrue(stackTrace.indexOf(ExceptionUtils.WRAPPED_MARKER) == -1);
+        assertTrue(!stackTrace.contains(ExceptionUtils.WRAPPED_MARKER));
     }
 
     //-----------------------------------------------------------------------


### PR DESCRIPTION
Since the project defines a JDK 7 source compatibility, it's safe to use JDK 5's features.
This patch replaces usages of `String#indexOf` with `String#contains` where possible to make the code easier to read and maintain.