### PR TITLE
Update text tests to JUnit Jupiter

### DIFF
--- a/src/test/java/org/apache/commons/lang3/text/CompositeFormatTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/CompositeFormatTest.java
@@ -17,9 +17,9 @@
 
 package org.apache.commons.lang3.text;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.text.FieldPosition;
 import java.text.Format;
@@ -71,8 +71,8 @@ public class CompositeFormatTest {
 
         composite.parseObject("", null);
         composite.format(new Object(), new StringBuffer(), null);
-        assertEquals( "Parser get method incorrectly implemented", parser, composite.getParser() );
-        assertEquals( "Formatter get method incorrectly implemented", formatter, composite.getFormatter() );
+        assertEquals(parser, composite.getParser(), "Parser get method incorrectly implemented");
+        assertEquals(formatter, composite.getFormatter(), "Formatter get method incorrectly implemented");
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/text/ExtendedMessageFormatTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/ExtendedMessageFormatTest.java
@@ -16,12 +16,12 @@
  */
 package org.apache.commons.lang3.text;
 
-import org.junit.Test;
-import org.junit.Before;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.text.DateFormat;
 import java.text.FieldPosition;
@@ -47,7 +47,7 @@ public class ExtendedMessageFormatTest {
 
     private final Map<String, FormatFactory> registry = new HashMap<>();
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         registry.put("lower", new LowerCaseFormatFactory());
         registry.put("upper", new UpperCaseFormatFactory());
@@ -60,12 +60,12 @@ public class ExtendedMessageFormatTest {
     public void testExtendedFormats() {
         final String pattern = "Lower: {0,lower} Upper: {1,upper}";
         final ExtendedMessageFormat emf = new ExtendedMessageFormat(pattern, registry);
-        assertEquals("TOPATTERN", pattern, emf.toPattern());
-        assertEquals("Lower: foo Upper: BAR", emf.format(new Object[] {"foo", "bar"}));
-        assertEquals("Lower: foo Upper: BAR", emf.format(new Object[] {"Foo", "Bar"}));
-        assertEquals("Lower: foo Upper: BAR", emf.format(new Object[] {"FOO", "BAR"}));
-        assertEquals("Lower: foo Upper: BAR", emf.format(new Object[] {"FOO", "bar"}));
-        assertEquals("Lower: foo Upper: BAR", emf.format(new Object[] {"foo", "BAR"}));
+        assertEquals(pattern, emf.toPattern(), "TOPATTERN");
+        assertEquals(emf.format(new Object[] {"foo", "bar"}), "Lower: foo Upper: BAR");
+        assertEquals(emf.format(new Object[] {"Foo", "Bar"}), "Lower: foo Upper: BAR");
+        assertEquals(emf.format(new Object[] {"FOO", "BAR"}), "Lower: foo Upper: BAR");
+        assertEquals(emf.format(new Object[] {"FOO", "bar"}), "Lower: foo Upper: BAR");
+        assertEquals(emf.format(new Object[] {"foo", "BAR"}), "Lower: foo Upper: BAR");
     }
 
     /**
@@ -143,8 +143,8 @@ public class ExtendedMessageFormatTest {
             expected.append(df.format(args[1]));
             expected.append(" Salary: ");
             expected.append(nf.format(args[2]));
-            assertEquals("pattern comparison for locale " + locale, expectedPattern, emf.toPattern());
-            assertEquals(String.valueOf(locale), expected.toString(), emf.format(args));
+            assertEquals(expectedPattern, emf.toPattern(), "pattern comparison for locale " + locale);
+            assertEquals(expected.toString(), emf.format(args), String.valueOf(locale));
         }
     }
 
@@ -268,8 +268,8 @@ public class ExtendedMessageFormatTest {
             final MessageFormat dateDefault = createMessageFormat("{0,date}", locale);
             final String pattern = "{0,date,short}";
             final ExtendedMessageFormat dateShort = new ExtendedMessageFormat(pattern, locale, dateRegistry);
-            assertEquals("overridden date,short format", dateDefault.format(args), dateShort.format(args));
-            assertEquals("overridden date,short pattern", pattern, dateShort.toPattern());
+            assertEquals(dateDefault.format(args), dateShort.format(args), "overridden date,short format");
+            assertEquals(pattern, dateShort.toPattern(), "overridden date,short pattern");
         }
     }
 
@@ -301,33 +301,33 @@ public class ExtendedMessageFormatTest {
         ExtendedMessageFormat other = null;
 
         // Same object
-        assertTrue("same, equals()",   emf.equals(emf));
-        assertTrue("same, hashcode()", emf.hashCode() == emf.hashCode());
+        assertTrue(emf.equals(emf), "same, equals()");
+        assertTrue(emf.hashCode() == emf.hashCode(), "same, hashcode()");
 
         // Equal Object
         other = new ExtendedMessageFormat(pattern, Locale.US, fmtRegistry);
-        assertTrue("equal, equals()",   emf.equals(other));
-        assertTrue("equal, hashcode()", emf.hashCode() == other.hashCode());
+        assertTrue(emf.equals(other), "equal, equals()");
+        assertTrue(emf.hashCode() == other.hashCode(), "equal, hashcode()");
 
         // Different Class
         other = new OtherExtendedMessageFormat(pattern, Locale.US, fmtRegistry);
-        assertFalse("class, equals()",  emf.equals(other));
-        assertTrue("class, hashcode()", emf.hashCode() == other.hashCode()); // same hashcode
+        assertFalse(emf.equals(other), "class, equals()");
+        assertTrue(emf.hashCode() == other.hashCode(), "class, hashcode()"); // same hashcode
 
         // Different pattern
         other = new ExtendedMessageFormat("X" + pattern, Locale.US, fmtRegistry);
-        assertFalse("pattern, equals()",   emf.equals(other));
-        assertFalse("pattern, hashcode()", emf.hashCode() == other.hashCode());
+        assertFalse(emf.equals(other), "pattern, equals()");
+        assertFalse(emf.hashCode() == other.hashCode(), "pattern, hashcode()");
 
         // Different registry
         other = new ExtendedMessageFormat(pattern, Locale.US, otherRegitry);
-        assertFalse("registry, equals()",   emf.equals(other));
-        assertFalse("registry, hashcode()", emf.hashCode() == other.hashCode());
+        assertFalse(emf.equals(other), "registry, equals()");
+        assertFalse(emf.hashCode() == other.hashCode(), "registry, hashcode()");
 
         // Different Locale
         other = new ExtendedMessageFormat(pattern, Locale.FRANCE, fmtRegistry);
-        assertFalse("locale, equals()",  emf.equals(other));
-        assertTrue("locale, hashcode()", emf.hashCode() == other.hashCode()); // same hashcode
+        assertFalse(emf.equals(other), "locale, equals()");
+        assertTrue(emf.hashCode() == other.hashCode(), "locale, hashcode()"); // same hashcode
     }
 
     /**
@@ -376,8 +376,8 @@ public class ExtendedMessageFormatTest {
         } else {
             emf = new ExtendedMessageFormat(pattern, locale);
         }
-        assertEquals("format "    + buffer.toString(), mf.format(args), emf.format(args));
-        assertEquals("toPattern " + buffer.toString(), mf.toPattern(), emf.toPattern());
+        assertEquals(mf.format(args), emf.format(args), "format "    + buffer.toString());
+        assertEquals(mf.toPattern(), emf.toPattern(), "toPattern " + buffer.toString());
     }
 
     /**

--- a/src/test/java/org/apache/commons/lang3/text/FormattableUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/FormattableUtilsTest.java
@@ -17,11 +17,12 @@
 package org.apache.commons.lang3.text;
 
 import static java.util.FormattableFlags.LEFT_JUSTIFY;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Formatter;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests {@link FormattableUtils}.
@@ -83,9 +84,9 @@ public class FormattableUtilsTest {
         assertEquals("+*   ", FormattableUtils.append("foo", new Formatter(), LEFT_JUSTIFY, 5, 2, "+*").toString());
     }
 
-    @Test(expected=IllegalArgumentException.class)
+    @Test
     public void testIllegalEllipsis() {
-        FormattableUtils.append("foo", new Formatter(), 0, -1, 1, "xx");
+        assertThrows(IllegalArgumentException.class, () -> FormattableUtils.append("foo", new Formatter(), 0, -1, 1, "xx"));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/text/StrBuilderAppendInsertTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/StrBuilderAppendInsertTest.java
@@ -17,10 +17,10 @@
 
 package org.apache.commons.lang3.text;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.text.DecimalFormatSymbols;
 import java.util.Arrays;

--- a/src/test/java/org/apache/commons/lang3/text/StrBuilderTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/StrBuilderTest.java
@@ -17,16 +17,16 @@
 
 package org.apache.commons.lang3.text;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.io.Reader;
@@ -479,13 +479,13 @@ public class StrBuilderTest {
         assertEquals(ArrayUtils.EMPTY_CHAR_ARRAY, sb.toCharArray());
 
         char[] a = sb.toCharArray();
-        assertNotNull("toCharArray() result is null", a);
-        assertEquals("toCharArray() result is too large", 0, a.length);
+        assertNotNull(a, "toCharArray() result is null");
+        assertEquals(0, a.length, "toCharArray() result is too large");
 
         sb.append("junit");
         a = sb.toCharArray();
-        assertEquals("toCharArray() result incorrect length", 5, a.length);
-        assertTrue("toCharArray() result does not match", Arrays.equals("junit".toCharArray(), a));
+        assertEquals(5, a.length, "toCharArray() result incorrect length");
+        assertTrue(Arrays.equals("junit".toCharArray(), a), "toCharArray() result does not match");
     }
 
     @Test
@@ -495,19 +495,19 @@ public class StrBuilderTest {
 
         sb.append("junit");
         char[] a = sb.toCharArray(0, 20); // too large test
-        assertEquals("toCharArray(int,int) result incorrect length", 5, a.length);
-        assertTrue("toCharArray(int,int) result does not match", Arrays.equals("junit".toCharArray(), a));
+        assertEquals(5, a.length, "toCharArray(int,int) result incorrect length");
+        assertTrue(Arrays.equals("junit".toCharArray(), a), "toCharArray(int,int) result does not match");
 
         a = sb.toCharArray(0, 4);
-        assertEquals("toCharArray(int,int) result incorrect length", 4, a.length);
-        assertTrue("toCharArray(int,int) result does not match", Arrays.equals("juni".toCharArray(), a));
+        assertEquals(4, a.length, "toCharArray(int,int) result incorrect length");
+        assertTrue(Arrays.equals("juni".toCharArray(), a), "toCharArray(int,int) result does not match");
 
         a = sb.toCharArray(0, 4);
-        assertEquals("toCharArray(int,int) result incorrect length", 4, a.length);
-        assertTrue("toCharArray(int,int) result does not match", Arrays.equals("juni".toCharArray(), a));
+        assertEquals(4, a.length, "toCharArray(int,int) result incorrect length");
+        assertTrue(Arrays.equals("juni".toCharArray(), a), "toCharArray(int,int) result does not match");
 
         a = sb.toCharArray(0, 1);
-        assertNotNull("toCharArray(int,int) result is null", a);
+        assertNotNull(a, "toCharArray(int,int) result is null");
 
         try {
             sb.toCharArray(-1, 5);
@@ -1927,8 +1927,8 @@ public class StrBuilderTest {
     public void testLang295() {
         final StrBuilder sb = new StrBuilder("onetwothree");
         sb.deleteFirst("three");
-        assertFalse( "The contains(char) method is looking beyond the end of the string", sb.contains('h'));
-        assertEquals( "The indexOf(char) method is looking beyond the end of the string", -1, sb.indexOf('h'));
+        assertFalse(sb.contains('h'), "The contains(char) method is looking beyond the end of the string");
+        assertEquals(-1, sb.indexOf('h'), "The indexOf(char) method is looking beyond the end of the string");
     }
 
     //-----------------------------------------------------------------------
@@ -1936,14 +1936,14 @@ public class StrBuilderTest {
     public void testLang412Right() {
         final StrBuilder sb = new StrBuilder();
         sb.appendFixedWidthPadRight(null, 10, '*');
-        assertEquals( "Failed to invoke appendFixedWidthPadRight correctly", "**********", sb.toString());
+        assertEquals("**********", sb.toString(), "Failed to invoke appendFixedWidthPadRight correctly");
     }
 
     @Test
     public void testLang412Left() {
         final StrBuilder sb = new StrBuilder();
         sb.appendFixedWidthPadLeft(null, 10, '*');
-        assertEquals( "Failed to invoke appendFixedWidthPadLeft correctly", "**********", sb.toString());
+        assertEquals("**********", sb.toString(), "Failed to invoke appendFixedWidthPadLeft correctly");
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/text/StrLookupTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/StrLookupTest.java
@@ -17,15 +17,15 @@
 
 package org.apache.commons.lang3.text;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test class for StrLookup.
@@ -70,7 +70,7 @@ public class StrLookupTest  {
         newProps.setProperty(osName, newOsName);
         System.setProperties(newProps);
         try {
-            assertEquals("Changed properties not detected", newOsName, sysLookup.lookup(osName));
+            assertEquals(newOsName, sysLookup.lookup(osName), "Changed properties not detected");
         } finally {
             System.setProperties(oldProperties);
         }
@@ -89,7 +89,7 @@ public class StrLookupTest  {
         final StrLookup<String> sysLookup = StrLookup.systemPropertiesLookup();
         System.setProperty(osName, newOsName);
         try {
-            assertEquals("Changed properties not detected", newOsName, sysLookup.lookup(osName));
+            assertEquals(newOsName, sysLookup.lookup(osName), "Changed properties not detected");
         } finally {
             System.setProperty(osName, oldOs);
         }

--- a/src/test/java/org/apache/commons/lang3/text/StrMatcherTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/StrMatcherTest.java
@@ -17,11 +17,11 @@
 
 package org.apache.commons.lang3.text;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for {@link org.apache.commons.lang3.text.StrMatcher}.

--- a/src/test/java/org/apache/commons/lang3/text/StrSubstitutorTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/StrSubstitutorTest.java
@@ -17,21 +17,21 @@
 
 package org.apache.commons.lang3.text;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
 import org.apache.commons.lang3.mutable.MutableObject;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test class for StrSubstitutor.
@@ -41,14 +41,14 @@ public class StrSubstitutorTest {
 
     private Map<String, String> values;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         values = new HashMap<>();
         values.put("animal", "quick brown fox");
         values.put("target", "lazy dog");
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         values = null;
     }
@@ -308,18 +308,18 @@ public class StrSubstitutorTest {
         final StrSubstitutor sub = new StrSubstitutor(values);
         sub.setEnableSubstitutionInVariables(true);
         assertEquals(
-                "Wrong result (1)",
                 "The mouse jumps over the lazy dog.",
-                sub.replace("The ${animal.${species}} jumps over the ${target}."));
+                sub.replace("The ${animal.${species}} jumps over the ${target}."),
+                "Wrong result (1)");
         values.put("species", "1");
         assertEquals(
-                "Wrong result (2)",
                 "The fox jumps over the lazy dog.",
-                sub.replace("The ${animal.${species}} jumps over the ${target}."));
+                sub.replace("The ${animal.${species}} jumps over the ${target}."),
+                "Wrong result (2)");
         assertEquals(
-                "Wrong result (3)",
                 "The fox jumps over the lazy dog.",
-                sub.replace("The ${unknown.animal.${unknown.species:-1}:-fox} jumps over the ${unknown.target:-lazy dog}."));
+                sub.replace("The ${unknown.animal.${unknown.species:-1}:-fox} jumps over the ${unknown.target:-lazy dog}."),
+                "Wrong result (3)");
     }
 
     /**
@@ -332,13 +332,13 @@ public class StrSubstitutorTest {
         values.put("species", "2");
         final StrSubstitutor sub = new StrSubstitutor(values);
         assertEquals(
-                "Wrong result (1)",
                 "The ${animal.${species}} jumps over the lazy dog.",
-                sub.replace("The ${animal.${species}} jumps over the ${target}."));
+                sub.replace("The ${animal.${species}} jumps over the ${target}."),
+                "Wrong result (1)");
         assertEquals(
-                "Wrong result (2)",
                 "The ${animal.${species:-1}} jumps over the lazy dog.",
-                sub.replace("The ${animal.${species:-1}} jumps over the ${target}."));
+                sub.replace("The ${animal.${species:-1}} jumps over the ${target}."),
+                "Wrong result (2)");
     }
 
     /**
@@ -354,13 +354,13 @@ public class StrSubstitutorTest {
         final StrSubstitutor sub = new StrSubstitutor(values);
         sub.setEnableSubstitutionInVariables(true);
         assertEquals(
-                "Wrong result (1)",
                 "The white mouse jumps over the lazy dog.",
-                sub.replace("The ${animal.${species.${color}}} jumps over the ${target}."));
+                sub.replace("The ${animal.${species.${color}}} jumps over the ${target}."),
+                "Wrong result (1)");
         assertEquals(
-                "Wrong result (2)",
                 "The brown fox jumps over the lazy dog.",
-                sub.replace("The ${animal.${species.${unknownColor:-brown}}} jumps over the ${target}."));
+                sub.replace("The ${animal.${species.${unknownColor:-brown}}} jumps over the ${target}."),
+                "Wrong result (2)");
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/text/StrTokenizerTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/StrTokenizerTest.java
@@ -17,13 +17,13 @@
 
 package org.apache.commons.lang3.text;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -61,10 +61,10 @@ public class StrTokenizerTest {
 
         final String expected[] = new String[]{"a", "b", "c", "d;\"e", "f", "", "", "",};
 
-        assertEquals(ArrayUtils.toString(tokens), expected.length, tokens.length);
+        assertEquals(expected.length, tokens.length, ArrayUtils.toString(tokens));
         for (int i = 0; i < expected.length; i++) {
-            assertEquals("token[" + i + "] was '" + tokens[i] + "' but was expected to be '" + expected[i] + "'",
-                    expected[i], tokens[i]);
+            assertEquals(expected[i], tokens[i],
+                    "token[" + i + "] was '" + tokens[i] + "' but was expected to be '" + expected[i] + "'");
         }
 
     }
@@ -82,10 +82,10 @@ public class StrTokenizerTest {
 
         final String expected[] = new String[]{"a", "b", "c ", "d;\"e", "f", " ", " ", "",};
 
-        assertEquals(ArrayUtils.toString(tokens), expected.length, tokens.length);
+        assertEquals(expected.length, tokens.length, ArrayUtils.toString(tokens));
         for (int i = 0; i < expected.length; i++) {
-            assertEquals("token[" + i + "] was '" + tokens[i] + "' but was expected to be '" + expected[i] + "'",
-                    expected[i], tokens[i]);
+            assertEquals(expected[i], tokens[i],
+                    "token[" + i + "] was '" + tokens[i] + "' but was expected to be '" + expected[i] + "'");
         }
 
     }
@@ -103,10 +103,10 @@ public class StrTokenizerTest {
 
         final String expected[] = new String[]{"a", "b", " c", "d;\"e", "f", " ", " ", "",};
 
-        assertEquals(ArrayUtils.toString(tokens), expected.length, tokens.length);
+        assertEquals(expected.length, tokens.length, ArrayUtils.toString(tokens));
         for (int i = 0; i < expected.length; i++) {
-            assertEquals("token[" + i + "] was '" + tokens[i] + "' but was expected to be '" + expected[i] + "'",
-                    expected[i], tokens[i]);
+            assertEquals(expected[i], tokens[i],
+                    "token[" + i + "] was '" + tokens[i] + "' but was expected to be '" + expected[i] + "'");
         }
 
     }
@@ -124,10 +124,10 @@ public class StrTokenizerTest {
 
         final String expected[] = new String[]{"a", "b", "c", "d;\"e", "f",};
 
-        assertEquals(ArrayUtils.toString(tokens), expected.length, tokens.length);
+        assertEquals(expected.length, tokens.length, ArrayUtils.toString(tokens));
         for (int i = 0; i < expected.length; i++) {
-            assertEquals("token[" + i + "] was '" + tokens[i] + "' but was expected to be '" + expected[i] + "'",
-                    expected[i], tokens[i]);
+            assertEquals(expected[i], tokens[i],
+                    "token[" + i + "] was '" + tokens[i] + "' but was expected to be '" + expected[i] + "'");
         }
 
     }
@@ -146,10 +146,10 @@ public class StrTokenizerTest {
 
         final String expected[] = new String[]{"a", "b", "c", "d;\"e", "f", null, null, null,};
 
-        assertEquals(ArrayUtils.toString(tokens), expected.length, tokens.length);
+        assertEquals(expected.length, tokens.length, ArrayUtils.toString(tokens));
         for (int i = 0; i < expected.length; i++) {
-            assertEquals("token[" + i + "] was '" + tokens[i] + "' but was expected to be '" + expected[i] + "'",
-                    expected[i], tokens[i]);
+            assertEquals(expected[i], tokens[i],
+                    "token[" + i + "] was '" + tokens[i] + "' but was expected to be '" + expected[i] + "'");
         }
 
     }
@@ -180,13 +180,13 @@ public class StrTokenizerTest {
             prevCount++;
         }
 
-        assertEquals(ArrayUtils.toString(tokens), expected.length, tokens.length);
+        assertEquals(expected.length, tokens.length, ArrayUtils.toString(tokens));
 
-        assertTrue("could not cycle through entire token list" + " using the 'hasNext' and 'next' methods",
-                nextCount == expected.length);
+        assertTrue(nextCount == expected.length,
+                "could not cycle through entire token list" + " using the 'hasNext' and 'next' methods");
 
-        assertTrue("could not cycle through entire token list" + " using the 'hasPrevious' and 'previous' methods",
-                prevCount == expected.length);
+        assertTrue(prevCount == expected.length,
+                "could not cycle through entire token list" + " using the 'hasPrevious' and 'previous' methods");
 
     }
 
@@ -203,10 +203,10 @@ public class StrTokenizerTest {
 
         final String expected[] = new String[]{"a", "", "", "b", "c", "d e", "f", "",};
 
-        assertEquals(ArrayUtils.toString(tokens), expected.length, tokens.length);
+        assertEquals(expected.length, tokens.length, ArrayUtils.toString(tokens));
         for (int i = 0; i < expected.length; i++) {
-            assertEquals("token[" + i + "] was '" + tokens[i] + "' but was expected to be '" + expected[i] + "'",
-                    expected[i], tokens[i]);
+            assertEquals(expected[i], tokens[i],
+                    "token[" + i + "] was '" + tokens[i] + "' but was expected to be '" + expected[i] + "'");
         }
 
     }
@@ -224,10 +224,10 @@ public class StrTokenizerTest {
 
         final String expected[] = new String[]{"a", "b", "c", "d e", "f",};
 
-        assertEquals(ArrayUtils.toString(tokens), expected.length, tokens.length);
+        assertEquals(expected.length, tokens.length, ArrayUtils.toString(tokens));
         for (int i = 0; i < expected.length; i++) {
-            assertEquals("token[" + i + "] was '" + tokens[i] + "' but was expected to be '" + expected[i] + "'",
-                    expected[i], tokens[i]);
+            assertEquals(expected[i], tokens[i],
+                    "token[" + i + "] was '" + tokens[i] + "' but was expected to be '" + expected[i] + "'");
         }
 
     }

--- a/src/test/java/org/apache/commons/lang3/text/WordUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/WordUtilsTest.java
@@ -16,16 +16,16 @@
  */
 package org.apache.commons.lang3.text;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for WordUtils class.

--- a/src/test/java/org/apache/commons/lang3/text/translate/EntityArraysTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/translate/EntityArraysTest.java
@@ -17,12 +17,12 @@
 
 package org.apache.commons.lang3.text.translate;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashSet;
 import java.util.Set;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for {@link org.apache.commons.lang3.text.translate.EntityArrays}.
@@ -42,8 +42,8 @@ public class EntityArraysTest  {
         final Set<String> col1 = new HashSet<>();
         final String [][] sa = EntityArrays.HTML40_EXTENDED_ESCAPE();
         for(int i =0; i <sa.length; i++){
-            assertTrue("Already added entry 0: "+i+" "+sa[i][0],col0.add(sa[i][0]));
-            assertTrue("Already added entry 1: "+i+" "+sa[i][1],col1.add(sa[i][1]));
+            assertTrue(col0.add(sa[i][0]), "Already added entry 0: "+i+" "+sa[i][0]);
+            assertTrue(col1.add(sa[i][1]), "Already added entry 1: "+i+" "+sa[i][1]);
         }
     }
 
@@ -66,7 +66,7 @@ public class EntityArraysTest  {
                 System.out.println("Already added entry 1: "+i+" "+sa[i][0]+" "+sa[i][1]);
             }
         }
-        assertTrue("One or more errors detected",success);
+        assertTrue(success, "One or more errors detected");
     }
 
 

--- a/src/test/java/org/apache/commons/lang3/text/translate/LookupTranslatorTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/translate/LookupTranslatorTest.java
@@ -17,12 +17,12 @@
 
 package org.apache.commons.lang3.text.translate;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.io.StringWriter;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for {@link org.apache.commons.lang3.text.translate.LookupTranslator}.
@@ -35,8 +35,8 @@ public class LookupTranslatorTest  {
         final LookupTranslator lt = new LookupTranslator(new CharSequence[][] { { "one", "two" } });
         final StringWriter out = new StringWriter();
         final int result = lt.translate("one", 0, out);
-        assertEquals("Incorrect codepoint consumption", 3, result);
-        assertEquals("Incorrect value", "two", out.toString());
+        assertEquals(3, result, "Incorrect codepoint consumption");
+        assertEquals("two", out.toString(), "Incorrect value");
     }
 
     // Tests: https://issues.apache.org/jira/browse/LANG-882
@@ -45,8 +45,8 @@ public class LookupTranslatorTest  {
         final LookupTranslator lt = new LookupTranslator(new CharSequence[][] { { new StringBuffer("one"), new StringBuffer("two") } });
         final StringWriter out = new StringWriter();
         final int result = lt.translate(new StringBuffer("one"), 0, out);
-        assertEquals("Incorrect codepoint consumption", 3, result);
-        assertEquals("Incorrect value", "two", out.toString());
+        assertEquals(3, result, "Incorrect codepoint consumption");
+        assertEquals("two", out.toString(), "Incorrect value");
     }
 
 }

