### PR TITLE
Fix TypeUtils.parameterize to work correctly with narrower-typed array

### DIFF
--- a/src/main/java/org/apache/commons/lang3/reflect/TypeUtils.java
+++ b/src/main/java/org/apache/commons/lang3/reflect/TypeUtils.java
@@ -157,7 +157,7 @@ public class TypeUtils {
         private ParameterizedTypeImpl(final Class<?> raw, final Type useOwner, final Type[] typeArguments) {
             this.raw = raw;
             this.useOwner = useOwner;
-            this.typeArguments = typeArguments.clone();
+            this.typeArguments = Arrays.copyOf(typeArguments, typeArguments.length, Type[].class);
         }
 
         /**

--- a/src/test/java/org/apache/commons/lang3/reflect/TypeUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/reflect/TypeUtilsTest.java
@@ -34,6 +34,7 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -688,6 +689,15 @@ public class TypeUtilsTest<B> {
         assertTrue(TypeUtils.equals(getClass().getField("stringComparable").getGenericType(),
             stringComparableType));
         assertEquals("java.lang.Comparable<java.lang.String>", stringComparableType.toString());
+    }
+
+    @Test
+    public void testParameterizeNarrowerTypeArray() {
+        final TypeVariable<?>[] variables = ArrayList.class.getTypeParameters();
+        final ParameterizedType parameterizedType = TypeUtils.parameterize(ArrayList.class, variables);
+        final Map<TypeVariable<?>, Type> mapping = Collections.<TypeVariable<?>, Type>singletonMap(variables[0], String.class);
+        final Type unrolled = TypeUtils.unrollVariables(mapping, parameterizedType);
+        assertEquals(TypeUtils.parameterize(ArrayList.class, String.class), unrolled);
     }
 
     @Test


### PR DESCRIPTION
Currently the following code:
```
final TypeVariable<?>[] variables = ArrayList.class.getTypeParameters();
final ParameterizedType parameterizedType = TypeUtils.parameterize(ArrayList.class, variables);
final Map<TypeVariable<?>, Type> mapping = Collections.<TypeVariable<?>, Type>singletonMap(variables[0], String.class);
final Type unrolled = TypeUtils.unrollVariables(mapping, parameterizedType); // exception !
assertEquals(TypeUtils.parameterize(ArrayList.class, String.class), unrolled);
```
throws an exception.

So, I added a test and fixed the ParameterizedTypeImpl class.