### PR TITLE
LANG-1373 Stopwatch based capability for nested, named, timings 

### DIFF
--- a/src/main/java/org/apache/commons/lang3/time/StackWatch.java
+++ b/src/main/java/org/apache/commons/lang3/time/StackWatch.java
@@ -1,0 +1,597 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.lang3.time;
+
+import org.apache.commons.lang3.Validate;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * <p>
+ * The {@code StackWatch}, provides a wrapper around the {@code StopWatch} for creating multiple and
+ * possibly nested named timings.
+ * </p>
+ * <p>
+ * While the {@link StopWatch} provides functionality to time the length of operations, there is no
+ * context or name to go with the time tracked. It is also not possible to time nested calls with
+ * the {@code StopWatch}.
+ * </p>
+ * <p>
+ * {@code StackWatch} provides that functionality, allowing successive calls to
+ * {@link StackWatch#startTiming} to track nested calls.
+ * </p>
+ * <p>
+ * At the end of a timing 'run', a visitor interface provides the ability to visit all the timing
+ * 'nodes' and capture their output, including the level of the call if nested. The visitor is passed
+ * the {@code level} of the current node, it's path elements, and a {@link Timing} instance.
+ * </p>
+ * <p>
+ * Through the {@link Timing} the visitor can access the {@link StopWatch} instance for the timing.
+ * </p>
+ * <p>
+ * The {@link TimingNodeInternal} provide a tree structure in support of nesting.
+ * A {@code Deque} is use to track the current time node.
+ * </p>
+ * <p>
+ * The generic type {@code N} is used to type the {@link TimingNodeInternal#name}.
+ * The generic type {@code T} is used to type the {@link TimingNodeInternal#tags}.
+ * </p>
+ * <pre>
+ *   <code>
+ *    private void outerFunction() {
+ *      try {
+ *        StackWatch{@code <String,String> watch = new StackWatch<>("OuterFunction");}
+ *        watch.start();
+ *        functionOne(watch);
+ *        watch.stop();
+ *        watch.visit({@code new StackWatch.TimingVisitor<String,String>()} {
+ *         {@literal @}Override
+ *          public void visitTiming({@code int level, List<String> path,  StackWatch.Timing<String,String>} timing) {
+ *            System.out.println("Visit level " + level + " timing: " + timing.getName()) + " path: " + path + " time: " + timing.getStopWatch().getNanoTime() + "ns");
+ *          }
+ *        });
+ *      } catch (Exception e){}
+ *    }
+ *
+ *    private void functionOne({@code StackWatch<String,String>} watch) throws Exception {
+ *      watch.startTiming("One", "tagOne");
+ *      functionOneOne(watch);
+ *      watch.stopTiming();
+ *    }
+ *
+ *    private void functionOneOne({@code StackWatch<String,String>} watch) throws Exception {
+ *      watch.startTiming("OneOne", "tagTwo");
+ *      functionOneTwo(watch);
+ *      watch.stopTiming();
+ *    }
+ *
+ *    private void functionOneTwo({@code StackWatch<String,String>} watch) throws Exception {
+ *      watch.startTiming("OneTwo", "tagThree");
+ *      watch.stopTiming();
+ *    }
+ *   </code>
+ * </pre>
+ * <p>
+ * The example above would result in the following output.
+ * </p>
+ * <pre>
+ *   <code>
+ *    Visit level 0 timing: OuterFunction path: [OuterFunction] time: 316032287ns
+ *    Visit level 1 timing: One path: [OuterFunction, One] time: 156596831ns
+ *    Visit level 2 timing: OneOne path: [OuterFunction, One, OneOne] time: 106207892ns
+ *    Visit level 3 timing: OneTwo path: [OuterFunction, One, OneOne, OneTwo] time: 52851139ns
+ *   </code>
+ * </pre>
+ * <p>
+ * This class is not thread safe, and is meant to track timings across multiple calls on the same
+ * thread
+ * </p>
+ *
+ * @since 3.8
+ */
+public class StackWatch<N,T> {
+    /**
+     * The Deque used to track the timings
+     */
+    private Deque<TimingNode> deque = new LinkedList<>();
+
+    /**
+     * The root {@code TimingNodeInternal}.
+     * The root node represents the root of a tree structure, and contains all {@code TimingNodeInternal}
+     * instances.
+     */
+    private TimingNode<N,T> rootNode;
+
+    /**
+     * <p>
+     * Constructor
+     * </p>
+     * <p>
+     * The top most timing will be created with the rootName on {@link StackWatch#start()} ()}
+     * </p>
+     * @param rootName the root name
+     * @throws NullPointerException if rootName is null
+     */
+    public StackWatch(N rootName) {
+        Validate.notNull(rootName,"The rootName cannot be null");
+        rootNode = new TimingNodeInternal<>(rootName);
+    }
+
+    /**
+     * <p>
+     * Returns the root name.
+     * </p>
+     *
+     * @return the root name.
+     */
+    public N getRootName() {
+        return this.rootNode.getName();
+    }
+
+    /**
+     * <p>
+     * Starts the {@code StackWatch}.
+     * </p>
+     * <p>
+     * A root timing will be created named for the rootName and started.
+     * </p>
+     * <p>
+     * If not called before the first {@link  StackWatch#startTiming} call, then the
+     * {@code StackWatch} will be started at that time.
+     * </p>
+     *
+     * @throws IllegalStateException if the {@code StackWatch} has already been started.
+     */
+    public void start() {
+        if(rootNode.isRunning()) {
+            throw new IllegalStateException("StackWatch already started");
+        }
+        rootNode.start();
+        deque.push(rootNode);
+    }
+
+    /**
+     * <p>
+     * Start a timing.  If {@link StackWatch#start()} has not been called, the {@code StackWatch} will be
+     * started.
+     * </p>
+     * <p>
+     * This may be called multiple times, before a {@link StackWatch#stopTiming()} call is made, if calls are nested,
+     * for example:
+     * </p>
+     * <pre>
+     *   <code>
+     *    private void functionOne({@code StackWatch<String,String>} watch) throws Exception {
+     *      watch.startTiming("One", "tagOne");
+     *      functionOneOne(watch);
+     *      watch.stopTiming();
+     *    }
+     *
+     *    private void functionOneOne({@code StackWatch<String,String>} watch) throws Exception {
+     *      watch.startTiming("OneOne", "tagTwo");
+     *      functionOneTwo(watch);
+     *      watch.stopTiming();
+     *    }
+     *
+     *    private void functionOneTwo({@code StackWatch<String,String>} watch) throws Exception {
+     *      watch.startTiming("OneTwo", "tagThree");
+     *      watch.stopTiming();
+     *    }
+     *   </code>
+     * </pre>
+     * <p>
+     * Starting a timing, when it's parent timing is not running results in an
+     * {@code IllegalStateException}.
+     * </p>
+     * <p>
+     * For example, this code, although contrived, would throw an {@code IllegalStateException}, because
+     * functionOne is not running:
+     * </p>
+     * <pre>
+     *   <code>
+     *    private void functionOne({@code StackWatch<String,String>} watch) throws Exception {
+     *      watch.startTiming("One", "tagOne");
+     *      watch.visit({@code new StackWatch.TimingVisitor<String,String>}() {
+     *       {@literal @}Override
+     *        public void visitTiming(int level, {@code List<String> path, StackWatch.Timing<String,String>} timing) {
+     *          timing.getStopWatch().stop();
+     *        }
+     *      });
+     *      functionOneOne(watch);
+     *    }
+     *
+     *    private void functionOneOne({@code StackWatch<String,String>} watch) throws Exception {
+     *      watch.startTiming("OneOne", "tagTwo");
+     *      functionOneTwo(watch);
+     *      watch.stopTiming();
+     *    }
+     *   </code>
+     * </pre>
+     * <p>
+     *
+     * @param name the name of this timing
+     * @param tags the tags to associate with this timing
+     * @throws IllegalStateException if the parent timing is not running or there is an attempt to start
+     *                               a new timing after creating a number of timings and closing them all.
+     * @throws NullPointerException if the name is null
+     */
+    @SafeVarargs
+    @SuppressWarnings("unchecked")
+    public final void startTiming(N name, T... tags) {
+        final TimingNode<N,T> parentNode;
+        // If the deque is empty, then the root needs to be added and started
+        if (deque.isEmpty()) {
+            // we are starting a timing, having not started the StackWatch
+            // it needs to be started.
+            start();
+            parentNode = rootNode;
+        } else {
+            // if the current node is not running, then this is an InvalidStateException, as the parent
+            // cannot close before it's children
+            if (!deque.peek().isRunning()) {
+                throw new IllegalStateException(String
+                        .format("Parent TimingNodeInternal %s is not running", deque.peek().getName().toString()));
+            }
+            // this is a nested start, add as child to current running
+            parentNode = deque.peek();
+        }
+
+        // request the current node to create a new child with this timing name and start it
+        TimingNode<N,T> node = parentNode.createChild(name, tags);
+        node.start();
+        // this node is now top of the stack
+        deque.push(node);
+    }
+
+    /**
+     * <p>
+     * Stop the current timing.
+     * </p>
+     * <p>
+     * In the case of nested timings, the current timing is stopped and removed from the {@code Deque}
+     * causing the parent node to be the top of the stack.
+     * </p>
+     * <p>
+     * If the timing being stopped has running child timings an {@code IllegalStateException} will
+     * be thrown.
+     * </p>
+     *
+     * @throws IllegalStateException if stopping a timing with running child timings
+     */
+    public void stopTiming() {
+        if (deque.isEmpty()) {
+            throw new IllegalStateException(
+                    "Trying to stop time, there are no running records in deque");
+        }
+        deque.pop().stop();
+    }
+
+    /**
+     * Stops the {@code StackWatch}.
+     *
+     * @throws IllegalStateException if there are running timings other than the root timing
+     */
+    public void stop() {
+        if (deque.size() > 1) {
+            throw new IllegalStateException("Stopping with running timings");
+        }
+        stopTiming();
+    }
+
+    /**
+     * Clears the stack and the root node.
+     */
+    public void clear() {
+        deque.clear();
+        if(rootNode.isRunning()) {
+            rootNode.stop();
+        }
+
+        rootNode = new TimingNodeInternal<>(rootNode.getName());
+    }
+
+    /**
+     * <p>
+     * Initiate the visitation of the nodes in this timing.
+     * </p>
+     * <p>
+     * The {@link TimingVisitor} will be called back for each node in the tree, and will
+     * pass the level of the node in the tree. The root level is 0.
+     * </p>
+     *
+     * @param visitor callback interface.
+     */
+    public void visit(TimingVisitor<N,T> visitor) {
+        rootNode.visit(0, new LinkedList<N>(), visitor);
+    }
+
+    public interface TimingVisitor<N,T> {
+
+        /**
+         * Visit a {@code TimingNodeInternal}.
+         *
+         * @param level the depth level of this node
+         * @param path the names from this node to root
+         * @param node the {@code Timing}
+         */
+        void visitTiming(int level, List<N> path, Timing<N,T> node);
+    }
+
+    public interface TimingNode<N, T> extends Timing<N,T>{
+
+        /**
+         * Returns this node's children.
+         * @return List of child nodes
+         */
+        List<TimingNode<N,T>> getChildren();
+
+        /**
+         * Return the status of the internally manage {@link StopWatch}.
+         * @return true if it is running
+         */
+        boolean isRunning();
+
+        /**
+         * Starts the node and it's {@link StopWatch}.
+         */
+        void start();
+
+        /**
+         * <p>
+         * Stops the StopWatch.
+         * </p>
+         * <p>
+         * If this node has running children, an {@code IllegalStateException} will result.
+         * </p>
+         *
+         * @throws IllegalStateException if stop is called on a node with running children
+         */
+        void stop();
+
+        /**
+         * Creates a new child node to this node.
+         * If the current node is not started, then this operation results in an
+         * {@code IllegalStateException}
+         *
+         * @param childName the name of the child
+         * @param tags the tags for this timing
+         * @return the child node created
+         * @throws IllegalStateException if the current node is not started.
+         * @throws IllegalArgumentException if the node name is null or empty.
+         */
+        TimingNode<N,T> createChild(N childName, T... tags)
+                throws IllegalStateException;
+
+        /**
+         * Visits the current node and each of its children in turn.
+         * The provided {@link TimingVisitor} will be called this node, and passed to each
+         * child node in descent.
+         *
+         * @param level the level of this node.
+         * @param path the path
+         * @param visitor the visitor callback
+         */
+        void visit(int level, LinkedList<N> path, StackWatch.TimingVisitor<N, T> visitor);
+    }
+
+    public interface Timing<N,T> {
+
+        /**
+         * Returns the name of this {@code Timing}.
+         * @return the name
+         */
+        N getName();
+
+        /**
+         * Returns the {@link StopWatch} for this record.
+         * @return {@link StopWatch}
+         */
+        StopWatch getStopWatch();
+
+        /**
+         * Returns the tags of type T for this record.
+         * @return List of tags
+         */
+        List<T> getTags();
+
+    }
+
+    /**
+     * The tree node to track time and children.
+     * The {@code StopWatch} class is used for timings
+     *
+     * The generic type {@code N} is used for the node's name.
+     * The generic type {@code T} is used for the node's tags.
+     *
+     * @since 3.8
+     */
+    private static final class TimingNodeInternal<N,T> implements TimingNode<N, T> {
+
+        /**
+         * The name of this node.
+         */
+        private N name;
+
+        /**
+         * The tags associated with this timing.
+         */
+        private List<T> tags;
+
+        /**
+         * The child nodes of this node.
+         */
+        private List<TimingNode<N,T>> children = new ArrayList<>();
+
+        /**
+         * The {@code StopWatch} for this node.
+         */
+        private StopWatch stopWatch = new StopWatch();
+
+        /**
+         * <p>
+         * Constructor.
+         * </p>
+         * <p>
+         * Creates a new TimingNodeInternal for a given parent name, with a given name.
+         * </p>
+         *
+         * @param name the name of the timing
+         * @param tags the tags to associate with this timing
+         * @throws NullPointerException if the name is null.
+         */
+        @SafeVarargs
+        TimingNodeInternal(N name, T... tags) {
+            Validate.notNull(name,"name cannot be null");
+            this.name = name;
+
+            // if tags were not passed, this will be an Object[0] and not T
+            if(tags.length == 0) {
+                this.tags = new ArrayList<>();
+            }else{
+                this.tags = new ArrayList<>(Arrays.asList(tags));
+            }
+        }
+
+        /**
+         * Returns the node's timing name.
+         *
+         * @return the node timing name
+         */
+        @Override
+        public N getName() {
+            return name;
+        }
+
+        @Override
+        public List<TimingNode<N,T>> getChildren() {
+            return Collections.unmodifiableList(children);
+        }
+
+        /**
+         * Return if the node's StopWatch is running.
+         *
+         * @return true if it is running, false if not
+         */
+        @Override
+        public boolean isRunning() {
+            return stopWatch.isStarted();
+        }
+
+        /**
+         * Starts the StopWatch.
+         */
+        @Override
+        public void start() {
+            if (!stopWatch.isStarted()) {
+                stopWatch.reset();
+                stopWatch.start();
+            }
+        }
+
+        /**
+         * <p>
+         * Stops the StopWatch.
+         * </p>
+         * <p>
+         * If this node has running children, an {@code IllegalStateException} will result.
+         * </p>
+         *
+         * @throws IllegalStateException if stop is called on a node with running children
+         */
+        @Override
+        public void stop() {
+            for (TimingNode child : children) {
+                if (child.isRunning()) {
+                    throw new IllegalStateException("Cannot stop a timing with running children");
+                }
+            }
+            if(stopWatch.isStarted()) {
+                stopWatch.stop();
+            }
+        }
+
+        /**
+         * Returns the {@link StopWatch} for this node.
+         *
+         * @return {@link StopWatch}
+         */
+        @Override
+        public StopWatch getStopWatch() {
+            return stopWatch;
+        }
+
+        /**
+         * The tags associated with this timing.
+         *
+         * @return List of tags
+         */
+        @Override
+        public List<T> getTags() {
+            return Collections.unmodifiableList(tags);
+        }
+
+        /**
+         * Creates a new child node to this node.
+         * If the current node is not started, then this operation results in an
+         * {@code IllegalStateException}
+         *
+         * @param childName the name of the child
+         * @param tags the tags for this timing
+         * @return the child node created
+         * @throws IllegalStateException if the current node is not started.
+         * @throws IllegalArgumentException if the node name is null or empty.
+         */
+        @Override
+        @SafeVarargs
+        public final TimingNode<N,T> createChild(N childName, T... tags)
+                throws IllegalStateException {
+            if (!stopWatch.isStarted()) {
+                throw new IllegalStateException("Adding a child to a non-started parent");
+            }
+            TimingNodeInternal<N,T> child = new TimingNodeInternal<>(childName, tags);
+            children.add(child);
+            return child;
+        }
+
+        /**
+         * Visits the current node and each of its children in turn.
+         * The provided {@link TimingVisitor} will be called this node, and passed to each
+         * child node in descent.
+         *
+         * @param level the level of this node.
+         * @param path the path
+         * @param visitor the visitor callback
+         */
+        @Override
+        @SuppressWarnings("unchecked")
+        public void visit(int level, LinkedList<N> path, TimingVisitor<N, T> visitor) {
+            path.addLast(name);
+            visitor.visitTiming(level, Collections.unmodifiableList(path),this);
+            for (TimingNode child : children) {
+                child.visit(level + 1, path, visitor);
+            }
+            path.removeLast();
+
+        }
+    }
+}

--- a/src/main/java/org/apache/commons/lang3/time/StackWatch.java
+++ b/src/main/java/org/apache/commons/lang3/time/StackWatch.java
@@ -103,6 +103,27 @@ import java.util.List;
  *   </code>
  * </pre>
  * <p>
+ *     {@code StackWatch} also has a static factory method to create and start an instance.
+ * </p>
+ * <pre>
+ *   <code>
+ *    private void outerFunction() {
+ *      try {
+ *        StackWatch{@code <String,String> watch = StackWatch.startStackWatch("OuterFunction");}
+ *        watch.start();
+ *        functionOne(watch);
+ *        watch.stop();
+ *        watch.visit({@code new StackWatch.TimingVisitor<String,String>()} {
+ *         {@literal @}Override
+ *          public void visitTiming({@code int level, List<String> path,  StackWatch.Timing<String,String>} timing) {
+ *            System.out.println("Visit level " + level + " timing: " + timing.getName()) + " path: " + path + " time: " + timing.getStopWatch().getNanoTime() + "ns");
+ *          }
+ *        });
+ *      } catch (Exception e){}
+ *    }
+ *   </code>
+ * </pre>
+ * <p>
  * This class is not thread safe, and is meant to track timings across multiple calls on the same
  * thread
  * </p>
@@ -116,11 +137,25 @@ public class StackWatch<N,T> {
     private Deque<TimingNode> deque = new LinkedList<>();
 
     /**
-     * The root {@code TimingNodeInternal}.
-     * The root node represents the root of a tree structure, and contains all {@code TimingNodeInternal}
+     * The root {@link TimingNode}.
+     * The root node represents the root of a tree structure, and contains all {@link TimingNode}
      * instances.
      */
     private TimingNode<N,T> rootNode;
+
+    /**
+     * Creates and starts a new {@code StackWatch} instance.
+     * @param <N> type of the names
+     * @param <T> type of the tags
+     * @param rootName the root name
+     * @return started StackWatch
+     * @throws NullPointerException if rootName is null
+     */
+    public static <N,T> StackWatch<N,T> startStackWatch(N rootName) {
+        StackWatch<N,T> stackWatch = new StackWatch<>(rootName);
+        stackWatch.start();
+        return stackWatch;
+    }
 
     /**
      * <p>

--- a/src/test/java/org/apache/commons/lang3/time/StackWatchTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/StackWatchTest.java
@@ -1,0 +1,640 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.lang3.time;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class StackWatchTest {
+    private static final String NODE_NAME = "testFunction";
+    private static final String TAG_ONE = "tag_one";
+    private static final String TAG_TWO = "tag_two";
+    private static final String CHILD_NAME = "the child";
+    private static final String ROOT_NAME = "root";
+    @Test
+    public void testRootNameConstructor() {
+        StackWatch<String,String> watch = new StackWatch<>(ROOT_NAME);
+        assertEquals(ROOT_NAME, watch.getRootName());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testRootNameWithNullThrows() {
+        new StackWatch<>(null);
+    }
+
+    @Test
+    public void start() {
+        final StopWatch stopWatch = new StopWatch();
+        StackWatch<String,String> watch = new StackWatch<>("testStackWatch");
+        watch.start();
+        stopWatch.start();
+        stopWatch.stop();
+        watch.stop();
+        watch.visit(new StackWatch.TimingVisitor<String,String>() {
+            @Override
+            public void visitTiming(int level, List<String> path, StackWatch.Timing<String,String> node) {
+                assertTrue(node.getStopWatch().getNanoTime() > stopWatch.getNanoTime());
+            }
+        });
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testStartASecondTimeThrowsException() {
+        StackWatch<String,String> watch = new StackWatch<>("testStackWatch");
+        watch.start();
+        watch.start();
+    }
+
+    @Test
+    public void startTiming() {
+        final StopWatch stopWatch = new StopWatch();
+        StackWatch<String,String> watch = new StackWatch<>("testStackWatch");
+        watch.start();
+        watch.startTiming("one");
+        stopWatch.start();
+        stopWatch.stop();
+        watch.stopTiming();
+        watch.stop();
+        watch.visit(new StackWatch.TimingVisitor<String,String>() {
+            @Override
+            public void visitTiming(int level, List<String> path, StackWatch.Timing<String,String> node) {
+                if (level > 0) {
+                    assertTrue(node.getStopWatch().getNanoTime() > stopWatch.getNanoTime());
+                }
+            }
+        });
+    }
+
+    @Test
+    public void stopTiming() throws Exception {
+        StackWatch<String,String> watch = new StackWatch<>("testStackWatch");
+        watch.start();
+        watch.startTiming("one");
+        Thread.sleep(100);
+        watch.stopTiming();
+        watch.stop();
+        final ArrayList<Long> times = new ArrayList<>();
+        watch.visit(new StackWatch.TimingVisitor<String,String>() {
+            @Override
+            public void visitTiming(int level, List<String> path,StackWatch.Timing<String,String> node) {
+                if (level > 0) {
+                    times.add(node.getStopWatch().getNanoTime());
+                }
+            }
+        });
+
+        watch.visit(new StackWatch.TimingVisitor<String,String>() {
+            @Override
+            public void visitTiming(int level, List<String> path, StackWatch.Timing<String,String> node) {
+                if (level > 0) {
+                    times.add(node.getStopWatch().getNanoTime());
+                }
+            }
+        });
+
+        assertEquals(times.size(), 2);
+        assertEquals(times.get(0), times.get(1));
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void stopWithoutStopTimingThrowsException() {
+        StackWatch<String,String> watch = new StackWatch<>("testStackWatch");
+        watch.start();
+        watch.startTiming("one");
+        watch.stop();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void clearBeforeStopThrowsException() {
+        StackWatch<String,String> watch = new StackWatch<>("testStackWatch");
+        watch.start();
+        watch.startTiming("one");
+        watch.stopTiming();
+        watch.clear();
+        watch.stop();
+    }
+
+    @Test
+    public void testNonStringNameTiming() throws Exception {
+        StackWatch<Integer,String> watch = new StackWatch<>(99);
+        watch.start();
+        watch.startTiming(100);
+        Thread.sleep(100);
+        watch.stopTiming();
+        watch.stop();
+        final ArrayList<Long> times = new ArrayList<>();
+        watch.visit(new StackWatch.TimingVisitor<Integer, String>() {
+            @Override
+            public void visitTiming(int level, List<Integer> path, StackWatch.Timing<Integer,String> node) {
+                if (level > 0) {
+                    times.add(node.getStopWatch().getNanoTime());
+                    assertTrue(node.getName().getClass() == Integer.class);
+                }
+            }
+        });
+
+        watch.visit(new StackWatch.TimingVisitor<Integer, String>() {
+            @Override
+            public void visitTiming(int level, List<Integer> path, StackWatch.Timing<Integer,String> node) {
+                if (level > 0) {
+                    times.add(node.getStopWatch().getNanoTime());
+                }
+            }
+        });
+
+        assertEquals(times.size(), 2);
+        assertEquals(times.get(0), times.get(1));
+    }
+
+    @Test
+    public void testStackWatch() throws Exception {
+        // General test, call three top level functions, the first of two having
+        // nested calls
+        StackWatch<String,String> watch = new StackWatch<>("testStackWatch");
+        watch.start();
+        // root timing
+        watch.startTiming("Test");
+        functionOne(watch);
+        functionTwo(watch);
+        functionThree(watch);
+        watch.stopTiming();
+        watch.stop();
+        final ArrayList<Integer> levels = new ArrayList<>();
+        watch.visit(new StackWatch.TimingVisitor<String,String>() {
+            @Override
+            public void visitTiming(int level, List<String> path, StackWatch.Timing<String,String> node) {
+                levels.add(level);
+            }
+        });
+        // validate that we have the right number of 'timings'
+        assertEquals(levels.size(), 9);
+    }
+
+    @Test
+    public void testStackWatchWithoutStarting() throws Exception {
+        // General test, call three top level functions, the first of two having
+        // nested calls
+        StackWatch<String,String> watch = new StackWatch<>("testStackWatch");
+        // root timing
+        watch.startTiming("Test");
+        functionOne(watch);
+        functionTwo(watch);
+        functionThree(watch);
+        watch.stopTiming();
+        watch.stop();
+        final ArrayList<Integer> levels = new ArrayList<>();
+        watch.visit(new StackWatch.TimingVisitor<String,String>() {
+            @Override
+            public void visitTiming(int level, List<String> path, StackWatch.Timing<String,String> node) {
+                levels.add(level);
+            }
+        });
+        // validate that we have the right number of 'timings'
+        assertEquals(levels.size(), 9);
+    }
+
+    @Test
+    public void testStackWatchFiltered() throws Exception {
+        StackWatch<String,String> watch = new StackWatch<>("testStackWatch");
+        final List<String> filter = new ArrayList<>();
+        filter.add("ThreeFunc");
+        watch.startTiming("Test");
+        functionOne(watch);
+        functionTwo(watch);
+        functionThree(watch);
+        watch.stopTiming();
+        watch.stop();
+        final ArrayList<Integer> levels = new ArrayList<>();
+        watch.visit(new StackWatch.TimingVisitor<String,String>() {
+            @Override
+            public void visitTiming(int level, List<String> path, StackWatch.Timing<String,String> node) {
+                List<String> tags = node.getTags();
+                if (tags != null) {
+                    if (tags.containsAll(filter)) {
+                        levels.add(level);
+                    }
+                }
+            }
+        });
+
+        // validate that we have the right number of 'timings'
+        // there is only one ThreeFunc
+        assertEquals(levels.size(), 1);
+    }
+
+    @Test
+    public void testNonStartOuter() throws Exception {
+        // Test a case where we are doing timings, but don't give it an 'outer' time
+        StackWatch<String,String> watch = new StackWatch<>("testStackWatch");
+        functionOne(watch);
+        functionTwo(watch);
+        functionThree(watch);
+        watch.stop();
+
+        final ArrayList<Integer> levels = new ArrayList<>();
+        watch.visit(new StackWatch.TimingVisitor<String,String>() {
+            @Override
+            public void visitTiming(int level, List<String> path, StackWatch.Timing<String,String> node) {
+                levels.add(level);
+            }
+        });
+        assertEquals(levels.size(), 8);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testMissMatchedStopThrowsException() throws Exception {
+        StackWatch<String,String> watch = new StackWatch<>("testStackWatch");
+        functionOne(watch);
+        functionTwo(watch);
+        functionThree(watch);
+        // we are stopping when we didn't explicitly start, so this will stop the root
+        // and empty the queue
+        watch.stopTiming();
+        // exception
+        watch.stop();
+    }
+
+    @Test
+    public void testDidNotStopAll() throws Exception {
+        StackWatch<String,String> watch = new StackWatch<>("testStackWatch");
+        watch.startTiming("Test");
+        functionOne(watch);
+        functionTwo(watch);
+        functionThree(watch);
+        functionNoStop(watch);
+        watch.stopTiming();
+        final ArrayList<Integer> levels = new ArrayList<>();
+        watch.visit(new StackWatch.TimingVisitor<String, String>() {
+            @Override
+            public void visitTiming(int level, List<String> path, StackWatch.Timing<String,String> node) {
+                levels.add(level);
+            }
+        });
+
+        assertEquals(levels.size(), 10);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testNullNameThrowsException() {
+        StackWatch<String,String> watch = new StackWatch<>("testStackWatch");
+        watch.startTiming(null);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testParentNotRunningThrowsException() throws Exception {
+        StackWatch<String,String> watch = new StackWatch<>("testStackWatch");
+        watch.startTiming("test");
+        functionOneCloseParent(watch);
+    }
+
+    @Test
+    public void testStartingSecondSetOfTimingsClear() throws Exception {
+        StackWatch<String,String> watch = new StackWatch<>("testStackWatch");
+        watch.startTiming("Test");
+        functionOne(watch);
+        watch.stopTiming();
+        watch.stop();
+        watch.clear();
+        watch.startTiming("More Test");
+        watch.stopTiming();
+        final ArrayList<Integer> levels = new ArrayList<>();
+        watch.visit(new StackWatch.TimingVisitor<String,String>() {
+            @Override
+            public void visitTiming(int level, List<String> path, StackWatch.Timing<String,String> node) {
+                levels.add(level);
+            }
+        });
+        watch.stop();
+        assertEquals(levels.size(),2);
+    }
+
+    private void functionOne(StackWatch<String,String> watch) throws Exception {
+        watch.startTiming("One", "OneFunc");
+        Thread.sleep(50);
+        functionOneOne(watch);
+        watch.stopTiming();
+    }
+
+    private void functionOneCloseParent(StackWatch<String,String> watch) throws Exception {
+        watch.startTiming("One", "OneFunc");
+        Thread.sleep(50);
+        watch.visit(new StackWatch.TimingVisitor<String,String>() {
+            @Override
+            public void visitTiming(int level, List<String> path, StackWatch.Timing<String,String> node) {
+                node.getStopWatch().stop();
+            }
+        });
+        functionOneOne(watch);
+    }
+
+    private void functionOneOne(StackWatch<String,String> watch) throws Exception {
+        watch.startTiming("OneOne", "OneFunc");
+        Thread.sleep(50);
+        functionOneTwo(watch);
+        watch.stopTiming();
+
+    }
+
+    private void functionOneTwo(StackWatch<String,String> watch) throws Exception {
+        watch.startTiming("OneTwo", "OneFunc");
+        Thread.sleep(50);
+        watch.stopTiming();
+    }
+
+    private void functionTwo(StackWatch<String,String> watch) throws Exception {
+        watch.startTiming("Two", "TwoFunc");
+        Thread.sleep(50);
+        functionTwoOne(watch);
+        watch.stopTiming();
+    }
+
+    private void functionTwoOne(StackWatch<String,String> watch) throws Exception {
+        watch.startTiming("TwoOne", "TwoFunc");
+        Thread.sleep(50);
+        functionTwoTwo(watch);
+        watch.stopTiming();
+    }
+
+    private void functionTwoTwo(StackWatch<String,String> watch) throws Exception {
+        watch.startTiming("TwoTwo", "TwoFunc");
+        Thread.sleep(50);
+        watch.stopTiming();
+    }
+
+    private void functionThree(StackWatch<String,String> watch) throws Exception {
+        watch.startTiming("Three", "ThreeFunc");
+        Thread.sleep(50);
+        watch.stopTiming();
+    }
+
+    private void functionNoStop(StackWatch<String,String> watch) throws Exception {
+        watch.startTiming("NoStop");
+        Thread.sleep(50);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testNullTimingNodeNameThrowsException() {
+        StackWatch<String,String> watch = new StackWatch<>("testStackWatch");
+        watch.start();
+        watch.startTiming("one");
+        watch.visit(new StackWatch.TimingVisitor<String,String>() {
+            @Override
+            public void visitTiming(int level, List<String> path, StackWatch.Timing<String,String> node) {
+                if (level > 0) {
+                    ((StackWatch.TimingNode<String,String>)node).createChild(null);
+                }
+            }
+        });
+        watch.stopTiming();
+        watch.stop();
+    }
+
+    @Test
+    public void testGetTimingName() {
+        StackWatch<String,String> watch = new StackWatch<>("testStackWatch");
+        watch.start();
+        watch.startTiming("one");
+        watch.stopTiming();
+        watch.stop();
+        watch.visit(new StackWatch.TimingVisitor<String,String>() {
+            @Override
+            public void visitTiming(int level, List<String> path, StackWatch.Timing<String,String> node) {
+                if (level > 0) {
+                    assertNotNull(node.getName());
+                }
+            }
+        });
+    }
+
+    @Test
+    public void testIsRunning() {
+        StackWatch<String,String> watch = new StackWatch<>("testStackWatch");
+        watch.start();
+        watch.startTiming("one");
+        watch.visit(new StackWatch.TimingVisitor<String,String>() {
+            @Override
+            public void visitTiming(int level, List<String> path, StackWatch.Timing<String,String> node) {
+                if (level > 0) {
+                    assertTrue(((StackWatch.TimingNode<String,String>)node).isRunning());
+                }
+            }
+        });
+        watch.stopTiming();
+        watch.stop();
+        watch.visit(new StackWatch.TimingVisitor<String,String>() {
+            @Override
+            public void visitTiming(int level, List<String> path, StackWatch.Timing<String,String> node) {
+                if (level > 0) {
+                    assertFalse(((StackWatch.TimingNode<String,String>)node).isRunning());
+                }
+            }
+        });
+    }
+
+    @Test
+    public void testStartStart() {
+        StackWatch<String,String> watch = new StackWatch<>("testStackWatch");
+        watch.start();
+        watch.startTiming("one");
+        watch.visit(new StackWatch.TimingVisitor<String,String>() {
+            @Override
+            public void visitTiming(int level, List<String> path, StackWatch.Timing<String,String> node) {
+                if (level > 0) {
+                    ((StackWatch.TimingNode<String,String>)node).start();
+                }
+            }
+        });
+        watch.stopTiming();
+        watch.stop();
+    }
+
+    @Test
+    public void testStop() {
+        StackWatch<String,String> watch = new StackWatch<>("testStackWatch");
+        watch.start();
+        watch.startTiming("one");
+        watch.visit(new StackWatch.TimingVisitor<String,String>() {
+            @Override
+            public void visitTiming(int level, List<String> path, StackWatch.Timing<String,String> node) {
+                if (level > 0) {
+                    ((StackWatch.TimingNode<String,String>)node).stop();
+                    assertFalse(((StackWatch.TimingNode<String,String>)node).isRunning());
+                }
+            }
+        });
+        watch.stopTiming();
+        watch.stop();
+    }
+
+
+    @Test(expected = IllegalStateException.class)
+    @SuppressWarnings("unchecked")
+    public void testStopWhileAddingChildrenThrowsException() {
+        StackWatch<String,String> watch = new StackWatch<>("testStackWatch");
+        watch.start();
+        watch.startTiming("one");
+        watch.visit(new StackWatch.TimingVisitor<String,String>() {
+            @Override
+            public void visitTiming(int level, List<String> path, StackWatch.Timing<String,String> node) {
+                if (level > 0) {
+                    ((StackWatch.TimingNode<String,String>)node).stop();
+                    ((StackWatch.TimingNode<String,String>)node).createChild("boom");
+                }
+            }
+        });
+        watch.stopTiming();
+        watch.stop();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    @SuppressWarnings("unchecked")
+    public void testStopWithRunningChildrenThrowsException() {
+           StackWatch<String,String> watch = new StackWatch<>("testStackWatch");
+        watch.start();
+        watch.startTiming("one");
+        watch.visit(new StackWatch.TimingVisitor<String,String>() {
+            @Override
+            public void visitTiming(int level, List<String> path, StackWatch.Timing<String,String> node) {
+                if (level == 0) {
+                    ((StackWatch.TimingNode<String,String>)node).stop();
+                }
+            }
+        });
+        watch.stopTiming();
+        watch.stop();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testCreateChild() {
+        StackWatch<String,String> watch = new StackWatch<>("testStackWatch");
+        watch.start();
+        watch.startTiming("one");
+        watch.visit(new StackWatch.TimingVisitor<String,String>() {
+            @Override
+            public void visitTiming(int level, List<String> path, StackWatch.Timing<String,String> node) {
+                if (node.getName().equals("one")) {
+                    StackWatch.TimingNode<String,String> child = ((StackWatch.TimingNode<String,String>)node)
+                            .createChild("child");
+                    assertNotNull(child);
+                }
+            }
+        });
+        watch.stopTiming();
+        watch.stop();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    @SuppressWarnings("unchecked")
+    public void testCreateChildWhenNotStartedThrowsException() {
+      StackWatch<String,String> watch = new StackWatch<>("testStackWatch");
+        watch.start();
+        watch.startTiming("one");
+        watch.visit(new StackWatch.TimingVisitor<String,String>() {
+            @Override
+            public void visitTiming(int level, List<String> path, StackWatch.Timing<String,String> node) {
+                // this has the effect of trying to add a child to.. child
+                if (level > 0) {
+                    StackWatch.TimingNode<String,String> child = ((StackWatch.TimingNode<String,String>)node)
+                            .createChild("child");
+                    assertNotNull(child);
+                }
+            }
+        });
+        watch.stopTiming();
+        watch.stop();
+    }
+
+    @Test
+    public void getStopWatch() {
+        StackWatch<String, String> watch = new StackWatch<>("testStackWatch");
+        watch.start();
+        watch.startTiming("one");
+        watch.visit(new StackWatch.TimingVisitor<String, String>() {
+            @Override
+            public void visitTiming(int level, List<String> path, StackWatch.Timing<String, String> node) {
+                assertNotNull(node.getStopWatch());
+            }
+        });
+        watch.stopTiming();
+        watch.stop();
+    }
+
+    @Test
+    public void getTags() {
+        StackWatch<String, String> watch = new StackWatch<>("testStackWatch");
+        watch.start();
+        watch.startTiming(NODE_NAME, TAG_ONE, TAG_TWO);
+        watch.visit(new StackWatch.TimingVisitor<String, String>() {
+            @Override
+            public void visitTiming(int level, List<String> path, StackWatch.Timing<String, String> node) {
+                if (node.getName().equals(NODE_NAME)) {
+                    assertEquals(2, node.getTags().size());
+                }
+            }
+        });
+        watch.stopTiming();
+        watch.stop();
+    }
+
+    @Test
+    public void getTagsWithNoTags() {
+        StackWatch<String, String> watch = new StackWatch<>("testStackWatch");
+        watch.start();
+        watch.startTiming(NODE_NAME);
+        watch.visit(new StackWatch.TimingVisitor<String, String>() {
+            @Override
+            public void visitTiming(int level, List<String> path, StackWatch.Timing<String, String> node) {
+                if (node.getName().equals(NODE_NAME)) {
+                    assertNotNull(node.getTags());
+                    assertEquals(0, node.getTags().size());
+                }
+            }
+        });
+        watch.stopTiming();
+        watch.stop();
+    }
+
+    //@Test
+    // function for testing java doc code
+    public void outerFunction() {
+        try {
+            StackWatch<String, String> watch = new StackWatch<>("OuterFunction");
+            watch.start();
+            functionOne(watch);
+            functionTwo(watch);
+            watch.stop();
+            watch.visit(new StackWatch.TimingVisitor<String, String>() {
+                @Override
+                public void visitTiming(int level, List<String> path, StackWatch.Timing<String, String> timing) {
+                    System.out.println("Visit level " + level + " timing: " + timing.getName() + " path: " + path
+                    + " time: " + timing.getStopWatch().getNanoTime() + "ns");
+                }
+            });
+        } catch (Exception e) {
+        }
+    }
+}
+


### PR DESCRIPTION
There are times when you want to do a number or related timings across a sequence of calls or operations.  This is difficult to do with just the StopWatch.

StackWatch provides an abstraction over the  StopWatch class that allows callers to create multiple named and possibly nested timing operations.

StackWatch uses a combination of Deque and a custom Tree implementation to create, start and end timing operations.

A Visitor pattern is also implemented to allow for retrieving the results after the completion of the operation, and timings may be tagged to allow the consumer to filter the results.



I have built this in my personal travis and all three jobs pass
