### PR TITLE
SerializationUtilsTest cleanup

### DIFF
--- a/src/test/java/org/apache/commons/lang3/SerializationUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/SerializationUtilsTest.java
@@ -19,6 +19,7 @@ package org.apache.commons.lang3;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
@@ -197,12 +198,12 @@ public class SerializationUtilsTest {
         final Object test = SerializationUtils.deserialize(inTest);
         assertNotNull(test);
         assertTrue(test instanceof HashMap<?, ?>);
-        assertTrue(test != iMap);
+        assertNotSame(test, iMap);
         final HashMap<?, ?> testMap = (HashMap<?, ?>) test;
         assertEquals(iString, testMap.get("FOO"));
-        assertTrue(iString != testMap.get("FOO"));
+        assertNotSame(iString, testMap.get("FOO"));
         assertEquals(iInteger, testMap.get("BAR"));
-        assertTrue(iInteger != testMap.get("BAR"));
+        assertNotSame(iInteger, testMap.get("BAR"));
         assertEquals(iMap, testMap);
     }
 
@@ -333,12 +334,12 @@ public class SerializationUtilsTest {
         final Object test = SerializationUtils.deserialize(streamReal.toByteArray());
         assertNotNull(test);
         assertTrue(test instanceof HashMap<?, ?>);
-        assertTrue(test != iMap);
+        assertNotSame(test, iMap);
         final HashMap<?, ?> testMap = (HashMap<?, ?>) test;
         assertEquals(iString, testMap.get("FOO"));
-        assertTrue(iString != testMap.get("FOO"));
+        assertNotSame(iString, testMap.get("FOO"));
         assertEquals(iInteger, testMap.get("BAR"));
-        assertTrue(iInteger != testMap.get("BAR"));
+        assertNotSame(iInteger, testMap.get("BAR"));
         assertEquals(iMap, testMap);
     }
 
@@ -381,12 +382,12 @@ public class SerializationUtilsTest {
         final Object test = SerializationUtils.clone(iMap);
         assertNotNull(test);
         assertTrue(test instanceof HashMap<?,?>);
-        assertTrue(test != iMap);
+        assertNotSame(test, iMap);
         final HashMap<?, ?> testMap = (HashMap<?, ?>) test;
         assertEquals(iString, testMap.get("FOO"));
-        assertTrue(iString != testMap.get("FOO"));
+        assertNotSame(iString, testMap.get("FOO"));
         assertEquals(iInteger, testMap.get("BAR"));
-        assertTrue(iInteger != testMap.get("BAR"));
+        assertNotSame(iInteger, testMap.get("BAR"));
         assertEquals(iMap, testMap);
     }
 

--- a/src/test/java/org/apache/commons/lang3/SerializationUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/SerializationUtilsTest.java
@@ -23,7 +23,6 @@ import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -116,16 +115,11 @@ public class SerializationUtilsTest {
         }
     }
 
-    @Test
+    @Test(expected = SerializationException.class)
     public void testSerializeStreamUnserializable() throws Exception {
         final ByteArrayOutputStream streamTest = new ByteArrayOutputStream();
-        try {
-            iMap.put(new Object(), new Object());
-            SerializationUtils.serialize(iMap, streamTest);
-        } catch (final SerializationException ex) {
-            return;
-        }
-        fail();
+        iMap.put(new Object(), new Object());
+        SerializationUtils.serialize(iMap, streamTest);
     }
 
     @Test