--- a/src/test/java/org/apache/commons/lang3/text/translate/NumericEntityEscaperTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/translate/NumericEntityEscaperTest.java
@@ -17,9 +17,9 @@
 
 package org.apache.commons.lang3.text.translate;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for {@link org.apache.commons.lang3.text.translate.NumericEntityEscaper}.
@@ -33,7 +33,7 @@ public class NumericEntityEscaperTest  {
 
         final String input = "ADFGZ";
         final String result = nee.translate(input);
-        assertEquals("Failed to escape numeric entities via the below method", "&#65;&#68;FGZ", result);
+        assertEquals("&#65;&#68;FGZ", result, "Failed to escape numeric entities via the below method");
     }
 
     @Test
@@ -42,7 +42,7 @@ public class NumericEntityEscaperTest  {
 
         final String input = "ADFGZ";
         final String result = nee.translate(input);
-        assertEquals("Failed to escape numeric entities via the between method", "AD&#70;&#71;Z", result);
+        assertEquals("AD&#70;&#71;Z", result, "Failed to escape numeric entities via the between method");
     }
 
     @Test
@@ -51,7 +51,7 @@ public class NumericEntityEscaperTest  {
 
         final String input = "ADFGZ";
         final String result = nee.translate(input);
-        assertEquals("Failed to escape numeric entities via the above method", "ADF&#71;&#90;", result);
+        assertEquals("ADF&#71;&#90;", result, "Failed to escape numeric entities via the above method");
     }
 
     // See LANG-617
