### PR TITLE
Move combine.children to manifestEntries in order to have right entries in MANIFEST.MF

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -709,8 +709,8 @@
           </execution>
         </executions>
         <configuration>
-          <archive combine.children="append">
-            <manifestEntries>
+          <archive>
+            <manifestEntries combine.children="append">
               <Automatic-Module-Name>${commons.module.name}</Automatic-Module-Name>
             </manifestEntries>
           </archive>


### PR DESCRIPTION
Hi,

While working on Commons Imaging 1.0-alpha release candidate, I noticed that after copying most of the entries missing from Commons Lang's `pom.xml`, I couldn't pass the [step](https://commons.apache.org/releases/prepare.html) that asks to check for `X-Compile-Source-JDK` in `MANIFEST.MF` .

After some troubleshooting (and updating my Maven for the just-in-case), I realized that the combine.child seemed to result in `manifestEntries` child node being replaced.

But moving the `combine.child` to the `manifestEntries` made more sense, as that's the key that we want Maven to append parent+child.

Tested locally in Commons Imaging, and also in Commons Lang. After this change, I can successfully see the entries in the Lang's new MANIFEST.MF generated locally.

```
...
Bundle-Version: 3.9.0.SNAPSHOT
X-Compile-Target-JDK: 1.8
Implementation-Build: master@r6dc3a6db11d7e63c960ccc6cf48aa15d6f00e903
 ; 2018-09-08 10:35:11+0000
X-Compile-Source-JDK: 1.8
Created-By: Apache Maven Bundle Plugin
Build-Jdk: 1.8.0_181
...
```

Cheers
Bruno