@@ -147,24 +141,14 @@ public class SerializationUtilsTest {
         }
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void testSerializeStreamObjNull() throws Exception {
-        try {
-            SerializationUtils.serialize(iMap, null);
-        } catch (final IllegalArgumentException ex) {
-            return;
-        }
-        fail();
+        SerializationUtils.serialize(iMap, null);
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void testSerializeStreamNullNull() throws Exception {
-        try {
-            SerializationUtils.serialize(null, null);
-        } catch (final IllegalArgumentException ex) {
-            return;
-        }
-        fail();
+        SerializationUtils.serialize(null, null);
     }
 
     @Test
@@ -230,24 +214,14 @@ public class SerializationUtilsTest {
         assertNull(test);
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void testDeserializeStreamNull() throws Exception {
-        try {
-            SerializationUtils.deserialize((InputStream) null);
-        } catch (final IllegalArgumentException ex) {
-            return;
-        }
-        fail();
+        SerializationUtils.deserialize((InputStream) null);
     }
 
-    @Test
+    @Test(expected = SerializationException.class)
     public void testDeserializeStreamBadStream() throws Exception {
-        try {
-            SerializationUtils.deserialize(new ByteArrayInputStream(new byte[0]));
-        } catch (final SerializationException ex) {
-            return;
-        }
-        fail();
+        SerializationUtils.deserialize(new ByteArrayInputStream(new byte[0]));
     }
 
     @Test
@@ -293,15 +267,10 @@ public class SerializationUtilsTest {
         }
     }
 
-    @Test
+    @Test(expected = SerializationException.class)
     public void testSerializeBytesUnserializable() throws Exception {
-        try {
-            iMap.put(new Object(), new Object());
-            SerializationUtils.serialize(iMap);
-        } catch (final SerializationException ex) {
-            return;
-        }
-        fail();
+        iMap.put(new Object(), new Object());
+        SerializationUtils.serialize(iMap);
     }
 
     @Test
@@ -355,24 +324,14 @@ public class SerializationUtilsTest {
         assertNull(test);
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void testDeserializeBytesNull() throws Exception {
-        try {
-            SerializationUtils.deserialize((byte[]) null);
-        } catch (final IllegalArgumentException ex) {
-            return;
-        }
-        fail();
+        SerializationUtils.deserialize((byte[]) null);
     }
 
-    @Test
+    @Test(expected = SerializationException.class)
     public void testDeserializeBytesBadStream() throws Exception {
-        try {
-            SerializationUtils.deserialize(new byte[0]);
-        } catch (final SerializationException ex) {
-            return;
-        }
-        fail();
+        SerializationUtils.deserialize(new byte[0]);
     }
 
     //-----------------------------------------------------------------------
@@ -397,15 +356,10 @@ public class SerializationUtilsTest {
         assertNull(test);
     }
 
-    @Test
+    @Test(expected = SerializationException.class)
     public void testCloneUnserializable() throws Exception {
-        try {
-            iMap.put(new Object(), new Object());
-            SerializationUtils.clone(iMap);
-        } catch (final SerializationException ex) {
-            return;
-        }
-        fail();
+        iMap.put(new Object(), new Object());
+        SerializationUtils.clone(iMap);
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/SerializationUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/SerializationUtilsTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.commons.lang3;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -110,9 +111,7 @@ public class SerializationUtilsTest {
         final byte[] testBytes = streamTest.toByteArray();
         final byte[] realBytes = streamReal.toByteArray();
         assertEquals(testBytes.length, realBytes.length);
-        for (int i = 0; i < realBytes.length; i++) {
-            assertEquals(realBytes[i], testBytes[i]);
-        }
+        assertArrayEquals(realBytes, testBytes);
     }
 
     @Test(expected = SerializationException.class)
@@ -136,9 +135,7 @@ public class SerializationUtilsTest {
         final byte[] testBytes = streamTest.toByteArray();
         final byte[] realBytes = streamReal.toByteArray();
         assertEquals(testBytes.length, realBytes.length);
-        for (int i = 0; i < realBytes.length; i++) {
-            assertEquals(realBytes[i], testBytes[i]);
-        }
+        assertArrayEquals(realBytes, testBytes);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -262,9 +259,7 @@ public class SerializationUtilsTest {
 
         final byte[] realBytes = streamReal.toByteArray();
         assertEquals(testBytes.length, realBytes.length);
-        for (int i = 0; i < realBytes.length; i++) {
-            assertEquals(realBytes[i], testBytes[i]);
-        }
+        assertArrayEquals(realBytes, testBytes);
     }
 
     @Test(expected = SerializationException.class)
@@ -285,9 +280,7 @@ public class SerializationUtilsTest {
 
         final byte[] realBytes = streamReal.toByteArray();
         assertEquals(testBytes.length, realBytes.length);
-        for (int i = 0; i < realBytes.length; i++) {
-            assertEquals(realBytes[i], testBytes[i]);
-        }
+        assertArrayEquals(realBytes, testBytes);
     }
 
     //-----------------------------------------------------------------------


### PR DESCRIPTION
This PR includes several improvements to `SerializationUtilsTest` that both clean up the code and make the error message in case of a failure clearer by using JUnit's built-in capabilities.

Changes include:
- replacing `assertTrue(x != y)` with `assertNotSame(x, y)`.
- Using the `expected` argument of the `@Test` annotation to test expected exceptions
- Using `assertArraysEquals` to compare arrays