### PR TITLE
Update math tests to JUnit Jupiter

### DIFF
--- a/src/test/java/org/apache/commons/lang3/math/FractionTest.java
+++ b/src/test/java/org/apache/commons/lang3/math/FractionTest.java
@@ -18,13 +18,14 @@
  */
 package org.apache.commons.lang3.math;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test cases for the {@link Fraction} class
@@ -428,9 +429,9 @@ public class FractionTest  {
         }
     }
 
-    @Test(expected=IllegalArgumentException.class)
+    @Test
     public void testFactory_String() {
-        Fraction.getFraction(null);
+        assertThrows(IllegalArgumentException.class, () -> Fraction.getFraction(null));
     }
 
 

--- a/src/test/java/org/apache/commons/lang3/math/IEEE754rUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/math/IEEE754rUtilsTest.java
@@ -16,11 +16,11 @@
  */
 package org.apache.commons.lang3.math;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests {@link org.apache.commons.lang3.math.IEEE754rUtils}.

--- a/src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java
@@ -16,11 +16,12 @@
  */
 package org.apache.commons.lang3.math;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
@@ -28,7 +29,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 
 import java.math.RoundingMode;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests {@link org.apache.commons.lang3.math.NumberUtils}.
@@ -53,10 +54,10 @@ public class NumberUtilsTest {
      */
     @Test
     public void testToIntString() {
-        assertTrue("toInt(String) 1 failed", NumberUtils.toInt("12345") == 12345);
-        assertTrue("toInt(String) 2 failed", NumberUtils.toInt("abc") == 0);
-        assertTrue("toInt(empty) failed", NumberUtils.toInt("") == 0);
-        assertTrue("toInt(null) failed", NumberUtils.toInt(null) == 0);
+        assertTrue(NumberUtils.toInt("12345") == 12345, "toInt(String) 1 failed");
+        assertTrue(NumberUtils.toInt("abc") == 0, "toInt(String) 2 failed");
+        assertTrue(NumberUtils.toInt("") == 0, "toInt(empty) failed");
+        assertTrue(NumberUtils.toInt(null) == 0, "toInt(null) failed");
     }
 
     /**
@@ -64,8 +65,8 @@ public class NumberUtilsTest {
      */
     @Test
     public void testToIntStringI() {
-        assertTrue("toInt(String,int) 1 failed", NumberUtils.toInt("12345", 5) == 12345);
-        assertTrue("toInt(String,int) 2 failed", NumberUtils.toInt("1234.5", 5) == 5);
+        assertTrue(NumberUtils.toInt("12345", 5) == 12345, "toInt(String,int) 1 failed");
+        assertTrue(NumberUtils.toInt("1234.5", 5) == 5, "toInt(String,int) 2 failed");
     }
 
     /**
@@ -73,14 +74,14 @@ public class NumberUtilsTest {
      */
     @Test
     public void testToLongString() {
-        assertTrue("toLong(String) 1 failed", NumberUtils.toLong("12345") == 12345L);
-        assertTrue("toLong(String) 2 failed", NumberUtils.toLong("abc") == 0L);
-        assertTrue("toLong(String) 3 failed", NumberUtils.toLong("1L") == 0L);
-        assertTrue("toLong(String) 4 failed", NumberUtils.toLong("1l") == 0L);
-        assertTrue("toLong(Long.MAX_VALUE) failed", NumberUtils.toLong(Long.MAX_VALUE+"") == Long.MAX_VALUE);
-        assertTrue("toLong(Long.MIN_VALUE) failed", NumberUtils.toLong(Long.MIN_VALUE+"") == Long.MIN_VALUE);
-        assertTrue("toLong(empty) failed", NumberUtils.toLong("") == 0L);
-        assertTrue("toLong(null) failed", NumberUtils.toLong(null) == 0L);
+        assertTrue(NumberUtils.toLong("12345") == 12345L, "toLong(String) 1 failed");
+        assertTrue(NumberUtils.toLong("abc") == 0L, "toLong(String) 2 failed");
+        assertTrue(NumberUtils.toLong("1L") == 0L, "toLong(String) 3 failed");
+        assertTrue(NumberUtils.toLong("1l") == 0L, "toLong(String) 4 failed");
+        assertTrue(NumberUtils.toLong(Long.MAX_VALUE+"") == Long.MAX_VALUE, "toLong(Long.MAX_VALUE) failed");
+        assertTrue(NumberUtils.toLong(Long.MIN_VALUE+"") == Long.MIN_VALUE, "toLong(Long.MIN_VALUE) failed");
+        assertTrue(NumberUtils.toLong("") == 0L, "toLong(empty) failed");
+        assertTrue(NumberUtils.toLong(null) == 0L, "toLong(null) failed");
     }
 
     /**
@@ -88,8 +89,8 @@ public class NumberUtilsTest {
      */
     @Test
     public void testToLongStringL() {
-        assertTrue("toLong(String,long) 1 failed", NumberUtils.toLong("12345", 5L) == 12345L);
-        assertTrue("toLong(String,long) 2 failed", NumberUtils.toLong("1234.5", 5L) == 5L);
+        assertTrue(NumberUtils.toLong("12345", 5L) == 12345L, "toLong(String,long) 1 failed");
+        assertTrue(NumberUtils.toLong("1234.5", 5L) == 5L, "toLong(String,long) 2 failed");
     }
 
     /**
@@ -97,19 +98,19 @@ public class NumberUtilsTest {
      */
     @Test
     public void testToFloatString() {
-        assertTrue("toFloat(String) 1 failed", NumberUtils.toFloat("-1.2345") == -1.2345f);
-        assertTrue("toFloat(String) 2 failed", NumberUtils.toFloat("1.2345") == 1.2345f);
-        assertTrue("toFloat(String) 3 failed", NumberUtils.toFloat("abc") == 0.0f);
+        assertTrue(NumberUtils.toFloat("-1.2345") == -1.2345f, "toFloat(String) 1 failed");
+        assertTrue(NumberUtils.toFloat("1.2345") == 1.2345f, "toFloat(String) 2 failed");
+        assertTrue(NumberUtils.toFloat("abc") == 0.0f, "toFloat(String) 3 failed");
         // LANG-1060
-        assertTrue("toFloat(String) 4 failed", NumberUtils.toFloat("-001.2345") == -1.2345f);
-        assertTrue("toFloat(String) 5 failed", NumberUtils.toFloat("+001.2345") == 1.2345f);
-        assertTrue("toFloat(String) 6 failed", NumberUtils.toFloat("001.2345") == 1.2345f);
-        assertTrue("toFloat(String) 7 failed", NumberUtils.toFloat("000.00") == 0f);
+        assertTrue(NumberUtils.toFloat("-001.2345") == -1.2345f, "toFloat(String) 4 failed");
+        assertTrue(NumberUtils.toFloat("+001.2345") == 1.2345f, "toFloat(String) 5 failed");
+        assertTrue(NumberUtils.toFloat("001.2345") == 1.2345f, "toFloat(String) 6 failed");
+        assertTrue(NumberUtils.toFloat("000.00") == 0f, "toFloat(String) 7 failed");
 
-        assertTrue("toFloat(Float.MAX_VALUE) failed", NumberUtils.toFloat(Float.MAX_VALUE+"") ==  Float.MAX_VALUE);
-        assertTrue("toFloat(Float.MIN_VALUE) failed", NumberUtils.toFloat(Float.MIN_VALUE+"") == Float.MIN_VALUE);
-        assertTrue("toFloat(empty) failed", NumberUtils.toFloat("") == 0.0f);
-        assertTrue("toFloat(null) failed", NumberUtils.toFloat(null) == 0.0f);
+        assertTrue(NumberUtils.toFloat(Float.MAX_VALUE+"") ==  Float.MAX_VALUE, "toFloat(Float.MAX_VALUE) failed");
+        assertTrue(NumberUtils.toFloat(Float.MIN_VALUE+"") == Float.MIN_VALUE, "toFloat(Float.MIN_VALUE) failed");
+        assertTrue(NumberUtils.toFloat("") == 0.0f, "toFloat(empty) failed");
+        assertTrue(NumberUtils.toFloat(null) == 0.0f, "toFloat(null) failed");
     }
 
     /**
@@ -117,12 +118,12 @@ public class NumberUtilsTest {
      */
     @Test
     public void testToFloatStringF() {
-        assertTrue("toFloat(String,int) 1 failed", NumberUtils.toFloat("1.2345", 5.1f) == 1.2345f);
-        assertTrue("toFloat(String,int) 2 failed", NumberUtils.toFloat("a", 5.0f) == 5.0f);
+        assertTrue(NumberUtils.toFloat("1.2345", 5.1f) == 1.2345f, "toFloat(String,int) 1 failed");
+        assertTrue(NumberUtils.toFloat("a", 5.0f) == 5.0f, "toFloat(String,int) 2 failed");
         // LANG-1060
-        assertTrue("toFloat(String,int) 3 failed", NumberUtils.toFloat("-001Z.2345", 5.0f) == 5.0f);
-        assertTrue("toFloat(String,int) 4 failed", NumberUtils.toFloat("+001AB.2345", 5.0f) == 5.0f);
-        assertTrue("toFloat(String,int) 5 failed", NumberUtils.toFloat("001Z.2345", 5.0f) == 5.0f);
+        assertTrue(NumberUtils.toFloat("-001Z.2345", 5.0f) == 5.0f, "toFloat(String,int) 3 failed");
+        assertTrue(NumberUtils.toFloat("+001AB.2345", 5.0f) == 5.0f, "toFloat(String,int) 4 failed");
+        assertTrue(NumberUtils.toFloat("001Z.2345", 5.0f) == 5.0f, "toFloat(String,int) 5 failed");
     }
 
     /**
@@ -152,19 +153,19 @@ public class NumberUtilsTest {
      */
     @Test
     public void testStringToDoubleString() {
-        assertTrue("toDouble(String) 1 failed", NumberUtils.toDouble("-1.2345") == -1.2345d);
-        assertTrue("toDouble(String) 2 failed", NumberUtils.toDouble("1.2345") == 1.2345d);
-        assertTrue("toDouble(String) 3 failed", NumberUtils.toDouble("abc") == 0.0d);
+        assertTrue(NumberUtils.toDouble("-1.2345") == -1.2345d, "toDouble(String) 1 failed");
+        assertTrue(NumberUtils.toDouble("1.2345") == 1.2345d, "toDouble(String) 2 failed");
+        assertTrue(NumberUtils.toDouble("abc") == 0.0d, "toDouble(String) 3 failed");
         // LANG-1060
-        assertTrue("toDouble(String) 4 failed", NumberUtils.toDouble("-001.2345") == -1.2345d);
-        assertTrue("toDouble(String) 5 failed", NumberUtils.toDouble("+001.2345") == 1.2345d);
-        assertTrue("toDouble(String) 6 failed", NumberUtils.toDouble("001.2345") == 1.2345d);
-        assertTrue("toDouble(String) 7 failed", NumberUtils.toDouble("000.00000") == 0d);
+        assertTrue(NumberUtils.toDouble("-001.2345") == -1.2345d, "toDouble(String) 4 failed");
+        assertTrue(NumberUtils.toDouble("+001.2345") == 1.2345d, "toDouble(String) 5 failed");
+        assertTrue(NumberUtils.toDouble("001.2345") == 1.2345d, "toDouble(String) 6 failed");
+        assertTrue(NumberUtils.toDouble("000.00000") == 0d, "toDouble(String) 7 failed");
 
-        assertTrue("toDouble(Double.MAX_VALUE) failed", NumberUtils.toDouble(Double.MAX_VALUE+"") == Double.MAX_VALUE);
-        assertTrue("toDouble(Double.MIN_VALUE) failed", NumberUtils.toDouble(Double.MIN_VALUE+"") == Double.MIN_VALUE);
-        assertTrue("toDouble(empty) failed", NumberUtils.toDouble("") == 0.0d);
-        assertTrue("toDouble(null) failed", NumberUtils.toDouble((String) null) == 0.0d);
+        assertTrue(NumberUtils.toDouble(Double.MAX_VALUE+"") == Double.MAX_VALUE, "toDouble(Double.MAX_VALUE) failed");
+        assertTrue(NumberUtils.toDouble(Double.MIN_VALUE+"") == Double.MIN_VALUE, "toDouble(Double.MIN_VALUE) failed");
+        assertTrue(NumberUtils.toDouble("") == 0.0d, "toDouble(empty) failed");
+        assertTrue(NumberUtils.toDouble((String) null) == 0.0d, "toDouble(null) failed");
     }
 
     /**
@@ -172,13 +173,13 @@ public class NumberUtilsTest {
      */
     @Test
     public void testStringToDoubleStringD() {
-        assertTrue("toDouble(String,int) 1 failed", NumberUtils.toDouble("1.2345", 5.1d) == 1.2345d);
-        assertTrue("toDouble(String,int) 2 failed", NumberUtils.toDouble("a", 5.0d) == 5.0d);
+        assertTrue(NumberUtils.toDouble("1.2345", 5.1d) == 1.2345d, "toDouble(String,int) 1 failed");
+        assertTrue(NumberUtils.toDouble("a", 5.0d) == 5.0d, "toDouble(String,int) 2 failed");
         // LANG-1060
-        assertTrue("toDouble(String,int) 3 failed", NumberUtils.toDouble("001.2345", 5.1d) == 1.2345d);
-        assertTrue("toDouble(String,int) 4 failed", NumberUtils.toDouble("-001.2345", 5.1d) == -1.2345d);
-        assertTrue("toDouble(String,int) 5 failed", NumberUtils.toDouble("+001.2345", 5.1d) == 1.2345d);
-        assertTrue("toDouble(String,int) 7 failed", NumberUtils.toDouble("000.00", 5.1d) == 0d);
+        assertTrue(NumberUtils.toDouble("001.2345", 5.1d) == 1.2345d, "toDouble(String,int) 3 failed");
+        assertTrue(NumberUtils.toDouble("-001.2345", 5.1d) == -1.2345d, "toDouble(String,int) 4 failed");
+        assertTrue(NumberUtils.toDouble("+001.2345", 5.1d) == 1.2345d, "toDouble(String,int) 5 failed");
+        assertTrue(NumberUtils.toDouble("000.00", 5.1d) == 0d, "toDouble(String,int) 7 failed");
     }
 
     /**
@@ -186,8 +187,8 @@ public class NumberUtilsTest {
      */
     @Test
     public void testBigIntegerToDoubleBigInteger() {
-        assertTrue("toDouble(BigInteger) 1 failed", NumberUtils.toDouble((BigDecimal) null) == 0.0d);
-        assertTrue("toDouble(BigInteger) 2 failed", NumberUtils.toDouble(BigDecimal.valueOf(8.5d)) == 8.5d);
+        assertTrue(NumberUtils.toDouble((BigDecimal) null) == 0.0d, "toDouble(BigInteger) 1 failed");
+        assertTrue(NumberUtils.toDouble(BigDecimal.valueOf(8.5d)) == 8.5d, "toDouble(BigInteger) 2 failed");
     }
 
     /**
@@ -195,8 +196,8 @@ public class NumberUtilsTest {
      */
     @Test
     public void testBigIntegerToDoubleBigIntegerD() {
-        assertTrue("toDouble(BigInteger) 1 failed", NumberUtils.toDouble((BigDecimal) null, 1.1d) == 1.1d);
-        assertTrue("toDouble(BigInteger) 2 failed", NumberUtils.toDouble(BigDecimal.valueOf(8.5d), 1.1d) == 8.5d);
+        assertTrue(NumberUtils.toDouble((BigDecimal) null, 1.1d) == 1.1d, "toDouble(BigInteger) 1 failed");
+        assertTrue(NumberUtils.toDouble(BigDecimal.valueOf(8.5d), 1.1d) == 8.5d, "toDouble(BigInteger) 2 failed");
     }
 
      /**
@@ -204,10 +205,10 @@ public class NumberUtilsTest {
      */
     @Test
     public void testToByteString() {
-        assertTrue("toByte(String) 1 failed", NumberUtils.toByte("123") == 123);
-        assertTrue("toByte(String) 2 failed", NumberUtils.toByte("abc") == 0);
-        assertTrue("toByte(empty) failed", NumberUtils.toByte("") == 0);
-        assertTrue("toByte(null) failed", NumberUtils.toByte(null) == 0);
+        assertTrue(NumberUtils.toByte("123") == 123, "toByte(String) 1 failed");
+        assertTrue(NumberUtils.toByte("abc") == 0, "toByte(String) 2 failed");
+        assertTrue(NumberUtils.toByte("") == 0, "toByte(empty) failed");
+        assertTrue(NumberUtils.toByte(null) == 0, "toByte(null) failed");
     }
 
     /**
@@ -215,8 +216,8 @@ public class NumberUtilsTest {
      */
     @Test
     public void testToByteStringI() {
-        assertTrue("toByte(String,byte) 1 failed", NumberUtils.toByte("123", (byte) 5) == 123);
-        assertTrue("toByte(String,byte) 2 failed", NumberUtils.toByte("12.3", (byte) 5) == 5);
+        assertTrue(NumberUtils.toByte("123", (byte) 5) == 123, "toByte(String,byte) 1 failed");
+        assertTrue(NumberUtils.toByte("12.3", (byte) 5) == 5, "toByte(String,byte) 2 failed");
     }
 
     /**
@@ -224,10 +225,10 @@ public class NumberUtilsTest {
      */
     @Test
     public void testToShortString() {
-        assertTrue("toShort(String) 1 failed", NumberUtils.toShort("12345") == 12345);
-        assertTrue("toShort(String) 2 failed", NumberUtils.toShort("abc") == 0);
-        assertTrue("toShort(empty) failed", NumberUtils.toShort("") == 0);
-        assertTrue("toShort(null) failed", NumberUtils.toShort(null) == 0);
+        assertTrue(NumberUtils.toShort("12345") == 12345, "toShort(String) 1 failed");
+        assertTrue(NumberUtils.toShort("abc") == 0, "toShort(String) 2 failed");
+        assertTrue(NumberUtils.toShort("") == 0, "toShort(empty) failed");
+        assertTrue(NumberUtils.toShort(null) == 0, "toShort(null) failed");
     }
 
     /**
@@ -235,8 +236,8 @@ public class NumberUtilsTest {
      */
     @Test
     public void testToShortStringI() {
-        assertTrue("toShort(String,short) 1 failed", NumberUtils.toShort("12345", (short) 5) == 12345);
-        assertTrue("toShort(String,short) 2 failed", NumberUtils.toShort("1234.5", (short) 5) == 5);
+        assertTrue(NumberUtils.toShort("12345", (short) 5) == 12345, "toShort(String,short) 1 failed");
+        assertTrue(NumberUtils.toShort("1234.5", (short) 5) == 5, "toShort(String,short) 2 failed");
     }
 
     /**
@@ -244,19 +245,19 @@ public class NumberUtilsTest {
      */
     @Test
     public void testToScaledBigDecimalBigDecimal() {
-        assertTrue("toScaledBigDecimal(BigDecimal) 1 failed",
-            NumberUtils.toScaledBigDecimal(BigDecimal.valueOf(123.456)).equals(BigDecimal.valueOf(123.46)));
+        assertTrue(NumberUtils.toScaledBigDecimal(BigDecimal.valueOf(123.456)).equals(BigDecimal.valueOf(123.46)),
+                "toScaledBigDecimal(BigDecimal) 1 failed");
         // Test RoudingMode.HALF_EVEN default rounding.
-        assertTrue("toScaledBigDecimal(BigDecimal) 2 failed",
-            NumberUtils.toScaledBigDecimal(BigDecimal.valueOf(23.515)).equals(BigDecimal.valueOf(23.52)));
-        assertTrue("toScaledBigDecimal(BigDecimal) 3 failed",
-            NumberUtils.toScaledBigDecimal(BigDecimal.valueOf(23.525)).equals(BigDecimal.valueOf(23.52)));
-        assertTrue("toScaledBigDecimal(BigDecimal) 4 failed",
-            NumberUtils.toScaledBigDecimal(BigDecimal.valueOf(23.525))
-                .multiply(BigDecimal.valueOf(100)).toString()
-                .equals("2352.00"));
-        assertTrue("toScaledBigDecimal(BigDecimal) 5 failed",
-            NumberUtils.toScaledBigDecimal((BigDecimal) null).equals(BigDecimal.ZERO));
+        assertTrue(NumberUtils.toScaledBigDecimal(BigDecimal.valueOf(23.515)).equals(BigDecimal.valueOf(23.52)),
+                "toScaledBigDecimal(BigDecimal) 2 failed");
+        assertTrue(NumberUtils.toScaledBigDecimal(BigDecimal.valueOf(23.525)).equals(BigDecimal.valueOf(23.52)),
+                "toScaledBigDecimal(BigDecimal) 3 failed");
+        assertTrue(NumberUtils.toScaledBigDecimal(BigDecimal.valueOf(23.525))
+                        .multiply(BigDecimal.valueOf(100)).toString()
+                        .equals("2352.00"),
+                "toScaledBigDecimal(BigDecimal) 4 failed");
+        assertTrue(NumberUtils.toScaledBigDecimal((BigDecimal) null).equals(BigDecimal.ZERO),
+                "toScaledBigDecimal(BigDecimal) 5 failed");
     }
 
     /**
@@ -264,19 +265,19 @@ public class NumberUtilsTest {
      */
     @Test
     public void testToScaledBigDecimalBigDecimalIRM() {
-        assertTrue("toScaledBigDecimal(BigDecimal, int, RoudingMode) 1 failed",
-            NumberUtils.toScaledBigDecimal(BigDecimal.valueOf(123.456), 1, RoundingMode.CEILING).equals(BigDecimal.valueOf(123.5)));
-        assertTrue("toScaledBigDecimal(BigDecimal, int, RoudingMode) 2 failed",
-            NumberUtils.toScaledBigDecimal(BigDecimal.valueOf(23.5159), 3, RoundingMode.FLOOR).equals(BigDecimal.valueOf(23.515)));
-        assertTrue("toScaledBigDecimal(BigDecimal, int, RoudingMode) 3 failed",
-            NumberUtils.toScaledBigDecimal(BigDecimal.valueOf(23.525), 2, RoundingMode.HALF_UP).equals(BigDecimal.valueOf(23.53)));
-        assertTrue("toScaledBigDecimal(BigDecimal, int, RoudingMode) 4 failed",
-            NumberUtils.toScaledBigDecimal(BigDecimal.valueOf(23.521), 4, RoundingMode.HALF_EVEN)
-                .multiply(BigDecimal.valueOf(1000))
-                .toString()
-                .equals("23521.0000"));
-        assertTrue("toScaledBigDecimal(BigDecimal, int, RoudingMode) 5 failed",
-            NumberUtils.toScaledBigDecimal((BigDecimal) null, 2, RoundingMode.HALF_UP).equals(BigDecimal.ZERO));
+        assertTrue(NumberUtils.toScaledBigDecimal(BigDecimal.valueOf(123.456), 1, RoundingMode.CEILING).equals(BigDecimal.valueOf(123.5)),
+                "toScaledBigDecimal(BigDecimal, int, RoudingMode) 1 failed");
+        assertTrue(NumberUtils.toScaledBigDecimal(BigDecimal.valueOf(23.5159), 3, RoundingMode.FLOOR).equals(BigDecimal.valueOf(23.515)),
+                "toScaledBigDecimal(BigDecimal, int, RoudingMode) 2 failed");
+        assertTrue(NumberUtils.toScaledBigDecimal(BigDecimal.valueOf(23.525), 2, RoundingMode.HALF_UP).equals(BigDecimal.valueOf(23.53)),
+                "toScaledBigDecimal(BigDecimal, int, RoudingMode) 3 failed");
+        assertTrue(NumberUtils.toScaledBigDecimal(BigDecimal.valueOf(23.521), 4, RoundingMode.HALF_EVEN)
+                        .multiply(BigDecimal.valueOf(1000))
+                        .toString()
+                        .equals("23521.0000"),
+                "toScaledBigDecimal(BigDecimal, int, RoudingMode) 4 failed");
+        assertTrue(NumberUtils.toScaledBigDecimal((BigDecimal) null, 2, RoundingMode.HALF_UP).equals(BigDecimal.ZERO),
+                "toScaledBigDecimal(BigDecimal, int, RoudingMode) 5 failed");
     }
 
     /**
@@ -284,21 +285,21 @@ public class NumberUtilsTest {
      */
     @Test
     public void testToScaledBigDecimalFloat() {
-        assertTrue("toScaledBigDecimal(Float) 1 failed",
-            NumberUtils.toScaledBigDecimal(Float.valueOf(123.456f)).equals(BigDecimal.valueOf(123.46)));
+        assertTrue(NumberUtils.toScaledBigDecimal(Float.valueOf(123.456f)).equals(BigDecimal.valueOf(123.46)),
+                "toScaledBigDecimal(Float) 1 failed");
         // Test RoudingMode.HALF_EVEN default rounding.
-        assertTrue("toScaledBigDecimal(Float) 2 failed",
-            NumberUtils.toScaledBigDecimal(Float.valueOf(23.515f)).equals(BigDecimal.valueOf(23.51)));
+        assertTrue(NumberUtils.toScaledBigDecimal(Float.valueOf(23.515f)).equals(BigDecimal.valueOf(23.51)),
+                "toScaledBigDecimal(Float) 2 failed");
         // Note. NumberUtils.toScaledBigDecimal(Float.valueOf(23.515f)).equals(BigDecimal.valueOf(23.51))
         // because of roundoff error. It is ok.
-        assertTrue("toScaledBigDecimal(Float) 3 failed",
-            NumberUtils.toScaledBigDecimal(Float.valueOf(23.525f)).equals(BigDecimal.valueOf(23.52)));
-        assertTrue("toScaledBigDecimal(Float) 4 failed",
-            NumberUtils.toScaledBigDecimal(Float.valueOf(23.525f))
-                .multiply(BigDecimal.valueOf(100)).toString()
-                .equals("2352.00"));
-        assertTrue("toScaledBigDecimal(Float) 5 failed",
-            NumberUtils.toScaledBigDecimal((Float) null).equals(BigDecimal.ZERO));
+        assertTrue(NumberUtils.toScaledBigDecimal(Float.valueOf(23.525f)).equals(BigDecimal.valueOf(23.52)),
+                "toScaledBigDecimal(Float) 3 failed");
+        assertTrue(NumberUtils.toScaledBigDecimal(Float.valueOf(23.525f))
+                        .multiply(BigDecimal.valueOf(100)).toString()
+                        .equals("2352.00"),
+                "toScaledBigDecimal(Float) 4 failed");
+        assertTrue(NumberUtils.toScaledBigDecimal((Float) null).equals(BigDecimal.ZERO),
+                "toScaledBigDecimal(Float) 5 failed");
     }
 
     /**
@@ -306,20 +307,20 @@ public class NumberUtilsTest {
      */
     @Test
     public void testToScaledBigDecimalFloatIRM() {
-        assertTrue("toScaledBigDecimal(Float, int, RoudingMode) 1 failed",
-            NumberUtils.toScaledBigDecimal(Float.valueOf(123.456f), 1, RoundingMode.CEILING).equals(BigDecimal.valueOf(123.5)));
-        assertTrue("toScaledBigDecimal(Float, int, RoudingMode) 2 failed",
-            NumberUtils.toScaledBigDecimal(Float.valueOf(23.5159f), 3, RoundingMode.FLOOR).equals(BigDecimal.valueOf(23.515)));
+        assertTrue(NumberUtils.toScaledBigDecimal(Float.valueOf(123.456f), 1, RoundingMode.CEILING).equals(BigDecimal.valueOf(123.5)),
+                "toScaledBigDecimal(Float, int, RoudingMode) 1 failed");
+        assertTrue(NumberUtils.toScaledBigDecimal(Float.valueOf(23.5159f), 3, RoundingMode.FLOOR).equals(BigDecimal.valueOf(23.515)),
+                "toScaledBigDecimal(Float, int, RoudingMode) 2 failed");
         // The following happens due to roundoff error. We're ok with this.
-        assertTrue("toScaledBigDecimal(Float, int, RoudingMode) 3 failed",
-            NumberUtils.toScaledBigDecimal(Float.valueOf(23.525f), 2, RoundingMode.HALF_UP).equals(BigDecimal.valueOf(23.52)));
-        assertTrue("toScaledBigDecimal(Float, int, RoudingMode) 4 failed",
-            NumberUtils.toScaledBigDecimal(Float.valueOf(23.521f), 4, RoundingMode.HALF_EVEN)
-                .multiply(BigDecimal.valueOf(1000))
-                .toString()
-                .equals("23521.0000"));
-        assertTrue("toScaledBigDecimal(Float, int, RoudingMode) 5 failed",
-            NumberUtils.toScaledBigDecimal((Float) null, 2, RoundingMode.HALF_UP).equals(BigDecimal.ZERO));
+        assertTrue(NumberUtils.toScaledBigDecimal(Float.valueOf(23.525f), 2, RoundingMode.HALF_UP).equals(BigDecimal.valueOf(23.52)),
+                "toScaledBigDecimal(Float, int, RoudingMode) 3 failed");
+        assertTrue(NumberUtils.toScaledBigDecimal(Float.valueOf(23.521f), 4, RoundingMode.HALF_EVEN)
+                        .multiply(BigDecimal.valueOf(1000))
+                        .toString()
+                        .equals("23521.0000"),
+                "toScaledBigDecimal(Float, int, RoudingMode) 4 failed");
+        assertTrue(NumberUtils.toScaledBigDecimal((Float) null, 2, RoundingMode.HALF_UP).equals(BigDecimal.ZERO),
+                "toScaledBigDecimal(Float, int, RoudingMode) 5 failed");
     }
 
     /**
@@ -327,19 +328,19 @@ public class NumberUtilsTest {
      */
     @Test
     public void testToScaledBigDecimalDouble() {
-        assertTrue("toScaledBigDecimal(Double) 1 failed",
-            NumberUtils.toScaledBigDecimal(Double.valueOf(123.456d)).equals(BigDecimal.valueOf(123.46)));
+        assertTrue(NumberUtils.toScaledBigDecimal(Double.valueOf(123.456d)).equals(BigDecimal.valueOf(123.46)),
+                "toScaledBigDecimal(Double) 1 failed");
         // Test RoudingMode.HALF_EVEN default rounding.
-        assertTrue("toScaledBigDecimal(Double) 2 failed",
-            NumberUtils.toScaledBigDecimal(Double.valueOf(23.515d)).equals(BigDecimal.valueOf(23.52)));
-        assertTrue("toScaledBigDecimal(Double) 3 failed",
-            NumberUtils.toScaledBigDecimal(Double.valueOf(23.525d)).equals(BigDecimal.valueOf(23.52)));
-        assertTrue("toScaledBigDecimal(Double) 4 failed",
-            NumberUtils.toScaledBigDecimal(Double.valueOf(23.525d))
-                .multiply(BigDecimal.valueOf(100)).toString()
-                .equals("2352.00"));
-        assertTrue("toScaledBigDecimal(Double) 5 failed",
-            NumberUtils.toScaledBigDecimal((Double) null).equals(BigDecimal.ZERO));
+        assertTrue(NumberUtils.toScaledBigDecimal(Double.valueOf(23.515d)).equals(BigDecimal.valueOf(23.52)),
+                "toScaledBigDecimal(Double) 2 failed");
+        assertTrue(NumberUtils.toScaledBigDecimal(Double.valueOf(23.525d)).equals(BigDecimal.valueOf(23.52)),
+                "toScaledBigDecimal(Double) 3 failed");
+        assertTrue(NumberUtils.toScaledBigDecimal(Double.valueOf(23.525d))
+                        .multiply(BigDecimal.valueOf(100)).toString()
+                        .equals("2352.00"),
+                "toScaledBigDecimal(Double) 4 failed");
+        assertTrue(NumberUtils.toScaledBigDecimal((Double) null).equals(BigDecimal.ZERO),
+                "toScaledBigDecimal(Double) 5 failed");
     }
 
     /**
@@ -347,19 +348,19 @@ public class NumberUtilsTest {
      */
     @Test
     public void testToScaledBigDecimalDoubleIRM() {
-        assertTrue("toScaledBigDecimal(Double, int, RoudingMode) 1 failed",
-            NumberUtils.toScaledBigDecimal(Double.valueOf(123.456d), 1, RoundingMode.CEILING).equals(BigDecimal.valueOf(123.5)));
-        assertTrue("toScaledBigDecimal(Double, int, RoudingMode) 2 failed",
-            NumberUtils.toScaledBigDecimal(Double.valueOf(23.5159d), 3, RoundingMode.FLOOR).equals(BigDecimal.valueOf(23.515)));
-        assertTrue("toScaledBigDecimal(Double, int, RoudingMode) 3 failed",
-            NumberUtils.toScaledBigDecimal(Double.valueOf(23.525d), 2, RoundingMode.HALF_UP).equals(BigDecimal.valueOf(23.53)));
-        assertTrue("toScaledBigDecimal(Double, int, RoudingMode) 4 failed",
-            NumberUtils.toScaledBigDecimal(Double.valueOf(23.521d), 4, RoundingMode.HALF_EVEN)
-                .multiply(BigDecimal.valueOf(1000))
-                .toString()
-                .equals("23521.0000"));
-        assertTrue("toScaledBigDecimal(Double, int, RoudingMode) 5 failed",
-            NumberUtils.toScaledBigDecimal((Double) null, 2, RoundingMode.HALF_UP).equals(BigDecimal.ZERO));
+        assertTrue(NumberUtils.toScaledBigDecimal(Double.valueOf(123.456d), 1, RoundingMode.CEILING).equals(BigDecimal.valueOf(123.5)),
+                "toScaledBigDecimal(Double, int, RoudingMode) 1 failed");
+        assertTrue(NumberUtils.toScaledBigDecimal(Double.valueOf(23.5159d), 3, RoundingMode.FLOOR).equals(BigDecimal.valueOf(23.515)),
+                "toScaledBigDecimal(Double, int, RoudingMode) 2 failed");
+        assertTrue(NumberUtils.toScaledBigDecimal(Double.valueOf(23.525d), 2, RoundingMode.HALF_UP).equals(BigDecimal.valueOf(23.53)),
+                "toScaledBigDecimal(Double, int, RoudingMode) 3 failed");
+        assertTrue(NumberUtils.toScaledBigDecimal(Double.valueOf(23.521d), 4, RoundingMode.HALF_EVEN)
+                        .multiply(BigDecimal.valueOf(1000))
+                        .toString()
+                        .equals("23521.0000"),
+                "toScaledBigDecimal(Double, int, RoudingMode) 4 failed");
+        assertTrue(NumberUtils.toScaledBigDecimal((Double) null, 2, RoundingMode.HALF_UP).equals(BigDecimal.ZERO),
+                "toScaledBigDecimal(Double, int, RoudingMode) 5 failed");
     }
 
     /**
@@ -367,19 +368,19 @@ public class NumberUtilsTest {
      */
     @Test
     public void testToScaledBigDecimalString() {
-        assertTrue("toScaledBigDecimal(String) 1 failed",
-            NumberUtils.toScaledBigDecimal("123.456").equals(BigDecimal.valueOf(123.46)));
+        assertTrue(NumberUtils.toScaledBigDecimal("123.456").equals(BigDecimal.valueOf(123.46)),
+                "toScaledBigDecimal(String) 1 failed");
         // Test RoudingMode.HALF_EVEN default rounding.
-        assertTrue("toScaledBigDecimal(String) 2 failed",
-            NumberUtils.toScaledBigDecimal("23.515").equals(BigDecimal.valueOf(23.52)));
-        assertTrue("toScaledBigDecimal(String) 3 failed",
-            NumberUtils.toScaledBigDecimal("23.525").equals(BigDecimal.valueOf(23.52)));
-        assertTrue("toScaledBigDecimal(String) 4 failed",
-            NumberUtils.toScaledBigDecimal("23.525")
-                .multiply(BigDecimal.valueOf(100)).toString()
-                .equals("2352.00"));
-        assertTrue("toScaledBigDecimal(String) 5 failed",
-            NumberUtils.toScaledBigDecimal((String) null).equals(BigDecimal.ZERO));
+        assertTrue(NumberUtils.toScaledBigDecimal("23.515").equals(BigDecimal.valueOf(23.52)),
+                "toScaledBigDecimal(String) 2 failed");
+        assertTrue(NumberUtils.toScaledBigDecimal("23.525").equals(BigDecimal.valueOf(23.52)),
+                "toScaledBigDecimal(String) 3 failed");
+        assertTrue(NumberUtils.toScaledBigDecimal("23.525")
+                        .multiply(BigDecimal.valueOf(100)).toString()
+                        .equals("2352.00"),
+                "toScaledBigDecimal(String) 4 failed");
+        assertTrue(NumberUtils.toScaledBigDecimal((String) null).equals(BigDecimal.ZERO),
+                "toScaledBigDecimal(String) 5 failed");
     }
 
     /**
@@ -387,67 +388,61 @@ public class NumberUtilsTest {
      */
     @Test
     public void testToScaledBigDecimalStringIRM() {
-        assertTrue("toScaledBigDecimal(String, int, RoudingMode) 1 failed",
-            NumberUtils.toScaledBigDecimal("123.456", 1, RoundingMode.CEILING).equals(BigDecimal.valueOf(123.5)));
-        assertTrue("toScaledBigDecimal(String, int, RoudingMode) 2 failed",
-            NumberUtils.toScaledBigDecimal("23.5159", 3, RoundingMode.FLOOR).equals(BigDecimal.valueOf(23.515)));
-        assertTrue("toScaledBigDecimal(String, int, RoudingMode) 3 failed",
-            NumberUtils.toScaledBigDecimal("23.525", 2, RoundingMode.HALF_UP).equals(BigDecimal.valueOf(23.53)));
-        assertTrue("toScaledBigDecimal(String, int, RoudingMode) 4 failed",
-            NumberUtils.toScaledBigDecimal("23.521", 4, RoundingMode.HALF_EVEN)
-                .multiply(BigDecimal.valueOf(1000))
-                .toString()
-                .equals("23521.0000"));
-        assertTrue("toScaledBigDecimal(String, int, RoudingMode) 5 failed",
-            NumberUtils.toScaledBigDecimal((String) null, 2, RoundingMode.HALF_UP).equals(BigDecimal.ZERO));
+        assertTrue(NumberUtils.toScaledBigDecimal("123.456", 1, RoundingMode.CEILING).equals(BigDecimal.valueOf(123.5)),
+                "toScaledBigDecimal(String, int, RoudingMode) 1 failed");
+        assertTrue(NumberUtils.toScaledBigDecimal("23.5159", 3, RoundingMode.FLOOR).equals(BigDecimal.valueOf(23.515)),
+                "toScaledBigDecimal(String, int, RoudingMode) 2 failed");
+        assertTrue(NumberUtils.toScaledBigDecimal("23.525", 2, RoundingMode.HALF_UP).equals(BigDecimal.valueOf(23.53)),
+                "toScaledBigDecimal(String, int, RoudingMode) 3 failed");
+        assertTrue(NumberUtils.toScaledBigDecimal("23.521", 4, RoundingMode.HALF_EVEN)
+                        .multiply(BigDecimal.valueOf(1000))
+                        .toString()
+                        .equals("23521.0000"),
+                "toScaledBigDecimal(String, int, RoudingMode) 4 failed");
+        assertTrue(NumberUtils.toScaledBigDecimal((String) null, 2, RoundingMode.HALF_UP).equals(BigDecimal.ZERO),
+                "toScaledBigDecimal(String, int, RoudingMode) 5 failed");
     }
 
     @Test
     public void testCreateNumber() {
         // a lot of things can go wrong
-        assertEquals("createNumber(String) 1 failed", Float.valueOf("1234.5"), NumberUtils.createNumber("1234.5"));
-        assertEquals("createNumber(String) 2 failed", Integer.valueOf("12345"), NumberUtils.createNumber("12345"));
-        assertEquals("createNumber(String) 3 failed", Double.valueOf("1234.5"), NumberUtils.createNumber("1234.5D"));
-        assertEquals("createNumber(String) 3 failed", Double.valueOf("1234.5"), NumberUtils.createNumber("1234.5d"));
-        assertEquals("createNumber(String) 4 failed", Float.valueOf("1234.5"), NumberUtils.createNumber("1234.5F"));
-        assertEquals("createNumber(String) 4 failed", Float.valueOf("1234.5"), NumberUtils.createNumber("1234.5f"));
-        assertEquals("createNumber(String) 5 failed", Long.valueOf(Integer.MAX_VALUE + 1L), NumberUtils.createNumber(""
-            + (Integer.MAX_VALUE + 1L)));
-        assertEquals("createNumber(String) 6 failed", Long.valueOf(12345), NumberUtils.createNumber("12345L"));
-        assertEquals("createNumber(String) 6 failed", Long.valueOf(12345), NumberUtils.createNumber("12345l"));
-        assertEquals("createNumber(String) 7 failed", Float.valueOf("-1234.5"), NumberUtils.createNumber("-1234.5"));
-        assertEquals("createNumber(String) 8 failed", Integer.valueOf("-12345"), NumberUtils.createNumber("-12345"));
-        assertTrue("createNumber(String) 9a failed", 0xFADE == NumberUtils.createNumber("0xFADE").intValue());
-        assertTrue("createNumber(String) 9b failed", 0xFADE == NumberUtils.createNumber("0Xfade").intValue());
-        assertTrue("createNumber(String) 10a failed", -0xFADE == NumberUtils.createNumber("-0xFADE").intValue());
-        assertTrue("createNumber(String) 10b failed", -0xFADE == NumberUtils.createNumber("-0Xfade").intValue());
-        assertEquals("createNumber(String) 11 failed", Double.valueOf("1.1E200"), NumberUtils.createNumber("1.1E200"));
-        assertEquals("createNumber(String) 12 failed", Float.valueOf("1.1E20"), NumberUtils.createNumber("1.1E20"));
-        assertEquals("createNumber(String) 13 failed", Double.valueOf("-1.1E200"), NumberUtils.createNumber("-1.1E200"));
-        assertEquals("createNumber(String) 14 failed", Double.valueOf("1.1E-200"), NumberUtils.createNumber("1.1E-200"));
-        assertEquals("createNumber(null) failed", null, NumberUtils.createNumber(null));
-        assertEquals("createNumber(String) failed", new BigInteger("12345678901234567890"), NumberUtils
-                .createNumber("12345678901234567890L"));
+        assertEquals(Float.valueOf("1234.5"), NumberUtils.createNumber("1234.5"), "createNumber(String) 1 failed");
+        assertEquals(Integer.valueOf("12345"), NumberUtils.createNumber("12345"), "createNumber(String) 2 failed");
+        assertEquals(Double.valueOf("1234.5"), NumberUtils.createNumber("1234.5D"), "createNumber(String) 3 failed");
+        assertEquals(Double.valueOf("1234.5"), NumberUtils.createNumber("1234.5d"), "createNumber(String) 3 failed");
+        assertEquals(Float.valueOf("1234.5"), NumberUtils.createNumber("1234.5F"), "createNumber(String) 4 failed");
+        assertEquals(Float.valueOf("1234.5"), NumberUtils.createNumber("1234.5f"), "createNumber(String) 4 failed");
+        assertEquals(Long.valueOf(Integer.MAX_VALUE + 1L), NumberUtils.createNumber(""
+                    + (Integer.MAX_VALUE + 1L)), "createNumber(String) 5 failed");
+        assertEquals(Long.valueOf(12345), NumberUtils.createNumber("12345L"), "createNumber(String) 6 failed");
+        assertEquals(Long.valueOf(12345), NumberUtils.createNumber("12345l"), "createNumber(String) 6 failed");
+        assertEquals(Float.valueOf("-1234.5"), NumberUtils.createNumber("-1234.5"), "createNumber(String) 7 failed");
+        assertEquals(Integer.valueOf("-12345"), NumberUtils.createNumber("-12345"), "createNumber(String) 8 failed");
+        assertTrue(0xFADE == NumberUtils.createNumber("0xFADE").intValue(), "createNumber(String) 9a failed");
+        assertTrue(0xFADE == NumberUtils.createNumber("0Xfade").intValue(), "createNumber(String) 9b failed");
+        assertTrue(-0xFADE == NumberUtils.createNumber("-0xFADE").intValue(), "createNumber(String) 10a failed");
+        assertTrue(-0xFADE == NumberUtils.createNumber("-0Xfade").intValue(), "createNumber(String) 10b failed");
+        assertEquals(Double.valueOf("1.1E200"), NumberUtils.createNumber("1.1E200"), "createNumber(String) 11 failed");
+        assertEquals(Float.valueOf("1.1E20"), NumberUtils.createNumber("1.1E20"), "createNumber(String) 12 failed");
+        assertEquals(Double.valueOf("-1.1E200"), NumberUtils.createNumber("-1.1E200"), "createNumber(String) 13 failed");
+        assertEquals(Double.valueOf("1.1E-200"), NumberUtils.createNumber("1.1E-200"), "createNumber(String) 14 failed");
+        assertEquals(null, NumberUtils.createNumber(null), "createNumber(null) failed");
+        assertEquals(new BigInteger("12345678901234567890"), NumberUtils.createNumber("12345678901234567890L"), "createNumber(String) failed");
 
-        assertEquals("createNumber(String) 15 failed", new BigDecimal("1.1E-700"), NumberUtils
-                    .createNumber("1.1E-700F"));
+        assertEquals(new BigDecimal("1.1E-700"), NumberUtils.createNumber("1.1E-700F"), "createNumber(String) 15 failed");
 
-        assertEquals("createNumber(String) 16 failed", Long.valueOf("10" + Integer.MAX_VALUE), NumberUtils
-                .createNumber("10" + Integer.MAX_VALUE + "L"));
-        assertEquals("createNumber(String) 17 failed", Long.valueOf("10" + Integer.MAX_VALUE), NumberUtils
-                .createNumber("10" + Integer.MAX_VALUE));
-        assertEquals("createNumber(String) 18 failed", new BigInteger("10" + Long.MAX_VALUE), NumberUtils
-                .createNumber("10" + Long.MAX_VALUE));
+        assertEquals(Long.valueOf("10" + Integer.MAX_VALUE), NumberUtils.createNumber("10" + Integer.MAX_VALUE + "L"), "createNumber(String) 16 failed");
+        assertEquals(Long.valueOf("10" + Integer.MAX_VALUE), NumberUtils.createNumber("10" + Integer.MAX_VALUE), "createNumber(String) 17 failed");
+        assertEquals(new BigInteger("10" + Long.MAX_VALUE), NumberUtils.createNumber("10" + Long.MAX_VALUE), "createNumber(String) 18 failed");
 
         // LANG-521
-        assertEquals("createNumber(String) LANG-521 failed", Float.valueOf("2."), NumberUtils.createNumber("2."));
+        assertEquals(Float.valueOf("2."), NumberUtils.createNumber("2."), "createNumber(String) LANG-521 failed");
 
         // LANG-638
-        assertFalse("createNumber(String) succeeded", checkCreateNumber("1eE"));
+        assertFalse(checkCreateNumber("1eE"), "createNumber(String) succeeded");
 
         // LANG-693
-        assertEquals("createNumber(String) LANG-693 failed", Double.valueOf(Double.MAX_VALUE), NumberUtils
-                    .createNumber("" + Double.MAX_VALUE));
+        assertEquals(Double.valueOf(Double.MAX_VALUE), NumberUtils.createNumber("" + Double.MAX_VALUE), "createNumber(String) LANG-693 failed");
 
         // LANG-822
         // ensure that the underlying negative number would create a BigDecimal
@@ -456,29 +451,29 @@ public class NumberUtilsTest {
         assertEquals(BigDecimal.class, bigNum.getClass());
 
         // LANG-1018
-        assertEquals("createNumber(String) LANG-1018 failed",
-                Double.valueOf("-160952.54"), NumberUtils.createNumber("-160952.54"));
+        assertEquals(Double.valueOf("-160952.54"), NumberUtils.createNumber("-160952.54"),
+                "createNumber(String) LANG-1018 failed");
         // LANG-1187
-        assertEquals("createNumber(String) LANG-1187 failed",
-                Double.valueOf("6264583.33"), NumberUtils.createNumber("6264583.33"));
+        assertEquals(Double.valueOf("6264583.33"), NumberUtils.createNumber("6264583.33"),
+                "createNumber(String) LANG-1187 failed");
         // LANG-1215
-        assertEquals("createNumber(String) LANG-1215 failed",
-                Double.valueOf("193343.82"), NumberUtils.createNumber("193343.82"));
+        assertEquals(Double.valueOf("193343.82"), NumberUtils.createNumber("193343.82"),
+                "createNumber(String) LANG-1215 failed");
         // LANG-1060
-        assertEquals("createNumber(String) LANG-1060a failed", Double.valueOf("001234.5678"), NumberUtils.createNumber("001234.5678"));
-        assertEquals("createNumber(String) LANG-1060b failed", Double.valueOf("+001234.5678"), NumberUtils.createNumber("+001234.5678"));
-        assertEquals("createNumber(String) LANG-1060c failed", Double.valueOf("-001234.5678"), NumberUtils.createNumber("-001234.5678"));
-        assertEquals("createNumber(String) LANG-1060d failed", Double.valueOf("0000.00000"), NumberUtils.createNumber("0000.00000d"));
-        assertEquals("createNumber(String) LANG-1060e failed", Float.valueOf("001234.56"), NumberUtils.createNumber("001234.56"));
-        assertEquals("createNumber(String) LANG-1060f failed", Float.valueOf("+001234.56"), NumberUtils.createNumber("+001234.56"));
-        assertEquals("createNumber(String) LANG-1060g failed", Float.valueOf("-001234.56"), NumberUtils.createNumber("-001234.56"));
-        assertEquals("createNumber(String) LANG-1060h failed", Float.valueOf("0000.10"), NumberUtils.createNumber("0000.10"));
-        assertEquals("createNumber(String) LANG-1060i failed", Float.valueOf("001.1E20"), NumberUtils.createNumber("001.1E20"));
-        assertEquals("createNumber(String) LANG-1060j failed", Float.valueOf("+001.1E20"), NumberUtils.createNumber("+001.1E20"));
-        assertEquals("createNumber(String) LANG-1060k failed", Float.valueOf("-001.1E20"), NumberUtils.createNumber("-001.1E20"));
-        assertEquals("createNumber(String) LANG-1060l failed", Double.valueOf("001.1E200"), NumberUtils.createNumber("001.1E200"));
-        assertEquals("createNumber(String) LANG-1060m failed", Double.valueOf("+001.1E200"), NumberUtils.createNumber("+001.1E200"));
-        assertEquals("createNumber(String) LANG-1060n failed", Double.valueOf("-001.1E200"), NumberUtils.createNumber("-001.1E200"));
+        assertEquals(Double.valueOf("001234.5678"), NumberUtils.createNumber("001234.5678"), "createNumber(String) LANG-1060a failed");
+        assertEquals(Double.valueOf("+001234.5678"), NumberUtils.createNumber("+001234.5678"), "createNumber(String) LANG-1060b failed");
+        assertEquals(Double.valueOf("-001234.5678"), NumberUtils.createNumber("-001234.5678"), "createNumber(String) LANG-1060c failed");
+        assertEquals(Double.valueOf("0000.00000"), NumberUtils.createNumber("0000.00000d"), "createNumber(String) LANG-1060d failed");
+        assertEquals(Float.valueOf("001234.56"), NumberUtils.createNumber("001234.56"), "createNumber(String) LANG-1060e failed");
+        assertEquals(Float.valueOf("+001234.56"), NumberUtils.createNumber("+001234.56"), "createNumber(String) LANG-1060f failed");
+        assertEquals(Float.valueOf("-001234.56"), NumberUtils.createNumber("-001234.56"), "createNumber(String) LANG-1060g failed");
+        assertEquals(Float.valueOf("0000.10"), NumberUtils.createNumber("0000.10"), "createNumber(String) LANG-1060h failed");
+        assertEquals(Float.valueOf("001.1E20"), NumberUtils.createNumber("001.1E20"), "createNumber(String) LANG-1060i failed");
+        assertEquals(Float.valueOf("+001.1E20"), NumberUtils.createNumber("+001.1E20"), "createNumber(String) LANG-1060j failed");
+        assertEquals(Float.valueOf("-001.1E20"), NumberUtils.createNumber("-001.1E20"), "createNumber(String) LANG-1060k failed");
+        assertEquals(Double.valueOf("001.1E200"), NumberUtils.createNumber("001.1E200"), "createNumber(String) LANG-1060l failed");
+        assertEquals(Double.valueOf("+001.1E200"), NumberUtils.createNumber("+001.1E200"), "createNumber(String) LANG-1060m failed");
+        assertEquals(Double.valueOf("-001.1E200"), NumberUtils.createNumber("-001.1E200"), "createNumber(String) LANG-1060n failed");
     }
 
     @Test
@@ -531,52 +526,52 @@ public class NumberUtilsTest {
         assertEquals(new BigInteger("FFFFFFFFFFFFFFFF", 16), NumberUtils.createNumber("0x0FFFFFFFFFFFFFFFF"));
     }
 
-    @Test(expected=NumberFormatException.class)
+    @Test
     // Check that the code fails to create a valid number when preceded by -- rather than -
     public void testCreateNumberFailure_1() {
-        NumberUtils.createNumber("--1.1E-700F");
+        assertThrows(NumberFormatException.class, () -> NumberUtils.createNumber("--1.1E-700F"));
     }
 
-    @Test(expected=NumberFormatException.class)
+    @Test
     // Check that the code fails to create a valid number when both e and E are present (with decimal)
     public void testCreateNumberFailure_2() {
-        NumberUtils.createNumber("-1.1E+0-7e00");
+        assertThrows(NumberFormatException.class, () -> NumberUtils.createNumber("-1.1E+0-7e00"));
     }
 
-    @Test(expected=NumberFormatException.class)
+    @Test
     // Check that the code fails to create a valid number when both e and E are present (no decimal)
     public void testCreateNumberFailure_3() {
-        NumberUtils.createNumber("-11E+0-7e00");
+        assertThrows(NumberFormatException.class, () -> NumberUtils.createNumber("-11E+0-7e00"));
     }
 
-    @Test(expected=NumberFormatException.class)
+    @Test
     // Check that the code fails to create a valid number when both e and E are present (no decimal)
     public void testCreateNumberFailure_4() {
-        NumberUtils.createNumber("1eE+00001");
+        assertThrows(NumberFormatException.class, () -> NumberUtils.createNumber("1eE+00001"));
     }
 
-    @Test(expected=NumberFormatException.class)
+    @Test
     // Check that the code fails to create a valid number when there are multiple trailing 'f' characters (LANG-1205)
     public void testCreateNumberFailure_5() {
-        NumberUtils.createNumber("1234.5ff");
+        assertThrows(NumberFormatException.class, () -> NumberUtils.createNumber("1234.5ff"));
     }
 
-    @Test(expected=NumberFormatException.class)
+    @Test
     // Check that the code fails to create a valid number when there are multiple trailing 'F' characters (LANG-1205)
     public void testCreateNumberFailure_6() {
-        NumberUtils.createNumber("1234.5FF");
+        assertThrows(NumberFormatException.class, () -> NumberUtils.createNumber("1234.5FF"));
     }
 
-    @Test(expected=NumberFormatException.class)
+    @Test
     // Check that the code fails to create a valid number when there are multiple trailing 'd' characters (LANG-1205)
     public void testCreateNumberFailure_7() {
-        NumberUtils.createNumber("1234.5dd");
+        assertThrows(NumberFormatException.class, () -> NumberUtils.createNumber("1234.5dd"));
     }
 
-    @Test(expected=NumberFormatException.class)
+    @Test
     // Check that the code fails to create a valid number when there are multiple trailing 'D' characters (LANG-1205)
     public void testCreateNumberFailure_8() {
-        NumberUtils.createNumber("1234.5DD");
+        assertThrows(NumberFormatException.class, () -> NumberUtils.createNumber("1234.5DD"));
     }
 
     // Tests to show when magnitude causes switch to next Number type
@@ -611,8 +606,8 @@ public class NumberUtilsTest {
 
     @Test
     public void testCreateFloat() {
-        assertEquals("createFloat(String) failed", Float.valueOf("1234.5"), NumberUtils.createFloat("1234.5"));
-        assertEquals("createFloat(null) failed", null, NumberUtils.createFloat(null));
+        assertEquals(Float.valueOf("1234.5"), NumberUtils.createFloat("1234.5"), "createFloat(String) failed");
+        assertEquals(null, NumberUtils.createFloat(null), "createFloat(null) failed");
         this.testCreateFloatFailure("");
         this.testCreateFloatFailure(" ");
         this.testCreateFloatFailure("\b\t\n\f\r");
@@ -631,8 +626,8 @@ public class NumberUtilsTest {
 
     @Test
     public void testCreateDouble() {
-        assertEquals("createDouble(String) failed", Double.valueOf("1234.5"), NumberUtils.createDouble("1234.5"));
-        assertEquals("createDouble(null) failed", null, NumberUtils.createDouble(null));
+        assertEquals(Double.valueOf("1234.5"), NumberUtils.createDouble("1234.5"), "createDouble(String) failed");
+        assertEquals(null, NumberUtils.createDouble(null), "createDouble(null) failed");
         this.testCreateDoubleFailure("");
         this.testCreateDoubleFailure(" ");
         this.testCreateDoubleFailure("\b\t\n\f\r");
@@ -651,8 +646,8 @@ public class NumberUtilsTest {
 
     @Test
     public void testCreateInteger() {
-        assertEquals("createInteger(String) failed", Integer.valueOf("12345"), NumberUtils.createInteger("12345"));
-        assertEquals("createInteger(null) failed", null, NumberUtils.createInteger(null));
+        assertEquals(Integer.valueOf("12345"), NumberUtils.createInteger("12345"), "createInteger(String) failed");
+        assertEquals(null, NumberUtils.createInteger(null), "createInteger(null) failed");
         this.testCreateIntegerFailure("");
         this.testCreateIntegerFailure(" ");
         this.testCreateIntegerFailure("\b\t\n\f\r");
@@ -671,8 +666,8 @@ public class NumberUtilsTest {
 
     @Test
     public void testCreateLong() {
-        assertEquals("createLong(String) failed", Long.valueOf("12345"), NumberUtils.createLong("12345"));
-        assertEquals("createLong(null) failed", null, NumberUtils.createLong(null));
+        assertEquals(Long.valueOf("12345"), NumberUtils.createLong("12345"), "createLong(String) failed");
+        assertEquals(null, NumberUtils.createLong(null), "createLong(null) failed");
         this.testCreateLongFailure("");
         this.testCreateLongFailure(" ");
         this.testCreateLongFailure("\b\t\n\f\r");
@@ -691,22 +686,22 @@ public class NumberUtilsTest {
 
     @Test
     public void testCreateBigInteger() {
-        assertEquals("createBigInteger(String) failed", new BigInteger("12345"), NumberUtils.createBigInteger("12345"));
-        assertEquals("createBigInteger(null) failed", null, NumberUtils.createBigInteger(null));
+        assertEquals(new BigInteger("12345"), NumberUtils.createBigInteger("12345"), "createBigInteger(String) failed");
+        assertEquals(null, NumberUtils.createBigInteger(null), "createBigInteger(null) failed");
         this.testCreateBigIntegerFailure("");
         this.testCreateBigIntegerFailure(" ");
         this.testCreateBigIntegerFailure("\b\t\n\f\r");
         // Funky whitespaces
         this.testCreateBigIntegerFailure("\u00A0\uFEFF\u000B\u000C\u001C\u001D\u001E\u001F");
-        assertEquals("createBigInteger(String) failed", new BigInteger("255"), NumberUtils.createBigInteger("0xff"));
-        assertEquals("createBigInteger(String) failed", new BigInteger("255"), NumberUtils.createBigInteger("0Xff"));
-        assertEquals("createBigInteger(String) failed", new BigInteger("255"), NumberUtils.createBigInteger("#ff"));
-        assertEquals("createBigInteger(String) failed", new BigInteger("-255"), NumberUtils.createBigInteger("-0xff"));
-        assertEquals("createBigInteger(String) failed", new BigInteger("255"), NumberUtils.createBigInteger("0377"));
-        assertEquals("createBigInteger(String) failed", new BigInteger("-255"), NumberUtils.createBigInteger("-0377"));
-        assertEquals("createBigInteger(String) failed", new BigInteger("-255"), NumberUtils.createBigInteger("-0377"));
-        assertEquals("createBigInteger(String) failed", new BigInteger("-0"), NumberUtils.createBigInteger("-0"));
-        assertEquals("createBigInteger(String) failed", new BigInteger("0"), NumberUtils.createBigInteger("0"));
+        assertEquals(new BigInteger("255"), NumberUtils.createBigInteger("0xff"), "createBigInteger(String) failed");
+        assertEquals(new BigInteger("255"), NumberUtils.createBigInteger("0Xff"), "createBigInteger(String) failed");
+        assertEquals(new BigInteger("255"), NumberUtils.createBigInteger("#ff"), "createBigInteger(String) failed");
+        assertEquals(new BigInteger("-255"), NumberUtils.createBigInteger("-0xff"), "createBigInteger(String) failed");
+        assertEquals(new BigInteger("255"), NumberUtils.createBigInteger("0377"), "createBigInteger(String) failed");
+        assertEquals(new BigInteger("-255"), NumberUtils.createBigInteger("-0377"), "createBigInteger(String) failed");
+        assertEquals(new BigInteger("-255"), NumberUtils.createBigInteger("-0377"), "createBigInteger(String) failed");
+        assertEquals(new BigInteger("-0"), NumberUtils.createBigInteger("-0"), "createBigInteger(String) failed");
+        assertEquals(new BigInteger("0"), NumberUtils.createBigInteger("0"), "createBigInteger(String) failed");
         testCreateBigIntegerFailure("#");
         testCreateBigIntegerFailure("-#");
         testCreateBigIntegerFailure("0x");
@@ -724,8 +719,8 @@ public class NumberUtilsTest {
 
     @Test
     public void testCreateBigDecimal() {
-        assertEquals("createBigDecimal(String) failed", new BigDecimal("1234.5"), NumberUtils.createBigDecimal("1234.5"));
-        assertEquals("createBigDecimal(null) failed", null, NumberUtils.createBigDecimal(null));
+        assertEquals(new BigDecimal("1234.5"), NumberUtils.createBigDecimal("1234.5"), "createBigDecimal(String) failed");
+        assertEquals(null, NumberUtils.createBigDecimal(null), "createBigDecimal(null) failed");
         this.testCreateBigDecimalFailure("");
         this.testCreateBigDecimalFailure(" ");
         this.testCreateBigDecimalFailure("\b\t\n\f\r");
@@ -750,304 +745,210 @@ public class NumberUtilsTest {
 
     // min/max tests
     // ----------------------------------------------------------------------
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testMinLong_nullArray() {
-        NumberUtils.min((long[]) null);
+        assertThrows(IllegalArgumentException.class, () -> NumberUtils.min((long[]) null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testMinLong_emptyArray() {
-        NumberUtils.min(new long[0]);
+        assertThrows(IllegalArgumentException.class, () -> NumberUtils.min(new long[0]));
     }
 
     @Test
     public void testMinLong() {
-        assertEquals(
-            "min(long[]) failed for array length 1",
-            5,
-            NumberUtils.min(new long[] { 5 }));
-
-        assertEquals(
-            "min(long[]) failed for array length 2",
-            6,
-            NumberUtils.min(new long[] { 6, 9 }));
+        assertEquals(5, NumberUtils.min(new long[] { 5 }), "min(long[]) failed for array length 1");
+        assertEquals(6, NumberUtils.min(new long[] { 6, 9 }), "min(long[]) failed for array length 2");
 
         assertEquals(-10, NumberUtils.min(new long[] { -10, -5, 0, 5, 10 }));
         assertEquals(-10, NumberUtils.min(new long[] { -5, 0, -10, 5, 10 }));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testMinInt_nullArray() {
-        NumberUtils.min((int[]) null);
+        assertThrows(IllegalArgumentException.class, () -> NumberUtils.min((int[]) null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testMinInt_emptyArray() {
-        NumberUtils.min(new int[0]);
+        assertThrows(IllegalArgumentException.class, () -> NumberUtils.min(new int[0]));
     }
 
     @Test
     public void testMinInt() {
-        assertEquals(
-            "min(int[]) failed for array length 1",
-            5,
-            NumberUtils.min(5));
-
-        assertEquals(
-            "min(int[]) failed for array length 2",
-            6,
-            NumberUtils.min(6, 9));
+        assertEquals(5, NumberUtils.min(5), "min(int[]) failed for array length 1");
+        assertEquals(6, NumberUtils.min(6, 9), "min(int[]) failed for array length 2");
 
         assertEquals(-10, NumberUtils.min(-10, -5, 0, 5, 10));
         assertEquals(-10, NumberUtils.min(-5, 0, -10, 5, 10));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testMinShort_nullArray() {
-        NumberUtils.min((short[]) null);
+        assertThrows(IllegalArgumentException.class, () -> NumberUtils.min((short[]) null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testMinShort_emptyArray() {
-        NumberUtils.min(new short[0]);
+        assertThrows(IllegalArgumentException.class, () -> NumberUtils.min(new short[0]));
     }
 
     @Test
     public void testMinShort() {
-        assertEquals(
-            "min(short[]) failed for array length 1",
-            5,
-            NumberUtils.min(new short[] { 5 }));
-
-        assertEquals(
-            "min(short[]) failed for array length 2",
-            6,
-            NumberUtils.min(new short[] { 6, 9 }));
+        assertEquals(5, NumberUtils.min(new short[] { 5 }), "min(short[]) failed for array length 1");
+        assertEquals(6, NumberUtils.min(new short[] { 6, 9 }), "min(short[]) failed for array length 2");
 
         assertEquals(-10, NumberUtils.min(new short[] { -10, -5, 0, 5, 10 }));
         assertEquals(-10, NumberUtils.min(new short[] { -5, 0, -10, 5, 10 }));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testMinByte_nullArray() {
-        NumberUtils.min((byte[]) null);
+        assertThrows(IllegalArgumentException.class, () -> NumberUtils.min((byte[]) null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testMinByte_emptyArray() {
-        NumberUtils.min();
+        assertThrows(IllegalArgumentException.class, NumberUtils::min);
     }
 
     @Test
     public void testMinByte() {
-        assertEquals(
-            "min(byte[]) failed for array length 1",
-            5,
-            NumberUtils.min(new byte[] { 5 }));
-
-        assertEquals(
-            "min(byte[]) failed for array length 2",
-            6,
-            NumberUtils.min(new byte[] { 6, 9 }));
+        assertEquals(5, NumberUtils.min(new byte[] { 5 }), "min(byte[]) failed for array length 1");
+        assertEquals(6, NumberUtils.min(new byte[] { 6, 9 }), "min(byte[]) failed for array length 2");
 
         assertEquals(-10, NumberUtils.min(new byte[] { -10, -5, 0, 5, 10 }));
         assertEquals(-10, NumberUtils.min(new byte[] { -5, 0, -10, 5, 10 }));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testMinDouble_nullArray() {
-        NumberUtils.min((double[]) null);
+        assertThrows(IllegalArgumentException.class, () -> NumberUtils.min((double[]) null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testMinDouble_emptyArray() {
-        NumberUtils.min(new double[0]);
+        assertThrows(IllegalArgumentException.class, () -> NumberUtils.min(new double[0]));
     }
 
     @Test
     public void testMinDouble() {
-        assertEquals(
-            "min(double[]) failed for array length 1",
-            5.12,
-            NumberUtils.min(5.12),
-            0);
-
-        assertEquals(
-            "min(double[]) failed for array length 2",
-            6.23,
-            NumberUtils.min(6.23, 9.34),
-            0);
-
-        assertEquals(
-            "min(double[]) failed for array length 5",
-            -10.45,
-            NumberUtils.min(-10.45, -5.56, 0, 5.67, 10.78),
-            0);
+        // TODO: JUnit Jupiter 5.3.1 doesn't support delta=0.
+        // This should be replaced when it is supported in JUnit Jupiter 5.4.
+        // See https://github.com/junit-team/junit5/pull/1613 for details.
+        assertTrue(5.12 == NumberUtils.min(5.12), "min(double[]) failed for array length 1");
+        assertTrue(6.23 == NumberUtils.min(6.23, 9.34), "min(double[]) failed for array length 2");
+        assertTrue(-10.45 == NumberUtils.min(-10.45, -5.56, 0, 5.67, 10.78), "min(double[]) failed for array length 5");
         assertEquals(-10, NumberUtils.min(new double[] { -10, -5, 0, 5, 10 }), 0.0001);
         assertEquals(-10, NumberUtils.min(new double[] { -5, 0, -10, 5, 10 }), 0.0001);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testMinFloat_nullArray() {
-        NumberUtils.min((float[]) null);
+        assertThrows(IllegalArgumentException.class, () -> NumberUtils.min((float[]) null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testMinFloat_emptyArray() {
-        NumberUtils.min(new float[0]);
+        assertThrows(IllegalArgumentException.class, () -> NumberUtils.min(new float[0]));
     }
 
     @Test
     public void testMinFloat() {
-        assertEquals(
-            "min(float[]) failed for array length 1",
-            5.9f,
-            NumberUtils.min(5.9f),
-            0);
-
-        assertEquals(
-            "min(float[]) failed for array length 2",
-            6.8f,
-            NumberUtils.min(6.8f, 9.7f),
-            0);
-
-        assertEquals(
-            "min(float[]) failed for array length 5",
-            -10.6f,
-            NumberUtils.min(-10.6f, -5.5f, 0, 5.4f, 10.3f),
-            0);
+        // TODO: JUnit Jupiter 5.3.1 doesn't support delta=0.
+        // This should be replaced when it is supported in JUnit Jupiter 5.4.
+        // See https://github.com/junit-team/junit5/pull/1613 for details.
+        assertTrue(5.9f == NumberUtils.min(5.9f), "min(float[]) failed for array length 1");
+        assertTrue(6.8f == NumberUtils.min(6.8f, 9.7f), "min(float[]) failed for array length 2");
+        assertTrue(-10.6f == NumberUtils.min(-10.6f, -5.5f, 0, 5.4f, 10.3f), "min(float[]) failed for array length 5");
         assertEquals(-10, NumberUtils.min(new float[] { -10, -5, 0, 5, 10 }), 0.0001f);
         assertEquals(-10, NumberUtils.min(new float[] { -5, 0, -10, 5, 10 }), 0.0001f);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testMaxLong_nullArray() {
-        NumberUtils.max((long[]) null);
+        assertThrows(IllegalArgumentException.class, () -> NumberUtils.max((long[]) null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testMaxLong_emptyArray() {
-        NumberUtils.max(new long[0]);
+        assertThrows(IllegalArgumentException.class, () -> NumberUtils.max(new long[0]));
     }
 
     @Test
     public void testMaxLong() {
-        assertEquals(
-            "max(long[]) failed for array length 1",
-            5,
-            NumberUtils.max(new long[] { 5 }));
-
-        assertEquals(
-            "max(long[]) failed for array length 2",
-            9,
-            NumberUtils.max(new long[] { 6, 9 }));
-
-        assertEquals(
-            "max(long[]) failed for array length 5",
-            10,
-            NumberUtils.max(new long[] { -10, -5, 0, 5, 10 }));
+        assertEquals(5, NumberUtils.max(new long[] { 5 }), "max(long[]) failed for array length 1");
+        assertEquals(9, NumberUtils.max(new long[] { 6, 9 }), "max(long[]) failed for array length 2");
+        assertEquals(10, NumberUtils.max(new long[] { -10, -5, 0, 5, 10 }), "max(long[]) failed for array length 5");
         assertEquals(10, NumberUtils.max(new long[] { -10, -5, 0, 5, 10 }));
         assertEquals(10, NumberUtils.max(new long[] { -5, 0, 10, 5, -10 }));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testMaxInt_nullArray() {
-        NumberUtils.max((int[]) null);
+        assertThrows(IllegalArgumentException.class, () -> NumberUtils.max((int[]) null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testMaxInt_emptyArray() {
-        NumberUtils.max(new int[0]);
+        assertThrows(IllegalArgumentException.class, () -> NumberUtils.max(new int[0]));
     }
 
     @Test
     public void testMaxInt() {
-        assertEquals(
-            "max(int[]) failed for array length 1",
-            5,
-            NumberUtils.max(5));
-
-        assertEquals(
-            "max(int[]) failed for array length 2",
-            9,
-            NumberUtils.max(6, 9));
-
-        assertEquals(
-            "max(int[]) failed for array length 5",
-            10,
-            NumberUtils.max(-10, -5, 0, 5, 10));
+        assertEquals(5, NumberUtils.max(5), "max(int[]) failed for array length 1");
+        assertEquals(9, NumberUtils.max(6, 9), "max(int[]) failed for array length 2");
+        assertEquals(10, NumberUtils.max(-10, -5, 0, 5, 10), "max(int[]) failed for array length 5");
         assertEquals(10, NumberUtils.max(-10, -5, 0, 5, 10));
         assertEquals(10, NumberUtils.max(-5, 0, 10, 5, -10));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testMaxShort_nullArray() {
-        NumberUtils.max((short[]) null);
+        assertThrows(IllegalArgumentException.class, () -> NumberUtils.max((short[]) null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testMaxShort_emptyArray() {
-        NumberUtils.max(new short[0]);
+        assertThrows(IllegalArgumentException.class, () -> NumberUtils.max(new short[0]));
     }
 
     @Test
     public void testMaxShort() {
-        assertEquals(
-            "max(short[]) failed for array length 1",
-            5,
-            NumberUtils.max(new short[] { 5 }));
-
-        assertEquals(
-            "max(short[]) failed for array length 2",
-            9,
-            NumberUtils.max(new short[] { 6, 9 }));
-
-        assertEquals(
-            "max(short[]) failed for array length 5",
-            10,
-            NumberUtils.max(new short[] { -10, -5, 0, 5, 10 }));
+        assertEquals(5, NumberUtils.max(new short[] { 5 }), "max(short[]) failed for array length 1");
+        assertEquals(9, NumberUtils.max(new short[] { 6, 9 }), "max(short[]) failed for array length 2");
+        assertEquals(10, NumberUtils.max(new short[] { -10, -5, 0, 5, 10 }), "max(short[]) failed for array length 5");
         assertEquals(10, NumberUtils.max(new short[] { -10, -5, 0, 5, 10 }));
         assertEquals(10, NumberUtils.max(new short[] { -5, 0, 10, 5, -10 }));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testMaxByte_nullArray() {
-        NumberUtils.max((byte[]) null);
+        assertThrows(IllegalArgumentException.class, () -> NumberUtils.max((byte[]) null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testMaxByte_emptyArray() {
-        NumberUtils.max();
+        assertThrows(IllegalArgumentException.class, NumberUtils::max);
     }
 
     @Test
     public void testMaxByte() {
-        assertEquals(
-            "max(byte[]) failed for array length 1",
-            5,
-            NumberUtils.max(new byte[] { 5 }));
-
-        assertEquals(
-            "max(byte[]) failed for array length 2",
-            9,
-            NumberUtils.max(new byte[] { 6, 9 }));
-
-        assertEquals(
-            "max(byte[]) failed for array length 5",
-            10,
-            NumberUtils.max(new byte[] { -10, -5, 0, 5, 10 }));
+        assertEquals(5, NumberUtils.max(new byte[] { 5 }), "max(byte[]) failed for array length 1");
+        assertEquals(9, NumberUtils.max(new byte[] { 6, 9 }), "max(byte[]) failed for array length 2");
+        assertEquals(10, NumberUtils.max(new byte[] { -10, -5, 0, 5, 10 }), "max(byte[]) failed for array length 5");
         assertEquals(10, NumberUtils.max(new byte[] { -10, -5, 0, 5, 10 }));
         assertEquals(10, NumberUtils.max(new byte[] { -5, 0, 10, 5, -10 }));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testMaxDouble_nullArray() {
-        NumberUtils.max((double[]) null);
+        assertThrows(IllegalArgumentException.class, () -> NumberUtils.max((double[]) null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testMaxDouble_emptyArray() {
-        NumberUtils.max(new double[0]);
+        assertThrows(IllegalArgumentException.class, () -> NumberUtils.max(new double[0]));
     }
 
     @Test
@@ -1063,76 +964,54 @@ public class NumberUtilsTest {
             fail("No exception was thrown for empty input.");
         } catch (final IllegalArgumentException ex) {}
 
-        assertEquals(
-            "max(double[]) failed for array length 1",
-            5.1f,
-            NumberUtils.max(new double[] { 5.1f }),
-            0);
-
-        assertEquals(
-            "max(double[]) failed for array length 2",
-            9.2f,
-            NumberUtils.max(new double[] { 6.3f, 9.2f }),
-            0);
-
-        assertEquals(
-            "max(double[]) failed for float length 5",
-            10.4f,
-            NumberUtils.max(new double[] { -10.5f, -5.6f, 0, 5.7f, 10.4f }),
-            0);
+        // TODO: JUnit Jupiter 5.3.1 doesn't support delta=0.
+        // This should be replaced when it is supported in JUnit Jupiter 5.4.
+        // See https://github.com/junit-team/junit5/pull/1613 for details.
+        assertTrue(5.1f == NumberUtils.max(new double[] { 5.1f }), "max(double[]) failed for array length 1");
+        assertTrue(9.2f == NumberUtils.max(new double[] { 6.3f, 9.2f }), "max(double[]) failed for array length 2");
+        assertTrue(10.4f == NumberUtils.max(new double[] { -10.5f, -5.6f, 0, 5.7f, 10.4f }), "max(double[]) failed for float length 5");
         assertEquals(10, NumberUtils.max(new double[] { -10, -5, 0, 5, 10 }), 0.0001);
         assertEquals(10, NumberUtils.max(new double[] { -5, 0, 10, 5, -10 }), 0.0001);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testMaxFloat_nullArray() {
-        NumberUtils.max((float[]) null);
+        assertThrows(IllegalArgumentException.class, () -> NumberUtils.max((float[]) null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testMaxFloat_emptyArray() {
-        NumberUtils.max(new float[0]);
+        assertThrows(IllegalArgumentException.class, () -> NumberUtils.max(new float[0]));
     }
 
     @Test
     public void testMaxFloat() {
-        assertEquals(
-            "max(float[]) failed for array length 1",
-            5.1f,
-            NumberUtils.max(5.1f),
-            0);
-
-        assertEquals(
-            "max(float[]) failed for array length 2",
-            9.2f,
-            NumberUtils.max(6.3f, 9.2f),
-            0);
-
-        assertEquals(
-            "max(float[]) failed for float length 5",
-            10.4f,
-            NumberUtils.max(-10.5f, -5.6f, 0, 5.7f, 10.4f),
-            0);
+        // TODO: JUnit Jupiter 5.3.1 doesn't support delta=0.
+        // This should be replaced when it is supported in JUnit Jupiter 5.4.
+        // See https://github.com/junit-team/junit5/pull/1613 for details.
+        assertTrue(5.1f == NumberUtils.max(5.1f), "max(float[]) failed for array length 1");
+        assertTrue(9.2f == NumberUtils.max(6.3f, 9.2f), "max(float[]) failed for array length 2");
+        assertTrue(10.4f == NumberUtils.max(-10.5f, -5.6f, 0, 5.7f, 10.4f), "max(float[]) failed for float length 5");
         assertEquals(10, NumberUtils.max(new float[] { -10, -5, 0, 5, 10 }), 0.0001f);
         assertEquals(10, NumberUtils.max(new float[] { -5, 0, 10, 5, -10 }), 0.0001f);
     }
 
     @Test
     public void testMinimumLong() {
-        assertEquals("minimum(long,long,long) 1 failed", 12345L, NumberUtils.min(12345L, 12345L + 1L, 12345L + 2L));
-        assertEquals("minimum(long,long,long) 2 failed", 12345L, NumberUtils.min(12345L + 1L, 12345L, 12345 + 2L));
-        assertEquals("minimum(long,long,long) 3 failed", 12345L, NumberUtils.min(12345L + 1L, 12345L + 2L, 12345L));
-        assertEquals("minimum(long,long,long) 4 failed", 12345L, NumberUtils.min(12345L + 1L, 12345L, 12345L));
-        assertEquals("minimum(long,long,long) 5 failed", 12345L, NumberUtils.min(12345L, 12345L, 12345L));
+        assertEquals(12345L, NumberUtils.min(12345L, 12345L + 1L, 12345L + 2L), "minimum(long,long,long) 1 failed");
+        assertEquals(12345L, NumberUtils.min(12345L + 1L, 12345L, 12345 + 2L), "minimum(long,long,long) 2 failed");
+        assertEquals(12345L, NumberUtils.min(12345L + 1L, 12345L + 2L, 12345L), "minimum(long,long,long) 3 failed");
+        assertEquals(12345L, NumberUtils.min(12345L + 1L, 12345L, 12345L), "minimum(long,long,long) 4 failed");
+        assertEquals(12345L, NumberUtils.min(12345L, 12345L, 12345L), "minimum(long,long,long) 5 failed");
     }
 
     @Test
     public void testMinimumInt() {
-        assertEquals("minimum(int,int,int) 1 failed", 12345, NumberUtils.min(12345, 12345 + 1, 12345 + 2));
-        assertEquals("minimum(int,int,int) 2 failed", 12345, NumberUtils.min(12345 + 1, 12345, 12345 + 2));
-        assertEquals("minimum(int,int,int) 3 failed", 12345, NumberUtils.min(12345 + 1, 12345 + 2, 12345));
-        assertEquals("minimum(int,int,int) 4 failed", 12345, NumberUtils.min(12345 + 1, 12345, 12345));
-        assertEquals("minimum(int,int,int) 5 failed", 12345, NumberUtils.min(12345, 12345, 12345));
+        assertEquals(12345, NumberUtils.min(12345, 12345 + 1, 12345 + 2), "minimum(int,int,int) 1 failed");
+        assertEquals(12345, NumberUtils.min(12345 + 1, 12345, 12345 + 2), "minimum(int,int,int) 2 failed");
+        assertEquals(12345, NumberUtils.min(12345 + 1, 12345 + 2, 12345), "minimum(int,int,int) 3 failed");
+        assertEquals(12345, NumberUtils.min(12345 + 1, 12345, 12345), "minimum(int,int,int) 4 failed");
+        assertEquals(12345, NumberUtils.min(12345, 12345, 12345), "minimum(int,int,int) 5 failed");
     }
 
     @Test
@@ -1140,10 +1019,10 @@ public class NumberUtilsTest {
         final short low = 1234;
         final short mid = 1234 + 1;
         final short high = 1234 + 2;
-        assertEquals("minimum(short,short,short) 1 failed", low, NumberUtils.min(low, mid, high));
-        assertEquals("minimum(short,short,short) 1 failed", low, NumberUtils.min(mid, low, high));
-        assertEquals("minimum(short,short,short) 1 failed", low, NumberUtils.min(mid, high, low));
-        assertEquals("minimum(short,short,short) 1 failed", low, NumberUtils.min(low, mid, low));
+        assertEquals(low, NumberUtils.min(low, mid, high), "minimum(short,short,short) 1 failed");
+        assertEquals(low, NumberUtils.min(mid, low, high), "minimum(short,short,short) 2 failed");
+        assertEquals(low, NumberUtils.min(mid, high, low), "minimum(short,short,short) 3 failed");
+        assertEquals(low, NumberUtils.min(low, mid, low), "minimum(short,short,short) 4 failed");
     }
 
     @Test
@@ -1151,10 +1030,10 @@ public class NumberUtilsTest {
         final byte low = 123;
         final byte mid = 123 + 1;
         final byte high = 123 + 2;
-        assertEquals("minimum(byte,byte,byte) 1 failed", low, NumberUtils.min(low, mid, high));
-        assertEquals("minimum(byte,byte,byte) 1 failed", low, NumberUtils.min(mid, low, high));
-        assertEquals("minimum(byte,byte,byte) 1 failed", low, NumberUtils.min(mid, high, low));
-        assertEquals("minimum(byte,byte,byte) 1 failed", low, NumberUtils.min(low, mid, low));
+        assertEquals(low, NumberUtils.min(low, mid, high), "minimum(byte,byte,byte) 1 failed");
+        assertEquals(low, NumberUtils.min(mid, low, high), "minimum(byte,byte,byte) 2 failed");
+        assertEquals(low, NumberUtils.min(mid, high, low), "minimum(byte,byte,byte) 3 failed");
+        assertEquals(low, NumberUtils.min(low, mid, low), "minimum(byte,byte,byte) 4 failed");
     }
 
     @Test
@@ -1183,20 +1062,20 @@ public class NumberUtilsTest {
 
     @Test
     public void testMaximumLong() {
-        assertEquals("maximum(long,long,long) 1 failed", 12345L, NumberUtils.max(12345L, 12345L - 1L, 12345L - 2L));
-        assertEquals("maximum(long,long,long) 2 failed", 12345L, NumberUtils.max(12345L - 1L, 12345L, 12345L - 2L));
-        assertEquals("maximum(long,long,long) 3 failed", 12345L, NumberUtils.max(12345L - 1L, 12345L - 2L, 12345L));
-        assertEquals("maximum(long,long,long) 4 failed", 12345L, NumberUtils.max(12345L - 1L, 12345L, 12345L));
-        assertEquals("maximum(long,long,long) 5 failed", 12345L, NumberUtils.max(12345L, 12345L, 12345L));
+        assertEquals(12345L, NumberUtils.max(12345L, 12345L - 1L, 12345L - 2L), "maximum(long,long,long) 1 failed");
+        assertEquals(12345L, NumberUtils.max(12345L - 1L, 12345L, 12345L - 2L), "maximum(long,long,long) 2 failed");
+        assertEquals(12345L, NumberUtils.max(12345L - 1L, 12345L - 2L, 12345L), "maximum(long,long,long) 3 failed");
+        assertEquals(12345L, NumberUtils.max(12345L - 1L, 12345L, 12345L), "maximum(long,long,long) 4 failed");
+        assertEquals(12345L, NumberUtils.max(12345L, 12345L, 12345L), "maximum(long,long,long) 5 failed");
     }
 
     @Test
     public void testMaximumInt() {
-        assertEquals("maximum(int,int,int) 1 failed", 12345, NumberUtils.max(12345, 12345 - 1, 12345 - 2));
-        assertEquals("maximum(int,int,int) 2 failed", 12345, NumberUtils.max(12345 - 1, 12345, 12345 - 2));
-        assertEquals("maximum(int,int,int) 3 failed", 12345, NumberUtils.max(12345 - 1, 12345 - 2, 12345));
-        assertEquals("maximum(int,int,int) 4 failed", 12345, NumberUtils.max(12345 - 1, 12345, 12345));
-        assertEquals("maximum(int,int,int) 5 failed", 12345, NumberUtils.max(12345, 12345, 12345));
+        assertEquals(12345, NumberUtils.max(12345, 12345 - 1, 12345 - 2), "maximum(int,int,int) 1 failed");
+        assertEquals(12345, NumberUtils.max(12345 - 1, 12345, 12345 - 2), "maximum(int,int,int) 2 failed");
+        assertEquals(12345, NumberUtils.max(12345 - 1, 12345 - 2, 12345), "maximum(int,int,int) 3 failed");
+        assertEquals(12345, NumberUtils.max(12345 - 1, 12345, 12345), "maximum(int,int,int) 4 failed");
+        assertEquals(12345, NumberUtils.max(12345, 12345, 12345), "maximum(int,int,int) 5 failed");
     }
 
     @Test
@@ -1204,10 +1083,10 @@ public class NumberUtilsTest {
         final short low = 1234;
         final short mid = 1234 + 1;
         final short high = 1234 + 2;
-        assertEquals("maximum(short,short,short) 1 failed", high, NumberUtils.max(low, mid, high));
-        assertEquals("maximum(short,short,short) 1 failed", high, NumberUtils.max(mid, low, high));
-        assertEquals("maximum(short,short,short) 1 failed", high, NumberUtils.max(mid, high, low));
-        assertEquals("maximum(short,short,short) 1 failed", high, NumberUtils.max(high, mid, high));
+        assertEquals(high, NumberUtils.max(low, mid, high), "maximum(short,short,short) 1 failed");
+        assertEquals(high, NumberUtils.max(mid, low, high), "maximum(short,short,short) 2 failed");
+        assertEquals(high, NumberUtils.max(mid, high, low), "maximum(short,short,short) 3 failed");
+        assertEquals(high, NumberUtils.max(high, mid, high), "maximum(short,short,short) 4 failed");
     }
 
     @Test
@@ -1215,10 +1094,10 @@ public class NumberUtilsTest {
         final byte low = 123;
         final byte mid = 123 + 1;
         final byte high = 123 + 2;
-        assertEquals("maximum(byte,byte,byte) 1 failed", high, NumberUtils.max(low, mid, high));
-        assertEquals("maximum(byte,byte,byte) 1 failed", high, NumberUtils.max(mid, low, high));
-        assertEquals("maximum(byte,byte,byte) 1 failed", high, NumberUtils.max(mid, high, low));
-        assertEquals("maximum(byte,byte,byte) 1 failed", high, NumberUtils.max(high, mid, high));
+        assertEquals(high, NumberUtils.max(low, mid, high), "maximum(byte,byte,byte) 1 failed");
+        assertEquals(high, NumberUtils.max(mid, low, high), "maximum(byte,byte,byte) 2 failed");
+        assertEquals(high, NumberUtils.max(mid, high, low), "maximum(byte,byte,byte) 3 failed");
+        assertEquals(high, NumberUtils.max(high, mid, high), "maximum(byte,byte,byte) 4 failed");
     }
 
     @Test
@@ -1434,12 +1313,12 @@ public class NumberUtilsTest {
 
     @Test
     public void testIsDigits() {
-        assertFalse("isDigits(null) failed", NumberUtils.isDigits(null));
-        assertFalse("isDigits('') failed", NumberUtils.isDigits(""));
-        assertTrue("isDigits(String) failed", NumberUtils.isDigits("12345"));
-        assertFalse("isDigits(String) neg 1 failed", NumberUtils.isDigits("1234.5"));
-        assertFalse("isDigits(String) neg 3 failed", NumberUtils.isDigits("1ab"));
-        assertFalse("isDigits(String) neg 4 failed", NumberUtils.isDigits("abc"));
+        assertFalse(NumberUtils.isDigits(null), "isDigits(null) failed");
+        assertFalse(NumberUtils.isDigits(""), "isDigits('') failed");
+        assertTrue(NumberUtils.isDigits("12345"), "isDigits(String) failed");
+        assertFalse(NumberUtils.isDigits("1234.5"), "isDigits(String) neg 1 failed");
+        assertFalse(NumberUtils.isDigits("1ab"), "isDigits(String) neg 3 failed");
+        assertFalse(NumberUtils.isDigits("abc"), "isDigits(String) neg 4 failed");
     }
 
     /**


### PR DESCRIPTION
Upgrade the tests in the `math` package to use JUnit Jupiter as part of the effort to remove the dependency on the Vintage Engine.

While most of these changes are drop-in replacements with no functional benefit, there are some non-obvious changes worth mentioning.

Unlike `org.junit.Test`, `org.junit.jupiter.api.Test` does not have an `expected` argument. Instead, an explicit call to `org.junit.jupiter.api.Assertions.assertThrows` is used.

Unlike `org.junit.Assert.assertEquals(double, double, double)`, `org.junit.jupiter.api.Assertions.assertEquals(double, double, double)` does not support deltas of zero, only strictly positive deltas. This issue will be addressed in JUnit Jupiter 5.4 (see https://github.com/junit-team/junit5/pull/1613 for details). In the meanwhile, `assertTrue(expected==actual)` was used, and `TODO` comments were placed in the code to refactor it to assertEquals once JUnit 5.4 is available.

It's also worth noting this is a minimal patch for migrating the package's tests to Jupiter. There are several tests that can be made more elegant with Jupiter's new features, but that work is left for subsequent patches.