@@ -62,7 +62,7 @@ public class NumericEntityEscaperTest  {
         final String expected = "&#68642;";
 
         final String result = nee.translate(input);
-        assertEquals("Failed to escape numeric entities supplementary characters", expected, result);
+        assertEquals(expected, result, "Failed to escape numeric entities supplementary characters");
 
     }
 

--- a/src/test/java/org/apache/commons/lang3/text/translate/NumericEntityUnescaperTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/translate/NumericEntityUnescaperTest.java
@@ -17,10 +17,10 @@
 
 package org.apache.commons.lang3.text.translate;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for {@link org.apache.commons.lang3.text.translate.NumericEntityUnescaper}.
@@ -35,17 +35,17 @@ public class NumericEntityUnescaperTest  {
         final String expected = "\uD803\uDC22";
 
         final String result = neu.translate(input);
-        assertEquals("Failed to unescape numeric entities supplementary characters", expected, result);
+        assertEquals(expected, result, "Failed to unescape numeric entities supplementary characters");
     }
 
     @Test
     public void testOutOfBounds() {
         final NumericEntityUnescaper neu = new NumericEntityUnescaper();
 
-        assertEquals("Failed to ignore when last character is &", "Test &", neu.translate("Test &"));
-        assertEquals("Failed to ignore when last character is &", "Test &#", neu.translate("Test &#"));
-        assertEquals("Failed to ignore when last character is &", "Test &#x", neu.translate("Test &#x"));
-        assertEquals("Failed to ignore when last character is &", "Test &#X", neu.translate("Test &#X"));
+        assertEquals("Test &", neu.translate("Test &"), "Failed to ignore when last character is &");
+        assertEquals("Test &#", neu.translate("Test &#"), "Failed to ignore when last character is &");
+        assertEquals("Test &#x", neu.translate("Test &#x"), "Failed to ignore when last character is &");
+        assertEquals("Test &#X", neu.translate("Test &#X"), "Failed to ignore when last character is &");
     }
 
     @Test
