### PR TITLE
Update event tests to JUnit Jupiter

### DIFF
--- a/src/test/java/org/apache/commons/lang3/event/EventListenerSupportTest.java
+++ b/src/test/java/org/apache/commons/lang3/event/EventListenerSupportTest.java
@@ -17,8 +17,9 @@
 
 package org.apache.commons.lang3.event;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyVetoException;
@@ -34,7 +35,7 @@ import java.util.Date;
 import java.util.List;
 
 import org.easymock.EasyMock;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @since 3.0
@@ -61,16 +62,16 @@ public class EventListenerSupportTest {
         assertSame(empty, listenerSupport.getListeners());
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testAddNullListener() {
         final EventListenerSupport<VetoableChangeListener> listenerSupport = EventListenerSupport.create(VetoableChangeListener.class);
-        listenerSupport.addListener(null);
+        assertThrows(NullPointerException.class, () -> listenerSupport.addListener(null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testRemoveNullListener() {
         final EventListenerSupport<VetoableChangeListener> listenerSupport = EventListenerSupport.create(VetoableChangeListener.class);
-        listenerSupport.removeListener(null);
+        assertThrows(NullPointerException.class, () -> listenerSupport.removeListener(null));
     }
 
     @Test
@@ -88,14 +89,14 @@ public class EventListenerSupportTest {
         assertSame(calledListeners.get(1), listener2);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateWithNonInterfaceParameter() {
-        EventListenerSupport.create(String.class);
+        assertThrows(IllegalArgumentException.class, () -> EventListenerSupport.create(String.class));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testCreateWithNullParameter() {
-        EventListenerSupport.create(null);
+        assertThrows(NullPointerException.class, () -> EventListenerSupport.create(null));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/event/EventUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/event/EventUtilsTest.java
@@ -16,10 +16,11 @@
  */
 package org.apache.commons.lang3.event;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
@@ -35,18 +36,12 @@ import java.util.TreeMap;
 
 import javax.naming.event.ObjectChangeListener;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 /**
  * @since 3.0
  */
 public class EventUtilsTest {
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
-
     @Test
     public void testConstructor() {
         assertNotNull(new EventUtils());
@@ -74,21 +69,23 @@ public class EventUtilsTest {
         final PropertyChangeSource src = new PropertyChangeSource();
         final EventCountingInvociationHandler handler = new EventCountingInvociationHandler();
         final ObjectChangeListener listener = handler.createListener(ObjectChangeListener.class);
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Class " + src.getClass().getName() + " does not have a public add" + ObjectChangeListener.class.getSimpleName() + " method which takes a parameter of type " + ObjectChangeListener.class.getName() + ".");
-        EventUtils.addEventListener(src, ObjectChangeListener.class, listener);
+        IllegalArgumentException e =
+                assertThrows(IllegalArgumentException.class, () -> EventUtils.addEventListener(src, ObjectChangeListener.class, listener));
+        assertEquals("Class " + src.getClass().getName() + " does not have a public add" + ObjectChangeListener.class.getSimpleName() + " method which takes a parameter of type " + ObjectChangeListener.class.getName() + ".",
+                e.getMessage());
     }
 
     @Test
     public void testAddEventListenerThrowsException() {
         final ExceptionEventSource src = new ExceptionEventSource();
-        expectedException.expect(RuntimeException.class);
-        EventUtils.addEventListener(src, PropertyChangeListener.class, new PropertyChangeListener() {
-            @Override
-            public void propertyChange(final PropertyChangeEvent e) {
-                // Do nothing!
-            }
-        });
+        assertThrows(RuntimeException.class, () ->
+            EventUtils.addEventListener(src, PropertyChangeListener.class, new PropertyChangeListener() {
+                @Override
+                public void propertyChange(final PropertyChangeEvent e) {
+                    // Do nothing!
+                }
+            })
+        );
     }
 
     @Test
@@ -96,9 +93,10 @@ public class EventUtilsTest {
         final PropertyChangeSource src = new PropertyChangeSource();
         final EventCountingInvociationHandler handler = new EventCountingInvociationHandler();
         final VetoableChangeListener listener = handler.createListener(VetoableChangeListener.class);
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Class " + src.getClass().getName() + " does not have a public add" + VetoableChangeListener.class.getSimpleName() + " method which takes a parameter of type " + VetoableChangeListener.class.getName() + ".");
-        EventUtils.addEventListener(src, VetoableChangeListener.class, listener);
+        IllegalArgumentException e =
+                assertThrows(IllegalArgumentException.class, () -> EventUtils.addEventListener(src, VetoableChangeListener.class, listener));
+        assertEquals("Class " + src.getClass().getName() + " does not have a public add" + VetoableChangeListener.class.getSimpleName() + " method which takes a parameter of type " + VetoableChangeListener.class.getName() + ".",
+                e.getMessage());
     }
 
     @Test


### PR DESCRIPTION
Upgrade the tests in the event package to use JUnit Jupiter as part of the effort to remove the dependency on the Vintage Engine.

While most of these changes are drop-in replacements with no functional benefit, it is worth noting the tests that test thrown exceptions.
Prior to this patch, this package tested for exceptions in two ways, neither of which are supported in JUnit Jupiter:
1. With the `expected` argument of the `org.junit.Test` annotation.
2. With the `org.junit.rules.ExpectedException` `@Rule`

Both of these usages were replaced with calls to `org.junit.jupiter.api.Assertions#assertThrows`.