### PR TITLE
LANG-1350: Fix varargs array invokeConstructor

### DIFF
--- a/src/main/java/org/apache/commons/lang3/reflect/MemberUtils.java
+++ b/src/main/java/org/apache/commons/lang3/reflect/MemberUtils.java
@@ -255,6 +255,10 @@ abstract class MemberUtils {
 
     private static boolean isMatchingExecutable(final Executable method, final Class<?>[] parameterTypes) {
         final Class<?>[] methodParameterTypes = method.getParameterTypes();
+        if (ClassUtils.isAssignable(parameterTypes, methodParameterTypes, true)) {
+            return true;
+        }
+
         if (method.isVarArgs()) {
             int i;
             for (i = 0; i < methodParameterTypes.length - 1 && i < parameterTypes.length; i++) {
@@ -270,7 +274,8 @@ abstract class MemberUtils {
             }
             return true;
         }
-        return ClassUtils.isAssignable(parameterTypes, methodParameterTypes, true);
+
+        return false;
     }
 
     /**

--- a/src/test/java/org/apache/commons/lang3/reflect/ConstructorUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/reflect/ConstructorUtilsTest.java
@@ -77,6 +77,11 @@ public class ConstructorUtilsTest {
             varArgs = s;
         }
 
+        public TestBean(final BaseClass bc, String... s) {
+            toString = "(BaseClass, String...)";
+            varArgs = s;
+        }
+
         public TestBean(final Integer i, final String... s) {
             toString = "(Integer, String...)";
             varArgs = s;
@@ -100,6 +105,10 @@ public class ConstructorUtilsTest {
           assertArrayEquals(args, varArgs);
         }
     }
+
+    private static class BaseClass {}
+
+    private static class SubClass extends BaseClass {}
 
     static class PrivateClass {
         @SuppressWarnings("unused")
@@ -157,6 +166,8 @@ public class ConstructorUtilsTest {
           .verify("(String...)", new String[]{"a", "b"});
         ConstructorUtils.invokeConstructor(TestBean.class, NumberUtils.INTEGER_ONE, "a", "b")
           .verify("(Integer, String...)", new String[]{"a", "b"});
+        ConstructorUtils.invokeConstructor(TestBean.class, new SubClass(), new String[]{"a", "b"})
+          .verify("(BaseClass, String...)", new String[]{"a", "b"});
     }
 
     @Test
@@ -252,6 +263,9 @@ public class ConstructorUtilsTest {
                 singletonArray(Double.class), singletonArray(Double.TYPE));
         expectMatchingAccessibleConstructorParameterTypes(TestBean.class,
                 singletonArray(Double.TYPE), singletonArray(Double.TYPE));
+        expectMatchingAccessibleConstructorParameterTypes(TestBean.class,
+                new Class<?>[]{SubClass.class, String[].class},
+                new Class<?>[]{BaseClass.class, String[].class});
     }
 
     @Test


### PR DESCRIPTION
If ConstructorUtils.invokeConstructor(Class, Object...) is invoked with an array of arguments whose classes do not match a constructor exactly (for example, a subclass is used) and an array is used for a varargs parameter, then the array is not matched to the varargs parameter type.