@@ -56,7 +56,7 @@ public class NumericEntityUnescaperTest  {
         String expected = "Test \u0030 not test";
 
         String result = neu.translate(input);
-        assertEquals("Failed to support unfinished entities (i.e. missing semi-colon)", expected, result);
+        assertEquals(expected, result, "Failed to support unfinished entities (i.e. missing semi-colon)");
 
         // ignore it
         neu = new NumericEntityUnescaper();
@@ -64,7 +64,7 @@ public class NumericEntityUnescaperTest  {
         expected = input;
 
         result = neu.translate(input);
-        assertEquals("Failed to ignore unfinished entities (i.e. missing semi-colon)", expected, result);
+        assertEquals(expected, result, "Failed to ignore unfinished entities (i.e. missing semi-colon)");
 
         // fail it
         neu = new NumericEntityUnescaper(NumericEntityUnescaper.OPTION.errorIfNoSemiColon);

--- a/src/test/java/org/apache/commons/lang3/text/translate/OctalUnescaperTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/translate/OctalUnescaperTest.java
@@ -17,8 +17,8 @@
 
 package org.apache.commons.lang3.text.translate;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Unit tests for {@link org.apache.commons.lang3.text.translate.OctalUnescaper}.
@@ -32,51 +32,51 @@ public class OctalUnescaperTest {
 
         String input = "\\45";
         String result = oue.translate(input);
-        assertEquals("Failed to unescape octal characters via the between method", "\45", result);
+        assertEquals("\45", result, "Failed to unescape octal characters via the between method");
 
         input = "\\377";
         result = oue.translate(input);
-        assertEquals("Failed to unescape octal characters via the between method", "\377", result);
+        assertEquals("\377", result, "Failed to unescape octal characters via the between method");
 
         input = "\\377 and";
         result = oue.translate(input);
-        assertEquals("Failed to unescape octal characters via the between method", "\377 and", result);
+        assertEquals("\377 and", result, "Failed to unescape octal characters via the between method");
 
         input = "\\378 and";
         result = oue.translate(input);
-        assertEquals("Failed to unescape octal characters via the between method", "\37" + "8 and", result);
+        assertEquals("\37" + "8 and", result, "Failed to unescape octal characters via the between method");
 
         input = "\\378";
         result = oue.translate(input);
-        assertEquals("Failed to unescape octal characters via the between method", "\37" + "8", result);
+        assertEquals("\37" + "8", result, "Failed to unescape octal characters via the between method");
 
         input = "\\1";
         result = oue.translate(input);
-        assertEquals("Failed to unescape octal characters via the between method", "\1", result);
+        assertEquals("\1", result, "Failed to unescape octal characters via the between method");
 
         input = "\\036";
         result = oue.translate(input);
-        assertEquals("Failed to unescape octal characters via the between method", "\036", result);
+        assertEquals("\036", result, "Failed to unescape octal characters via the between method");
 
         input = "\\0365";
         result = oue.translate(input);
-        assertEquals("Failed to unescape octal characters via the between method", "\036" + "5", result);
+        assertEquals("\036" + "5", result, "Failed to unescape octal characters via the between method");
 
         input = "\\003";
         result = oue.translate(input);
-        assertEquals("Failed to unescape octal characters via the between method", "\003", result);
+        assertEquals("\003", result, "Failed to unescape octal characters via the between method");
 
         input = "\\0003";
         result = oue.translate(input);
-        assertEquals("Failed to unescape octal characters via the between method", "\000" + "3", result);
+        assertEquals("\000" + "3", result, "Failed to unescape octal characters via the between method");
 
         input = "\\279";
         result = oue.translate(input);
-        assertEquals("Failed to unescape octal characters via the between method", "\279", result);
+        assertEquals("\279", result, "Failed to unescape octal characters via the between method");
 
         input = "\\999";
         result = oue.translate(input);
-        assertEquals("Failed to ignore an out of range octal character via the between method", "\\999", result);
+        assertEquals("\\999", result, "Failed to ignore an out of range octal character via the between method");
     }
 
 }

--- a/src/test/java/org/apache/commons/lang3/text/translate/UnicodeEscaperTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/translate/UnicodeEscaperTest.java
@@ -17,9 +17,9 @@
 
 package org.apache.commons.lang3.text.translate;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for {@link org.apache.commons.lang3.text.translate.UnicodeEscaper}.
@@ -33,7 +33,7 @@ public class UnicodeEscaperTest  {
 
         final String input = "ADFGZ";
         final String result = ue.translate(input);
-        assertEquals("Failed to escape Unicode characters via the below method", "\\u0041\\u0044FGZ", result);
+        assertEquals("\\u0041\\u0044FGZ", result, "Failed to escape Unicode characters via the below method");
     }
 
     @Test
@@ -42,7 +42,7 @@ public class UnicodeEscaperTest  {
 
         final String input = "ADFGZ";
         final String result = ue.translate(input);
-        assertEquals("Failed to escape Unicode characters via the between method", "AD\\u0046\\u0047Z", result);
+        assertEquals("AD\\u0046\\u0047Z", result, "Failed to escape Unicode characters via the between method");
     }
 
     @Test
@@ -51,6 +51,6 @@ public class UnicodeEscaperTest  {
 
         final String input = "ADFGZ";
         final String result = ue.translate(input);
-        assertEquals("Failed to escape Unicode characters via the above method", "ADF\\u0047\\u005A", result);
+        assertEquals("ADF\\u0047\\u005A", result, "Failed to escape Unicode characters via the above method");
     }
 }

