### PR TITLE
Improve StringUtils#replace throughput

### DIFF
--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -5515,14 +5515,14 @@ public class StringUtils {
          increase *= max < 0 ? 16 : max > 64 ? 64 : max;
          final StringBuilder buf = new StringBuilder(text.length() + increase);
          while (end != INDEX_NOT_FOUND) {
-             buf.append(text.substring(start, end)).append(replacement);
+             buf.append(text, start, end).append(replacement);
              start = end + replLength;
              if (--max == 0) {
                  break;
              }
              end = searchText.indexOf(searchString, start);
          }
-         buf.append(text.substring(start));
+         buf.append(text, start, text.length());
          return buf.toString();
      }
 


### PR DESCRIPTION
Motivation:

`StringUtils#replace` uses `substring` to append a String region into a
StringBuilder. This causes useless copies, as `StringBuilder#append`
can take start and end indexes.

Modification:

Use proper `StringBuilder#append`
[overload](https://docs.oracle.com/javase/8/docs/api/java/lang/StringBui
lder.html#append-java.lang.CharSequence-int-int-).

Result:

Based on benchmark from [JOOQ’s
post](https://blog.jooq.org/2017/10/11/benchmarking-jdk-string-replace-v
s-apache-commons-stringutils-replace):

```
Benchmark Mode Cnt Score Error Units
StringReplaceBenchmark.testFastStringReplaceLongStringOneMatch thrpt 21
7546534,219 ± 145523,962 ops/s
StringReplaceBenchmark.testStringUtilsReplaceLongStringOneMatch thrpt
21 7353512,552 ± 124498,228 ops/s

StringReplaceBenchmark.testFastStringReplaceLongStringSeveralMatches
thrpt 21 5077255,810 ± 62358,937 ops/s
StringReplaceBenchmark.testStringUtilsReplaceLongStringSeveralMatches
thrpt 21 4108357,612 ± 92909,038 ops/s

StringReplaceBenchmark.testFastStringReplaceShortStringOneMatch thrpt
21 15911221,949 ± 541064,693 ops/s
StringReplaceBenchmark.testStringUtilsReplaceShortStringOneMatch thrpt
21 10677897,475 ± 491091,973 ops/s

StringReplaceBenchmark.testFastStringReplaceShortStringSeveralMatches
thrpt 21 9271742,251 ± 220150,121 ops/s
StringReplaceBenchmark.testStringUtilsReplaceShortStringSeveralMatches
thrpt 21 6158829,188 ± 99637,607 ops/s
```