### PR TITLE
Update exception tests to JUnit Jupiter

### DIFF
--- a/src/test/java/org/apache/commons/lang3/exception/AbstractExceptionContextTest.java
+++ b/src/test/java/org/apache/commons/lang3/exception/AbstractExceptionContextTest.java
@@ -16,12 +16,12 @@
  */
 package org.apache.commons.lang3.exception;
 
-import org.junit.Test;
-import org.junit.Before;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.Serializable;
 import java.util.Arrays;
@@ -51,7 +51,7 @@ public abstract class AbstractExceptionContextTest<T extends ExceptionContext & 
     }
 
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         exceptionContext
             .addContextValue("test1", null)

--- a/src/test/java/org/apache/commons/lang3/exception/CloneFailedExceptionTest.java
+++ b/src/test/java/org/apache/commons/lang3/exception/CloneFailedExceptionTest.java
@@ -16,48 +16,55 @@
  */
 package org.apache.commons.lang3.exception;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * JUnit tests for {@link CloneFailedExceptionTest}.
  */
 public class CloneFailedExceptionTest extends AbstractExceptionTest {
 
-    @Test(expected = CloneFailedException.class)
-    public void testThrowingInformativeException() throws Exception {
-        throw new CloneFailedException(EXCEPTION_MESSAGE, generateCause());
+    @Test
+    public void testThrowingInformativeException() {
+        assertThrows(CloneFailedException.class, () -> {
+            throw new CloneFailedException(EXCEPTION_MESSAGE, generateCause());
+        });
     }
 
-    @Test(expected = CloneFailedException.class)
-    public void testThrowingExceptionWithMessage() throws Exception {
-        throw new CloneFailedException(EXCEPTION_MESSAGE);
+    @Test
+    public void testThrowingExceptionWithMessage() {
+        assertThrows(CloneFailedException.class, () -> {
+            throw new CloneFailedException(EXCEPTION_MESSAGE);
+        });
     }
 
-    @Test(expected = CloneFailedException.class)
-    public void testThrowingExceptionWithCause() throws Exception {
-        throw new CloneFailedException(generateCause());
+    @Test
+    public void testThrowingExceptionWithCause() {
+        assertThrows(CloneFailedException.class, () -> {
+            throw new CloneFailedException(generateCause());
+        });
     }
 
     @Test
     public void testWithCauseAndMessage() throws Exception {
         final Exception exception = new CloneFailedException(EXCEPTION_MESSAGE, generateCause());
         assertNotNull(exception);
-        assertEquals(WRONG_EXCEPTION_MESSAGE, EXCEPTION_MESSAGE, exception.getMessage());
+        assertEquals(EXCEPTION_MESSAGE, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
 
         final Throwable cause = exception.getCause();
         assertNotNull(cause);
-        assertEquals(WRONG_CAUSE_MESSAGE, CAUSE_MESSAGE, cause.getMessage());
+        assertEquals(CAUSE_MESSAGE, cause.getMessage(), WRONG_CAUSE_MESSAGE);
     }
 
     @Test
     public void testWithoutCause() throws Exception {
         final Exception exception = new CloneFailedException(EXCEPTION_MESSAGE);
         assertNotNull(exception);
-        assertEquals(WRONG_EXCEPTION_MESSAGE, EXCEPTION_MESSAGE, exception.getMessage());
+        assertEquals(EXCEPTION_MESSAGE, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
 
         final Throwable cause = exception.getCause();
         assertNull(cause);
@@ -71,6 +78,6 @@ public class CloneFailedExceptionTest extends AbstractExceptionTest {
 
         final Throwable cause = exception.getCause();
         assertNotNull(cause);
-        assertEquals(WRONG_CAUSE_MESSAGE, CAUSE_MESSAGE, cause.getMessage());
+        assertEquals(CAUSE_MESSAGE, cause.getMessage(), WRONG_CAUSE_MESSAGE);
     }
 }

--- a/src/test/java/org/apache/commons/lang3/exception/ContextedExceptionTest.java
+++ b/src/test/java/org/apache/commons/lang3/exception/ContextedExceptionTest.java
@@ -16,20 +16,22 @@
  */
 package org.apache.commons.lang3.exception;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Date;
 
 import org.apache.commons.lang3.StringUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * JUnit tests for ContextedException.
  */
 public class ContextedExceptionTest extends AbstractExceptionContextTest<ContextedException> {
 
+    @BeforeEach
     @Override
     public void setUp() throws Exception {
         exceptionContext = new ContextedException(new Exception(TEST_MESSAGE));

--- a/src/test/java/org/apache/commons/lang3/exception/ContextedRuntimeExceptionTest.java
+++ b/src/test/java/org/apache/commons/lang3/exception/ContextedRuntimeExceptionTest.java
@@ -16,23 +16,23 @@
  */
 package org.apache.commons.lang3.exception;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Date;
 
 import org.apache.commons.lang3.StringUtils;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * JUnit tests for ContextedRuntimeException.
  */
 public class ContextedRuntimeExceptionTest extends AbstractExceptionContextTest<ContextedRuntimeException> {
 
+    @BeforeEach
     @Override
-    @Before
     public void setUp() throws Exception {
         exceptionContext = new ContextedRuntimeException(new Exception(TEST_MESSAGE));
         super.setUp();

--- a/src/test/java/org/apache/commons/lang3/exception/DefaultExceptionContextTest.java
+++ b/src/test/java/org/apache/commons/lang3/exception/DefaultExceptionContextTest.java
@@ -16,8 +16,8 @@
  */
 package org.apache.commons.lang3.exception;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * JUnit tests for DefaultExceptionContext.
@@ -25,7 +25,7 @@ import org.junit.Test;
 public class DefaultExceptionContextTest extends AbstractExceptionContextTest<DefaultExceptionContext> {
 
     @Override
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         exceptionContext = new DefaultExceptionContext();
         super.setUp();

--- a/src/test/java/org/apache/commons/lang3/exception/ExceptionUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/exception/ExceptionUtilsTest.java
@@ -16,12 +16,13 @@
  */
 package org.apache.commons.lang3.exception;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -33,9 +34,9 @@ import java.lang.reflect.Modifier;
 import java.util.List;
 
 import org.apache.commons.lang3.test.NotVisibleExceptionFactory;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests {@link org.apache.commons.lang3.exception.ExceptionUtils}.
@@ -52,7 +53,7 @@ public class ExceptionUtilsTest {
     private Throwable notVisibleException;
 
 
-    @Before
+    @BeforeEach
     public void setUp() {
         withoutCause = createExceptionWithoutCause();
         nested = new NestableException(withoutCause);
@@ -66,7 +67,7 @@ public class ExceptionUtilsTest {
     }
 
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         withoutCause = null;
         nested = null;
@@ -449,9 +450,9 @@ public class ExceptionUtilsTest {
         assertFalse(match);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testRemoveCommonFrames_ListList() throws Exception {
-        ExceptionUtils.removeCommonFrames(null, null);
+        assertThrows(IllegalArgumentException.class, () -> ExceptionUtils.removeCommonFrames(null, null));
     }
 
     @Test


### PR DESCRIPTION
Upgrade the tests in the `exception` package to use JUnit Jupiter as part of the effort to remove the dependency on the Vintage Engine.

While most of these changes are drop-in replacements with no functional benefit, there are some non-obvious changes worth mentioning.

Unlike `org.junit.Test`, `org.junit.jupiter.api.Test` does not have an `expected` argument. Instead, an explicit call to `org.junit.jupiter.api.Assertions.assertThrows` is used.

Another non-obvious change was performed in `ContextedRuntimeExceptionTest`. Unlike JUnit Vintage's `@Before`, JUnit Jupiter's `@BeforeEach` does not apply if a parent's method is annotated with it and the overriding method is not, so an explicit `@BeforeEach` annotation had to be added to `ContexedTuntimeExceptionTest#setUp()`.

It's also worth noting this is a minimal patch for migrating the package's tests to Jupiter. There are several tests that can be made more elegant with Jupiter's new features, but that work is left for subsequent patches.