### PR TITLE
(doc) Remove invalid example of `lastIndexOf` from javadoc

### DIFF
--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -1822,7 +1822,6 @@ public class StringUtils {
      * StringUtils.lastIndexOf("aabaabaa", "b", 0)  = -1
      * StringUtils.lastIndexOf("aabaabaa", "b", 1)  = -1
      * StringUtils.lastIndexOf("aabaabaa", "b", 2)  = 2
-     * StringUtils.lastIndexOf("aabaabaa", "ba", 2)  = -1
      * StringUtils.lastIndexOf("aabaabaa", "ba", 2)  = 2
      * </pre>
      *


### PR DESCRIPTION
`StringUtils.lastIndexOf("aabaabaa", "ba", 2)  = -1` is invalid; moreover, example below is applied to the same arguments, but gets another (correct) result.