### PR TITLE
Remove ObjectUtils' trailing white spaces

### DIFF
--- a/src/main/java/org/apache/commons/lang3/ObjectUtils.java
+++ b/src/main/java/org/apache/commons/lang3/ObjectUtils.java
@@ -1035,7 +1035,7 @@ public class ObjectUtils {
 
     /**
      * Gets the class name of the given object.
-     * 
+     *
      * @param object the object to query, may be null
      * @return the given object's class name or null if the object is null
      * @since 3.7
@@ -1046,7 +1046,7 @@ public class ObjectUtils {
 
     /**
      * Gets the class simple name of the given object.
-     * 
+     *
      * @param object the object to query, may be null
      * @return the given object's class simple name or null if the object is null
      * @since 3.7
@@ -1057,7 +1057,7 @@ public class ObjectUtils {
 
     /**
      * Gets the class canonical name of the given object.
-     * 
+     *
      * @param object the object to query, may be null
      * @return the given object's class canonical name or null if the object is null
      * @since 3.7


### PR DESCRIPTION
Commit 6ea2fc8 inadvertently introduced trailing white spaces in `ObjectUtils`' code, thus breaking the Checkstyle validation.

This patch removes these redundant TWS in order to allow the build to pass.