### PR TITLE
Update reflect tests to JUnit Jupiter

### DIFF
--- a/src/test/java/org/apache/commons/lang3/reflect/ConstructorUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/reflect/ConstructorUtilsTest.java
@@ -16,12 +16,12 @@
  */
 package org.apache.commons.lang3.reflect;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.lang.reflect.Constructor;
 import java.util.Arrays;
@@ -31,8 +31,8 @@ import java.util.Map;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.commons.lang3.mutable.MutableObject;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests ConstructorUtils
@@ -129,7 +129,7 @@ public class ConstructorUtilsTest {
     }
 
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         classCache.clear();
     }
@@ -278,9 +278,8 @@ public class ConstructorUtilsTest {
             final Class<?>[] requestTypes, final Class<?>[] actualTypes) {
         final Constructor<?> c = ConstructorUtils.getMatchingAccessibleConstructor(cls,
                 requestTypes);
-        assertTrue(toString(c.getParameterTypes()) + " not equals "
-                + toString(actualTypes), Arrays.equals(actualTypes, c
-                .getParameterTypes()));
+        assertTrue(Arrays.equals(actualTypes, c.getParameterTypes()),
+                toString(c.getParameterTypes()) + " not equals " + toString(actualTypes));
     }
 
     private String toString(final Class<?>[] c) {

--- a/src/test/java/org/apache/commons/lang3/reflect/FieldUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/reflect/FieldUtilsTest.java
@@ -26,8 +26,8 @@ import org.apache.commons.lang3.reflect.testbed.PublicChild;
 import org.apache.commons.lang3.reflect.testbed.PubliclyShadowedChild;
 import org.apache.commons.lang3.reflect.testbed.StaticContainer;
 import org.apache.commons.lang3.reflect.testbed.StaticContainerChild;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
@@ -36,14 +36,15 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeNotNull;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  * Unit tests FieldUtils
@@ -63,7 +64,7 @@ public class FieldUtilsTest {
     private PrivatelyShadowedChild privatelyShadowedChild;
     private final Class<? super PublicChild> parentClass = PublicChild.class.getSuperclass();
 
-    @Before
+    @BeforeEach
     public void setUp() {
         StaticContainer.reset();
         publicChild = new PublicChild();
@@ -100,24 +101,24 @@ public class FieldUtilsTest {
         assertNull(FieldUtils.getField(PrivatelyShadowedChild.class, "d"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGetFieldIllegalArgumentException1() {
-        FieldUtils.getField(null, "none");
+        assertThrows(IllegalArgumentException.class, () -> FieldUtils.getField(null, "none"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGetFieldIllegalArgumentException2() {
-        FieldUtils.getField(PublicChild.class, null);
+        assertThrows(IllegalArgumentException.class, () -> FieldUtils.getField(PublicChild.class, null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGetFieldIllegalArgumentException3() {
-        FieldUtils.getField(PublicChild.class, "");
+        assertThrows(IllegalArgumentException.class, () -> FieldUtils.getField(PublicChild.class, ""));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGetFieldIllegalArgumentException4() {
-        FieldUtils.getField(PublicChild.class, " ");
+        assertThrows(IllegalArgumentException.class, () -> FieldUtils.getField(PublicChild.class, " "));
     }
 
     @Test
@@ -139,24 +140,24 @@ public class FieldUtilsTest {
         assertEquals(PrivatelyShadowedChild.class, FieldUtils.getField(PrivatelyShadowedChild.class, "d", true).getDeclaringClass());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGetFieldForceAccessIllegalArgumentException1() {
-        FieldUtils.getField(null, "none", true);
+        assertThrows(IllegalArgumentException.class, () -> FieldUtils.getField(null, "none", true));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGetFieldForceAccessIllegalArgumentException2() {
-        FieldUtils.getField(PublicChild.class, null, true);
+        assertThrows(IllegalArgumentException.class, () -> FieldUtils.getField(PublicChild.class, null, true));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGetFieldForceAccessIllegalArgumentException3() {
-        FieldUtils.getField(PublicChild.class, "", true);
+        assertThrows(IllegalArgumentException.class, () -> FieldUtils.getField(PublicChild.class, "", true));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGetFieldForceAccessIllegalArgumentException4() {
-        FieldUtils.getField(PublicChild.class, " ", true);
+        assertThrows(IllegalArgumentException.class, () -> FieldUtils.getField(PublicChild.class, " ", true));
     }
 
     @Test
@@ -174,7 +175,7 @@ public class FieldUtilsTest {
                 expected++;
             }
         }
-        assertEquals(Arrays.toString(allFields), expected, allFields.length);
+        assertEquals(expected, allFields.length, Arrays.toString(allFields));
     }
 
     @Test
@@ -194,7 +195,7 @@ public class FieldUtilsTest {
                 expected++;
             }
         }
-        assertEquals(allFields.toString(), expected, allFields.size());
+        assertEquals(expected, allFields.size(), allFields.toString());
 
     }
 
@@ -208,19 +209,19 @@ public class FieldUtilsTest {
         assertArrayEquals(annotatedFields, FieldUtils.getFieldsWithAnnotation(FieldUtilsTest.class, Annotated.class));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGetFieldsWithAnnotationIllegalArgumentException1() {
-        FieldUtils.getFieldsWithAnnotation(FieldUtilsTest.class, null);
+        assertThrows(IllegalArgumentException.class, () -> FieldUtils.getFieldsWithAnnotation(FieldUtilsTest.class, null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGetFieldsWithAnnotationIllegalArgumentException2() {
-        FieldUtils.getFieldsWithAnnotation(null, Annotated.class);
+        assertThrows(IllegalArgumentException.class, () -> FieldUtils.getFieldsWithAnnotation(null, Annotated.class));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGetFieldsWithAnnotationIllegalArgumentException3() {
-        FieldUtils.getFieldsWithAnnotation(null, null);
+        assertThrows(IllegalArgumentException.class, () -> FieldUtils.getFieldsWithAnnotation(null, null));
     }
 
     @Test
@@ -236,19 +237,19 @@ public class FieldUtilsTest {
         assertTrue(fieldUtilsTestAnnotatedFields.contains(annotatedFields.get(1)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGetFieldsListWithAnnotationIllegalArgumentException1() {
-        FieldUtils.getFieldsListWithAnnotation(FieldUtilsTest.class, null);
+        assertThrows(IllegalArgumentException.class, () -> FieldUtils.getFieldsListWithAnnotation(FieldUtilsTest.class, null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGetFieldsListWithAnnotationIllegalArgumentException2() {
-        FieldUtils.getFieldsListWithAnnotation(null, Annotated.class);
+        assertThrows(IllegalArgumentException.class, () -> FieldUtils.getFieldsListWithAnnotation(null, Annotated.class));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGetFieldsListWithAnnotationIllegalArgumentException3() {
-        FieldUtils.getFieldsListWithAnnotation(null, null);
+        assertThrows(IllegalArgumentException.class, () -> FieldUtils.getFieldsListWithAnnotation(null, null));
     }
 
     @Test
@@ -270,24 +271,24 @@ public class FieldUtilsTest {
         assertNull(FieldUtils.getDeclaredField(PrivatelyShadowedChild.class, "d"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGetDeclaredFieldAccessIllegalArgumentException1() {
-        FieldUtils.getDeclaredField(null, "none");
+        assertThrows(IllegalArgumentException.class, () -> FieldUtils.getDeclaredField(null, "none"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGetDeclaredFieldAccessIllegalArgumentException2() {
-        FieldUtils.getDeclaredField(PublicChild.class, null);
+        assertThrows(IllegalArgumentException.class, () -> FieldUtils.getDeclaredField(PublicChild.class, null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGetDeclaredFieldAccessIllegalArgumentException3() {
-        FieldUtils.getDeclaredField(PublicChild.class, "");
+        assertThrows(IllegalArgumentException.class, () -> FieldUtils.getDeclaredField(PublicChild.class, ""));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGetDeclaredFieldAccessIllegalArgumentException4() {
-        FieldUtils.getDeclaredField(PublicChild.class, " ");
+        assertThrows(IllegalArgumentException.class, () -> FieldUtils.getDeclaredField(PublicChild.class, " "));
     }
 
     @Test
@@ -309,24 +310,24 @@ public class FieldUtilsTest {
         assertEquals(PrivatelyShadowedChild.class, FieldUtils.getDeclaredField(PrivatelyShadowedChild.class, "d", true).getDeclaringClass());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGetDeclaredFieldForceAccessIllegalArgumentException1() {
-        FieldUtils.getDeclaredField(null, "none", true);
+        assertThrows(IllegalArgumentException.class, () -> FieldUtils.getDeclaredField(null, "none", true));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGetDeclaredFieldForceAccessIllegalArgumentException2() {
-        FieldUtils.getDeclaredField(PublicChild.class, null, true);
+        assertThrows(IllegalArgumentException.class, () -> FieldUtils.getDeclaredField(PublicChild.class, null, true));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGetDeclaredFieldForceAccessIllegalArgumentException3() {
-        FieldUtils.getDeclaredField(PublicChild.class, "", true);
+        assertThrows(IllegalArgumentException.class, () -> FieldUtils.getDeclaredField(PublicChild.class, "", true));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGetDeclaredFieldForceAccessIllegalArgumentException4() {
-        FieldUtils.getDeclaredField(PublicChild.class, " ", true);
+        assertThrows(IllegalArgumentException.class, () -> FieldUtils.getDeclaredField(PublicChild.class, " ", true));
     }
 
     @Test
@@ -334,17 +335,17 @@ public class FieldUtilsTest {
         assertEquals(Foo.VALUE, FieldUtils.readStaticField(FieldUtils.getField(Foo.class, "VALUE")));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testReadStaticFieldIllegalArgumentException1() throws Exception {
-        FieldUtils.readStaticField(null);
+        assertThrows(IllegalArgumentException.class, () -> FieldUtils.readStaticField(null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testReadStaticFieldIllegalArgumentException2() throws Exception {
         assertEquals(Foo.VALUE, FieldUtils.readStaticField(FieldUtils.getField(Foo.class, "VALUE")));
         final Field nonStaticField = FieldUtils.getField(PublicChild.class, "s");
-        assumeNotNull(nonStaticField);
-        FieldUtils.readStaticField(nonStaticField);
+        assumeTrue(nonStaticField != null);
+        assertThrows(IllegalArgumentException.class, () -> FieldUtils.readStaticField(nonStaticField));
     }
 
     @Test
@@ -353,16 +354,16 @@ public class FieldUtilsTest {
         assertEquals(Foo.VALUE, FieldUtils.readStaticField(FieldUtils.getField(PublicChild.class, "VALUE")));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testReadStaticFieldForceAccessIllegalArgumentException1() throws Exception {
-        FieldUtils.readStaticField(null, true);
+        assertThrows(IllegalArgumentException.class, () -> FieldUtils.readStaticField(null, true));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testReadStaticFieldForceAccessIllegalArgumentException2() throws Exception {
         final Field nonStaticField = FieldUtils.getField(PublicChild.class, "s", true);
-        assumeNotNull(nonStaticField);
-        FieldUtils.readStaticField(nonStaticField);
+        assumeTrue(nonStaticField != null);
+        assertThrows(IllegalArgumentException.class, () -> FieldUtils.readStaticField(nonStaticField));
     }
 
     @Test
@@ -1335,9 +1336,9 @@ public class FieldUtilsTest {
         assertEquals(Double.valueOf(0.0), FieldUtils.readDeclaredField(privatelyShadowedChild, "d", true));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testAmbig() {
-        FieldUtils.getField(Ambig.class, "VALUE");
+        assertThrows(IllegalArgumentException.class, () -> FieldUtils.getField(Ambig.class, "VALUE"));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/reflect/InheritanceUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/reflect/InheritanceUtilsTest.java
@@ -19,10 +19,10 @@ package org.apache.commons.lang3.reflect;
 import org.apache.commons.lang3.reflect.testbed.AnotherChild;
 import org.apache.commons.lang3.reflect.testbed.AnotherParent;
 import org.apache.commons.lang3.reflect.testbed.Grandchild;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Unit tests InheritanceUtils

--- a/src/test/java/org/apache/commons/lang3/reflect/MethodUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/reflect/MethodUtilsTest.java
@@ -18,16 +18,17 @@ package org.apache.commons.lang3.reflect;
 
 import static org.hamcrest.Matchers.hasItemInArray;
 import static org.hamcrest.Matchers.hasItems;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
@@ -50,8 +51,8 @@ import org.apache.commons.lang3.reflect.testbed.GenericParent;
 import org.apache.commons.lang3.reflect.testbed.PublicChild;
 import org.apache.commons.lang3.reflect.testbed.StringParameterizedChild;
 import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests MethodUtils
@@ -316,7 +317,7 @@ public class MethodUtilsTest {
     private TestBean testBean;
     private final Map<Class<?>, Class<?>[]> classCache = new HashMap<>();
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         testBean = new TestBean();
         classCache.clear();
@@ -854,19 +855,19 @@ public class MethodUtilsTest {
                 Annotated.class, false, false));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGetMethodsWithAnnotationIllegalArgumentException1() {
-        MethodUtils.getMethodsWithAnnotation(FieldUtilsTest.class, null);
+        assertThrows(IllegalArgumentException.class, () -> MethodUtils.getMethodsWithAnnotation(FieldUtilsTest.class, null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGetMethodsWithAnnotationIllegalArgumentException2() {
-        MethodUtils.getMethodsWithAnnotation(null, Annotated.class);
+        assertThrows(IllegalArgumentException.class, () -> MethodUtils.getMethodsWithAnnotation(null, Annotated.class));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGetMethodsWithAnnotationIllegalArgumentException3() {
-        MethodUtils.getMethodsWithAnnotation(null, null);
+        assertThrows(IllegalArgumentException.class, () -> MethodUtils.getMethodsWithAnnotation(null, null));
     }
 
     @Test
@@ -882,46 +883,45 @@ public class MethodUtilsTest {
         ));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGetMethodsListWithAnnotationIllegalArgumentException1() {
-        MethodUtils.getMethodsListWithAnnotation(FieldUtilsTest.class, null);
+        assertThrows(IllegalArgumentException.class, () -> MethodUtils.getMethodsListWithAnnotation(FieldUtilsTest.class, null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGetMethodsListWithAnnotationIllegalArgumentException2() {
-        MethodUtils.getMethodsListWithAnnotation(null, Annotated.class);
+        assertThrows(IllegalArgumentException.class, () -> MethodUtils.getMethodsListWithAnnotation(null, Annotated.class));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGetMethodsListWithAnnotationIllegalArgumentException3() {
-        MethodUtils.getMethodsListWithAnnotation(null, null);
+        assertThrows(IllegalArgumentException.class, () -> MethodUtils.getMethodsListWithAnnotation(null, null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGetAnnotationIllegalArgumentException1() {
-        MethodUtils.getAnnotation(FieldUtilsTest.class.getDeclaredMethods()[0], null, true,
-                true);
+        assertThrows(IllegalArgumentException.class,
+                () -> MethodUtils.getAnnotation(FieldUtilsTest.class.getDeclaredMethods()[0], null, true, true));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGetAnnotationIllegalArgumentException2() {
-        MethodUtils.getAnnotation(null, Annotated.class, true, true);
+        assertThrows(IllegalArgumentException.class, () -> MethodUtils.getAnnotation(null, Annotated.class, true, true));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGetAnnotationIllegalArgumentException3() {
-        MethodUtils.getAnnotation(null, null, true, true);
+        assertThrows(IllegalArgumentException.class, () -> MethodUtils.getAnnotation(null, null, true, true));
     }
 
     private void expectMatchingAccessibleMethodParameterTypes(final Class<?> cls,
                                                               final String methodName, final Class<?>[] requestTypes, final Class<?>[] actualTypes) {
         final Method m = MethodUtils.getMatchingAccessibleMethod(cls, methodName,
                 requestTypes);
-        assertNotNull("could not find any matches for " + methodName
-                + " (" + (requestTypes == null ? null : toString(requestTypes)) + ")", m);
-        assertTrue(toString(m.getParameterTypes()) + " not equals "
-                + toString(actualTypes), Arrays.equals(actualTypes, m
-                .getParameterTypes()));
+        assertNotNull(m, "could not find any matches for " + methodName
+                + " (" + (requestTypes == null ? null : toString(requestTypes)) + ")");
+        assertTrue(Arrays.equals(actualTypes, m.getParameterTypes()),
+                toString(m.getParameterTypes()) + " not equals " + toString(actualTypes));
     }
 
     private String toString(final Class<?>[] c) {

--- a/src/test/java/org/apache/commons/lang3/reflect/TypeLiteralTest.java
+++ b/src/test/java/org/apache/commons/lang3/reflect/TypeLiteralTest.java
@@ -16,13 +16,14 @@
  */
 package org.apache.commons.lang3.reflect;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TypeLiteralTest {
 
@@ -49,8 +50,8 @@ public class TypeLiteralTest {
     }
 
     @SuppressWarnings("rawtypes")
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testRaw() {
-        new TypeLiteral() {};
+        assertThrows(NullPointerException.class, () -> new TypeLiteral() {});
     }
 }

--- a/src/test/java/org/apache/commons/lang3/reflect/TypeUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/reflect/TypeUtilsTest.java
@@ -16,11 +16,11 @@
  */
 package org.apache.commons.lang3.reflect;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.Serializable;
 import java.lang.reflect.Field;
@@ -44,7 +44,7 @@ import org.apache.commons.lang3.reflect.testbed.Foo;
 import org.apache.commons.lang3.reflect.testbed.GenericParent;
 import org.apache.commons.lang3.reflect.testbed.GenericTypeHolder;
 import org.apache.commons.lang3.reflect.testbed.StringParameterizedChild;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test TypeUtils
@@ -353,8 +353,8 @@ public class TypeUtilsTest<B> {
         dis = uhder;
         assertTrue(TypeUtils.isAssignable(uhderType, disType));
         dis = ding;
-        assertFalse(String.format("type %s not assignable to %s!", dingType, disType),
-                TypeUtils.isAssignable(dingType, disType));
+        assertFalse(TypeUtils.isAssignable(dingType, disType),
+                String.format("type %s not assignable to %s!", dingType, disType));
         dis = tester;
         assertTrue(TypeUtils.isAssignable(testerType, disType));
         // dis = tester2;
@@ -459,13 +459,15 @@ public class TypeUtilsTest<B> {
         final boolean isAssignable = TypeUtils.isAssignable(type2, type1);
 
         if (expected) {
-            assertTrue("[" + i1 + ", " + i2 + "]: From "
-                    + String.valueOf(type2) + " to "
-                    + String.valueOf(type1), isAssignable);
+            assertTrue(isAssignable,
+                    "[" + i1 + ", " + i2 + "]: From "
+                                + String.valueOf(type2) + " to "
+                                + String.valueOf(type1));
         } else {
-            assertFalse("[" + i1 + ", " + i2 + "]: From "
-                    + String.valueOf(type2) + " to "
-                    + String.valueOf(type1), isAssignable);
+            assertFalse(isAssignable,
+                    "[" + i1 + ", " + i2 + "]: From "
+                                + String.valueOf(type2) + " to "
+                                + String.valueOf(type1));
         }
     }
 
@@ -488,25 +490,25 @@ public class TypeUtilsTest<B> {
 
         typeVarAssigns = TypeUtils.getTypeArguments(Integer.class, Comparable.class);
         treeSetTypeVar = Comparable.class.getTypeParameters()[0];
-        assertTrue("Type var assigns for Comparable from Integer: " + typeVarAssigns,
-                typeVarAssigns.containsKey(treeSetTypeVar));
+        assertTrue(typeVarAssigns.containsKey(treeSetTypeVar),
+                "Type var assigns for Comparable from Integer: " + typeVarAssigns);
         typeArg = typeVarAssigns.get(treeSetTypeVar);
-        assertEquals("Type argument of Comparable from Integer: " + typeArg, Integer.class,
-                typeVarAssigns.get(treeSetTypeVar));
+        assertEquals(Integer.class, typeVarAssigns.get(treeSetTypeVar),
+                "Type argument of Comparable from Integer: " + typeArg);
 
         typeVarAssigns = TypeUtils.getTypeArguments(int.class, Comparable.class);
         treeSetTypeVar = Comparable.class.getTypeParameters()[0];
-        assertTrue("Type var assigns for Comparable from int: " + typeVarAssigns,
-                typeVarAssigns.containsKey(treeSetTypeVar));
+        assertTrue(typeVarAssigns.containsKey(treeSetTypeVar),
+                "Type var assigns for Comparable from int: " + typeVarAssigns);
         typeArg = typeVarAssigns.get(treeSetTypeVar);
-        assertEquals("Type argument of Comparable from int: " + typeArg, Integer.class,
-                typeVarAssigns.get(treeSetTypeVar));
+        assertEquals(Integer.class, typeVarAssigns.get(treeSetTypeVar),
+                "Type argument of Comparable from int: " + typeArg);
 
         final Collection<Integer> col = Arrays.asList(new Integer[0]);
         typeVarAssigns = TypeUtils.getTypeArguments(List.class, Collection.class);
         treeSetTypeVar = Comparable.class.getTypeParameters()[0];
-        assertFalse("Type var assigns for Collection from List: " + typeVarAssigns,
-                typeVarAssigns.containsKey(treeSetTypeVar));
+        assertFalse(typeVarAssigns.containsKey(treeSetTypeVar),
+                "Type var assigns for Collection from List: " + typeVarAssigns);
 
         typeVarAssigns = TypeUtils.getTypeArguments(AAAClass.BBBClass.class, AAClass.BBClass.class);
         assertEquals(2, typeVarAssigns.size());


### PR DESCRIPTION
Upgrade the tests in the `reflect` package to use JUnit Jupiter as part of the effort to remove the dependency on the Vintage Engine.

While most of these changes are drop-in replacements with no functional benefit, there are some non-obvious changes worth mentioning.

Unlike `org.junit.Test`, `org.junit.jupiter.api.Test` does not have an `expected` argument. Instead, an explicit call to `org.junit.jupiter.api.Assertions.assertThrows` is used.

Unlike `org.junit.Assume`, `org.junit.jupiter.api.Assumptions` does not have an `assumeNotNull` method. Instead, `assumeTrue` was used with an explicit condition of a variable being different than `null`.

It's also worth noting this is a minimal patch for migrating the package's tests to Jupiter. There are several tests that can be made more elegant with Jupiter's new features, but that work is left for
subsequent patches.