### PR TITLE
LANG-1380: FastDateParser too strict on abbreviated short month symbols

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -46,6 +46,7 @@ The <action> type attribute can be add,update,fix,remove.
   <body>
 
   <release version="3.8" date="2018-MM-DD" description="New features and bug fixes. Requires Java 7, supports Java 8, 9, 10.">
+    <action issue="LANG-1380" type="fix" dev="chas" due-to="Markus Jelsma">FastDateParser too strict on abbreviated short month symbols</action>
     <action issue="LANG-1396" type="fix" dev="sebb">JsonToStringStyle does not escape string names</action>
     <action issue="LANG-1395" type="fix" dev="sebb" due-to="Jim Gan">JsonToStringStyle does not escape double quote in a string value</action>
     <action issue="LANG-1384" type="fix" dev="erans" due-to="Ian Young">New Java version ("11") must be handled</action>
@@ -64,7 +65,7 @@ The <action> type attribute can be add,update,fix,remove.
     <action issue="LANG-1391" type="add" dev="ggregory" due-to="Sauro Matulli, Oleg Chubaryov">Improve Javadoc for StringUtils.isAnyEmpty(null)</action>   
     <action issue="LANG-1393" type="add" dev="ggregory" due-to="Gary Gregory">Add API SystemUtils.String getEnvironmentVariable(final String name, final String defaultValue)</action>   
     <action issue="LANG-1394" type="add" dev="ggregory" due-to="Sebb, Gary Gregory">org.apache.commons.lang3.SystemUtils should not write to System.err.</action>   
-    <action issue="LANG-1238" type="add" dev="ggregory" due-to="Christopher Cordeiro, Gary Gregory, Bruno P. Kinoshita, Oleg Chubaryov">Add RegexUtils class instead of overloadinh methods in StringUtils that take a regex to take precompiled Pattern.</action>   
+    <action issue="LANG-1238" type="add" dev="ggregory" due-to="Christopher Cordeiro, Gary Gregory, Bruno P. Kinoshita, Oleg Chubaryov">Add RegexUtils class instead of overloading methods in StringUtils that take a regex to take precompiled Pattern.</action>
   </release>
 
   <release version="3.7" date="2017-11-04" description="New features and bug fixes. Requires Java 7, supports Java 8, 9, 10.">

