### PR TITLE
LANG-1340: Add ibmjdk8 support for travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,15 @@ jdk:
   - oraclejdk7
   - oraclejdk8
 
+services:
+  - docker
+
+before_install:
+  - docker pull ibmcom/ibmjava:8-sdk
+
 script:
   - mvn test apache-rat:check clirr:check checkstyle:check findbugs:check javadoc:javadoc -B
+  - docker run -v `pwd`:/work library/ibmjava:8-sdk /bin/bash -c "apt-get update && cd work && apt-get install -y maven && mvn test apache-rat:check clirr:check checkstyle:check findbugs:check javadoc:javadoc -B"
 
 after_success:
   - mvn clean cobertura:cobertura coveralls:report


### PR DESCRIPTION
Addition of the ibmjdk8 to Commons Text is successful, so adding it to Commons Lang would be an advantage.

https://github.com/apache/commons-text/pull/45