### PR TITLE
Convert tests for Validate.isTrue overloads to @Nested test

### DIFF
--- a/src/test/java/org/apache/commons/lang3/ValidateTest.java
+++ b/src/test/java/org/apache/commons/lang3/ValidateTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.commons.lang3;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Constructor;
@@ -34,6 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -42,63 +44,98 @@ import static org.junit.jupiter.api.Assertions.fail;
  */
 class ValidateTest {
 
-    //-----------------------------------------------------------------------
-    @Test
-    void testIsTrue1() {
-        Validate.isTrue(true);
-        try {
-            Validate.isTrue(false);
-            fail("Expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException ex) {
-            assertEquals("The validated expression is false", ex.getMessage());
-        }
-    }
+    @Nested
+    class IsTrue {
 
-    //-----------------------------------------------------------------------
-    @Test
-    void testIsTrue2() {
-        Validate.isTrue(true, "MSG");
-        try {
-            Validate.isTrue(false, "MSG");
-            fail("Expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException ex) {
-            assertEquals("MSG", ex.getMessage());
-        }
-    }
+        @Nested
+        class WithoutMessage {
 
-    //-----------------------------------------------------------------------
-    @Test
-    void testIsTrue3() {
-        Validate.isTrue(true, "MSG", 6);
-        try {
-            Validate.isTrue(false, "MSG", 6);
-            fail("Expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException ex) {
-            assertEquals("MSG", ex.getMessage());
-        }
-    }
+            @Test
+            void shouldNotThrowForTrueExpression() {
+                Validate.isTrue(true);
+            }
 
-    //-----------------------------------------------------------------------
-    @Test
-    void testIsTrue4() {
-        Validate.isTrue(true, "MSG", 7);
-        try {
-            Validate.isTrue(false, "MSG", 7);
-            fail("Expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException ex) {
-            assertEquals("MSG", ex.getMessage());
-        }
-    }
+            @Test
+            void shouldThrowExceptionWithDefaultMessageForFalseExpression() {
+                final IllegalArgumentException ex = assertThrows(
+                        IllegalArgumentException.class,
+                        () -> Validate.isTrue(false));
 
-    //-----------------------------------------------------------------------
-    @Test
-    void testIsTrue5() {
-        Validate.isTrue(true, "MSG", 7.4d);
-        try {
-            Validate.isTrue(false, "MSG", 7.4d);
-            fail("Expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException ex) {
-            assertEquals("MSG", ex.getMessage());
+                assertEquals("The validated expression is false", ex.getMessage());
+            }
+
+        }
+
+        @Nested
+        class WithMessage {
+
+            @Test
+            void shouldNotThrowForTrueExpression() {
+                Validate.isTrue(true, "MSG");
+            }
+
+            @Test
+            void shouldThrowExceptionWithGivenMessageForFalseExpression() {
+                final IllegalArgumentException ex = assertThrows(
+                        IllegalArgumentException.class,
+                        () -> Validate.isTrue(false, "MSG"));
+
+                assertEquals("MSG", ex.getMessage());
+            }
+        }
+
+        @Nested
+        class WithLongTemplate {
+
+            @Test
+            void shouldNotThrowForTrueExpression() {
+                Validate.isTrue(true, "MSG", 6);
+            }
+
+            @Test
+            void shouldThrowExceptionWithLongInsertedIntoTemplateMessageForFalseExpression() {
+                final IllegalArgumentException ex = assertThrows(
+                        IllegalArgumentException.class,
+                        () -> Validate.isTrue(false, "MSG %s", 6));
+
+                assertEquals("MSG 6", ex.getMessage());
+            }
+        }
+
+        @Nested
+        class WithDoubleTemplate {
+
+            @Test
+            void shouldNotThrowForTrueExpression() {
+                Validate.isTrue(true, "MSG", 7.4d);
+            }
+
+            @Test
+            void shouldThrowExceptionWithDoubleInsertedIntoTemplateMessageForFalseExpression() {
+                final IllegalArgumentException ex = assertThrows(
+                        IllegalArgumentException.class,
+                        () -> Validate.isTrue(false, "MSG %s", 7.4d));
+
+                assertEquals("MSG 7.4", ex.getMessage());
+            }
+        }
+
+        @Nested
+        class WithObjectTemplate {
+
+            @Test
+            void shouldNotThrowForTrueExpression() {
+                Validate.isTrue(true, "MSG", "Object 1", "Object 2");
+            }
+
+            @Test
+            void shouldThrowExceptionWithDoubleInsertedIntoTemplateMessageForFalseExpression() {
+                final IllegalArgumentException ex = assertThrows(
+                        IllegalArgumentException.class,
+                        () -> Validate.isTrue(false, "MSG %s %s", "Object 1", "Object 2"));
+
+                assertEquals("MSG Object 1 Object 2", ex.getMessage());
+            }
         }
     }
 

--- a/src/test/java/org/apache/commons/lang3/ValidateTest.java
+++ b/src/test/java/org/apache/commons/lang3/ValidateTest.java
@@ -1107,31 +1107,66 @@ class ValidateTest {
         }
     }
 
-    @Test
-    void testNotNaN1() {
-        Validate.notNaN(0.0);
-        Validate.notNaN(Double.POSITIVE_INFINITY);
-        Validate.notNaN(Double.NEGATIVE_INFINITY);
-        try {
-            Validate.notNaN(Double.NaN);
-            fail("Expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException ex) {
-            assertEquals("The validated value is not a number", ex.getMessage());
+    @Nested
+    class NotNaN {
+
+        @Nested
+        class WithoutMessage {
+
+            @Test
+            void shouldNotThrowExceptionForNumber() {
+                Validate.notNaN(0.0);
+            }
+
+            @Test
+            void shouldNotThrowExceptionForPositiveInfinity() {
+                Validate.notNaN(Double.POSITIVE_INFINITY);
+            }
+
+            @Test
+            void shouldNotThrowExceptionForNegativeInfinity() {
+                Validate.notNaN(Double.NEGATIVE_INFINITY);
+            }
+
+            @Test
+            void shouldThrowIllegalArgumentExceptionWithDefaultMessageForNaN() {
+                final IllegalArgumentException ex = assertThrows(
+                        IllegalArgumentException.class,
+                        () -> Validate.notNaN(Double.NaN));
+
+                assertEquals("The validated value is not a number", ex.getMessage());
+            }
+        }
+
+        @Nested
+        class WithMessage {
+
+            @Test
+            void shouldNotThrowExceptionForNumber() {
+                Validate.notNaN(0.0, "MSG");
+            }
+
+            @Test
+            void shouldNotThrowExceptionForPositiveInfinity() {
+                Validate.notNaN(Double.POSITIVE_INFINITY, "MSG");
+            }
+
+            @Test
+            void shouldNotThrowExceptionForNegativeInfinity() {
+                Validate.notNaN(Double.NEGATIVE_INFINITY, "MSG");
+            }
+
+            @Test
+            void shouldThrowIllegalArgumentExceptionWithGivenMessageForNaN() {
+                final IllegalArgumentException ex = assertThrows(
+                        IllegalArgumentException.class,
+                        () -> Validate.notNaN(Double.NaN, "MSG"));
+
+                assertEquals("MSG", ex.getMessage());
+            }
         }
     }
 
-    @Test
-    void testNotNaN2() {
-        Validate.notNaN(0.0, "MSG");
-        Validate.notNaN(Double.POSITIVE_INFINITY, "MSG");
-        Validate.notNaN(Double.NEGATIVE_INFINITY, "MSG");
-        try {
-            Validate.notNaN(Double.NaN, "MSG");
-            fail("Expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException ex) {
-            assertEquals("MSG", ex.getMessage());
-        }
-    }
 
     //-----------------------------------------------------------------------
     //-----------------------------------------------------------------------

--- a/src/test/java/org/apache/commons/lang3/ValidateTest.java
+++ b/src/test/java/org/apache/commons/lang3/ValidateTest.java
@@ -1843,32 +1843,43 @@ class ValidateTest {
         }
     }
 
-    @Test
-    void testIsAssignable() {
-        Validate.isAssignableFrom(CharSequence.class, String.class);
-        Validate.isAssignableFrom(AbstractList.class, ArrayList.class);
-    }
+    @Nested
+    class IsAssignable {
 
-    @Test
-    void testIsAssignableExceptionMessage() {
-        try {
-            Validate.isAssignableFrom(List.class, String.class);
-            fail("Expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            assertEquals("Cannot assign a java.lang.String to a java.util.List", e.getMessage());
+        @Nested
+        class WithoutMessage {
+
+            @Test
+            void shouldNotThrowExceptionWhenClassIsAssignable() {
+                Validate.isAssignableFrom(CharSequence.class, String.class);
+            }
+
+            @Test
+            void shouldThrowIllegalArgumentExceptionWithDefaultMessageWhenClassIsNotAssignable() {
+                final IllegalArgumentException ex = assertThrows(
+                        IllegalArgumentException.class,
+                        () -> Validate.isAssignableFrom(List.class, String.class));
+
+                assertEquals("Cannot assign a java.lang.String to a java.util.List", ex.getMessage());
+            }
+        }
+
+        @Nested
+        class WithMessage {
+
+            @Test
+            void shouldNotThrowExceptionWhenClassIsAssignable() {
+                Validate.isAssignableFrom(CharSequence.class, String.class, "MSG");
+            }
+
+            @Test
+            void shouldThrowIllegalArgumentExceptionWithGiventMessageWhenClassIsNotAssignable() {
+                final IllegalArgumentException ex = assertThrows(
+                        IllegalArgumentException.class,
+                        () -> Validate.isAssignableFrom(List.class, String.class, "MSG"));
+
+                assertEquals("MSG", ex.getMessage());
+            }
         }
     }
-
-    @Test
-    void testIsAssignable_withMessage() {
-        Validate.isAssignableFrom(CharSequence.class, String.class, "Error");
-        Validate.isAssignableFrom(AbstractList.class, ArrayList.class, "Error");
-        try {
-            Validate.isAssignableFrom(List.class, String.class, "Error");
-            fail("Expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            assertEquals("Error", e.getMessage());
-        }
-    }
-
 }

--- a/src/test/java/org/apache/commons/lang3/ValidateTest.java
+++ b/src/test/java/org/apache/commons/lang3/ValidateTest.java
@@ -1785,55 +1785,61 @@ class ValidateTest {
         }
     }
 
-    @Test
-    void testIsInstanceOf() {
-        Validate.isInstanceOf(String.class, "hi");
-        Validate.isInstanceOf(Integer.class, 1);
-    }
+    @Nested
+    class IsInstanceOf {
 
-    @Test
-    void testIsInstanceOfExceptionMessage() {
-        try {
-            Validate.isInstanceOf(List.class, "hi");
-            fail("Expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            assertEquals("Expected type: java.util.List, actual: java.lang.String", e.getMessage());
-        }
-    }
+        @Nested
+        class WithoutMessage {
 
-    @Test
-    void testIsInstanceOf_withMessage() {
-        Validate.isInstanceOf(String.class, "hi", "Error");
-        Validate.isInstanceOf(Integer.class, 1, "Error");
-        try {
-            Validate.isInstanceOf(List.class, "hi", "Error");
-            fail("Expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            assertEquals("Error", e.getMessage());
-        }
-    }
+            @Test
+            void shouldNotThrowExceptionWhenValueIsInstanceOfClass() {
+                Validate.isInstanceOf(String.class, "hi");
+            }
 
-    @Test
-    void testIsInstanceOf_withMessageArgs() {
-        Validate.isInstanceOf(String.class, "hi", "Error %s=%s", "Name", "Value");
-        Validate.isInstanceOf(Integer.class, 1, "Error %s=%s", "Name", "Value");
-        try {
-            Validate.isInstanceOf(List.class, "hi", "Error %s=%s", "Name", "Value");
-            fail("Expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            assertEquals("Error Name=Value", e.getMessage());
+            @Test
+            void shouldThrowIllegalArgumentExceptionWithDefaultMessageWhenValueIsNotInstanceOfClass() {
+                final IllegalArgumentException ex = assertThrows(
+                        IllegalArgumentException.class,
+                        () -> Validate.isInstanceOf(List.class, "hi"));
+
+                assertEquals("Expected type: java.util.List, actual: java.lang.String", ex.getMessage());
+            }
         }
-        try {
-            Validate.isInstanceOf(List.class, "hi", "Error %s=%s", List.class, "Value");
-            fail("Expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            assertEquals("Error interface java.util.List=Value", e.getMessage());
+
+        @Nested
+        class WithMessage {
+
+            @Test
+            void shouldNotThrowExceptionWhenValueIsInstanceOfClass() {
+                Validate.isInstanceOf(String.class, "hi", "MSG");
+            }
+
+            @Test
+            void shouldThrowIllegalArgumentExceptionWithGivenMessageWhenValueIsNotInstanceOfClass() {
+                final IllegalArgumentException ex = assertThrows(
+                        IllegalArgumentException.class,
+                        () -> Validate.isInstanceOf(List.class, "hi", "MSG"));
+
+                assertEquals("MSG", ex.getMessage());
+            }
         }
-        try {
-            Validate.isInstanceOf(List.class, "hi", "Error %s=%s", List.class, null);
-            fail("Expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            assertEquals("Error interface java.util.List=null", e.getMessage());
+
+        @Nested
+        class WithMessageTemplate {
+
+            @Test
+            void shouldNotThrowExceptionWhenValueIsInstanceOfClass() {
+                Validate.isInstanceOf(String.class, "hi", "Error %s=%s", "Name", "Value");
+            }
+
+            @Test
+            void shouldThrowIllegalArgumentExceptionWithGivenMessageWhenValueIsNotInstanceOfClass() {
+                final IllegalArgumentException ex = assertThrows(
+                        IllegalArgumentException.class,
+                        () -> Validate.isInstanceOf(List.class, "hi", "Error %s=%s", "Name", "Value"));
+
+                assertEquals("Error Name=Value", ex.getMessage());
+            }
         }
     }
 

--- a/src/test/java/org/apache/commons/lang3/ValidateTest.java
+++ b/src/test/java/org/apache/commons/lang3/ValidateTest.java
@@ -23,8 +23,6 @@ import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
-import java.util.AbstractList;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -37,22 +35,11 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Unit tests {@link org.apache.commons.lang3.Validate}.
  */
 class ValidateTest {
-
-    @Test
-    void testConstructor() {
-        assertNotNull(new Validate());
-        final Constructor<?>[] cons = Validate.class.getDeclaredConstructors();
-        assertEquals(1, cons.length);
-        assertTrue(Modifier.isPublic(cons[0].getModifiers()));
-        assertTrue(Modifier.isPublic(Validate.class.getModifiers()));
-        assertFalse(Modifier.isFinal(Validate.class.getModifiers()));
-    }
 
     @Nested
     class IsTrue {
@@ -1880,6 +1867,31 @@ class ValidateTest {
 
                 assertEquals("MSG", ex.getMessage());
             }
+        }
+    }
+
+    @Nested
+    class UtilClassConventions {
+
+        @Test
+        void instancesCanBeConstrcuted() {
+            assertNotNull(new Validate());
+        }
+
+        @Test
+        void hasOnlyOnePublicConstructor() {
+            final Constructor<?>[] cons = Validate.class.getDeclaredConstructors();
+            assertEquals(1, cons.length);
+        }
+
+        @Test
+        void isPublicClass() {
+            assertTrue(Modifier.isPublic(Validate.class.getModifiers()));
+        }
+
+        @Test
+        void isNonFinalClass() {
+            assertFalse(Modifier.isFinal(Validate.class.getModifiers()));
         }
     }
 }

--- a/src/test/java/org/apache/commons/lang3/ValidateTest.java
+++ b/src/test/java/org/apache/commons/lang3/ValidateTest.java
@@ -139,39 +139,60 @@ class ValidateTest {
         }
     }
 
-    //-----------------------------------------------------------------------
-    //-----------------------------------------------------------------------
-    @SuppressWarnings("unused")
-    @Test
-    void testNotNull1() {
-        Validate.notNull(new Object());
-        try {
-            Validate.notNull(null);
-            fail("Expecting NullPointerException");
-        } catch (final NullPointerException ex) {
-            assertEquals("The validated object is null", ex.getMessage());
+    @Nested
+    class NotNull {
+
+        @Nested
+        class WithoutMessage {
+
+            @Test
+            void shouldNotThrowForNonNullReference() {
+                Validate.notNull(new Object());
+            }
+
+            @Test
+            void shouldReturnTheSameInstance() {
+                final String str = "Hi";
+                final String result = Validate.notNull(str);
+
+                assertSame(str, result);
+            }
+
+            @Test
+            void shouldThrowExceptionWithDefaultMessageForNullReference() {
+                final NullPointerException ex = assertThrows(
+                        NullPointerException.class,
+                        () -> Validate.notNull(null));
+
+                assertEquals("The validated object is null", ex.getMessage());
+            }
         }
 
-        final String str = "Hi";
-        final String testStr = Validate.notNull(str);
-        assertSame(str, testStr);
-    }
+        @Nested
+        class WithMessage {
 
-    //-----------------------------------------------------------------------
-    @SuppressWarnings("unused")
-    @Test
-    void testNotNull2() {
-        Validate.notNull(new Object(), "MSG");
-        try {
-            Validate.notNull(null, "MSG");
-            fail("Expecting NullPointerException");
-        } catch (final NullPointerException ex) {
-            assertEquals("MSG", ex.getMessage());
+            @Test
+            void shouldNotThrowForNonNullReference() {
+                Validate.notNull(new Object(), "MSG");
+            }
+
+            @Test
+            void shouldReturnTheSameInstance() {
+                final String str = "Hi";
+                final String result = Validate.notNull(str, "MSG");
+
+                assertSame(str, result);
+            }
+
+            @Test
+            void shouldThrowExceptionWithGivenMessageForNullReference() {
+                final NullPointerException ex = assertThrows(
+                        NullPointerException.class,
+                        () -> Validate.notNull(null, "MSG"));
+
+                assertEquals("MSG", ex.getMessage());
+            }
         }
-
-        final String str = "Hi";
-        final String testStr = Validate.notNull(str, "Message");
-        assertSame(str, testStr);
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/apache/commons/lang3/ValidateTest.java
+++ b/src/test/java/org/apache/commons/lang3/ValidateTest.java
@@ -1243,76 +1243,250 @@ class ValidateTest {
         }
     }
 
-    //-----------------------------------------------------------------------
-    //-----------------------------------------------------------------------
+    @Nested
+    class InclusiveBetween {
 
-    @Test
-    void testInclusiveBetween() {
-        Validate.inclusiveBetween("a", "c", "b");
-        try {
-            Validate.inclusiveBetween("0", "5", "6");
-            fail("Expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            assertEquals("The value 6 is not in the specified inclusive range of 0 to 5", e.getMessage());
+        @Nested
+        class WithComparable {
+
+            private static final String LOWER_BOUND = "1";
+            private static final String UPPER_BOUND = "3";
+
+            @Nested
+            class WithoutMessage {
+
+                @Test
+                void shouldNotThrowExceptionWhenValueIsBetweenBounds() {
+                    Validate.inclusiveBetween(LOWER_BOUND, UPPER_BOUND, "2");
+                }
+
+                @Test
+                void shouldNotThrowExceptionWhenValueIsLowerBound() {
+                    Validate.inclusiveBetween(LOWER_BOUND, UPPER_BOUND, LOWER_BOUND);
+                }
+
+                @Test
+                void shouldNotThrowExceptionWhenValueIsUpperBound() {
+                    Validate.inclusiveBetween(LOWER_BOUND, UPPER_BOUND, UPPER_BOUND);
+                }
+
+                @Test
+                void shouldThrowIllegalArgumentExceptionWithDefaultMessageWhenValueIsBelowLowerBound() {
+                    final IllegalArgumentException ex = assertThrows(
+                            IllegalArgumentException.class,
+                            () -> Validate.inclusiveBetween(LOWER_BOUND, UPPER_BOUND, "0"));
+
+                    assertEquals("The value 0 is not in the specified inclusive range of 1 to 3", ex.getMessage());
+                }
+
+                @Test
+                void shouldThrowIllegalArgumentExceptionWithDefaultMessageWhenValueIsAboveUpperBound() {
+                    final IllegalArgumentException ex = assertThrows(
+                            IllegalArgumentException.class,
+                            () -> Validate.inclusiveBetween(LOWER_BOUND, UPPER_BOUND, "4"));
+
+                    assertEquals("The value 4 is not in the specified inclusive range of 1 to 3", ex.getMessage());
+                }
+            }
+
+            @Nested
+            class WithMessage {
+
+                @Test
+                void shouldNotThrowExceptionWhenValueIsBetweenBounds() {
+                    Validate.inclusiveBetween(LOWER_BOUND, UPPER_BOUND, "2", "MSG");
+                }
+
+                @Test
+                void shouldNotThrowExceptionWhenValueIsLowerBound() {
+                    Validate.inclusiveBetween(LOWER_BOUND, UPPER_BOUND, LOWER_BOUND, "MSG");
+                }
+
+                @Test
+                void shouldNotThrowExceptionWhenValueIsUpperBound() {
+                    Validate.inclusiveBetween(LOWER_BOUND, UPPER_BOUND, UPPER_BOUND, "MSG");
+                }
+
+                @Test
+                void shouldThrowIllegalArgumentExceptionWithGivenMessageWhenValueIsBelowLowerBound() {
+                    final IllegalArgumentException ex = assertThrows(
+                            IllegalArgumentException.class,
+                            () -> Validate.inclusiveBetween(LOWER_BOUND, UPPER_BOUND, "0", "MSG"));
+
+                    assertEquals("MSG", ex.getMessage());
+                }
+
+                @Test
+                void shouldThrowIllegalArgumentExceptionWithGivenMessageWhenValueIsAboveUpperBound() {
+                    final IllegalArgumentException ex = assertThrows(
+                            IllegalArgumentException.class,
+                            () -> Validate.inclusiveBetween(LOWER_BOUND, UPPER_BOUND, "4", "MSG"));
+
+                    assertEquals("MSG", ex.getMessage());
+                }
+            }
         }
-    }
 
-    @Test
-    void testInclusiveBetween_withMessage() {
-        Validate.inclusiveBetween("a", "c", "b", "Error");
-        try {
-            Validate.inclusiveBetween("0", "5", "6", "Error");
-            fail("Expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            assertEquals("Error", e.getMessage());
+        @Nested
+        class WithLong {
+
+            private static final long LOWER_BOUND = 1;
+            private static final long UPPER_BOUND = 3;
+
+            @Nested
+            class WithoutMessage {
+
+                @Test
+                void shouldNotThrowExceptionWhenValueIsBetweenBounds() {
+                    Validate.inclusiveBetween(LOWER_BOUND, UPPER_BOUND, 2);
+                }
+
+                @Test
+                void shouldNotThrowExceptionWhenValueIsLowerBound() {
+                    Validate.inclusiveBetween(LOWER_BOUND, UPPER_BOUND, LOWER_BOUND);
+                }
+
+                @Test
+                void shouldNotThrowExceptionWhenValueIsUpperBound() {
+                    Validate.inclusiveBetween(LOWER_BOUND, UPPER_BOUND, UPPER_BOUND);
+                }
+
+                @Test
+                void shouldThrowIllegalArgumentExceptionWithDefaultMessageWhenValueIsBelowLowerBound() {
+                    final IllegalArgumentException ex = assertThrows(
+                            IllegalArgumentException.class,
+                            () -> Validate.inclusiveBetween(LOWER_BOUND, UPPER_BOUND, 0));
+
+                    assertEquals("The value 0 is not in the specified inclusive range of 1 to 3", ex.getMessage());
+                }
+
+                @Test
+                void shouldThrowIllegalArgumentExceptionWithDefaultMessageWhenValueIsAboveUpperBound() {
+                    final IllegalArgumentException ex = assertThrows(
+                            IllegalArgumentException.class,
+                            () -> Validate.inclusiveBetween(LOWER_BOUND, UPPER_BOUND, 4));
+
+                    assertEquals("The value 4 is not in the specified inclusive range of 1 to 3", ex.getMessage());
+                }
+            }
+
+            @Nested
+            class WithMessage {
+
+                @Test
+                void shouldNotThrowExceptionWhenValueIsBetweenBounds() {
+                    Validate.inclusiveBetween(LOWER_BOUND, UPPER_BOUND, 2, "MSG");
+                }
+
+                @Test
+                void shouldNotThrowExceptionWhenValueIsLowerBound() {
+                    Validate.inclusiveBetween(LOWER_BOUND, UPPER_BOUND, LOWER_BOUND, "MSG");
+                }
+
+                @Test
+                void shouldNotThrowExceptionWhenValueIsUpperBound() {
+                    Validate.inclusiveBetween(LOWER_BOUND, UPPER_BOUND, UPPER_BOUND, "MSG");
+                }
+
+                @Test
+                void shouldThrowIllegalArgumentExceptionWithGivenMessageWhenValueIsBelowLowerBound() {
+                    final IllegalArgumentException ex = assertThrows(
+                            IllegalArgumentException.class,
+                            () -> Validate.inclusiveBetween(LOWER_BOUND, UPPER_BOUND, 0, "MSG"));
+
+                    assertEquals("MSG", ex.getMessage());
+                }
+
+                @Test
+                void shouldThrowIllegalArgumentExceptionWithGivenMessageWhenValueIsAboveUpperBound() {
+                    final IllegalArgumentException ex = assertThrows(
+                            IllegalArgumentException.class,
+                            () -> Validate.inclusiveBetween(LOWER_BOUND, UPPER_BOUND, 4, "MSG"));
+
+                    assertEquals("MSG", ex.getMessage());
+                }
+            }
         }
-    }
 
-    @Test
-    void testInclusiveBetweenLong() {
-        Validate.inclusiveBetween(0, 2, 1);
-        Validate.inclusiveBetween(0, 2, 2);
-        try {
-            Validate.inclusiveBetween(0, 5, 6);
-            fail("Expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            assertEquals("The value 6 is not in the specified inclusive range of 0 to 5", e.getMessage());
-        }
-    }
+        @Nested
+        class WithDouble {
 
-    @Test
-    void testInclusiveBetweenLong_withMessage() {
-        Validate.inclusiveBetween(0, 2, 1, "Error");
-        Validate.inclusiveBetween(0, 2, 2, "Error");
-        try {
-            Validate.inclusiveBetween(0, 5, 6, "Error");
-            fail("Expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            assertEquals("Error", e.getMessage());
-        }
-    }
+            private static final double LOWER_BOUND = 0.1;
+            private static final double UPPER_BOUND = 3.1;
 
-    @Test
-    void testInclusiveBetweenDouble() {
-        Validate.inclusiveBetween(0.1, 2.1, 1.1);
-        Validate.inclusiveBetween(0.1, 2.1, 2.1);
-        try {
-            Validate.inclusiveBetween(0.1, 5.1, 6.1);
-            fail("Expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            assertEquals("The value 6.1 is not in the specified inclusive range of 0.1 to 5.1", e.getMessage());
-        }
-    }
+            @Nested
+            class WithoutMessage {
 
-    @Test
-    void testInclusiveBetweenDouble_withMessage() {
-        Validate.inclusiveBetween(0.1, 2.1, 1.1, "Error");
-        Validate.inclusiveBetween(0.1, 2.1, 2.1, "Error");
-        try {
-            Validate.inclusiveBetween(0.1, 5.1, 6.1, "Error");
-            fail("Expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            assertEquals("Error", e.getMessage());
+                @Test
+                void shouldNotThrowExceptionWhenValueIsBetweenBounds() {
+                    Validate.inclusiveBetween(LOWER_BOUND, UPPER_BOUND, 2.1);
+                }
+
+                @Test
+                void shouldNotThrowExceptionWhenValueIsLowerBound() {
+                    Validate.inclusiveBetween(LOWER_BOUND, UPPER_BOUND, LOWER_BOUND);
+                }
+
+                @Test
+                void shouldNotThrowExceptionWhenValueIsUpperBound() {
+                    Validate.inclusiveBetween(LOWER_BOUND, UPPER_BOUND, UPPER_BOUND);
+                }
+
+                @Test
+                void shouldThrowIllegalArgumentExceptionWithDefaultMessageWhenValueIsBelowLowerBound() {
+                    final IllegalArgumentException ex = assertThrows(
+                            IllegalArgumentException.class,
+                            () -> Validate.inclusiveBetween(LOWER_BOUND, UPPER_BOUND, 0.01));
+
+                    assertEquals("The value 0.01 is not in the specified inclusive range of 0.1 to 3.1", ex.getMessage());
+                }
+
+                @Test
+                void shouldThrowIllegalArgumentExceptionWithDefaultMessageWhenValueIsAboveUpperBound() {
+                    final IllegalArgumentException ex = assertThrows(
+                            IllegalArgumentException.class,
+                            () -> Validate.inclusiveBetween(LOWER_BOUND, UPPER_BOUND, 4.1));
+
+                    assertEquals("The value 4.1 is not in the specified inclusive range of 0.1 to 3.1", ex.getMessage());
+                }
+            }
+
+            @Nested
+            class WithMessage {
+
+                @Test
+                void shouldNotThrowExceptionWhenValueIsBetweenBounds() {
+                    Validate.inclusiveBetween(LOWER_BOUND, UPPER_BOUND, 2.1, "MSG");
+                }
+
+                @Test
+                void shouldNotThrowExceptionWhenValueIsLowerBound() {
+                    Validate.inclusiveBetween(LOWER_BOUND, UPPER_BOUND, LOWER_BOUND, "MSG");
+                }
+
+                @Test
+                void shouldNotThrowExceptionWhenValueIsUpperBound() {
+                    Validate.inclusiveBetween(LOWER_BOUND, UPPER_BOUND, UPPER_BOUND, "MSG");
+                }
+
+                @Test
+                void shouldThrowIllegalArgumentExceptionWithGivenMessageWhenValueIsBelowLowerBound() {
+                    final IllegalArgumentException ex = assertThrows(
+                            IllegalArgumentException.class,
+                            () -> Validate.inclusiveBetween(LOWER_BOUND, UPPER_BOUND, 0.01, "MSG"));
+
+                    assertEquals("MSG", ex.getMessage());
+                }
+
+                @Test
+                void shouldThrowIllegalArgumentExceptionWithGivenMessageWhenValueIsAboveUpperBound() {
+                    final IllegalArgumentException ex = assertThrows(
+                            IllegalArgumentException.class,
+                            () -> Validate.inclusiveBetween(LOWER_BOUND, UPPER_BOUND, 4.1, "MSG"));
+
+                    assertEquals("MSG", ex.getMessage());
+                }
+            }
         }
     }
 

--- a/src/test/java/org/apache/commons/lang3/ValidateTest.java
+++ b/src/test/java/org/apache/commons/lang3/ValidateTest.java
@@ -1067,32 +1067,45 @@ class ValidateTest {
         }
     }
 
-    @Test
-    void testMatchesPattern() {
-        final CharSequence str = "hi";
-        Validate.matchesPattern(str, "[a-z]*");
-        try {
-            Validate.matchesPattern(str, "[0-9]*");
-            fail("Expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            assertEquals("The string hi does not match the pattern [0-9]*", e.getMessage());
+    @Nested
+    class MatchesPattern {
+
+        @Nested
+        class WithoutMessage {
+
+            @Test
+            void shouldNotThrowExceptionWhenStringMatchesPattern() {
+                Validate.matchesPattern("hi", "[a-z]*");
+            }
+
+            @Test
+            void shouldThrowIllegalArgumentExceptionWithDefaultMessageWhenStringDoesNotMatchPattern() {
+                final IllegalArgumentException ex = assertThrows(
+                        IllegalArgumentException.class,
+                        () -> Validate.matchesPattern("hi", "[0-9]*"));
+
+                assertEquals("The string hi does not match the pattern [0-9]*", ex.getMessage());
+            }
+        }
+
+        @Nested
+        class WithMessage {
+
+            @Test
+            void shouldNotThrowExceptionWhenStringMatchesPattern() {
+                Validate.matchesPattern("hi", "[a-z]*", "MSG");
+            }
+
+            @Test
+            void shouldThrowIllegalArgumentExceptionWhenStringDoesNotMatchPattern() {
+                final IllegalArgumentException ex = assertThrows(
+                        IllegalArgumentException.class,
+                        () -> Validate.matchesPattern("hi", "[0-9]*", "MSG"));
+
+                assertEquals("MSG", ex.getMessage());
+            }
         }
     }
-
-    @Test
-    void testMatchesPattern_withMessage() {
-        final CharSequence str = "hi";
-        Validate.matchesPattern(str, "[a-z]*", "Does not match");
-        try {
-            Validate.matchesPattern(str, "[0-9]*", "Does not match");
-            fail("Expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            assertEquals("Does not match", e.getMessage());
-        }
-    }
-
-    //-----------------------------------------------------------------------
-    //-----------------------------------------------------------------------
 
     @Test
     void testNotNaN1() {

--- a/src/test/java/org/apache/commons/lang3/ValidateTest.java
+++ b/src/test/java/org/apache/commons/lang3/ValidateTest.java
@@ -27,9 +27,11 @@ import java.util.AbstractList;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -195,188 +197,304 @@ class ValidateTest {
         }
     }
 
-    //-----------------------------------------------------------------------
-    //-----------------------------------------------------------------------
-    @Test
-    void testNotEmptyArray1() {
-        Validate.notEmpty(new Object[]{null});
-        try {
-            Validate.notEmpty((Object[]) null);
-            fail("Expecting NullPointerException");
-        } catch (final NullPointerException ex) {
-            assertEquals("The validated array is empty", ex.getMessage());
-        }
-        try {
-            Validate.notEmpty(new Object[0]);
-            fail("Expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException ex) {
-            assertEquals("The validated array is empty", ex.getMessage());
+    @Nested
+    class NotEmpty {
+
+        @Nested
+        class WithArray {
+
+            @Nested
+            class WithoutMessage {
+
+                @Test
+                void shouldNotThrowExceptionForArrayContainingNullReference() {
+                    Validate.notEmpty(new Object[]{null});
+                }
+
+                @Test
+                void shouldReturnTheSameInstance() {
+                    final String[] array = new String[]{"hi"};
+                    final String[] result = Validate.notEmpty(array);
+
+                    assertSame(array, result);
+                }
+
+                @Test
+                void shouldThrowNullPointerExceptionWithDefaultMessageForNullArray() {
+                    final NullPointerException ex = assertThrows(
+                            NullPointerException.class,
+                            () -> Validate.notEmpty((Object[]) null));
+
+                    assertEquals("The validated array is empty", ex.getMessage());
+                }
+
+                @Test
+                void shouldThrowIllegalArgumentExceptionWithDefaultMessageForEmptyArray() {
+                    final IllegalArgumentException ex = assertThrows(
+                            IllegalArgumentException.class,
+                            () -> Validate.notEmpty(new Object[0]));
+
+                    assertEquals("The validated array is empty", ex.getMessage());
+                }
+            }
+
+            @Nested
+            class WithMessage {
+
+                @Test
+                void shouldNotThrowExceptionForArrayContainingNullReference() {
+                    Validate.notEmpty(new Object[]{null}, "MSG");
+                }
+
+                @Test
+                void shouldReturnTheSameInstance() {
+                    final String[] array = new String[]{"hi"};
+                    final String[] result = Validate.notEmpty(array, "MSG");
+
+                    assertSame(array, result);
+                }
+
+                @Test
+                void shouldThrowNullPointerExceptionWithGivenMessageForNullArray() {
+                    final NullPointerException ex = assertThrows(
+                            NullPointerException.class,
+                            () -> Validate.notEmpty((Object[]) null, "MSG"));
+
+                    assertEquals("MSG", ex.getMessage());
+                }
+
+                @Test
+                void shouldThrowIllegalArgumentExceptionWithDefaultMessageForEmptyArray() {
+                    final IllegalArgumentException ex = assertThrows(
+                            IllegalArgumentException.class,
+                            () -> Validate.notEmpty(new Object[0], "MSG"));
+
+                    assertEquals("MSG", ex.getMessage());
+                }
+            }
         }
 
-        final String[] array = new String[]{"hi"};
-        final String[] test = Validate.notEmpty(array);
-        assertSame(array, test);
-    }
+        @Nested
+        class WithCollection {
 
-    //-----------------------------------------------------------------------
-    @Test
-    void testNotEmptyArray2() {
-        Validate.notEmpty(new Object[]{null}, "MSG");
-        try {
-            Validate.notEmpty((Object[]) null, "MSG");
-            fail("Expecting NullPointerException");
-        } catch (final NullPointerException ex) {
-            assertEquals("MSG", ex.getMessage());
-        }
-        try {
-            Validate.notEmpty(new Object[0], "MSG");
-            fail("Expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException ex) {
-            assertEquals("MSG", ex.getMessage());
-        }
+            @Nested
+            class WithoutMessage {
 
-        final String[] array = new String[]{"hi"};
-        final String[] test = Validate.notEmpty(array, "Message");
-        assertSame(array, test);
-    }
+                @Test
+                void shouldNotThrowExceptionForCollectionContainingNullReference() {
+                    Validate.notEmpty(Collections.singleton(null));
+                }
 
-    //-----------------------------------------------------------------------
-    //-----------------------------------------------------------------------
-    @Test
-    void testNotEmptyCollection1() {
-        final Collection<Integer> coll = new ArrayList<>();
-        try {
-            Validate.notEmpty((Collection<?>) null);
-            fail("Expecting NullPointerException");
-        } catch (final NullPointerException ex) {
-            assertEquals("The validated collection is empty", ex.getMessage());
-        }
-        try {
-            Validate.notEmpty(coll);
-            fail("Expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException ex) {
-            assertEquals("The validated collection is empty", ex.getMessage());
-        }
-        coll.add(Integer.valueOf(8));
-        Validate.notEmpty(coll);
+                @Test
+                void shouldReturnTheSameInstance() {
+                    final Set<String> col = Collections.singleton("Hi");
+                    final Set<String> result = Validate.notEmpty(col);
 
-        final Collection<Integer> test = Validate.notEmpty(coll);
-        assertSame(coll, test);
-    }
+                    assertSame(col, result);
+                }
 
-    //-----------------------------------------------------------------------
-    @Test
-    void testNotEmptyCollection2() {
-        final Collection<Integer> coll = new ArrayList<>();
-        try {
-            Validate.notEmpty((Collection<?>) null, "MSG");
-            fail("Expecting NullPointerException");
-        } catch (final NullPointerException ex) {
-            assertEquals("MSG", ex.getMessage());
-        }
-        try {
-            Validate.notEmpty(coll, "MSG");
-            fail("Expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException ex) {
-            assertEquals("MSG", ex.getMessage());
-        }
-        coll.add(Integer.valueOf(8));
-        Validate.notEmpty(coll, "MSG");
+                @Test
+                void shouldThrowNullPointerExceptionWithDefaultMessageForNullCollection() {
+                    final NullPointerException ex = assertThrows(
+                            NullPointerException.class,
+                            () -> Validate.notEmpty((Collection<?>) null));
 
-        final Collection<Integer> test = Validate.notEmpty(coll, "Message");
-        assertSame(coll, test);
-    }
+                    assertEquals("The validated collection is empty", ex.getMessage());
+                }
 
-    //-----------------------------------------------------------------------
-    //-----------------------------------------------------------------------
-    @Test
-    void testNotEmptyMap1() {
-        final Map<String, Integer> map = new HashMap<>();
-        try {
-            Validate.notEmpty((Map<?, ?>) null);
-            fail("Expecting NullPointerException");
-        } catch (final NullPointerException ex) {
-            assertEquals("The validated map is empty", ex.getMessage());
-        }
-        try {
-            Validate.notEmpty(map);
-            fail("Expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException ex) {
-            assertEquals("The validated map is empty", ex.getMessage());
-        }
-        map.put("ll", Integer.valueOf(8));
-        Validate.notEmpty(map);
+                @Test
+                void shouldThrowIllegalArgumentExceptionWithDefaultMessageForEmptyCollection() {
+                    final IllegalArgumentException ex = assertThrows(
+                            IllegalArgumentException.class,
+                            () -> Validate.notEmpty(Collections.emptySet()));
 
-        final Map<String, Integer> test = Validate.notEmpty(map);
-        assertSame(map, test);
-    }
+                    assertEquals("The validated collection is empty", ex.getMessage());
+                }
+            }
 
-    //-----------------------------------------------------------------------
-    @Test
-    void testNotEmptyMap2() {
-        final Map<String, Integer> map = new HashMap<>();
-        try {
-            Validate.notEmpty((Map<?, ?>) null, "MSG");
-            fail("Expecting NullPointerException");
-        } catch (final NullPointerException ex) {
-            assertEquals("MSG", ex.getMessage());
-        }
-        try {
-            Validate.notEmpty(map, "MSG");
-            fail("Expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException ex) {
-            assertEquals("MSG", ex.getMessage());
-        }
-        map.put("ll", Integer.valueOf(8));
-        Validate.notEmpty(map, "MSG");
+            @Nested
+            class WithMessage {
 
-        final Map<String, Integer> test = Validate.notEmpty(map, "Message");
-        assertSame(map, test);
-    }
+                @Test
+                void shouldNotThrowExceptionForCollectionContainingNullReference() {
+                    Validate.notEmpty(Collections.singleton(null), "MSG");
+                }
 
-    //-----------------------------------------------------------------------
-    //-----------------------------------------------------------------------
-    @Test
-    void testNotEmptyString1() {
-        Validate.notEmpty("hjl");
-        try {
-            Validate.notEmpty((String) null);
-            fail("Expecting NullPointerException");
-        } catch (final NullPointerException ex) {
-            assertEquals("The validated character sequence is empty", ex.getMessage());
-        }
-        try {
-            Validate.notEmpty("");
-            fail("Expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException ex) {
-            assertEquals("The validated character sequence is empty", ex.getMessage());
+                @Test
+                void shouldReturnTheSameInstance() {
+                    final Set<String> col = Collections.singleton("Hi");
+                    final Set<String> result = Validate.notEmpty(col, "MSG");
+
+                    assertSame(col, result);
+                }
+
+                @Test
+                void shouldThrowNullPointerExceptionWithGivenMessageForNullCollection() {
+                    final NullPointerException ex = assertThrows(
+                            NullPointerException.class,
+                            () -> Validate.notEmpty((Collection<?>) null, "MSG"));
+
+                    assertEquals("MSG", ex.getMessage());
+                }
+
+                @Test
+                void shouldThrowIllegalArgumentExceptionWithGivenMessageForEmptyCollection() {
+                    final IllegalArgumentException ex = assertThrows(
+                            IllegalArgumentException.class,
+                            () -> Validate.notEmpty(Collections.emptySet(), "MSG"));
+
+                    assertEquals("MSG", ex.getMessage());
+                }
+            }
         }
 
-        final String str = "Hi";
-        final String testStr = Validate.notEmpty(str);
-        assertSame(str, testStr);
-    }
+        @Nested
+        class WithMap {
 
-    //-----------------------------------------------------------------------
-    @Test
-    void testNotEmptyString2() {
-        Validate.notEmpty("a", "MSG");
-        try {
-            Validate.notEmpty((String) null, "MSG");
-            fail("Expecting NullPointerException");
-        } catch (final NullPointerException ex) {
-            assertEquals("MSG", ex.getMessage());
-        }
-        try {
-            Validate.notEmpty("", "MSG");
-            fail("Expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException ex) {
-            assertEquals("MSG", ex.getMessage());
+            @Nested
+            class WithoutMessage {
+
+                @Test
+                void shouldNotThrowExceptionForMapContainingNullMapping() {
+                    Validate.notEmpty(Collections.singletonMap("key", null));
+                }
+
+                @Test
+                void shouldReturnTheSameInstance() {
+                    final Map<String, String> map = Collections.singletonMap("key", "value");
+                    final Map<String, String> result = Validate.notEmpty(map);
+
+                    assertSame(map, result);
+                }
+
+                @Test
+                void shouldThrowNullPointerExceptionWithDefaultMessageForNullMap() {
+                    final NullPointerException ex = assertThrows(
+                            NullPointerException.class,
+                            () -> Validate.notEmpty((Map<?, ?>) null));
+
+                    assertEquals("The validated map is empty", ex.getMessage());
+                }
+
+                @Test
+                void shouldThrowIllegalArgumentExceptionWithDefaultMessageForEmptyMap() {
+                    final IllegalArgumentException ex = assertThrows(
+                            IllegalArgumentException.class,
+                            () -> Validate.notEmpty(Collections.emptyMap()));
+
+                    assertEquals("The validated map is empty", ex.getMessage());
+                }
+            }
+
+            @Nested
+            class WithMessage {
+
+                @Test
+                void shouldNotThrowExceptionForMapContainingNullMapping() {
+                    Validate.notEmpty(Collections.singletonMap("key", null), "MSG");
+                }
+
+                @Test
+                void shouldReturnTheSameInstance() {
+                    final Map<String, String> map = Collections.singletonMap("key", "value");
+                    final Map<String, String> result = Validate.notEmpty(map, "MSG");
+
+                    assertSame(map, result);
+                }
+
+                @Test
+                void shouldThrowNullPointerExceptionWithGivenMessageForNullMap() {
+                    final NullPointerException ex = assertThrows(
+                            NullPointerException.class,
+                            () -> Validate.notEmpty((Map<?, ?>) null, "MSG"));
+
+                    assertEquals("MSG", ex.getMessage());
+                }
+
+                @Test
+                void shouldThrowIllegalArgumentExceptionWithGivenMessageForEmptyMap() {
+                    final IllegalArgumentException ex = assertThrows(
+                            IllegalArgumentException.class,
+                            () -> Validate.notEmpty(Collections.emptyMap(), "MSG"));
+
+                    assertEquals("MSG", ex.getMessage());
+                }
+            }
         }
 
-        final String str = "Hi";
-        final String testStr = Validate.notEmpty(str, "Message");
-        assertSame(str, testStr);
+        @Nested
+        class WithCharSequence {
+
+            @Nested
+            class WithoutMessage {
+
+                @Test
+                void shouldNotThrowExceptionForNonEmptyString() {
+                    Validate.notEmpty("Hi");
+                }
+
+                @Test
+                void shouldReturnTheSameInstance() {
+                    final String str = "Hi";
+                    final String result = Validate.notEmpty(str);
+
+                    assertSame(str, result);
+                }
+
+                @Test
+                void shouldThrowNullPointerExceptionWithDefaultMessageForNullCharSequence() {
+                    final NullPointerException ex = assertThrows(
+                            NullPointerException.class,
+                            () -> Validate.notEmpty((CharSequence) null));
+
+                    assertEquals("The validated character sequence is empty", ex.getMessage());
+                }
+
+                @Test
+                void shouldThrowIllegalArgumentExceptionWithDefaultMessageForEmptyString() {
+                    final IllegalArgumentException ex = assertThrows(
+                            IllegalArgumentException.class,
+                            () -> Validate.notEmpty(""));
+
+                    assertEquals("The validated character sequence is empty", ex.getMessage());
+                }
+            }
+
+            @Nested
+            class WithMessage {
+
+                @Test
+                void shouldNotThrowExceptionForNonEmptyString() {
+                    Validate.notEmpty("Hi", "MSG");
+                }
+
+                @Test
+                void shouldReturnTheSameInstance() {
+                    final String str = "Hi";
+                    final String result = Validate.notEmpty(str, "MSG");
+
+                    assertSame(str, result);
+                }
+
+                @Test
+                void shouldThrowNullPointerExceptionWithGivenMessageForNullCharSequence() {
+                    final NullPointerException ex = assertThrows(
+                            NullPointerException.class,
+                            () -> Validate.notEmpty((CharSequence) null, "MSG"));
+
+                    assertEquals("MSG", ex.getMessage());
+                }
+
+                @Test
+                void shouldThrowIllegalArgumentExceptionWithGivenMessageForEmptyString() {
+                    final IllegalArgumentException ex = assertThrows(
+                            IllegalArgumentException.class,
+                            () -> Validate.notEmpty("", "MSG"));
+
+                    assertEquals("MSG", ex.getMessage());
+                }
+            }
+        }
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/apache/commons/lang3/ValidateTest.java
+++ b/src/test/java/org/apache/commons/lang3/ValidateTest.java
@@ -1490,105 +1490,298 @@ class ValidateTest {
         }
     }
 
-    @Test
-    void testExclusiveBetween() {
-        Validate.exclusiveBetween("a", "c", "b");
-        try {
-            Validate.exclusiveBetween("0", "5", "6");
-            fail("Expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            assertEquals("The value 6 is not in the specified exclusive range of 0 to 5", e.getMessage());
-        }
-        try {
-            Validate.exclusiveBetween("0", "5", "5");
-            fail("Expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            assertEquals("The value 5 is not in the specified exclusive range of 0 to 5", e.getMessage());
-        }
-    }
+    @Nested
+    class ExclusiveBetween {
 
-    @Test
-    void testExclusiveBetween_withMessage() {
-        Validate.exclusiveBetween("a", "c", "b", "Error");
-        try {
-            Validate.exclusiveBetween("0", "5", "6", "Error");
-            fail("Expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            assertEquals("Error", e.getMessage());
-        }
-        try {
-            Validate.exclusiveBetween("0", "5", "5", "Error");
-            fail("Expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            assertEquals("Error", e.getMessage());
-        }
-    }
+        @Nested
+        class WithComparable {
 
-    @Test
-    void testExclusiveBetweenLong() {
-        Validate.exclusiveBetween(0, 2, 1);
-        try {
-            Validate.exclusiveBetween(0, 5, 6);
-            fail("Expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            assertEquals("The value 6 is not in the specified exclusive range of 0 to 5", e.getMessage());
-        }
-        try {
-            Validate.exclusiveBetween(0, 5, 5);
-            fail("Expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            assertEquals("The value 5 is not in the specified exclusive range of 0 to 5", e.getMessage());
-        }
-    }
+            private static final String LOWER_BOUND = "1";
+            private static final String UPPER_BOUND = "3";
 
-    @Test
-    void testExclusiveBetweenLong_withMessage() {
-        Validate.exclusiveBetween(0, 2, 1, "Error");
-        try {
-            Validate.exclusiveBetween(0, 5, 6, "Error");
-            fail("Expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            assertEquals("Error", e.getMessage());
-        }
-        try {
-            Validate.exclusiveBetween(0, 5, 5, "Error");
-            fail("Expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            assertEquals("Error", e.getMessage());
-        }
-    }
+            @Nested
+            class WithoutMessage {
 
-    @Test
-    void testExclusiveBetweenDouble() {
-        Validate.exclusiveBetween(0.1, 2.1, 1.1);
-        try {
-            Validate.exclusiveBetween(0.1, 5.1, 6.1);
-            fail("Expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            assertEquals("The value 6.1 is not in the specified exclusive range of 0.1 to 5.1", e.getMessage());
-        }
-        try {
-            Validate.exclusiveBetween(0.1, 5.1, 5.1);
-            fail("Expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            assertEquals("The value 5.1 is not in the specified exclusive range of 0.1 to 5.1", e.getMessage());
-        }
-    }
+                @Test
+                void shouldNotThrowExceptionWhenValueIsBetweenBounds() {
+                    Validate.exclusiveBetween(LOWER_BOUND, UPPER_BOUND, "2");
+                }
 
-    @Test
-    void testExclusiveBetweenDouble_withMessage() {
-        Validate.exclusiveBetween(0.1, 2.1, 1.1, "Error");
-        try {
-            Validate.exclusiveBetween(0.1, 5.1, 6.1, "Error");
-            fail("Expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            assertEquals("Error", e.getMessage());
+                @Test
+                void shouldThrowIllegalArgumentExceptionWithDefaultMessageWhenValueIsLowerBound() {
+                    final IllegalArgumentException ex = assertThrows(
+                            IllegalArgumentException.class,
+                            () -> Validate.exclusiveBetween(LOWER_BOUND, UPPER_BOUND, LOWER_BOUND));
+
+                    assertEquals("The value 1 is not in the specified exclusive range of 1 to 3", ex.getMessage());
+                }
+
+                @Test
+                void shouldThrowIllegalArgumentExceptionWithDefaultMessageWhenValueIsUpperBound() {
+                    final IllegalArgumentException ex = assertThrows(
+                            IllegalArgumentException.class,
+                            () -> Validate.exclusiveBetween(LOWER_BOUND, UPPER_BOUND, UPPER_BOUND));
+
+                    assertEquals("The value 3 is not in the specified exclusive range of 1 to 3", ex.getMessage());
+                }
+
+                @Test
+                void shouldThrowIllegalArgumentExceptionWithDefaultMessageWhenValueIsBelowLowerBound() {
+                    final IllegalArgumentException ex = assertThrows(
+                            IllegalArgumentException.class,
+                            () -> Validate.exclusiveBetween(LOWER_BOUND, UPPER_BOUND, "0"));
+
+                    assertEquals("The value 0 is not in the specified exclusive range of 1 to 3", ex.getMessage());
+                }
+
+                @Test
+                void shouldThrowIllegalArgumentExceptionWithDefaultMessageWhenValueIsAboveUpperBound() {
+                    final IllegalArgumentException ex = assertThrows(
+                            IllegalArgumentException.class,
+                            () -> Validate.exclusiveBetween(LOWER_BOUND, UPPER_BOUND, "4"));
+
+                    assertEquals("The value 4 is not in the specified exclusive range of 1 to 3", ex.getMessage());
+                }
+            }
+
+            @Nested
+            class WithMessage {
+
+                @Test
+                void shouldNotThrowExceptionWhenValueIsBetweenBounds() {
+                    Validate.exclusiveBetween(LOWER_BOUND, UPPER_BOUND, "2", "MSG");
+                }
+
+                @Test
+                void shouldThrowIllegalArgumentExceptionWithGivenMessageWhenValueIsLowerBound() {
+                    final IllegalArgumentException ex = assertThrows(
+                            IllegalArgumentException.class,
+                            () -> Validate.exclusiveBetween(LOWER_BOUND, UPPER_BOUND, LOWER_BOUND, "MSG"));
+
+                    assertEquals("MSG", ex.getMessage());
+                }
+
+                @Test
+                void shouldThrowIllegalArgumentExceptionWithGivenMessageWhenValueIsUpperBound() {
+                    final IllegalArgumentException ex = assertThrows(
+                            IllegalArgumentException.class,
+                            () -> Validate.exclusiveBetween(LOWER_BOUND, UPPER_BOUND, UPPER_BOUND, "MSG"));
+
+                    assertEquals("MSG", ex.getMessage());
+                }
+
+                @Test
+                void shouldThrowIllegalArgumentExceptionWithGivenMessageWhenValueIsBelowLowerBound() {
+                    final IllegalArgumentException ex = assertThrows(
+                            IllegalArgumentException.class,
+                            () -> Validate.exclusiveBetween(LOWER_BOUND, UPPER_BOUND, "0", "MSG"));
+
+                    assertEquals("MSG", ex.getMessage());
+                }
+
+                @Test
+                void shouldThrowIllegalArgumentExceptionWithDefaultMessageWhenValueIsAboveUpperBound() {
+                    final IllegalArgumentException ex = assertThrows(
+                            IllegalArgumentException.class,
+                            () -> Validate.exclusiveBetween(LOWER_BOUND, UPPER_BOUND, "4", "MSG"));
+
+                    assertEquals("MSG", ex.getMessage());
+                }
+            }
         }
-        try {
-            Validate.exclusiveBetween(0.1, 5.1, 5.1, "Error");
-            fail("Expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            assertEquals("Error", e.getMessage());
+
+        @Nested
+        class WithLong {
+
+            private static final long LOWER_BOUND = 1;
+            private static final long UPPER_BOUND = 3;
+
+            @Nested
+            class WithoutMessage {
+
+                @Test
+                void shouldNotThrowExceptionWhenValueIsBetweenBounds() {
+                    Validate.exclusiveBetween(LOWER_BOUND, UPPER_BOUND, 2);
+                }
+
+                @Test
+                void shouldThrowIllegalArgumentExceptionWithDefaultMessageWhenValueIsLowerBound() {
+                    final IllegalArgumentException ex = assertThrows(
+                            IllegalArgumentException.class,
+                            () -> Validate.exclusiveBetween(LOWER_BOUND, UPPER_BOUND, LOWER_BOUND));
+
+                    assertEquals("The value 1 is not in the specified exclusive range of 1 to 3", ex.getMessage());
+                }
+
+                @Test
+                void shouldThrowIllegalArgumentExceptionWithDefaultMessageWhenValueIsUpperBound() {
+                    final IllegalArgumentException ex = assertThrows(
+                            IllegalArgumentException.class,
+                            () -> Validate.exclusiveBetween(LOWER_BOUND, UPPER_BOUND, UPPER_BOUND));
+
+                    assertEquals("The value 3 is not in the specified exclusive range of 1 to 3", ex.getMessage());
+                }
+
+                @Test
+                void shouldThrowIllegalArgumentExceptionWithDefaultMessageWhenValueIsBelowLowerBound() {
+                    final IllegalArgumentException ex = assertThrows(
+                            IllegalArgumentException.class,
+                            () -> Validate.exclusiveBetween(LOWER_BOUND, UPPER_BOUND, 0));
+
+                    assertEquals("The value 0 is not in the specified exclusive range of 1 to 3", ex.getMessage());
+                }
+
+                @Test
+                void shouldThrowIllegalArgumentExceptionWithDefaultMessageWhenValueIsAboveUpperBound() {
+                    final IllegalArgumentException ex = assertThrows(
+                            IllegalArgumentException.class,
+                            () -> Validate.exclusiveBetween(LOWER_BOUND, UPPER_BOUND, 4));
+
+                    assertEquals("The value 4 is not in the specified exclusive range of 1 to 3", ex.getMessage());
+                }
+            }
+
+            @Nested
+            class WithMessage {
+
+                @Test
+                void shouldNotThrowExceptionWhenValueIsBetweenBounds() {
+                    Validate.exclusiveBetween(LOWER_BOUND, UPPER_BOUND, 2, "MSG");
+                }
+
+                @Test
+                void shouldThrowIllegalArgumentExceptionWithGivenMessageWhenValueIsLowerBound() {
+                    final IllegalArgumentException ex = assertThrows(
+                            IllegalArgumentException.class,
+                            () -> Validate.exclusiveBetween(LOWER_BOUND, UPPER_BOUND, LOWER_BOUND, "MSG"));
+
+                    assertEquals("MSG", ex.getMessage());
+                }
+
+                @Test
+                void shouldThrowIllegalArgumentExceptionWithGivenMessageWhenValueIsUpperBound() {
+                    final IllegalArgumentException ex = assertThrows(
+                            IllegalArgumentException.class,
+                            () -> Validate.exclusiveBetween(LOWER_BOUND, UPPER_BOUND, UPPER_BOUND, "MSG"));
+
+                    assertEquals("MSG", ex.getMessage());
+                }
+
+                @Test
+                void shouldThrowIllegalArgumentExceptionWithGivenMessageWhenValueIsBelowLowerBound() {
+                    final IllegalArgumentException ex = assertThrows(
+                            IllegalArgumentException.class,
+                            () -> Validate.exclusiveBetween(LOWER_BOUND, UPPER_BOUND, 0, "MSG"));
+
+                    assertEquals("MSG", ex.getMessage());
+                }
+
+                @Test
+                void shouldThrowIllegalArgumentExceptionWithDefaultMessageWhenValueIsAboveUpperBound() {
+                    final IllegalArgumentException ex = assertThrows(
+                            IllegalArgumentException.class,
+                            () -> Validate.exclusiveBetween(LOWER_BOUND, UPPER_BOUND, 4, "MSG"));
+
+                    assertEquals("MSG", ex.getMessage());
+                }
+            }
+        }
+
+        @Nested
+        class WithDouble {
+
+            private static final double LOWER_BOUND = 0.1;
+            private static final double UPPER_BOUND = 3.1;
+
+            @Nested
+            class WithoutMessage {
+
+                @Test
+                void shouldNotThrowExceptionWhenValueIsBetweenBounds() {
+                    Validate.exclusiveBetween(LOWER_BOUND, UPPER_BOUND, 2.1);
+                }
+
+                @Test
+                void shouldThrowIllegalArgumentExcdeptionWhenValueIsLowerBound() {
+                    final IllegalArgumentException ex = assertThrows(
+                            IllegalArgumentException.class,
+                            () -> Validate.exclusiveBetween(LOWER_BOUND, UPPER_BOUND, LOWER_BOUND));
+
+                    assertEquals("The value 0.1 is not in the specified exclusive range of 0.1 to 3.1", ex.getMessage());
+                }
+
+                @Test
+                void shouldThrowIllegalArgumentExcdeptionWhenValueIsUpperBound() {
+                    final IllegalArgumentException ex = assertThrows(
+                            IllegalArgumentException.class,
+                            () -> Validate.exclusiveBetween(LOWER_BOUND, UPPER_BOUND, UPPER_BOUND));
+
+                    assertEquals("The value 3.1 is not in the specified exclusive range of 0.1 to 3.1", ex.getMessage());
+                }
+
+                @Test
+                void shouldThrowIllegalArgumentExceptionWithDefaultMessageWhenValueIsBelowLowerBound() {
+                    final IllegalArgumentException ex = assertThrows(
+                            IllegalArgumentException.class,
+                            () -> Validate.exclusiveBetween(LOWER_BOUND, UPPER_BOUND, 0.01));
+
+                    assertEquals("The value 0.01 is not in the specified exclusive range of 0.1 to 3.1", ex.getMessage());
+                }
+
+                @Test
+                void shouldThrowIllegalArgumentExceptionWithDefaultMessageWhenValueIsAboveUpperBound() {
+                    final IllegalArgumentException ex = assertThrows(
+                            IllegalArgumentException.class,
+                            () -> Validate.exclusiveBetween(LOWER_BOUND, UPPER_BOUND, 4.1));
+
+                    assertEquals("The value 4.1 is not in the specified exclusive range of 0.1 to 3.1", ex.getMessage());
+                }
+            }
+
+            @Nested
+            class WithMessage {
+
+                @Test
+                void shouldNotThrowExceptionWhenValueIsBetweenBounds() {
+                    Validate.exclusiveBetween(LOWER_BOUND, UPPER_BOUND, 2.1, "MSG");
+                }
+
+                @Test
+                void shouldThrowIllegalArgumentExcdeptionWhenValueIsLowerBound() {
+                    final IllegalArgumentException ex = assertThrows(
+                            IllegalArgumentException.class,
+                            () -> Validate.exclusiveBetween(LOWER_BOUND, UPPER_BOUND, LOWER_BOUND, "MSG"));
+
+                    assertEquals("MSG", ex.getMessage());
+                }
+
+                @Test
+                void shouldThrowIllegalArgumentExcdeptionWhenValueIsUpperBound() {
+                    final IllegalArgumentException ex = assertThrows(
+                            IllegalArgumentException.class,
+                            () -> Validate.exclusiveBetween(LOWER_BOUND, UPPER_BOUND, UPPER_BOUND, "MSG"));
+
+                    assertEquals("MSG", ex.getMessage());
+                }
+
+                @Test
+                void shouldThrowIllegalArgumentExceptionWithGivenMessageWhenValueIsBelowLowerBound() {
+                    final IllegalArgumentException ex = assertThrows(
+                            IllegalArgumentException.class,
+                            () -> Validate.exclusiveBetween(LOWER_BOUND, UPPER_BOUND, 0.01, "MSG"));
+
+                    assertEquals("MSG", ex.getMessage());
+                }
+
+                @Test
+                void shouldThrowIllegalArgumentExceptionWithGivenMessageWhenValueIsAboveUpperBound() {
+                    final IllegalArgumentException ex = assertThrows(
+                            IllegalArgumentException.class,
+                            () -> Validate.exclusiveBetween(LOWER_BOUND, UPPER_BOUND, 4.1, "MSG"));
+
+                    assertEquals("MSG", ex.getMessage());
+                }
+            }
         }
     }
 

--- a/src/test/java/org/apache/commons/lang3/ValidateTest.java
+++ b/src/test/java/org/apache/commons/lang3/ValidateTest.java
@@ -25,7 +25,6 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
 import java.util.AbstractList;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -788,152 +787,284 @@ class ValidateTest {
         }
     }
 
-    //-----------------------------------------------------------------------
-    //-----------------------------------------------------------------------
-    @Test
-    void testValidIndex_withMessage_array() {
-        final Object[] array = new Object[2];
-        Validate.validIndex(array, 0, "Broken: ");
-        Validate.validIndex(array, 1, "Broken: ");
-        try {
-            Validate.validIndex(array, -1, "Broken: ");
-            fail("Expecting IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException ex) {
-            assertEquals("Broken: ", ex.getMessage());
-        }
-        try {
-            Validate.validIndex(array, 2, "Broken: ");
-            fail("Expecting IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException ex) {
-            assertEquals("Broken: ", ex.getMessage());
+    @Nested
+    class ValidIndex {
+
+        @Nested
+        class WithArray {
+
+            @Nested
+            class WithoutMessage {
+
+                @Test
+                void shouldNotThrowExceptionForValidIndex() {
+                    Validate.validIndex(new String[]{"a"}, 0);
+                }
+
+                @Test
+                void shouldReturnSameInstance() {
+                    final String[] array = {"a"};
+                    final String[] result = Validate.validIndex(array, 0);
+
+                    assertSame(array, result);
+                }
+
+                @Test
+                void shouldThrowNullPointerExceptionWithDefaultForNullArray() {
+                    final NullPointerException ex = assertThrows(
+                            NullPointerException.class,
+                            () -> Validate.validIndex((Object[]) null, 1));
+
+                    assertEquals("The validated object is null", ex.getMessage());
+                }
+
+                @Test
+                void shouldThrowIndexOutOfBoundsExceptionWithDefaultMessageForNegativeIndex() {
+                    final IndexOutOfBoundsException ex = assertThrows(
+                            IndexOutOfBoundsException.class,
+                            () -> Validate.validIndex(new String[]{"a"}, -1));
+
+                    assertEquals("The validated array index is invalid: -1", ex.getMessage());
+                }
+
+                @Test
+                void shouldThrowIndexOutOfBoundsExceptionWithDefaultMessageForIndexOutOfBounds() {
+                    final IndexOutOfBoundsException ex = assertThrows(
+                            IndexOutOfBoundsException.class,
+                            () -> Validate.validIndex(new String[]{"a"}, 1));
+
+                    assertEquals("The validated array index is invalid: 1", ex.getMessage());
+                }
+            }
+
+            @Nested
+            class WithMessage {
+
+                @Test
+                void shouldNotThrowExceptionForValidIndex() {
+                    Validate.validIndex(new String[]{"a"}, 0, "MSG");
+                }
+
+                @Test
+                void shouldReturnSameInstance() {
+                    final String[] array = {"a"};
+                    final String[] result = Validate.validIndex(array, 0, "MSG");
+
+                    assertSame(array, result);
+                }
+
+                @Test
+                void shouldThrowNullPointerExceptionWithDefaultMessageForNullArray() {
+                    final NullPointerException ex = assertThrows(
+                            NullPointerException.class,
+                            () -> Validate.validIndex((Object[]) null, 1, "MSG"));
+
+                    assertEquals("The validated object is null", ex.getMessage());
+                }
+
+                @Test
+                void shouldThrowIndexOutOfBoundsExceptionWithGivenMessageForNegativeIndex() {
+                    final IndexOutOfBoundsException ex = assertThrows(
+                            IndexOutOfBoundsException.class,
+                            () -> Validate.validIndex(new String[]{"a"}, -1, "MSG"));
+
+                    assertEquals("MSG", ex.getMessage());
+                }
+
+                @Test
+                void shouldThrowIndexOutOfBoundsExceptionWithGivenMessageForIndexOutOfBounds() {
+                    final IndexOutOfBoundsException ex = assertThrows(
+                            IndexOutOfBoundsException.class,
+                            () -> Validate.validIndex(new String[]{"a"}, 1, "MSG"));
+
+                    assertEquals("MSG", ex.getMessage());
+                }
+            }
         }
 
-        final String[] strArray = new String[]{"Hi"};
-        final String[] test = Validate.noNullElements(strArray, "Message");
-        assertSame(strArray, test);
-    }
+        @Nested
+        class WithCollection {
 
-    @Test
-    void testValidIndex_array() {
-        final Object[] array = new Object[2];
-        Validate.validIndex(array, 0);
-        Validate.validIndex(array, 1);
-        try {
-            Validate.validIndex(array, -1);
-            fail("Expecting IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException ex) {
-            assertEquals("The validated array index is invalid: -1", ex.getMessage());
-        }
-        try {
-            Validate.validIndex(array, 2);
-            fail("Expecting IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException ex) {
-            assertEquals("The validated array index is invalid: 2", ex.getMessage());
-        }
+            @Nested
+            class WithoutMessage {
 
-        final String[] strArray = new String[]{"Hi"};
-        final String[] test = Validate.noNullElements(strArray);
-        assertSame(strArray, test);
-    }
+                @Test
+                void shouldNotThrowExceptionForValidIndex() {
+                    Validate.validIndex(Collections.singleton("a"), 0);
+                }
 
-    //-----------------------------------------------------------------------
-    //-----------------------------------------------------------------------
-    @Test
-    void testValidIndex_withMessage_collection() {
-        final Collection<String> coll = new ArrayList<>();
-        coll.add(null);
-        coll.add(null);
-        Validate.validIndex(coll, 0, "Broken: ");
-        Validate.validIndex(coll, 1, "Broken: ");
-        try {
-            Validate.validIndex(coll, -1, "Broken: ");
-            fail("Expecting IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException ex) {
-            assertEquals("Broken: ", ex.getMessage());
-        }
-        try {
-            Validate.validIndex(coll, 2, "Broken: ");
-            fail("Expecting IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException ex) {
-            assertEquals("Broken: ", ex.getMessage());
-        }
+                @Test
+                void shouldReturnSameInstance() {
+                    final Set<String> col = Collections.singleton("a");
+                    final Set<String> result = Validate.validIndex(col, 0);
 
-        final List<String> strColl = Arrays.asList("Hi");
-        final List<String> test = Validate.validIndex(strColl, 0, "Message");
-        assertSame(strColl, test);
-    }
+                    assertSame(col, result);
+                }
 
-    @Test
-    void testValidIndex_collection() {
-        final Collection<String> coll = new ArrayList<>();
-        coll.add(null);
-        coll.add(null);
-        Validate.validIndex(coll, 0);
-        Validate.validIndex(coll, 1);
-        try {
-            Validate.validIndex(coll, -1);
-            fail("Expecting IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException ex) {
-            assertEquals("The validated collection index is invalid: -1", ex.getMessage());
-        }
-        try {
-            Validate.validIndex(coll, 2);
-            fail("Expecting IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException ex) {
-            assertEquals("The validated collection index is invalid: 2", ex.getMessage());
-        }
+                @Test
+                void shouldThrowNullPointerExceptionWithDefaultForNullCollection() {
+                    final NullPointerException ex = assertThrows(
+                            NullPointerException.class,
+                            () -> Validate.validIndex((Collection<?>) null, 1));
 
-        final List<String> strColl = Arrays.asList("Hi");
-        final List<String> test = Validate.validIndex(strColl, 0);
-        assertSame(strColl, test);
-    }
+                    assertEquals("The validated object is null", ex.getMessage());
+                }
 
-    //-----------------------------------------------------------------------
-    //-----------------------------------------------------------------------
-    @Test
-    void testValidIndex_withMessage_charSequence() {
-        final CharSequence str = "Hi";
-        Validate.validIndex(str, 0, "Broken: ");
-        Validate.validIndex(str, 1, "Broken: ");
-        try {
-            Validate.validIndex(str, -1, "Broken: ");
-            fail("Expecting IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException ex) {
-            assertEquals("Broken: ", ex.getMessage());
-        }
-        try {
-            Validate.validIndex(str, 2, "Broken: ");
-            fail("Expecting IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException ex) {
-            assertEquals("Broken: ", ex.getMessage());
+                @Test
+                void shouldThrowIndexOutOfBoundsExceptionWithDefaultMessageForNegativeIndex() {
+                    final IndexOutOfBoundsException ex = assertThrows(
+                            IndexOutOfBoundsException.class,
+                            () -> Validate.validIndex(Collections.singleton("a"), -1));
+
+                    assertEquals("The validated collection index is invalid: -1", ex.getMessage());
+                }
+
+                @Test
+                void shouldThrowIndexOutOfBoundsExceptionWithDefaultMessageForIndexOutOfBounds() {
+                    final IndexOutOfBoundsException ex = assertThrows(
+                            IndexOutOfBoundsException.class,
+                            () -> Validate.validIndex(Collections.singleton("a"), 1));
+
+                    assertEquals("The validated collection index is invalid: 1", ex.getMessage());
+                }
+            }
+
+            @Nested
+            class WithMessage {
+
+                @Test
+                void shouldNotThrowExceptionForValidIndex() {
+                    Validate.validIndex(Collections.singleton("a"), 0, "MSG");
+                }
+
+                @Test
+                void shouldReturnSameInstance() {
+                    final Set<String> col = Collections.singleton("a");
+                    final Set<String> result = Validate.validIndex(col, 0, "MSG");
+
+                    assertSame(col, result);
+                }
+
+                @Test
+                void shouldThrowNullPointerExceptionWithDefaultMessageForNullCollection() {
+                    final NullPointerException ex = assertThrows(
+                            NullPointerException.class,
+                            () -> Validate.validIndex((Collection<?>) null, 1, "MSG"));
+
+                    assertEquals("The validated object is null", ex.getMessage());
+                }
+
+                @Test
+                void shouldThrowIndexOutOfBoundsExceptionWithGivenMessageForNegativeIndex() {
+                    final IndexOutOfBoundsException ex = assertThrows(
+                            IndexOutOfBoundsException.class,
+                            () -> Validate.validIndex(Collections.singleton("a"), -1, "MSG"));
+
+                    assertEquals("MSG", ex.getMessage());
+                }
+
+                @Test
+                void shouldThrowIndexOutOfBoundsExceptionWithGivenMessageForIndexOutOfBounds() {
+                    final IndexOutOfBoundsException ex = assertThrows(
+                            IndexOutOfBoundsException.class,
+                            () -> Validate.validIndex(Collections.singleton("a"), 1, "MSG"));
+
+                    assertEquals("MSG", ex.getMessage());
+                }
+            }
         }
 
-        final String input = "Hi";
-        final String test = Validate.validIndex(input, 0, "Message");
-        assertSame(input, test);
-    }
+        @Nested
+        class WithCharSequence {
 
-    @Test
-    void testValidIndex_charSequence() {
-        final CharSequence str = "Hi";
-        Validate.validIndex(str, 0);
-        Validate.validIndex(str, 1);
-        try {
-            Validate.validIndex(str, -1);
-            fail("Expecting IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException ex) {
-            assertEquals("The validated character sequence index is invalid: -1", ex.getMessage());
-        }
-        try {
-            Validate.validIndex(str, 2);
-            fail("Expecting IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException ex) {
-            assertEquals("The validated character sequence index is invalid: 2", ex.getMessage());
-        }
+            @Nested
+            class WithoutMessage {
 
-        final String input = "Hi";
-        final String test = Validate.validIndex(input, 0);
-        assertSame(input, test);
+                @Test
+                void shouldNotThrowExceptionForValidIndex() {
+                    Validate.validIndex("a", 0);
+                }
+
+                @Test
+                void shouldReturnSameInstance() {
+                    final String str = "a";
+                    final String result = Validate.validIndex(str, 0);
+
+                    assertSame(str, result);
+                }
+
+                @Test
+                void shouldThrowNullPointerExceptionWithDefaultForNullString() {
+                    final NullPointerException ex = assertThrows(
+                            NullPointerException.class,
+                            () -> Validate.validIndex((String) null, 1));
+
+                    assertEquals("The validated object is null", ex.getMessage());
+                }
+
+                @Test
+                void shouldThrowIndexOutOfBoundsExceptionWithDefaultMessageForNegativeIndex() {
+                    final IndexOutOfBoundsException ex = assertThrows(
+                            IndexOutOfBoundsException.class,
+                            () -> Validate.validIndex("a", -1));
+
+                    assertEquals("The validated character sequence index is invalid: -1", ex.getMessage());
+                }
+
+                @Test
+                void shouldThrowIndexOutOfBoundsExceptionWithDefaultMessageForIndexOutOfBounds() {
+                    final IndexOutOfBoundsException ex = assertThrows(
+                            IndexOutOfBoundsException.class,
+                            () -> Validate.validIndex("a", 1));
+
+                    assertEquals("The validated character sequence index is invalid: 1", ex.getMessage());
+                }
+            }
+
+            @Nested
+            class WithMessage {
+
+                @Test
+                void shouldNotThrowExceptionForValidIndex() {
+                    Validate.validIndex("a", 0, "MSG");
+                }
+
+                @Test
+                void shouldReturnSameInstance() {
+                    final String str = "a";
+                    final String result = Validate.validIndex(str, 0, "MSG");
+
+                    assertSame(str, result);
+                }
+
+                @Test
+                void shouldThrowNullPointerExceptionWithDefaultMessageForNullStr() {
+                    final NullPointerException ex = assertThrows(
+                            NullPointerException.class,
+                            () -> Validate.validIndex((String) null, 1, "MSG"));
+
+                    assertEquals("The validated object is null", ex.getMessage());
+                }
+
+                @Test
+                void shouldThrowIndexOutOfBoundsExceptionWithGivenMessageForNegativeIndex() {
+                    final IndexOutOfBoundsException ex = assertThrows(
+                            IndexOutOfBoundsException.class,
+                            () -> Validate.validIndex("a", -1, "MSG"));
+
+                    assertEquals("MSG", ex.getMessage());
+                }
+
+                @Test
+                void shouldThrowIndexOutOfBoundsExceptionWithGivenMessageForIndexOutOfBounds() {
+                    final IndexOutOfBoundsException ex = assertThrows(
+                            IndexOutOfBoundsException.class,
+                            () -> Validate.validIndex("a", 1, "MSG"));
+
+                    assertEquals("MSG", ex.getMessage());
+                }
+            }
+        }
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/ValidateTest.java
+++ b/src/test/java/org/apache/commons/lang3/ValidateTest.java
@@ -28,7 +28,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -497,220 +496,134 @@ class ValidateTest {
         }
     }
 
-    //-----------------------------------------------------------------------
-    //-----------------------------------------------------------------------
-    @Test
-    void testNotBlankNullStringShouldThrow() {
-        //given
-        final String string = null;
+    @Nested
+    class NotBlank {
 
-        try {
-            //when
-            Validate.notBlank(string);
-            fail("Expecting NullPointerException");
-        } catch (final NullPointerException e) {
-            //then
-            assertEquals("The validated character sequence is blank", e.getMessage());
+        @Nested
+        class WithoutMessage {
+
+            @Test
+            void shouldNotThrowExceptionForNonEmptyString() {
+                Validate.notBlank("abc");
+            }
+
+            @Test
+            void shouldNotThrowExceptionForNonEmptyStringContainingSpaces() {
+                Validate.notBlank("  abc   ");
+            }
+
+            @Test
+            void shouldNotThrowExceptionForNonEmptyStringContainingWhitespaceChars() {
+                Validate.notBlank(" \n \t abc \r \n ");
+            }
+
+            @Test
+            void shouldReturnNonBlankValue() {
+                final String str = "abc";
+                final String result = Validate.notBlank(str);
+
+                assertSame(str, result);
+            }
+
+            @Test
+            void shouldThrowNullPointerExceptionWithDefaultMessageForNullString() {
+                final NullPointerException ex = assertThrows(
+                        NullPointerException.class,
+                        () -> Validate.notBlank(null));
+
+                assertEquals("The validated character sequence is blank", ex.getMessage());
+            }
+
+            @Test
+            void shouldThrowIllegalArgumentExceptionWithDefaultMessageForEmptyString() {
+                final IllegalArgumentException ex = assertThrows(
+                        IllegalArgumentException.class,
+                        () -> Validate.notBlank(""));
+
+                assertEquals("The validated character sequence is blank", ex.getMessage());
+            }
+
+            @Test
+            void shouldThrowIllegalArgumentExceptionWithDefaultMessageForBlankString() {
+                final IllegalArgumentException ex = assertThrows(
+                        IllegalArgumentException.class,
+                        () -> Validate.notBlank("   "));
+
+                assertEquals("The validated character sequence is blank", ex.getMessage());
+            }
+
+            @Test
+            void shouldThrowIllegalArgumentExceptionWithDefaultMessageForStringContainingOnlyWhitespaceChars() {
+                final IllegalArgumentException ex = assertThrows(
+                        IllegalArgumentException.class,
+                        () -> Validate.notBlank(" \n \t \r \n "));
+
+                assertEquals("The validated character sequence is blank", ex.getMessage());
+            }
         }
-    }
 
-    //-----------------------------------------------------------------------
-    @Test
-    void testNotBlankMsgNullStringShouldThrow() {
-        //given
-        final String string = null;
+        @Nested
+        class WithMessage {
 
-        try {
-            //when
-            Validate.notBlank(string, "Message");
-            fail("Expecting NullPointerException");
-        } catch (final NullPointerException e) {
-            //then
-            assertEquals("Message", e.getMessage());
+            @Test
+            void shouldNotThrowExceptionForNonEmptyString() {
+                Validate.notBlank("abc", "MSG");
+            }
+
+            @Test
+            void shouldNotThrowExceptionForNonEmptyStringContainingSpaces() {
+                Validate.notBlank("  abc   ", "MSG");
+            }
+
+            @Test
+            void shouldNotThrowExceptionForNonEmptyStringContainingWhitespaceChars() {
+                Validate.notBlank(" \n \t abc \r \n ", "MSG");
+            }
+
+            @Test
+            void shouldReturnNonBlankValue() {
+                final String str = "abc";
+                final String result = Validate.notBlank(str, "MSG");
+
+                assertSame(str, result);
+            }
+
+            @Test
+            void shouldThrowNullPointerExceptionWithGivenMessageForNullString() {
+                final NullPointerException ex = assertThrows(
+                        NullPointerException.class,
+                        () -> Validate.notBlank(null, "MSG"));
+
+                assertEquals("MSG", ex.getMessage());
+            }
+
+            @Test
+            void shouldThrowIllegalArgumentExceptionWithGivenMessageForEmptyString() {
+                final IllegalArgumentException ex = assertThrows(
+                        IllegalArgumentException.class,
+                        () -> Validate.notBlank("", "MSG"));
+
+                assertEquals("MSG", ex.getMessage());
+            }
+
+            @Test
+            void shouldThrowIllegalArgumentExceptionWithGivenMessageForBlankString() {
+                final IllegalArgumentException ex = assertThrows(
+                        IllegalArgumentException.class,
+                        () -> Validate.notBlank("   ", "MSG"));
+
+                assertEquals("MSG", ex.getMessage());
+            }
+
+            @Test
+            void shouldThrowIllegalArgumentExceptionWithGivenMessageForStringContainingOnlyWhitespaceChars() {
+                final IllegalArgumentException ex = assertThrows(
+                        IllegalArgumentException.class,
+                        () -> Validate.notBlank(" \n \t \r \n ", "MSG"));
+
+                assertEquals("MSG", ex.getMessage());
+            }
         }
-    }
-
-    //-----------------------------------------------------------------------
-    @Test
-    void testNotBlankEmptyStringShouldThrow() {
-        //given
-        final String string = "";
-
-        try {
-            //when
-            Validate.notBlank(string);
-            fail("Expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            //then
-            assertEquals("The validated character sequence is blank", e.getMessage());
-        }
-    }
-
-    //-----------------------------------------------------------------------
-    @Test
-    void testNotBlankBlankStringWithWhitespacesShouldThrow() {
-        //given
-        final String string = "   ";
-
-        try {
-            //when
-            Validate.notBlank(string);
-            fail("Expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            //then
-            assertEquals("The validated character sequence is blank", e.getMessage());
-        }
-    }
-
-    //-----------------------------------------------------------------------
-    @Test
-    void testNotBlankBlankStringWithNewlinesShouldThrow() {
-        //given
-        final String string = " \n \t \r \n ";
-
-        try {
-            //when
-            Validate.notBlank(string);
-            fail("Expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            //then
-            assertEquals("The validated character sequence is blank", e.getMessage());
-        }
-    }
-
-    //-----------------------------------------------------------------------
-    @Test
-    void testNotBlankMsgBlankStringShouldThrow() {
-        //given
-        final String string = " \n \t \r \n ";
-
-        try {
-            //when
-            Validate.notBlank(string, "Message");
-            fail("Expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            //then
-            assertEquals("Message", e.getMessage());
-        }
-    }
-
-    //-----------------------------------------------------------------------
-    @Test
-    void testNotBlankMsgBlankStringWithWhitespacesShouldThrow() {
-        //given
-        final String string = "   ";
-
-        try {
-            //when
-            Validate.notBlank(string, "Message");
-            fail("Expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            //then
-            assertEquals("Message", e.getMessage());
-        }
-    }
-
-    //-----------------------------------------------------------------------
-    @Test
-    void testNotBlankMsgEmptyStringShouldThrow() {
-        //given
-        final String string = "";
-
-        try {
-            //when
-            Validate.notBlank(string, "Message");
-            fail("Expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            //then
-            assertEquals("Message", e.getMessage());
-        }
-    }
-
-    //-----------------------------------------------------------------------
-    @Test
-    void testNotBlankNotBlankStringShouldNotThrow() {
-        //given
-        final String string = "abc";
-
-        //when
-        Validate.notBlank(string);
-
-        //then should not throw
-    }
-
-    //-----------------------------------------------------------------------
-    @Test
-    void testNotBlankNotBlankStringWithWhitespacesShouldNotThrow() {
-        //given
-        final String string = "  abc   ";
-
-        //when
-        Validate.notBlank(string);
-
-        //then should not throw
-    }
-
-    //-----------------------------------------------------------------------
-    @Test
-    void testNotBlankNotBlankStringWithNewlinesShouldNotThrow() {
-        //given
-        final String string = " \n \t abc \r \n ";
-
-        //when
-        Validate.notBlank(string);
-
-        //then should not throw
-    }
-
-    //-----------------------------------------------------------------------
-    @Test
-    void testNotBlankMsgNotBlankStringShouldNotThrow() {
-        //given
-        final String string = "abc";
-
-        //when
-        Validate.notBlank(string, "Message");
-
-        //then should not throw
-    }
-
-    //-----------------------------------------------------------------------
-    @Test
-    void testNotBlankMsgNotBlankStringWithWhitespacesShouldNotThrow() {
-        //given
-        final String string = "  abc   ";
-
-        //when
-        Validate.notBlank(string, "Message");
-
-        //then should not throw
-    }
-
-    //-----------------------------------------------------------------------
-    @Test
-    void testNotBlankMsgNotBlankStringWithNewlinesShouldNotThrow() {
-        //given
-        final String string = " \n \t abc \r \n ";
-
-        //when
-        Validate.notBlank(string, "Message");
-
-        //then should not throw
-    }
-
-    //-----------------------------------------------------------------------
-    @Test
-    void testNotBlankReturnValues1() {
-        final String str = "Hi";
-        final String test = Validate.notBlank(str);
-        assertSame(str, test);
-    }
-
-    @Test
-    void testNotBlankReturnValues2() {
-        final String str = "Hi";
-        final String test = Validate.notBlank(str, "Message");
-        assertSame(str, test);
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/apache/commons/lang3/ValidateTest.java
+++ b/src/test/java/org/apache/commons/lang3/ValidateTest.java
@@ -45,6 +45,16 @@ import static org.junit.jupiter.api.Assertions.fail;
  */
 class ValidateTest {
 
+    @Test
+    void testConstructor() {
+        assertNotNull(new Validate());
+        final Constructor<?>[] cons = Validate.class.getDeclaredConstructors();
+        assertEquals(1, cons.length);
+        assertTrue(Modifier.isPublic(cons[0].getModifiers()));
+        assertTrue(Modifier.isPublic(Validate.class.getModifiers()));
+        assertFalse(Modifier.isFinal(Validate.class.getModifiers()));
+    }
+
     @Nested
     class IsTrue {
 
@@ -776,18 +786,6 @@ class ValidateTest {
                 }
             }
         }
-    }
-
-    //-----------------------------------------------------------------------
-    //-----------------------------------------------------------------------
-    @Test
-    void testConstructor() {
-        assertNotNull(new Validate());
-        final Constructor<?>[] cons = Validate.class.getDeclaredConstructors();
-        assertEquals(1, cons.length);
-        assertTrue(Modifier.isPublic(cons[0].getModifiers()));
-        assertTrue(Modifier.isPublic(Validate.class.getModifiers()));
-        assertFalse(Modifier.isFinal(Validate.class.getModifiers()));
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/apache/commons/lang3/ValidateTest.java
+++ b/src/test/java/org/apache/commons/lang3/ValidateTest.java
@@ -1167,53 +1167,79 @@ class ValidateTest {
         }
     }
 
+    @Nested
+    class Finite {
 
-    //-----------------------------------------------------------------------
-    //-----------------------------------------------------------------------
+        @Nested
+        class WithoutMessage {
 
-    @Test
-    void testFinite1() {
-        Validate.finite(0.0);
-        try {
-            Validate.finite(Double.POSITIVE_INFINITY);
-            fail("Expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException ex) {
-            assertEquals("The value is invalid: Infinity", ex.getMessage());
-        }
-        try {
-            Validate.finite(Double.NEGATIVE_INFINITY);
-            fail("Expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException ex) {
-            assertEquals("The value is invalid: -Infinity", ex.getMessage());
-        }
-        try {
-            Validate.finite(Double.NaN);
-            fail("Expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException ex) {
-            assertEquals("The value is invalid: NaN", ex.getMessage());
-        }
-    }
+            @Test
+            void shouldNotThrowExceptionForFiniteValue() {
+                Validate.finite(0.0);
+            }
 
-    @Test
-    void testFinite2() {
-        Validate.finite(0.0, "MSG");
-        try {
-            Validate.finite(Double.POSITIVE_INFINITY, "MSG");
-            fail("Expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException ex) {
-            assertEquals("MSG", ex.getMessage());
+            @Test
+            void shouldThrowIllegalArgumentExceptionWithDefaultMessageForPositiveInfinity() {
+                final IllegalArgumentException ex = assertThrows(
+                        IllegalArgumentException.class,
+                        () -> Validate.finite(Double.POSITIVE_INFINITY));
+
+                assertEquals("The value is invalid: Infinity", ex.getMessage());
+            }
+
+            @Test
+            void shouldThrowIllegalArgumentExceptionWithDefaultMessageForNegativeInfinity() {
+                final IllegalArgumentException ex = assertThrows(
+                        IllegalArgumentException.class,
+                        () -> Validate.finite(Double.NEGATIVE_INFINITY));
+
+                assertEquals("The value is invalid: -Infinity", ex.getMessage());
+            }
+
+            @Test
+            void shouldThrowIllegalArgumentExceptionWithDefaultMessageForNaN() {
+                final IllegalArgumentException ex = assertThrows(
+                        IllegalArgumentException.class,
+                        () -> Validate.finite(Double.NaN));
+
+                assertEquals("The value is invalid: NaN", ex.getMessage());
+            }
         }
-        try {
-            Validate.finite(Double.NEGATIVE_INFINITY, "MSG");
-            fail("Expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException ex) {
-            assertEquals("MSG", ex.getMessage());
-        }
-        try {
-            Validate.finite(Double.NaN, "MSG");
-            fail("Expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException ex) {
-            assertEquals("MSG", ex.getMessage());
+
+        @Nested
+        class WithMessage {
+
+            @Test
+            void shouldNotThrowExceptionForFiniteValue() {
+                Validate.finite(0.0, "MSG");
+            }
+
+            @Test
+            void shouldThrowIllegalArgumentExceptionWithDefaultMessageForPositiveInfinity() {
+                final IllegalArgumentException ex = assertThrows(
+                        IllegalArgumentException.class,
+                        () -> Validate.finite(Double.POSITIVE_INFINITY, "MSG"));
+
+                assertEquals("MSG", ex.getMessage());
+            }
+
+            @Test
+            void shouldThrowIllegalArgumentExceptionWithDefaultMessageForNegativeInfinity() {
+                final IllegalArgumentException ex = assertThrows(
+                        IllegalArgumentException.class,
+                        () -> Validate.finite(Double.NEGATIVE_INFINITY, "MSG"));
+
+                assertEquals("MSG", ex.getMessage());
+            }
+
+            @Test
+            void shouldThrowIllegalArgumentExceptionWithDefaultMessageForNaN() {
+                final IllegalArgumentException ex = assertThrows(
+                        IllegalArgumentException.class,
+                        () -> Validate.finite(Double.NaN, "MSG"));
+
+                assertEquals("MSG", ex.getMessage());
+            }
         }
     }
 

--- a/src/test/java/org/apache/commons/lang3/ValidateTest.java
+++ b/src/test/java/org/apache/commons/lang3/ValidateTest.java
@@ -626,106 +626,156 @@ class ValidateTest {
         }
     }
 
-    //-----------------------------------------------------------------------
-    //-----------------------------------------------------------------------
-    @Test
-    void testNoNullElementsArray1() {
-        String[] array = new String[]{"a", "b"};
-        Validate.noNullElements(array);
-        try {
-            Validate.noNullElements((Object[]) null);
-            fail("Expecting NullPointerException");
-        } catch (final NullPointerException ex) {
-            assertEquals("The validated object is null", ex.getMessage());
-        }
-        array[1] = null;
-        try {
-            Validate.noNullElements(array);
-            fail("Expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException ex) {
-            assertEquals("The validated array contains null element at index: 1", ex.getMessage());
+    @Nested
+    class NoNullElements {
+
+        @Nested
+        class WithArray {
+
+            @Nested
+            class WithoutMessage {
+
+                @Test
+                void shouldNotThrowExceptionForNonEmptyArray() {
+                    Validate.noNullElements(new String[]{"a", "b"});
+                }
+
+                @Test
+                void shouldReturnSameInstance() {
+                    final String[] array = {"a", "b"};
+                    final String[] result = Validate.noNullElements(array);
+
+                    assertSame(array, result);
+                }
+
+                @Test
+                void shouldThrowNullPointerExceptionWithDefaultMessageForNullArray() {
+                    final NullPointerException ex = assertThrows(
+                            NullPointerException.class,
+                            () -> Validate.noNullElements((Object[]) null));
+
+                    assertEquals("The validated object is null", ex.getMessage());
+                }
+
+                @Test
+                void shouldThrowIllegalArgumentExceptionWithDefaultMessageForArrayWithNullElement() {
+                    final IllegalArgumentException ex = assertThrows(
+                            IllegalArgumentException.class,
+                            () -> Validate.noNullElements(new String[]{"a", null}));
+
+                    assertEquals("The validated array contains null element at index: 1", ex.getMessage());
+                }
+            }
+
+            @Nested
+            class WithMessage {
+
+                @Test
+                void shouldNotThrowExceptionForNonEmptyArray() {
+                    Validate.noNullElements(new String[]{"a", "b"}, "MSG");
+                }
+
+                @Test
+                void shouldReturnSameInstance() {
+                    final String[] array = {"a", "b"};
+                    final String[] result = Validate.noNullElements(array, "MSG");
+
+                    assertSame(array, result);
+                }
+
+                @Test
+                void shouldThrowNullPointerExceptionWithDefaultMessageForNullArray() {
+                    final NullPointerException ex = assertThrows(
+                            NullPointerException.class,
+                            () -> Validate.noNullElements((Object[]) null, "MSG"));
+
+                    assertEquals("The validated object is null", ex.getMessage());
+                }
+
+                @Test
+                void shouldThrowIllegalArgumentExceptionWithGivenMessageForArrayWithNullElement() {
+                    final IllegalArgumentException ex = assertThrows(
+                            IllegalArgumentException.class,
+                            () -> Validate.noNullElements(new String[]{"a", null}, "MSG"));
+
+                    assertEquals("MSG", ex.getMessage());
+                }
+            }
         }
 
-        array = new String[]{"a", "b"};
-        final String[] test = Validate.noNullElements(array);
-        assertSame(array, test);
-    }
+        @Nested
+        class WithCollection {
 
-    //-----------------------------------------------------------------------
-    @Test
-    void testNoNullElementsArray2() {
-        String[] array = new String[]{"a", "b"};
-        Validate.noNullElements(array, "MSG");
-        try {
-            Validate.noNullElements((Object[]) null, "MSG");
-            fail("Expecting NullPointerException");
-        } catch (final NullPointerException ex) {
-            assertEquals("The validated object is null", ex.getMessage());
-        }
-        array[1] = null;
-        try {
-            Validate.noNullElements(array, "MSG");
-            fail("Expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException ex) {
-            assertEquals("MSG", ex.getMessage());
-        }
+            @Nested
+            class WithoutMessage {
 
-        array = new String[]{"a", "b"};
-        final String[] test = Validate.noNullElements(array, "Message");
-        assertSame(array, test);
-    }
+                @Test
+                void shouldNotThrowExceptionForNonEmptyCollection() {
+                    Validate.noNullElements(Collections.singleton("a"));
+                }
 
-    //-----------------------------------------------------------------------
-    //-----------------------------------------------------------------------
-    @Test
-    void testNoNullElementsCollection1() {
-        final List<String> coll = new ArrayList<>();
-        coll.add("a");
-        coll.add("b");
-        Validate.noNullElements(coll);
-        try {
-            Validate.noNullElements((Collection<?>) null);
-            fail("Expecting NullPointerException");
-        } catch (final NullPointerException ex) {
-            assertEquals("The validated object is null", ex.getMessage());
-        }
-        coll.set(1, null);
-        try {
-            Validate.noNullElements(coll);
-            fail("Expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException ex) {
-            assertEquals("The validated collection contains null element at index: 1", ex.getMessage());
-        }
+                @Test
+                void shouldReturnSameInstance() {
+                    Set<String> col = Collections.singleton("a");
+                    final Set<String> result = Validate.noNullElements(col);
 
-        coll.set(1, "b");
-        final List<String> test = Validate.noNullElements(coll);
-        assertSame(coll, test);
-    }
+                    assertSame(col, result);
+                }
 
-    //-----------------------------------------------------------------------
-    @Test
-    void testNoNullElementsCollection2() {
-        final List<String> coll = new ArrayList<>();
-        coll.add("a");
-        coll.add("b");
-        Validate.noNullElements(coll, "MSG");
-        try {
-            Validate.noNullElements((Collection<?>) null, "MSG");
-            fail("Expecting NullPointerException");
-        } catch (final NullPointerException ex) {
-            assertEquals("The validated object is null", ex.getMessage());
-        }
-        coll.set(1, null);
-        try {
-            Validate.noNullElements(coll, "MSG");
-            fail("Expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException ex) {
-            assertEquals("MSG", ex.getMessage());
-        }
+                @Test
+                void shouldThrowNullPointerExceptionWithDefaultMessageForNullCollection() {
+                    final NullPointerException ex = assertThrows(
+                            NullPointerException.class,
+                            () -> Validate.noNullElements((Collection<?>) null));
 
-        coll.set(1, "b");
-        final List<String> test = Validate.noNullElements(coll, "Message");
-        assertSame(coll, test);
+                    assertEquals("The validated object is null", ex.getMessage());
+                }
+
+                @Test
+                void shouldThrowIllegalArgumentExceptionWithDefaultMessageForCollectionWithNullElement() {
+                    final IllegalArgumentException ex = assertThrows(
+                            IllegalArgumentException.class,
+                            () -> Validate.noNullElements(Collections.singleton(null)));
+
+                    assertEquals("The validated collection contains null element at index: 0", ex.getMessage());
+                }
+            }
+
+            @Nested
+            class WithMessage {
+
+                @Test
+                void shouldNotThrowExceptionForNonEmptyCollection() {
+                    Validate.noNullElements(Collections.singleton("a"), "MSG");
+                }
+
+                @Test
+                void shouldReturnSameInstance() {
+                    Set<String> col = Collections.singleton("a");
+                    final Set<String> result = Validate.noNullElements(col, "MSG");
+
+                    assertSame(col, result);
+                }
+
+                @Test
+                void shouldThrowNullPointerExceptionWithDefaultMessageForNullCollection() {
+                    final NullPointerException ex = assertThrows(
+                            NullPointerException.class,
+                            () -> Validate.noNullElements((Collection<?>) null, "MSG"));
+
+                    assertEquals("The validated object is null", ex.getMessage());
+                }
+
+                @Test
+                void shouldThrowIllegalArgumentExceptionWithGivenMessageForCollectionWithNullElement() {
+                    final IllegalArgumentException ex = assertThrows(
+                            IllegalArgumentException.class,
+                            () -> Validate.noNullElements(Collections.singleton(null), "MSG"));
+
+                    assertEquals("MSG", ex.getMessage());
+                }
+            }
+        }
     }
 
     //-----------------------------------------------------------------------


### PR DESCRIPTION
Proposal for a better structure of tests using `@Nested`. Each method should have it's own `@Nested` container which is called like the method. Inside that container each overload has it's own `@Nested` container. I did this for `Validate.isTrue` to show the approach.