--- a/src/main/java/org/apache/commons/lang3/time/FastDateParser.java
+++ b/src/main/java/org/apache/commons/lang3/time/FastDateParser.java
@@ -427,55 +427,6 @@ public class FastDateParser implements DateParser, Serializable {
     // Support for strategies
     //-----------------------------------------------------------------------
 
-    private static StringBuilder simpleQuote(final StringBuilder sb, final String value) {
-        for (int i = 0; i < value.length(); ++i) {
-            final char c = value.charAt(i);
-            switch (c) {
-            case '\\':
-            case '^':
-            case '$':
-            case '.':
-            case '|':
-            case '?':
-            case '*':
-            case '+':
-            case '(':
-            case ')':
-            case '[':
-            case '{':
-                sb.append('\\');
-            default:
-                sb.append(c);
-            }
-        }
-        return sb;
-    }
-
-    /**
-     * Get the short and long values displayed for a field
-     * @param cal The calendar to obtain the short and long values
-     * @param locale The locale of display names
-     * @param field The field of interest
-     * @param regex The regular expression to build
-     * @return The map of string display names to field values
-     */
-    private static Map<String, Integer> appendDisplayNames(final Calendar cal, final Locale locale, final int field, final StringBuilder regex) {
-        final Map<String, Integer> values = new HashMap<>();
-
-        final Map<String, Integer> displayNames = cal.getDisplayNames(field, Calendar.ALL_STYLES, locale);
-        final TreeSet<String> sorted = new TreeSet<>(LONGER_FIRST_LOWERCASE);
-        for (final Map.Entry<String, Integer> displayName : displayNames.entrySet()) {
-            final String key = displayName.getKey().toLowerCase(locale);
-            if (sorted.add(key)) {
-                values.put(key, displayName.getValue());
-            }
-        }
-        for (final String symbol : sorted) {
-            simpleQuote(regex, symbol).append('|');
-        }
-        return values;
-    }
-
     /**
      * Adjust dates to be within appropriate century
      * @param twoDigitYear The year to adjust
@@ -510,10 +461,6 @@ public class FastDateParser implements DateParser, Serializable {
 
         private Pattern pattern;
 
-        void createPattern(final StringBuilder regex) {
-            createPattern(regex.toString());
-        }
-
         void createPattern(final String regex) {
             this.pattern = Pattern.compile(regex);
         }
@@ -542,6 +489,44 @@ public class FastDateParser implements DateParser, Serializable {
         }
 
         abstract void setCalendar(FastDateParser parser, Calendar cal, String value);
+
+        // order the regex alternatives with longer strings first, greedy
+        // match will ensure longest string will be consumed
+        void buildRegex(StringBuilder regex, Set<String> sorted) {
+            for (final String symbol : sorted) {
+                simpleQuote(regex, symbol).append('|');
+            }
+            regex.setCharAt(regex.length()-1, ')');
+            createPattern(regex.toString());
+        }
+
+        StringBuilder simpleQuote(final StringBuilder sb, final String value) {
+            for (int i = 0; i < value.length(); ++i) {
+                final char c = value.charAt(i);
+                switch (c) {
+                    case '\\':
+                    case '^':
+                    case '$':
+                    case '.':
+                    case '|':
+                    case '?':
+                    case '*':
+                    case '+':
+                    case '(':
+                    case ')':
+                    case '[':
+                    case '{':
+                        sb.append('\\');
+                    default:
+                        sb.append(c);
+                }
+            }
+            if(sb.charAt(sb.length() - 1) == '.') {
+                // trailing '.' is optional
+                sb.append('?');
+            }
+            return sb;
+        }
     }
 
     /**
@@ -699,13 +684,7 @@ public class FastDateParser implements DateParser, Serializable {
         CaseInsensitiveTextStrategy(final int field, final Calendar definingCalendar, final Locale locale) {
             this.field = field;
             this.locale = locale;
-
-            final StringBuilder regex = new StringBuilder();
-            regex.append("((?iu)");
-            lKeyValues = appendDisplayNames(definingCalendar, locale, field, regex);
-            regex.setLength(regex.length()-1);
-            regex.append(")");
-            createPattern(regex);
+            lKeyValues = appendDisplayNames(definingCalendar);
         }
 
         /**
@@ -713,11 +692,38 @@ public class FastDateParser implements DateParser, Serializable {
          */
         @Override
         void setCalendar(final FastDateParser parser, final Calendar cal, final String value) {
-            final Integer iVal = lKeyValues.get(value.toLowerCase(locale));
+            final String lowerCase = value.toLowerCase(locale);
+            Integer iVal = lKeyValues.get(lowerCase);
+            if(iVal == null) {
+                // match missing the optional trailing period
+                iVal = lKeyValues.get(lowerCase + '.');
+            }
             cal.set(field, iVal.intValue());
         }
-    }
 