--- a/src/test/java/org/apache/commons/lang3/text/translate/UnicodeUnescaperTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/translate/UnicodeUnescaperTest.java
@@ -17,10 +17,10 @@
 
 package org.apache.commons.lang3.text.translate;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for {@link org.apache.commons.lang3.text.translate.UnicodeEscaper}.
@@ -34,7 +34,7 @@ public class UnicodeUnescaperTest {
         final UnicodeUnescaper uu = new UnicodeUnescaper();
 
         final String input = "\\u+0047";
-        assertEquals("Failed to unescape Unicode characters with 'u+' notation", "G", uu.translate(input));
+        assertEquals("G", uu.translate(input), "Failed to unescape Unicode characters with 'u+' notation");
     }
 
     @Test
@@ -43,7 +43,7 @@ public class UnicodeUnescaperTest {
 
         final String input = "\\uuuuuuuu0047";
         final String result = uu.translate(input);
-        assertEquals("Failed to unescape Unicode characters with many 'u' characters", "G", result);
+        assertEquals("G", result, "Failed to unescape Unicode characters with many 'u' characters");
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/text/translate/UnicodeUnpairedSurrogateRemoverTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/translate/UnicodeUnpairedSurrogateRemoverTest.java
@@ -16,13 +16,13 @@
  */
 package org.apache.commons.lang3.text.translate;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.CharArrayWriter;
 import java.io.IOException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for {@link org.apache.commons.lang3.text.translate.UnicodeUnpairedSurrogateRemover}.


### PR DESCRIPTION
Upgrade the tests in the `text` package to use JUnit Jupiter as part of the effort to remove the dependency on the Vintage Engine.

While most of these changes are drop-in replacements with no functional benefit, there are some non-obvious changes worth mentioning.

Unlike `org.junit.Test`, `org.junit.jupiter.api.Test` does not have an `expected` argument. Instead, an explicit call to `org.junit.jupiter.api.Assertions.assertThrows` is used.

It's also worth noting this is a minimal patch for migrating the package's tests to Jupiter. There are several tests that can be made more elegant with Jupiter's new features, but that work is left for subsequent patches.