### PR TITLE
Update builder tests to JUnit Jupiter

### DIFF
--- a/src/test/java/org/apache/commons/lang3/builder/CompareToBuilderTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/CompareToBuilderTest.java
@@ -16,12 +16,13 @@
  */
 package org.apache.commons.lang3.builder;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.math.BigInteger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests {@link org.apache.commons.lang3.builder.CompareToBuilder}.
@@ -107,17 +108,17 @@ public class CompareToBuilderTest {
         assertTrue(CompareToBuilder.reflectionCompare(o2, o1) > 0);
     }
 
-    @Test(expected=NullPointerException.class)
+    @Test
     public void testReflectionCompareEx1() {
         final TestObject o1 = new TestObject(4);
-        CompareToBuilder.reflectionCompare(o1, null);
+        assertThrows(NullPointerException.class, () -> CompareToBuilder.reflectionCompare(o1, null));
     }
 
-    @Test(expected=ClassCastException.class)
+    @Test
     public void testReflectionCompareEx2() {
         final TestObject o1 = new TestObject(4);
         final Object o2 = new Object();
-        CompareToBuilder.reflectionCompare(o1, o2);
+        assertThrows(ClassCastException.class, () -> CompareToBuilder.reflectionCompare(o1, o2));
     }
 
     @Test
@@ -289,11 +290,11 @@ public class CompareToBuilderTest {
         assertTrue(new CompareToBuilder().append(null, o1).build().intValue() < 0);
     }
 