+        /**
+         * Get the short and long values displayed for a field
+         * @param cal The calendar to obtain the short and long values
+         * @return The map of string display names to field values
+         */
+        Map<String, Integer> appendDisplayNames(final Calendar cal) {
+            final Map<String, Integer> values = new HashMap<>();
+
+            final Map<String, Integer> displayNames = cal.getDisplayNames(field, Calendar.ALL_STYLES, locale);
+            final TreeSet<String> sorted = new TreeSet<>(LONGER_FIRST_LOWERCASE);
+            for (final Map.Entry<String, Integer> displayName : displayNames.entrySet()) {
+                final String key = displayName.getKey().toLowerCase(locale);
+                if (sorted.add(key)) {
+                    values.put(key, displayName.getValue());
+                }
+            }
+
+            final StringBuilder regex = new StringBuilder();
+            regex.append("((?iu)");
+            buildRegex(regex, sorted);
+            return values;
+        }
+    }
 
     /**
      * A strategy that handles a number field in the parsing pattern
@@ -809,6 +815,7 @@ public class FastDateParser implements DateParser, Serializable {
     static class TimeZoneStrategy extends PatternStrategy {
         private static final String RFC_822_TIME_ZONE = "[+-]\\d{4}";
         private static final String GMT_OPTION = TimeZones.GMT_ID + "[+-]\\d{1,2}:\\d{2}";
+        private static final String GMT_OR_RFC_PREFIX = "((?iu)" + RFC_822_TIME_ZONE + '|' + GMT_OPTION + '|';
 
         private final Locale locale;
         private final Map<String, TzInfo> tzNames= new HashMap<>();
@@ -834,9 +841,6 @@ public class FastDateParser implements DateParser, Serializable {
          */
         TimeZoneStrategy(final Locale locale) {
             this.locale = locale;
-
-            final StringBuilder sb = new StringBuilder();
-            sb.append("((?iu)" + RFC_822_TIME_ZONE + "|" + GMT_OPTION );
 
             final Set<String> sorted = new TreeSet<>(LONGER_FIRST_LOWERCASE);
 
@@ -874,13 +878,10 @@ public class FastDateParser implements DateParser, Serializable {
                     }
                 }
             }
-            // order the regex alternatives with longer strings first, greedy
-            // match will ensure longest string will be consumed
-            for (final String zoneName : sorted) {
-                simpleQuote(sb.append('|'), zoneName);
-            }
-            sb.append(")");
-            createPattern(sb);
+
+            final StringBuilder sb = new StringBuilder();
+            sb.append(GMT_OR_RFC_PREFIX);
+            buildRegex(sb, sorted);
         }
 
         /**
@@ -892,7 +893,12 @@ public class FastDateParser implements DateParser, Serializable {
             if (tz != null) {
                 cal.setTimeZone(tz);
             } else {
-                final TzInfo tzInfo = tzNames.get(timeZone.toLowerCase(locale));
+                final String lowerCase = timeZone.toLowerCase(locale);
+                TzInfo tzInfo = tzNames.get(lowerCase);
+                if (tzInfo == null) {
+                    // match missing the optional trailing period
+                    tzInfo = tzNames.get(lowerCase + '.');
+                }
                 cal.set(Calendar.DST_OFFSET, tzInfo.dstOffset);
                 cal.set(Calendar.ZONE_OFFSET, tzInfo.zone.getRawOffset());
             }

--- a/src/test/java/org/apache/commons/lang3/time/FastDateParserTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/FastDateParserTest.java
@@ -32,7 +32,6 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
-
 import org.apache.commons.lang3.LocaleUtils;
 import org.apache.commons.lang3.SerializationUtils;
 import org.junit.Test;
@@ -716,5 +715,17 @@ public class FastDateParserTest {
 
         calendar.setTime(parser.parse("7"));
         assertEquals(Calendar.SUNDAY, calendar.get(Calendar.DAY_OF_WEEK));
+    }
+
+    @Test
+    public void testLang1380() throws ParseException {
+        final Calendar expected = Calendar.getInstance(GMT, Locale.FRANCE);
+        expected.clear();
+        expected.set(2014, Calendar.APRIL, 14);
+
+        final DateParser fdp = getInstance("dd MMM yyyy", GMT, Locale.FRANCE);
+        assertEquals(expected.getTime(), fdp.parse("14 avril 2014"));
+        assertEquals(expected.getTime(), fdp.parse("14 avr. 2014"));
+        assertEquals(expected.getTime(), fdp.parse("14 avr 2014"));
     }
 }


### PR DESCRIPTION
I'm interested in feedback.  Particularly from recent committers - @garydgregory @britter @PascalSchumacher @sebbASF 
thanks
