### PR TITLE
LANG-1397: WordUtils.wrap throws StringIndexOutOfBoundsException when wrapLength is Integer.MAX_VALUE

### DIFF
--- a/src/main/java/org/apache/commons/lang3/text/WordUtils.java
+++ b/src/main/java/org/apache/commons/lang3/text/WordUtils.java
@@ -288,7 +288,8 @@ public class WordUtils {
 
         while (offset < inputLineLength) {
             int spaceToWrapAt = -1;
-            Matcher matcher = patternToWrapOn.matcher(str.substring(offset, Math.min(offset + wrapLength + 1, inputLineLength)));
+            Matcher matcher = patternToWrapOn.matcher(
+                str.substring(offset, Math.min((int)Math.min(Integer.MAX_VALUE, offset + wrapLength + 1L), inputLineLength)));
             if (matcher.find()) {
                 if (matcher.start() == 0) {
                     offset += matcher.end();

--- a/src/test/java/org/apache/commons/lang3/text/WordUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/WordUtilsTest.java
@@ -427,4 +427,11 @@ public class WordUtilsTest {
                 + "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",70);
     }
 
+    @Test
+    public void testLANG1397() throws Exception {
+        // Prior to fix, this was throwing StringIndexOutOfBoundsException
+        WordUtils.wrap("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa "
+            + "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa "
+            + "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", Integer.MAX_VALUE);
+    }
 }


### PR DESCRIPTION
There is a bug of WordUtils. WordUtils in commons-text has the same bug. I will work on it after merging this pull request.

This is my first contribute to this project. I confirmed `mvn clean verify` succeeds. If there is any problem, please let me know.