### PR TITLE
Looks like Java 11 no longer fails the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,6 @@ matrix:
 # Java 11 "Oracle JDK" (not yet provided by Travis CI)
     - env: JDK='Oracle JDK 11'
       install: . ./target/install-jdk.sh -F 11 -L BCL
-# some FastDateParser tests currently fail with java.text.ParseException: Unparseable date
-  allow_failures:
-    - env: JDK='Oracle JDK 11'
 
 script:
   - mvn


### PR DESCRIPTION
Remove the allow_failures section for Java 11.