### PR TITLE
LANG-1404 BooleanUtils.toBoolean(Integer) method added

### DIFF
--- a/src/main/java/org/apache/commons/lang3/BooleanUtils.java
+++ b/src/main/java/org/apache/commons/lang3/BooleanUtils.java
@@ -199,6 +199,26 @@ public class BooleanUtils {
     }
 
     /**
+     * <p>Converts an Integer to a boolean using the convention that {@code zero}
+     * and {@code null} is {@code false}.</p>
+     *
+     * <pre>
+     *   BooleanUtils.toBoolean(null) = false
+     *   BooleanUtils.toBoolean(Integer.valueOf(0)) = false
+     *   BooleanUtils.toBoolean(Integer.valueOf(1)) = true
+     *   BooleanUtils.toBoolean(Integer.valueOf(2)) = true
+     * </pre>
+     *
+     * @param value  the int to convert
+     * @return {@code true} if non-zero and non-null,
+     * {@code false} otherwise
+     * @since 3.8
+     */
+    public static boolean toBoolean(final Integer value) {
+        return value != null && value != 0;
+    }
+
+    /**
      * <p>Converts an int to a Boolean using the convention that {@code zero}
      * is {@code false}.</p>
      *

--- a/src/test/java/org/apache/commons/lang3/BooleanUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/BooleanUtilsTest.java
@@ -110,6 +110,19 @@ public class BooleanUtilsTest {
     }
 
     @Test
+    public void test_toBoolean_Integer() {
+        final Integer one = Integer.valueOf(1);
+        final Integer minusOne = Integer.valueOf(-1);
+        final Integer zero = Integer.valueOf(0);
+        final Integer nullInteger = null;
+
+        assertEquals(Boolean.TRUE, BooleanUtils.toBoolean(one));
+        assertEquals(Boolean.TRUE, BooleanUtils.toBoolean(minusOne));
+        assertEquals(Boolean.FALSE, BooleanUtils.toBoolean(zero));
+        assertEquals(Boolean.FALSE, BooleanUtils.toBoolean(nullInteger));
+    }
+
+    @Test
     public void test_toBooleanObject_int() {
         assertEquals(Boolean.TRUE, BooleanUtils.toBooleanObject(1));
         assertEquals(Boolean.TRUE, BooleanUtils.toBooleanObject(-1));


### PR DESCRIPTION
Right now to convert an Integer to boolean there is either a null check needed:
```
final Integer value = 1;
if (value != null) {
    if(BooleanUtils.toBoolean(value)) {
        // some code
      }
}
```
or two methods call:
```
final Integer value = 1;
final Boolean b = BooleanUtils.toBooleanObject(value);
if (BooleanUtils.toBoolean(b)) {
    // some code
}
```

Some code-sugar is added with the help of method that accepts Integer and returns boolean:
```
final Integer value = 1;
if (BooleanUtils.toBoolean(value)) {
      // some code
}
```