### PR TITLE
LANG-1352 EnumUtils.getEnumIgnoreCase and isValidEnumIgnoreCase methods added

### DIFF
--- a/src/main/java/org/apache/commons/lang3/EnumUtils.java
+++ b/src/main/java/org/apache/commons/lang3/EnumUtils.java
@@ -87,15 +87,23 @@ public class EnumUtils {
      * @return true if the enum name is valid, otherwise false
      */
     public static <E extends Enum<E>> boolean isValidEnum(final Class<E> enumClass, final String enumName) {
-        if (enumName == null) {
-            return false;
-        }
-        try {
-            Enum.valueOf(enumClass, enumName);
-            return true;
-        } catch (final IllegalArgumentException ex) {
-            return false;
-        }
+        return getEnum(enumClass, enumName) != null;
+    }
+
+    /**
+     * <p>Checks if the specified name is a valid enum for the class.</p>
+     *
+     * <p>This method differs from {@link Enum#valueOf} in that checks if the name is
+     * a valid enum without needing to catch the exception
+     * and performs case insensitive matching of the name.</p>
+     *
+     * @param <E> the type of the enumeration
+     * @param enumClass  the class of the enum to query, not null
+     * @param enumName   the enum name, null returns false
+     * @return true if the enum name is valid, otherwise false
+     */
+    public static <E extends Enum<E>> boolean isValidEnumIgnoreCase(final Class<E> enumClass, final String enumName) {
+        return getEnumIgnoreCase(enumClass, enumName) != null;
     }
 
     /**
@@ -118,6 +126,29 @@ public class EnumUtils {
         } catch (final IllegalArgumentException ex) {
             return null;
         }
+    }
+
+    /**
+     * <p>Gets the enum for the class, returning {@code null} if not found.</p>
+     *
+     * <p>This method differs from {@link Enum#valueOf} in that it does not throw an exception
+     * for an invalid enum name and performs case insensitive matching of the name.</p>
+     *
+     * @param <E>         the type of the enumeration
+     * @param enumClass   the class of the enum to query, not null
+     * @param enumName    the enum name, null returns null
+     * @return the enum, null if not found
+     */
+    public static <E extends Enum<E>> E getEnumIgnoreCase(final Class<E> enumClass, final String enumName) {
+        if (enumName == null || !enumClass.isEnum()) {
+            return null;
+        }
+        for (final E each : enumClass.getEnumConstants()) {
+            if (each.name().equalsIgnoreCase(enumName)) {
+                return each;
+            }
+        }
+        return null;
     }
 
     /**

--- a/src/test/java/org/apache/commons/lang3/EnumUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/EnumUtilsTest.java
@@ -20,6 +20,7 @@ package org.apache.commons.lang3;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
@@ -66,7 +67,7 @@ public class EnumUtilsTest {
     }
 
     @Test
-    public void test_isEnum() {
+    public void test_isValidEnum() {
         assertTrue(EnumUtils.isValidEnum(Traffic.class, "RED"));
         assertTrue(EnumUtils.isValidEnum(Traffic.class, "AMBER"));
         assertTrue(EnumUtils.isValidEnum(Traffic.class, "GREEN"));
@@ -75,8 +76,22 @@ public class EnumUtilsTest {
     }
 
     @Test(expected=NullPointerException.class)
-    public void test_isEnum_nullClass() {
+    public void test_isValidEnum_nullClass() {
         EnumUtils.isValidEnum(null, "PURPLE");
+    }
+
+    @Test
+    public void test_isValidEnumIgnoreCase() {
+        assertTrue(EnumUtils.isValidEnumIgnoreCase(Traffic.class, "red"));
+        assertTrue(EnumUtils.isValidEnumIgnoreCase(Traffic.class, "Amber"));
+        assertTrue(EnumUtils.isValidEnumIgnoreCase(Traffic.class, "grEEn"));
+        assertFalse(EnumUtils.isValidEnumIgnoreCase(Traffic.class, "purple"));
+        assertFalse(EnumUtils.isValidEnumIgnoreCase(Traffic.class, null));
+    }
+
+    @Test(expected=NullPointerException.class)
+    public void test_isValidEnumIgnoreCase_nullClass() {
+        EnumUtils.isValidEnumIgnoreCase(null, "PURPLE");
     }
 
     @Test
@@ -84,13 +99,39 @@ public class EnumUtilsTest {
         assertEquals(Traffic.RED, EnumUtils.getEnum(Traffic.class, "RED"));
         assertEquals(Traffic.AMBER, EnumUtils.getEnum(Traffic.class, "AMBER"));
         assertEquals(Traffic.GREEN, EnumUtils.getEnum(Traffic.class, "GREEN"));
-        assertEquals(null, EnumUtils.getEnum(Traffic.class, "PURPLE"));
-        assertEquals(null, EnumUtils.getEnum(Traffic.class, null));
+        assertNull(EnumUtils.getEnum(Traffic.class, "PURPLE"));
+        assertNull(EnumUtils.getEnum(Traffic.class, null));
+    }
+
+    @Test
+    public void test_getEnum_nonEnumClass() {
+        final Class rawType = Object.class;
+        assertNull(EnumUtils.getEnum(rawType, "rawType"));
     }
 
     @Test(expected=NullPointerException.class)
     public void test_getEnum_nullClass() {
         EnumUtils.getEnum((Class<Traffic>) null, "PURPLE");
+    }
+
+    @Test
+    public void test_getEnumIgnoreCase() {
+        assertEquals(Traffic.RED, EnumUtils.getEnumIgnoreCase(Traffic.class, "red"));
+        assertEquals(Traffic.AMBER, EnumUtils.getEnumIgnoreCase(Traffic.class, "Amber"));
+        assertEquals(Traffic.GREEN, EnumUtils.getEnumIgnoreCase(Traffic.class, "grEEn"));
+        assertNull(EnumUtils.getEnumIgnoreCase(Traffic.class, "purple"));
+        assertNull(EnumUtils.getEnumIgnoreCase(Traffic.class, null));
+    }
+
+    @Test
+    public void test_getEnumIgnoreCase_nonEnumClass() {
+        final Class rawType = Object.class;
+        assertNull(EnumUtils.getEnumIgnoreCase(rawType, "rawType"));
+    }
+
+    @Test(expected=NullPointerException.class)
+    public void test_getEnumIgnoreCase_nullClass() {
+        EnumUtils.getEnumIgnoreCase((Class<Traffic>) null, "PURPLE");
     }
 
     @Test(expected=NullPointerException.class)


### PR DESCRIPTION
I truly believe that such handy method must exist in this utility class.
[This ](https://stackoverflow.com/questions/28332924/case-insensitive-matching-of-a-string-to-a-java-enum)SO thread is just a prove of it. And also in the project I work for we need to perform this operation quite often.
