### PR TITLE
Update mutable tests to JUnit Jupiter

### DIFF
--- a/src/test/java/org/apache/commons/lang3/mutable/MutableBooleanTest.java
+++ b/src/test/java/org/apache/commons/lang3/mutable/MutableBooleanTest.java
@@ -17,11 +17,12 @@
 
 package org.apache.commons.lang3.mutable;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit tests.
@@ -42,10 +43,10 @@ public class MutableBooleanTest {
         assertEquals(0, mutBool.compareTo(new MutableBoolean(true)));
     }
 
-    @Test(expected=NullPointerException.class)
+    @Test
     public void testCompareToNull() {
         final MutableBoolean mutBool = new MutableBoolean(false);
-        mutBool.compareTo(null);
+        assertThrows(NullPointerException.class, () -> mutBool.compareTo(null));
     }
 
     // ----------------------------------------------------------------
@@ -61,9 +62,9 @@ public class MutableBooleanTest {
 
     }
 
-    @Test(expected=NullPointerException.class)
+    @Test
     public void testConstructorNull() {
-        new MutableBoolean(null);
+        assertThrows(NullPointerException.class, () -> new MutableBoolean(null));
     }
 
     @Test
@@ -115,10 +116,10 @@ public class MutableBooleanTest {
 
     }
 
