### PR TITLE
Boolean comparisons in CharRange

### DIFF
--- a/src/main/java/org/apache/commons/lang3/CharRange.java
+++ b/src/main/java/org/apache/commons/lang3/CharRange.java
@@ -206,7 +206,7 @@ final class CharRange implements Iterable<Character>, Serializable {
         if (obj == this) {
             return true;
         }
-        if (obj instanceof CharRange == false) {
+        if (!(obj instanceof CharRange)) {
             return false;
         }
         final CharRange other = (CharRange) obj;
@@ -335,7 +335,7 @@ final class CharRange implements Iterable<Character>, Serializable {
          */
         @Override
         public Character next() {
-            if (hasNext == false) {
+            if (!hasNext) {
                 throw new NoSuchElementException();
             }
             final char cur = current;


### PR DESCRIPTION
Cleaned up comparisons to false to just use the boolean negation operator (`!`).