### PR TITLE
Add a check to StringUtils.repeat() for large length repeat value

### DIFF
--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -6075,8 +6075,8 @@ public class StringUtils {
             end = temp;
         }
         return str.substring(0, start) +
-                overlay +
-                str.substring(end);
+            overlay +
+            str.substring(end);
     }
 
     // Chomping

--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -6075,8 +6075,8 @@ public class StringUtils {
             end = temp;
         }
         return str.substring(0, start) +
-            overlay +
-            str.substring(end);
+                overlay +
+                str.substring(end);
     }
 
     // Chomping
@@ -6222,6 +6222,7 @@ public class StringUtils {
      * StringUtils.repeat("a", 3)  = "aaa"
      * StringUtils.repeat("ab", 2) = "abab"
      * StringUtils.repeat("a", -2) = ""
+     * StringUtils.repeat("aaa", Integer.MAX_VALUE) = throws an ArrayIndexOutOfBoundsException
      * </pre>
      *
      * @param str  the String to repeat, may be null
@@ -6246,7 +6247,13 @@ public class StringUtils {
             return repeat(str.charAt(0), repeat);
         }
 
-        final int outputLength = inputLength * repeat;
+        final long longSize = (long) inputLength * (long) repeat;
+        final int outputLength = (int) longSize;
+
+        if (outputLength != longSize) {
+            throw new ArrayIndexOutOfBoundsException("Required string length is too large: " + longSize);
+        }
+
         switch (inputLength) {
             case 1 :
                 return repeat(str.charAt(0), repeat);
@@ -6820,7 +6827,7 @@ public class StringUtils {
             final int codepoint = str.codePointAt(inOffset);
             newCodePoints[outOffset++] = codepoint; // copy the remaining ones
             inOffset += Character.charCount(codepoint);
-         }
+        }
         return new String(newCodePoints, 0, outOffset);
     }
 

--- a/src/test/java/org/apache/commons/lang3/StringUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringUtilsTest.java
@@ -1592,6 +1592,12 @@ public class StringUtilsTest {
         final String str = StringUtils.repeat("a", 10000);  // bigger than pad limit
         assertEquals(10000, str.length());
         assertTrue(StringUtils.containsOnly(str, 'a'));
+        try {
+            StringUtils.repeat("aaa",Integer.MAX_VALUE);
+            fail("StringUtils.repeat expecting ArrayIndexOutOfBoundsException");
+        } catch (final ArrayIndexOutOfBoundsException ex) {
+            // empty
+        }
     }
 
     @Test


### PR DESCRIPTION
I have added a check to ensure that the resultant String from the repeat is not larger than the maximum allowed length.