-    @Test(expected=ClassCastException.class)
+    @Test
     public void testObjectEx2() {
         final TestObject o1 = new TestObject(4);
         final Object o2 = new Object();
-        new CompareToBuilder().append(o1, o2);
+        assertThrows(ClassCastException.class, () -> new CompareToBuilder().append(o1, o2));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/builder/DefaultToStringStyleTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/DefaultToStringStyleTest.java
@@ -16,15 +16,15 @@
  */
 package org.apache.commons.lang3.builder;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 
 import org.apache.commons.lang3.builder.ToStringStyleTest.Person;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests {@link org.apache.commons.lang3.builder.DefaultToStringStyleTest}.
@@ -34,12 +34,12 @@ public class DefaultToStringStyleTest {
     private final Integer base = Integer.valueOf(5);
     private final String baseStr = base.getClass().getName() + "@" + Integer.toHexString(System.identityHashCode(base));
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         ToStringBuilder.setDefaultStyle(ToStringStyle.DEFAULT_STYLE);
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         ToStringBuilder.setDefaultStyle(ToStringStyle.DEFAULT_STYLE);
     }

--- a/src/test/java/org/apache/commons/lang3/builder/DiffBuilderTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/DiffBuilderTest.java
@@ -16,16 +16,17 @@
  */
 package org.apache.commons.lang3.builder;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.hamcrest.Matcher;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 
 /**
@@ -424,15 +425,15 @@ public class DiffBuilderTest {
         assertEquals("prop1.int", list.getDiffs().get(0).getFieldName());
     }
 
-    @Test(expected=IllegalArgumentException.class)
+    @Test
     public void testNullLhs() {
-        new DiffBuilder(null, this, ToStringStyle.DEFAULT_STYLE);
+        assertThrows(IllegalArgumentException.class, () -> new DiffBuilder(null, this, ToStringStyle.DEFAULT_STYLE));
     }
 
 
-    @Test(expected=IllegalArgumentException.class)
+    @Test
     public void testNullRhs() {
-        new DiffBuilder(this, null, ToStringStyle.DEFAULT_STYLE);
+        assertThrows(IllegalArgumentException.class, () -> new DiffBuilder(this, null, ToStringStyle.DEFAULT_STYLE));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/builder/DiffResultTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/DiffResultTest.java
@@ -16,13 +16,14 @@
  */
 package org.apache.commons.lang3.builder;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Iterator;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests {@link DiffResult}.
@@ -55,7 +56,7 @@ public class DiffResultTest {
     private static class EmptyClass {
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testListIsNonModifiable() {
         final SimpleClass lhs = new SimpleClass(true);
         final SimpleClass rhs = new SimpleClass(false);
@@ -65,7 +66,7 @@ public class DiffResultTest {
         final DiffResult list = new DiffResult(lhs, rhs, diffs, SHORT_STYLE);
         assertEquals(diffs, list.getDiffs());
         assertEquals(1, list.getNumberOfDiffs());
-        list.getDiffs().remove(0);
+        assertThrows(UnsupportedOperationException.class, () -> list.getDiffs().remove(0));
     }
 
     @Test
@@ -114,21 +115,22 @@ public class DiffResultTest {
                 list.toString(ToStringStyle.MULTI_LINE_STYLE));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNullLhs() {
-        new DiffResult(null, SIMPLE_FALSE, SIMPLE_TRUE.diff(SIMPLE_FALSE)
-                .getDiffs(), SHORT_STYLE);
+        assertThrows(IllegalArgumentException.class,
+            () ->  new DiffResult(null, SIMPLE_FALSE, SIMPLE_TRUE.diff(SIMPLE_FALSE).getDiffs(), SHORT_STYLE));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNullRhs() {
-        new DiffResult(SIMPLE_TRUE, null, SIMPLE_TRUE.diff(SIMPLE_FALSE)
-                .getDiffs(), SHORT_STYLE);
+        assertThrows(IllegalArgumentException.class,
+            () -> new DiffResult(SIMPLE_TRUE, null, SIMPLE_TRUE.diff(SIMPLE_FALSE).getDiffs(), SHORT_STYLE));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNullList() {
-        new DiffResult(SIMPLE_TRUE, SIMPLE_FALSE, null, SHORT_STYLE);
+        assertThrows(IllegalArgumentException.class,
+            () -> new DiffResult(SIMPLE_TRUE, SIMPLE_FALSE, null, SHORT_STYLE));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/builder/DiffTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/DiffTest.java
@@ -16,9 +16,10 @@
  */
 package org.apache.commons.lang3.builder;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 
 /**
@@ -47,9 +48,9 @@ public class DiffTest {
         }
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testCannotModify() {
-        booleanDiff.setValue(Boolean.FALSE);
+        assertThrows(UnsupportedOperationException.class, () -> booleanDiff.setValue(Boolean.FALSE));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/builder/EqualsBuilderTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/EqualsBuilderTest.java
@@ -16,16 +16,16 @@
  */
 package org.apache.commons.lang3.builder;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.Method;
 import java.util.Arrays;
 
 import org.apache.commons.lang3.reflect.MethodUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests {@link org.apache.commons.lang3.builder.EqualsBuilder}.

--- a/src/test/java/org/apache/commons/lang3/builder/HashCodeBuilderAndEqualsBuilderTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/HashCodeBuilderAndEqualsBuilderTest.java
@@ -16,9 +16,9 @@
  */
 package org.apache.commons.lang3.builder;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests {@link org.apache.commons.lang3.builder.HashCodeBuilder} and

--- a/src/test/java/org/apache/commons/lang3/builder/HashCodeBuilderTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/HashCodeBuilderTest.java
@@ -17,9 +17,11 @@
 
 package org.apache.commons.lang3.builder;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests {@link org.apache.commons.lang3.builder.HashCodeBuilder}.
@@ -52,24 +54,24 @@ public class HashCodeBuilderTest {
 
     // -----------------------------------------------------------------------
 
-    @Test(expected=IllegalArgumentException.class)
+    @Test
     public void testConstructorExZero() {
-        new HashCodeBuilder(0, 0);
+        assertThrows(IllegalArgumentException.class, () -> new HashCodeBuilder(0, 0));
     }
 
-    @Test(expected=IllegalArgumentException.class)
+    @Test
     public void testConstructorExEvenFirst() {
-        new HashCodeBuilder(2, 3);
+        assertThrows(IllegalArgumentException.class, () -> new HashCodeBuilder(2, 3));
     }
 
-    @Test(expected=IllegalArgumentException.class)
+    @Test
     public void testConstructorExEvenSecond() {
-        new HashCodeBuilder(3, 2);
+        assertThrows(IllegalArgumentException.class, () -> new HashCodeBuilder(3, 2));
     }
 
-    @Test(expected=IllegalArgumentException.class)
+    @Test
     public void testConstructorExEvenNegative() {
-        new HashCodeBuilder(-2, -2);
+        assertThrows(IllegalArgumentException.class, () -> new HashCodeBuilder(-2, -2));
     }
 
     static class TestObject {
@@ -156,29 +158,29 @@ public class HashCodeBuilderTest {
                 123456, 7890, 0), true));
     }
 
-    @Test(expected=IllegalArgumentException.class)
+    @Test
     public void testReflectionHierarchyHashCodeEx1() {
-        HashCodeBuilder.reflectionHashCode(0, 0, new TestSubObject(0, 0, 0), true);
+        assertThrows(IllegalArgumentException.class, () -> HashCodeBuilder.reflectionHashCode(0, 0, new TestSubObject(0, 0, 0), true));
     }
 
-    @Test(expected=IllegalArgumentException.class)
+    @Test
     public void testReflectionHierarchyHashCodeEx2() {
-        HashCodeBuilder.reflectionHashCode(2, 2, new TestSubObject(0, 0, 0), true);
+        assertThrows(IllegalArgumentException.class, () -> HashCodeBuilder.reflectionHashCode(2, 2, new TestSubObject(0, 0, 0), true));
     }
 
-    @Test(expected=IllegalArgumentException.class)
+    @Test
     public void testReflectionHashCodeEx1() {
-        HashCodeBuilder.reflectionHashCode(0, 0, new TestObject(0), true);
+        assertThrows(IllegalArgumentException.class, () -> HashCodeBuilder.reflectionHashCode(0, 0, new TestObject(0), true));
     }
 
-    @Test(expected=IllegalArgumentException.class)
+    @Test
     public void testReflectionHashCodeEx2() {
-        HashCodeBuilder.reflectionHashCode(2, 2, new TestObject(0), true);
+        assertThrows(IllegalArgumentException.class, () -> HashCodeBuilder.reflectionHashCode(2, 2, new TestObject(0), true));
     }
 
-    @Test(expected=IllegalArgumentException.class)
+    @Test
     public void testReflectionHashCodeEx3() {
-        HashCodeBuilder.reflectionHashCode(13, 19, null, true);
+        assertThrows(IllegalArgumentException.class, () -> HashCodeBuilder.reflectionHashCode(13, 19, null, true));
     }
 
     @Test
@@ -559,8 +561,8 @@ public class HashCodeBuilderTest {
     @Test
     public void testToHashCodeEqualsHashCode() {
         final HashCodeBuilder hcb = new HashCodeBuilder(17, 37).append(new Object()).append('a');
-        assertEquals("hashCode() is no longer returning the same value as toHashCode() - see LANG-520",
-                     hcb.toHashCode(), hcb.hashCode());
+        assertEquals(hcb.toHashCode(), hcb.hashCode(),
+            "hashCode() is no longer returning the same value as toHashCode() - see LANG-520");
     }
 
     static class TestObjectHashCodeExclude {

--- a/src/test/java/org/apache/commons/lang3/builder/JsonToStringStyleTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/JsonToStringStyleTest.java
@@ -16,17 +16,17 @@
  */
 package org.apache.commons.lang3.builder;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 
 import org.apache.commons.lang3.builder.ToStringStyleTest.Person;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests {@link org.apache.commons.lang3.builder.JsonToStringStyleTest}.
@@ -35,12 +35,12 @@ public class JsonToStringStyleTest {
 
     private final Integer base = Integer.valueOf(5);
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         ToStringBuilder.setDefaultStyle(ToStringStyle.JSON_STYLE);
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         ToStringBuilder.setDefaultStyle(ToStringStyle.DEFAULT_STYLE);
     }

--- a/src/test/java/org/apache/commons/lang3/builder/MultiLineToStringStyleTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/MultiLineToStringStyleTest.java
@@ -16,15 +16,15 @@
  */
 package org.apache.commons.lang3.builder;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 
 import org.apache.commons.lang3.builder.ToStringStyleTest.Person;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests {@link org.apache.commons.lang3.builder.MultiLineToStringStyleTest}.
@@ -34,12 +34,12 @@ public class MultiLineToStringStyleTest {
     private final Integer base = Integer.valueOf(5);
     private final String baseStr = base.getClass().getName() + "@" + Integer.toHexString(System.identityHashCode(base));
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         ToStringBuilder.setDefaultStyle(ToStringStyle.MULTI_LINE_STYLE);
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         ToStringBuilder.setDefaultStyle(ToStringStyle.DEFAULT_STYLE);
     }

--- a/src/test/java/org/apache/commons/lang3/builder/MultilineRecursiveToStringStyleTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/MultilineRecursiveToStringStyleTest.java
@@ -17,12 +17,12 @@
 
 package org.apache.commons.lang3.builder;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  */

--- a/src/test/java/org/apache/commons/lang3/builder/NoClassNameToStringStyleTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/NoClassNameToStringStyleTest.java
@@ -17,14 +17,14 @@
 package org.apache.commons.lang3.builder;
 
 import org.apache.commons.lang3.builder.ToStringStyleTest.Person;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Unit tests {@link ToStringStyle#NO_CLASS_NAME_STYLE}.
@@ -33,12 +33,12 @@ public class NoClassNameToStringStyleTest {
 
     private final Integer base = Integer.valueOf(5);
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         ToStringBuilder.setDefaultStyle(ToStringStyle.NO_CLASS_NAME_STYLE);
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         ToStringBuilder.setDefaultStyle(ToStringStyle.DEFAULT_STYLE);
     }

--- a/src/test/java/org/apache/commons/lang3/builder/NoFieldNamesToStringStyleTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/NoFieldNamesToStringStyleTest.java
@@ -16,15 +16,15 @@
  */
 package org.apache.commons.lang3.builder;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 
 import org.apache.commons.lang3.builder.ToStringStyleTest.Person;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests {@link org.apache.commons.lang3.builder.NoFieldNamesToStringStyleTest}.
@@ -34,12 +34,12 @@ public class NoFieldNamesToStringStyleTest {
     private final Integer base = Integer.valueOf(5);
     private final String baseStr = base.getClass().getName() + "@" + Integer.toHexString(System.identityHashCode(base));
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         ToStringBuilder.setDefaultStyle(ToStringStyle.NO_FIELD_NAMES_STYLE);
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         ToStringBuilder.setDefaultStyle(ToStringStyle.DEFAULT_STYLE);
     }

--- a/src/test/java/org/apache/commons/lang3/builder/RecursiveToStringStyleTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/RecursiveToStringStyleTest.java
@@ -16,14 +16,14 @@
  */
 package org.apache.commons.lang3.builder;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests {@link org.apache.commons.lang3.builder.RecursiveToStringStyleTest}.
@@ -33,12 +33,12 @@ public class RecursiveToStringStyleTest {
     private final Integer base = Integer.valueOf(5);
     private final String baseStr = base.getClass().getName() + "@" + Integer.toHexString(System.identityHashCode(base));
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         ToStringBuilder.setDefaultStyle(new RecursiveToStringStyle());
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         ToStringBuilder.setDefaultStyle(ToStringStyle.DEFAULT_STYLE);
     }

--- a/src/test/java/org/apache/commons/lang3/builder/ReflectionDiffBuilderTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/ReflectionDiffBuilderTest.java
@@ -16,9 +16,9 @@
  */
 package org.apache.commons.lang3.builder;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 
 public class ReflectionDiffBuilderTest {

--- a/src/test/java/org/apache/commons/lang3/builder/ReflectionToStringBuilderConcurrencyTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/ReflectionToStringBuilderConcurrencyTest.java
@@ -17,7 +17,8 @@
 
 package org.apache.commons.lang3.builder;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -31,9 +32,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests concurrent access for {@link ReflectionToStringBuilder}.
@@ -63,19 +63,19 @@ public class ReflectionToStringBuilderConcurrencyTest {
     private static final int REPEAT = 100;
 
     @Test
-    @Ignore
+    @Disabled
     public void testLinkedList() throws InterruptedException, ExecutionException {
         this.testConcurrency(new CollectionHolder<>(new LinkedList<>()));
     }
 
     @Test
-    @Ignore
+    @Disabled
     public void testArrayList() throws InterruptedException, ExecutionException {
         this.testConcurrency(new CollectionHolder<>(new ArrayList<>()));
     }
 
     @Test
-    @Ignore
+    @Disabled
     public void testCopyOnWriteArrayList() throws InterruptedException, ExecutionException {
         this.testConcurrency(new CollectionHolder<>(new CopyOnWriteArrayList<>()));
     }
@@ -95,7 +95,7 @@ public class ReflectionToStringBuilderConcurrencyTest {
             public Integer call() {
                 for (int i = 0; i < REPEAT; i++) {
                     final String s = ReflectionToStringBuilder.toString(holder);
-                    Assert.assertNotNull(s);
+                    assertNotNull(s);
                 }
                 return Integer.valueOf(REPEAT);
             }

--- a/src/test/java/org/apache/commons/lang3/builder/ReflectionToStringBuilderExcludeNullValuesTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/ReflectionToStringBuilderExcludeNullValuesTest.java
@@ -17,10 +17,10 @@
 
 package org.apache.commons.lang3.builder;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ReflectionToStringBuilderExcludeNullValuesTest {
 

--- a/src/test/java/org/apache/commons/lang3/builder/ReflectionToStringBuilderExcludeTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/ReflectionToStringBuilderExcludeTest.java
@@ -17,15 +17,15 @@
 
 package org.apache.commons.lang3.builder;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
 import org.apache.commons.lang3.ArrayUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  */

--- a/src/test/java/org/apache/commons/lang3/builder/ReflectionToStringBuilderExcludeWithAnnotationTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/ReflectionToStringBuilderExcludeWithAnnotationTest.java
@@ -19,9 +19,9 @@ package org.apache.commons.lang3.builder;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test class for ToStringExclude annotation

--- a/src/test/java/org/apache/commons/lang3/builder/ReflectionToStringBuilderMutateInspectConcurrencyTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/ReflectionToStringBuilderMutateInspectConcurrencyTest.java
@@ -20,8 +20,8 @@ package org.apache.commons.lang3.builder;
 import java.util.LinkedList;
 import java.util.Random;
 
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests concurrent access for {@link ReflectionToStringBuilder}.
@@ -90,7 +90,7 @@ public class ReflectionToStringBuilderMutateInspectConcurrencyTest {
     }
 
     @Test
-    @Ignore
+    @Disabled
     public void testConcurrency() throws Exception {
         final TestFixture testFixture = new TestFixture();
         final int numMutators = 10;

--- a/src/test/java/org/apache/commons/lang3/builder/ReflectionToStringBuilderSummaryTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/ReflectionToStringBuilderSummaryTest.java
@@ -16,8 +16,9 @@
  */
 package org.apache.commons.lang3.builder;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ReflectionToStringBuilderSummaryTest {
 
@@ -29,7 +30,7 @@ public class ReflectionToStringBuilderSummaryTest {
 
     @Test
     public void testSummary() {
-        Assert.assertEquals("[stringField=string,summaryString=<String>]",
+        assertEquals("[stringField=string,summaryString=<String>]",
                 new ReflectionToStringBuilder(this, ToStringStyle.NO_CLASS_NAME_STYLE).build());
     }
 

--- a/src/test/java/org/apache/commons/lang3/builder/ReflectionToStringBuilderTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/ReflectionToStringBuilderTest.java
@@ -16,13 +16,16 @@
  */
 package org.apache.commons.lang3.builder;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ReflectionToStringBuilderTest {
 
-    @Test(expected=IllegalArgumentException.class)
+    @Test
     public void testConstructorWithNullObject() {
-        new ReflectionToStringBuilder(null, ToStringStyle.DEFAULT_STYLE, new StringBuffer());
+        assertThrows(IllegalArgumentException.class,
+            () -> new ReflectionToStringBuilder(null, ToStringStyle.DEFAULT_STYLE, new StringBuffer()));
     }
 
 }

--- a/src/test/java/org/apache/commons/lang3/builder/ShortPrefixToStringStyleTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/ShortPrefixToStringStyleTest.java
@@ -16,15 +16,15 @@
  */
 package org.apache.commons.lang3.builder;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 
 import org.apache.commons.lang3.builder.ToStringStyleTest.Person;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests {@link org.apache.commons.lang3.builder.ToStringStyle#SHORT_PREFIX_STYLE}.
@@ -34,12 +34,12 @@ public class ShortPrefixToStringStyleTest {
     private final Integer base = Integer.valueOf(5);
     private final String baseStr = "Integer";
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         ToStringBuilder.setDefaultStyle(ToStringStyle.SHORT_PREFIX_STYLE);
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         ToStringBuilder.setDefaultStyle(ToStringStyle.DEFAULT_STYLE);
     }

--- a/src/test/java/org/apache/commons/lang3/builder/SimpleToStringStyleTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/SimpleToStringStyleTest.java
@@ -16,15 +16,15 @@
  */
 package org.apache.commons.lang3.builder;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 
 import org.apache.commons.lang3.builder.ToStringStyleTest.Person;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests {@link org.apache.commons.lang3.builder.SimpleToStringStyleTest}.
@@ -33,12 +33,12 @@ public class SimpleToStringStyleTest {
 
     private final Integer base = Integer.valueOf(5);
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         ToStringBuilder.setDefaultStyle(ToStringStyle.SIMPLE_STYLE);
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         ToStringBuilder.setDefaultStyle(ToStringStyle.DEFAULT_STYLE);
     }

--- a/src/test/java/org/apache/commons/lang3/builder/StandardToStringStyleTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/StandardToStringStyleTest.java
@@ -16,15 +16,15 @@
  */
 package org.apache.commons.lang3.builder;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 
 import org.apache.commons.lang3.builder.ToStringStyleTest.Person;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests {@link org.apache.commons.lang3.builder.ToStringStyle}.
@@ -49,12 +49,12 @@ public class StandardToStringStyleTest {
         STYLE.setSummaryObjectEndText("%");
     }
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         ToStringBuilder.setDefaultStyle(STYLE);
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         ToStringBuilder.setDefaultStyle(ToStringStyle.DEFAULT_STYLE);
     }

--- a/src/test/java/org/apache/commons/lang3/builder/ToStringBuilderTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/ToStringBuilderTest.java
@@ -16,11 +16,12 @@
  */
 package org.apache.commons.lang3.builder;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assume.assumeFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -28,8 +29,8 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang3.SystemUtils;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for {@link org.apache.commons.lang3.builder.ToStringBuilder}.
@@ -44,7 +45,7 @@ public class ToStringBuilderTest {
     /*
      * All tests should leave the registry empty.
      */
-    @After
+    @AfterEach
     public void after(){
         validateNullToStringStyleRegistry();
     }
@@ -80,9 +81,9 @@ public class ToStringBuilderTest {
         }
     }
 
-    @Test(expected=IllegalArgumentException.class)
+    @Test
     public void testSetDefaultEx() {
-        ToStringBuilder.setDefaultStyle(null);
+        assertThrows(IllegalArgumentException.class, () -> ToStringBuilder.setDefaultStyle(null));
     }
 
     @Test
@@ -594,7 +595,7 @@ public class ToStringBuilderTest {
 
     void validateNullToStringStyleRegistry() {
         final Map<Object, Object> registry = ToStringStyle.getRegistry();
-        assertNull("Expected null, actual: "+registry, registry);
+        assertNull(registry, "Expected null, actual: " + registry);
     }
     //  End: Reflection cycle tests
 
@@ -1242,15 +1243,12 @@ public class ToStringBuilderTest {
     /**
      * Tests ReflectionToStringBuilder setUpToClass().
      */
-    @Test(expected=IllegalArgumentException.class)
+    @Test
     public void test_setUpToClass_invalid() {
         final Integer val = Integer.valueOf(5);
         final ReflectionToStringBuilder test = new ReflectionToStringBuilder(val);
-        try {
-            test.setUpToClass(String.class);
-        } finally {
-            test.toString();
-        }
+        assertThrows(IllegalArgumentException.class, () -> test.setUpToClass(String.class));
+        test.toString();
     }
 
     /**
@@ -1283,9 +1281,9 @@ public class ToStringBuilderTest {
         static final int staticInt2 = 67890;
     }
 
-    @Test(expected=IllegalArgumentException.class)
+    @Test
     public void testReflectionNull() {
-        assertEquals("<null>", ReflectionToStringBuilder.toString(null));
+        assertThrows(IllegalArgumentException.class, () -> ReflectionToStringBuilder.toString(null));
     }
 
     /**

--- a/src/test/java/org/apache/commons/lang3/builder/ToStringStyleConcurrencyTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/ToStringStyleConcurrencyTest.java
@@ -29,7 +29,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests concurrent access for the default {@link ToStringStyle}.

--- a/src/test/java/org/apache/commons/lang3/builder/ToStringStyleTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/ToStringStyleTest.java
@@ -16,9 +16,9 @@
  */
 package org.apache.commons.lang3.builder;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test case for ToStringStyle.


### PR DESCRIPTION
Upgrade the tests in the `builder` package to use JUnit Jupiter as part of the effort to remove the dependency on the Vintage Engine.

While most of these changes are drop-in replacements with no functional benefit, it is worth mentioning the change to how expected exceptions are tested.
Unlike `org.junit.Test`, `org.junit.jupiter.api.Test` does not have an `expected` argument. Instead, an explicit call to `org.junit.jupiter.api.Assertions.assertThrows` is used. This call allows the test to pinpoint the exact statement that is expected to throw the exception and allows making the tests a bit stricter by preventing
false-positives that could occur if the setup code would throw the expected exception instead of the statement that was supposed to throw it.