### PR TITLE
Add a rule of Locale.ENGLISH to String.toUpperCase() method.

### DIFF
--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -5501,7 +5501,7 @@ public class StringUtils {
          }
          String searchText = text;
          if (ignoreCase) {
-             searchText = text.toLowerCase();
+             searchText = text.toLowerCase(Locale.ENGLISH);
              searchString = searchString.toLowerCase();
          }
          int start = 0;

--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -6658,7 +6658,7 @@ public class StringUtils {
         if (str == null) {
             return null;
         }
-        return str.toLowerCase();
+        return str.toLowerCase(Locale.ENGLISH);
     }
 
     /**

--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -5502,7 +5502,7 @@ public class StringUtils {
          String searchText = text;
          if (ignoreCase) {
              searchText = text.toLowerCase(Locale.ENGLISH);
-             searchString = searchString.toLowerCase();
+             searchString = searchString.toLowerCase(Locale.ENGLISH);
          }
          int start = 0;
          int end = searchText.indexOf(searchString, start);

--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -6609,7 +6609,7 @@ public class StringUtils {
         if (str == null) {
             return null;
         }
-        return str.toUpperCase();
+        return str.toUpperCase(Locale.ENGLISH);
     }
 
     /**

--- a/src/main/java/org/apache/commons/lang3/text/WordUtils.java
+++ b/src/main/java/org/apache/commons/lang3/text/WordUtils.java
@@ -16,6 +16,7 @@
  */
 package org.apache.commons.lang3.text;
 
+import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -475,7 +476,7 @@ public class WordUtils {
         if (StringUtils.isEmpty(str) || delimLen == 0) {
             return str;
         }
-        str = str.toLowerCase();
+        str = str.toLowerCase(Locale.ENGLISH);
         return capitalize(str, delimiters);
     }
 

--- a/src/main/java/org/apache/commons/lang3/time/FastDateParser.java
+++ b/src/main/java/org/apache/commons/lang3/time/FastDateParser.java
@@ -892,7 +892,7 @@ public class FastDateParser implements DateParser, Serializable {
                 final TimeZone tz = TimeZone.getTimeZone("GMT" + value);
                 cal.setTimeZone(tz);
             } else if (value.regionMatches(true, 0, "GMT", 0, 3)) {
-                final TimeZone tz = TimeZone.getTimeZone(value.toUpperCase());
+                final TimeZone tz = TimeZone.getTimeZone(value.toUpperCase(Locale.ENGLISH));
                 cal.setTimeZone(tz);
             } else {
                 final TzInfo tzInfo = tzNames.get(value.toLowerCase(locale));


### PR DESCRIPTION
A String is being converted to upper case, using the platform's default encoding.
This may result in improper conversions when used with international characters.
Use the String.toUpperCase( Locale l ) version should be better.
http://findbugs.sourceforge.net/bugDescriptions.html#DM_CONVERT_CASE