### PR TITLE
Add an instanceof test in the implementation of equals(Object obj).

### DIFF
--- a/src/main/java/org/apache/commons/lang3/time/FormatCache.java
+++ b/src/main/java/org/apache/commons/lang3/time/FormatCache.java
@@ -240,7 +240,7 @@ abstract class FormatCache<F extends Format> {
             // Eliminate the usual boilerplate because
             // this inner static class is only used in a generic ConcurrentHashMap
             // which will not compare against other Object types
-            return Arrays.equals(keys, ((MultipartKey)obj).keys);
+            return obj instanceof MultipartKey && Arrays.equals(keys, ((MultipartKey)obj).keys);
         }
 
         /**


### PR DESCRIPTION
The equals(Object obj) method shouldn't make any assumptions about the type of obj. It should simply return false if obj is not the same type as this.
http://findbugs.sourceforge.net/bugDescriptions.html#BC_EQUALS_METHOD_SHOULD_WORK_FOR_ALL_OBJECTS