### PR TITLE
Fix ExceptionUtils#getStackFrame(String) javadoc

### DIFF
--- a/src/main/java/org/apache/commons/lang3/exception/ExceptionUtils.java
+++ b/src/main/java/org/apache/commons/lang3/exception/ExceptionUtils.java
@@ -605,7 +605,7 @@ public class ExceptionUtils {
     /**
      * <p>Returns an array where each element is a line from the argument.</p>
      *
-     * <p>The end of line is determined by the value of {@link SystemUtils#LINE_SEPARATOR}.</p>
+     * <p>The end of line is determined by the value of {@link System#lineSeparator()}.</p>
      *
      * @param stackTrace  a stack trace String
      * @return an array where each element is a line from the argument


### PR DESCRIPTION
`ExceptionUtils#getStackFrame(String)`'s javadoc contains a broken reference to `SystemUtils#LINE_SEPARATOR` (as the class name is not fully qualified, and there's no import of `org.apache.commons.lang3.SystemUtils`).

This patch fixes the broken reference by replacing it it with a reference to `System#lineSeparator()`, which the method actually uses.