-    @Test(expected=NullPointerException.class)
+    @Test
     public void testSetNull() {
         final MutableBoolean mutBool = new MutableBoolean(false);
-        mutBool.setValue(null);
+        assertThrows(NullPointerException.class, () -> mutBool.setValue(null));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/mutable/MutableByteTest.java
+++ b/src/test/java/org/apache/commons/lang3/mutable/MutableByteTest.java
@@ -16,11 +16,12 @@
  */
 package org.apache.commons.lang3.mutable;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit tests.
@@ -43,9 +44,9 @@ public class MutableByteTest {
 
     }
 
-    @Test(expected=NullPointerException.class)
+    @Test
     public void testConstructorNull() {
-        new MutableByte((Number)null);
+        assertThrows(NullPointerException.class, () -> new MutableByte((Number)null));
     }
 
     @Test
@@ -67,10 +68,10 @@ public class MutableByteTest {
         assertEquals(Byte.valueOf((byte) 3), mutNum.getValue());
     }
 
-    @Test(expected=NullPointerException.class)
+    @Test
     public void testSetNull() {
         final MutableByte mutNum = new MutableByte((byte) 0);
-        mutNum.setValue(null);
+        assertThrows(NullPointerException.class, () -> mutNum.setValue(null));
     }
 
     @Test
@@ -112,18 +113,21 @@ public class MutableByteTest {
         assertEquals((byte) -1, mutNum.compareTo(new MutableByte((byte) 1)));
     }
 
-    @Test(expected=NullPointerException.class)
+    @Test
     public void testCompareToNull() {
         final MutableByte mutNum = new MutableByte((byte) 0);
-        mutNum.compareTo(null);
+        assertThrows(NullPointerException.class, () -> mutNum.compareTo(null));
     }
 
     @Test
     public void testPrimitiveValues() {
         final MutableByte mutNum = new MutableByte( (byte) 1 );
 
-        assertEquals( 1.0F, mutNum.floatValue(), 0 );
-        assertEquals( 1.0, mutNum.doubleValue(), 0 );
+        // TODO: JUnit Jupiter 5.3.1 doesn't support delta=0.
+        // This should be replaced when it is supported in JUnit Jupiter 5.4.
+        // See https://github.com/junit-team/junit5/pull/1613 for details.
+        assertTrue( 1.0F == mutNum.floatValue() );
+        assertTrue( 1.0 == mutNum.doubleValue() );
         assertEquals( (byte) 1, mutNum.byteValue() );
         assertEquals( (short) 1, mutNum.shortValue() );
         assertEquals( 1, mutNum.intValue() );

--- a/src/test/java/org/apache/commons/lang3/mutable/MutableDoubleTest.java
+++ b/src/test/java/org/apache/commons/lang3/mutable/MutableDoubleTest.java
@@ -16,11 +16,12 @@
  */
 package org.apache.commons.lang3.mutable;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit tests.
@@ -43,9 +44,9 @@ public class MutableDoubleTest {
 
     }
 
-    @Test(expected=NullPointerException.class)
+    @Test
     public void testConstructorNull() {
-        new MutableDouble((Number)null);
+        assertThrows(NullPointerException.class, () -> new MutableDouble((Number)null));
     }
 
     @Test
@@ -67,10 +68,10 @@ public class MutableDoubleTest {
         assertEquals(Double.valueOf(3d), mutNum.getValue());
     }
 
-    @Test(expected=NullPointerException.class)
+    @Test
     public void testSetNull() {
         final MutableDouble mutNum = new MutableDouble(0d);
-        mutNum.setValue(null);
+        assertThrows(NullPointerException.class, () -> mutNum.setValue(null));
     }
 
     @Test
@@ -124,18 +125,21 @@ public class MutableDoubleTest {
         assertEquals(-1, mutNum.compareTo(new MutableDouble(1d)));
     }
 
-    @Test(expected=NullPointerException.class)
+    @Test
     public void testCompareToNull() {
         final MutableDouble mutNum = new MutableDouble(0d);
-        mutNum.compareTo(null);
+        assertThrows(NullPointerException.class, () -> mutNum.compareTo(null));
     }
 
     @Test
     public void testPrimitiveValues() {
         final MutableDouble mutNum = new MutableDouble(1.7);
 
-        assertEquals( 1.7F, mutNum.floatValue(), 0 );
-        assertEquals( 1.7, mutNum.doubleValue(), 0 );
+        // TODO: JUnit Jupiter 5.3.1 doesn't support delta=0.
+        // This should be replaced when it is supported in JUnit Jupiter 5.4.
+        // See https://github.com/junit-team/junit5/pull/1613 for details.
+        assertTrue ( 1.7F == mutNum.floatValue() );
+        assertTrue( 1.7 == mutNum.doubleValue() );
         assertEquals( (byte) 1, mutNum.byteValue() );
         assertEquals( (short) 1, mutNum.shortValue() );
         assertEquals( 1, mutNum.intValue() );

--- a/src/test/java/org/apache/commons/lang3/mutable/MutableFloatTest.java
+++ b/src/test/java/org/apache/commons/lang3/mutable/MutableFloatTest.java
@@ -16,11 +16,12 @@
  */
 package org.apache.commons.lang3.mutable;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit tests.
@@ -43,9 +44,9 @@ public class MutableFloatTest {
 
     }
 
-    @Test(expected=NullPointerException.class)
+    @Test
     public void testConstructorNull() {
-        new MutableFloat((Number)null);
+        assertThrows(NullPointerException.class, () -> new MutableFloat((Number)null));
     }
 
     @Test
@@ -67,10 +68,10 @@ public class MutableFloatTest {
         assertEquals(Float.valueOf(3f), mutNum.getValue());
     }
 
-    @Test(expected=NullPointerException.class)
+    @Test
     public void testSetNull() {
         final MutableFloat mutNum = new MutableFloat(0f);
-        mutNum.setValue(null);
+        assertThrows(NullPointerException.class, () -> mutNum.setValue(null));
     }
 
     @Test
@@ -124,10 +125,10 @@ public class MutableFloatTest {
         assertEquals(-1, mutNum.compareTo(new MutableFloat(1f)));
     }
 
-    @Test(expected=NullPointerException.class)
+    @Test
     public void testCompareToNull() {
         final MutableFloat mutNum = new MutableFloat(0f);
-        mutNum.compareTo(null);
+        assertThrows(NullPointerException.class, () -> mutNum.compareTo(null));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/mutable/MutableIntTest.java
+++ b/src/test/java/org/apache/commons/lang3/mutable/MutableIntTest.java
@@ -16,11 +16,12 @@
  */
 package org.apache.commons.lang3.mutable;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit tests.
@@ -43,9 +44,9 @@ public class MutableIntTest {
 
     }
 
-    @Test(expected=NullPointerException.class)
+    @Test
     public void testConstructorNull() {
-        new MutableInt((Number)null);
+        assertThrows(NullPointerException.class, () -> new MutableInt((Number)null));
     }
 
     @Test
@@ -67,10 +68,10 @@ public class MutableIntTest {
         assertEquals(Integer.valueOf(3), mutNum.getValue());
     }
 
-    @Test(expected=NullPointerException.class)
+    @Test
     public void testSetNull() {
         final MutableInt mutNum = new MutableInt(0);
-        mutNum.setValue(null);
+        assertThrows(NullPointerException.class, () -> mutNum.setValue(null));
     }
 
     @Test
@@ -119,20 +120,23 @@ public class MutableIntTest {
         assertEquals(-1, mutNum.compareTo(new MutableInt(1)));
     }
 
-    @Test(expected=NullPointerException.class)
+    @Test
     public void testCompareToNull() {
         final MutableInt mutNum = new MutableInt(0);
-        mutNum.compareTo(null);
+        assertThrows(NullPointerException.class, () -> mutNum.compareTo(null));
     }
 
     @Test
     public void testPrimitiveValues() {
         final MutableInt mutNum = new MutableInt(1);
 
+        // TODO: JUnit Jupiter 5.3.1 doesn't support delta=0.
+        // This should be replaced when it is supported in JUnit Jupiter 5.4.
+        // See https://github.com/junit-team/junit5/pull/1613 for details.
         assertEquals( (byte) 1, mutNum.byteValue() );
         assertEquals( (short) 1, mutNum.shortValue() );
-        assertEquals( 1.0F, mutNum.floatValue(), 0 );
-        assertEquals( 1.0, mutNum.doubleValue(), 0 );
+        assertTrue( 1.0F == mutNum.floatValue() );
+        assertTrue( 1.0 == mutNum.doubleValue() );
         assertEquals( 1L, mutNum.longValue() );
     }
 

--- a/src/test/java/org/apache/commons/lang3/mutable/MutableLongTest.java
+++ b/src/test/java/org/apache/commons/lang3/mutable/MutableLongTest.java
@@ -16,11 +16,12 @@
  */
 package org.apache.commons.lang3.mutable;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit tests.
@@ -43,9 +44,9 @@ public class MutableLongTest {
 
     }
 
-    @Test(expected=NullPointerException.class)
+    @Test
     public void testConstructorNull() {
-        new MutableLong((Number)null);
+        assertThrows(NullPointerException.class, () -> new MutableLong((Number)null));
     }
 
     @Test
@@ -67,10 +68,10 @@ public class MutableLongTest {
         assertEquals(Long.valueOf(3), mutNum.getValue());
     }
 
-    @Test(expected=NullPointerException.class)
+    @Test
     public void testSetNull() {
         final MutableLong mutNum = new MutableLong(0);
-        mutNum.setValue(null);
+        assertThrows(NullPointerException.class, () -> mutNum.setValue(null));
     }
 
     @Test
@@ -112,18 +113,21 @@ public class MutableLongTest {
         assertEquals(-1, mutNum.compareTo(new MutableLong(1)));
     }
 
-    @Test(expected=NullPointerException.class)
+    @Test
     public void testCompareToNull() {
         final MutableLong mutNum = new MutableLong(0);
-        mutNum.compareTo(null);
+        assertThrows(NullPointerException.class, () -> mutNum.compareTo(null));
     }
 
     @Test
     public void testPrimitiveValues() {
         final MutableLong mutNum = new MutableLong(1L);
 
-        assertEquals( 1.0F, mutNum.floatValue(), 0 );
-        assertEquals( 1.0, mutNum.doubleValue(), 0 );
+        // TODO: JUnit Jupiter 5.3.1 doesn't support delta=0.
+        // This should be replaced when it is supported in JUnit Jupiter 5.4.
+        // See https://github.com/junit-team/junit5/pull/1613 for details.
+        assertTrue( 1.0F == mutNum.floatValue() );
+        assertTrue ( 1.0 == mutNum.doubleValue() );
         assertEquals( (byte) 1, mutNum.byteValue() );
         assertEquals( (short) 1, mutNum.shortValue() );
         assertEquals( 1, mutNum.intValue() );

--- a/src/test/java/org/apache/commons/lang3/mutable/MutableObjectTest.java
+++ b/src/test/java/org/apache/commons/lang3/mutable/MutableObjectTest.java
@@ -16,13 +16,13 @@
  */
 package org.apache.commons.lang3.mutable;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 
 /**

--- a/src/test/java/org/apache/commons/lang3/mutable/MutableShortTest.java
+++ b/src/test/java/org/apache/commons/lang3/mutable/MutableShortTest.java
@@ -16,12 +16,12 @@
  */
 package org.apache.commons.lang3.mutable;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * JUnit tests.
@@ -118,8 +118,11 @@ public class MutableShortTest {
     public void testPrimitiveValues() {
         final MutableShort mutNum = new MutableShort( (short) 1 );
 
-        assertEquals( 1.0F, mutNum.floatValue(), 0 );
-        assertEquals( 1.0, mutNum.doubleValue(), 0 );
+        // TODO: JUnit Jupiter 5.3.1 doesn't support delta=0.
+        // This should be replaced when it is supported in JUnit Jupiter 5.4.
+        // See https://github.com/junit-team/junit5/pull/1613 for details.
+        assertTrue ( 1.0F == mutNum.floatValue() );
+        assertTrue ( 1.0 == mutNum.doubleValue() );
         assertEquals( (byte) 1, mutNum.byteValue() );
         assertEquals( (short) 1, mutNum.shortValue() );
         assertEquals( 1, mutNum.intValue() );


### PR DESCRIPTION
Upgrade the tests in the `mutable` package to use JUnit Jupiter as part of the effort to remove the dependency on the Vintage Engine.

While most of these changes are drop-in replacements with no functional benefit, there are some non-obvious changes worth mentioning.

Unlike `org.junit.Test`, `org.junit.jupiter.api.Test` does not have an `expected` argument. Instead, an explicit call to `org.junit.jupiter.api.Assertions.assertThrows` is used.

Unlike `org.junit.Assert.assertEquals(double, double, double)`, `org.junit.jupiter.api.Assertions.assertEquals(double, double, double)` does not support deltas of zero, only strictly positive deltas.
This issue will be addressed in JUnit Jupiter 5.4 (see https://github.com/junit-team/junit5/pull/1613 for details). In the meanwhile, `assertTrue(expected==actual)` was used, and `TODO` comments were placed in the code to refactor it to assertEquals once JUnit 5.4 is available.

It's also worth noting this is a minimal patch for migrating the package's tests to Jupiter. There are several tests that can be made more elegant with Jupiter's new features, but that work is left for subsequent patches.