### PR TITLE
Remove inequality check from shuffle tests

### DIFF
--- a/src/test/java/org/apache/commons/lang3/ArrayUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/ArrayUtilsTest.java
@@ -5008,7 +5008,6 @@ public class ArrayUtilsTest {
         final String[] array2 = ArrayUtils.clone(array1);
 
         ArrayUtils.shuffle(array1);
-        assertFalse(Arrays.equals(array1, array2));
         for (final String element : array2) {
             assertTrue("Element " + element + " not found", ArrayUtils.contains(array1, element));
         }
@@ -5017,10 +5016,8 @@ public class ArrayUtilsTest {
     @Test
     public void testShuffleBoolean() {
         final boolean[] array1 = new boolean[]{true, false, true, true, false, false, true, false, false, true};
-        final boolean[] array2 = ArrayUtils.clone(array1);
 
         ArrayUtils.shuffle(array1);
-        assertFalse(Arrays.equals(array1, array2));
         assertEquals(5, ArrayUtils.removeAllOccurences(array1, true).length);
     }
 
@@ -5030,7 +5027,6 @@ public class ArrayUtilsTest {
         final byte[] array2 = ArrayUtils.clone(array1);
 
         ArrayUtils.shuffle(array1);
-        assertFalse(Arrays.equals(array1, array2));
         for (final byte element : array2) {
             assertTrue("Element " + element + " not found", ArrayUtils.contains(array1, element));
         }
@@ -5042,7 +5038,6 @@ public class ArrayUtilsTest {
         final char[] array2 = ArrayUtils.clone(array1);
 
         ArrayUtils.shuffle(array1);
-        assertFalse(Arrays.equals(array1, array2));
         for (final char element : array2) {
             assertTrue("Element " + element + " not found", ArrayUtils.contains(array1, element));
         }
@@ -5054,7 +5049,6 @@ public class ArrayUtilsTest {
         final short[] array2 = ArrayUtils.clone(array1);
 
         ArrayUtils.shuffle(array1);
-        assertFalse(Arrays.equals(array1, array2));
         for (final short element : array2) {
             assertTrue("Element " + element + " not found", ArrayUtils.contains(array1, element));
         }
@@ -5066,7 +5060,6 @@ public class ArrayUtilsTest {
         final int[] array2 = ArrayUtils.clone(array1);
 
         ArrayUtils.shuffle(array1);
-        assertFalse(Arrays.equals(array1, array2));
         for (final int element : array2) {
             assertTrue("Element " + element + " not found", ArrayUtils.contains(array1, element));
         }
@@ -5078,7 +5071,6 @@ public class ArrayUtilsTest {
         final long[] array2 = ArrayUtils.clone(array1);
 
         ArrayUtils.shuffle(array1);
-        assertFalse(Arrays.equals(array1, array2));
         for (final long element : array2) {
             assertTrue("Element " + element + " not found", ArrayUtils.contains(array1, element));
         }
@@ -5090,7 +5082,6 @@ public class ArrayUtilsTest {
         final float[] array2 = ArrayUtils.clone(array1);
 
         ArrayUtils.shuffle(array1);
-        assertFalse(Arrays.equals(array1, array2));
         for (final float element : array2) {
             assertTrue("Element " + element + " not found", ArrayUtils.contains(array1, element));
         }
@@ -5102,7 +5093,6 @@ public class ArrayUtilsTest {
         final double[] array2 = ArrayUtils.clone(array1);
 
         ArrayUtils.shuffle(array1);
-        assertFalse(Arrays.equals(array1, array2));
         for (final double element : array2) {
             assertTrue("Element " + element + " not found", ArrayUtils.contains(array1, element));
         }


### PR DESCRIPTION
The `ArrayUtils.shuffle` methods could conceivably shuffle an array in a way that leaves the shuffled array equal to the original array, and thus asserting that the shuffled array differs from the original
array in the test only passes statistically.

The chance of this happening increases as an inverse of the number of distinct values in the array. E.g., in the edge case of an array where all the elements are equal to each other, shuffling the array has a 100% chance of producing an array that's equal to the original array. A less extreme case is the case of
`ArrayUtilsTest#testShuffleBoolean` that shuffles an array that contains ten elements, but only two distinct values (true and false) has been seen to fail in Travis CI [1].

This patch removes this problematic assertion and leaves only the tests on the content of the array.

[1] https://travis-ci.org/apache/commons-lang/jobs/346806985