### PR TITLE
Add comparison methods to ObjectUtils

### DIFF
--- a/src/main/java/org/apache/commons/lang3/ObjectUtils.java
+++ b/src/main/java/org/apache/commons/lang3/ObjectUtils.java
@@ -591,6 +591,58 @@ public class ObjectUtils {
     }
 
     /**
+     * <p>Null safe comparison of Comparables.
+     * {@code null} is assumed to be less than a non-{@code null} value.</p>
+     *
+     * @param <T> type of the values processed by this method
+     * @param c1  the first comparable, may be null
+     * @param c2  the second comparable, may be null
+     * @return {@code false} value if c1 &lt;= c2, and {@code true} value if c1 &gt; c2
+     */
+    public static <T extends Comparable<? super T>> boolean isGreaterThan(final T c1, final T c2) {
+        return compare(c1, c2, false) > 0;
+    }
+
+    /**
+     * <p>Null safe comparison of Comparables.
+     * {@code null} is assumed to be less than a non-{@code null} value.</p>
+     *
+     * @param <T> type of the values processed by this method
+     * @param c1  the first comparable, may be null
+     * @param c2  the second comparable, may be null
+     * @return {@code false} value if c1 &lt; c2, and {@code true} value if c1 &gt;= c2
+     */
+    public static <T extends Comparable<? super T>> boolean isGreaterOrEqualTo(final T c1, final T c2) {
+        return compare(c1, c2, false) >= 0;
+    }
+
+    /**
+     * <p>Null safe comparison of Comparables.
+     * {@code null} is assumed to be less than a non-{@code null} value.</p>
+     *
+     * @param <T> type of the values processed by this method
+     * @param c1  the first comparable, may be null
+     * @param c2  the second comparable, may be null
+     * @return {@code false} value if c1 &gt;= c2, and {@code true} value if c1 &lt; c2
+     */
+    public static <T extends Comparable<? super T>> boolean isLessThan(final T c1, final T c2) {
+        return compare(c1, c2, false) < 0;
+    }
+
+    /**
+     * <p>Null safe comparison of Comparables.
+     * {@code null} is assumed to be less than a non-{@code null} value.</p>
+     *
+     * @param <T> type of the values processed by this method
+     * @param c1  the first comparable, may be null
+     * @param c2  the second comparable, may be null
+     * @return {@code false} value if c1 &gt; c2, and {@code true} value if c1 &lt;= c2
+     */
+    public static <T extends Comparable<? super T>> boolean isLessOrEqualTo(final T c1, final T c2) {
+        return compare(c1, c2, false) <= 0;
+    }
+
+    /**
      * Find the "best guess" middle value among comparables. If there is an even
      * number of total values, the lower of the two middle values will be returned.
      * @param <T> type of values processed by this method

--- a/src/test/java/org/apache/commons/lang3/ObjectUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/ObjectUtilsTest.java
@@ -396,6 +396,78 @@ public class ObjectUtilsTest {
         assertEquals("one two true",  -1, ObjectUtils.compare(one, two, true));
     }
 
+    /**
+     * Tests {@link ObjectUtils#isGreaterThan(Comparable, Comparable)}.
+     */
+    @Test
+    public void testIsGreaterThan() {
+        final Integer one = Integer.valueOf(1);
+        final Integer two = Integer.valueOf(2);
+        final Integer nullValue = null;
+
+        assertFalse("Null Null", ObjectUtils.isGreaterThan(nullValue, nullValue));
+        assertFalse("Null one", ObjectUtils.isGreaterThan(nullValue, one));
+        assertTrue("one Null", ObjectUtils.isGreaterThan(one, nullValue));
+
+        assertFalse("one one", ObjectUtils.isGreaterThan(one, one));
+        assertFalse("one two", ObjectUtils.isGreaterThan(one, two));
+        assertTrue("two one", ObjectUtils.isGreaterThan(two, one));
+    }
+
+    /**
+     * Tests {@link ObjectUtils#isGreaterOrEqualTo(Comparable, Comparable)}.
+     */
+    @Test
+    public void testIsGreaterOrEqualTo() {
+        final Integer one = Integer.valueOf(1);
+        final Integer two = Integer.valueOf(2);
+        final Integer nullValue = null;
+
+        assertTrue("Null Null", ObjectUtils.isGreaterOrEqualTo(nullValue, nullValue));
+        assertFalse("Null one", ObjectUtils.isGreaterOrEqualTo(nullValue, one));
+        assertTrue("one Null", ObjectUtils.isGreaterOrEqualTo(one, nullValue));
+
+        assertTrue("one one", ObjectUtils.isGreaterOrEqualTo(one, one));
+        assertFalse("one two", ObjectUtils.isGreaterOrEqualTo(one, two));
+        assertTrue("two one", ObjectUtils.isGreaterOrEqualTo(two, one));
+    }
+
+    /**
+     * Tests {@link ObjectUtils#isLessThan(Comparable, Comparable)}.
+     */
+    @Test
+    public void testIsLessThan() {
+        final Integer one = Integer.valueOf(1);
+        final Integer two = Integer.valueOf(2);
+        final Integer nullValue = null;
+
+        assertFalse("Null Null", ObjectUtils.isLessThan(nullValue, nullValue));
+        assertTrue("Null one", ObjectUtils.isLessThan(nullValue, one));
+        assertFalse("one Null", ObjectUtils.isLessThan(one, nullValue));
+
+        assertFalse("one one", ObjectUtils.isLessThan(one, one));
+        assertTrue("one two", ObjectUtils.isLessThan(one, two));
+        assertFalse("two one", ObjectUtils.isLessThan(two, one));
+    }
+
+    /**
+     * Tests {@link ObjectUtils#isLessOrEqualTo(Comparable, Comparable)}.
+     */
+    @Test
+    public void testIsLessOrEqualTo() {
+        final Integer one = Integer.valueOf(1);
+        final Integer two = Integer.valueOf(2);
+        final Integer nullValue = null;
+
+        assertTrue("Null Null", ObjectUtils.isLessOrEqualTo(nullValue, nullValue));
+        assertTrue("Null one", ObjectUtils.isLessOrEqualTo(nullValue, one));
+        assertFalse("one Null", ObjectUtils.isLessOrEqualTo(one, nullValue));
+
+        assertTrue("one one", ObjectUtils.isLessOrEqualTo(one, one));
+        assertTrue("one two", ObjectUtils.isLessOrEqualTo(one, two));
+        assertFalse("two one", ObjectUtils.isLessOrEqualTo(two, one));
+    }
+
     @Test
     public void testMedian() {
         assertEquals("foo", ObjectUtils.median("foo"));


### PR DESCRIPTION
Additional comparison methods to make `greater than`, `greater than or equal to`, `less then` and `less than or equal to` easier to use instead of checking the int outcome of `compare` everywhere and making the code that utilises it more readable