### PR TITLE
run maven defaultGoal from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ jdk:
   - oraclejdk8
 
 script:
-  - mvn test apache-rat:check clirr:check checkstyle:check findbugs:check javadoc:javadoc -B
+  - mvn
 
 after_success:
   - mvn clean cobertura:cobertura coveralls:report


### PR DESCRIPTION
Hi @garydgregory ,

As we have added defaulGoals in pom.xml, putting them again in travis make things redundant, by simply specifying ```mvn``` we can trigger default goals from pom.xml, we already did this for commons-text