### PR TITLE
Update time tests to JUnit Jupiter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -544,6 +544,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit-pioneer</groupId>
+      <artifactId>junit-pioneer</artifactId>
+      <version>0.2.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-all</artifactId>
       <version>1.3</version>

--- a/src/test/java/org/apache/commons/lang3/time/DateFormatUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/DateFormatUtilsTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.commons.lang3.time;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
@@ -29,20 +29,15 @@ import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
 
-import org.apache.commons.lang3.test.SystemDefaultsSwitch;
-import org.apache.commons.lang3.test.SystemDefaults;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.DefaultLocale;
+import org.junitpioneer.jupiter.DefaultTimeZone;
 
 /**
  * TestCase for DateFormatUtils.
  */
 @SuppressWarnings("deprecation") // tests lots of deprecated items
 public class DateFormatUtilsTest {
-
-    @Rule
-    public SystemDefaultsSwitch defaults = new SystemDefaultsSwitch();
-
     //-----------------------------------------------------------------------
     @Test
     public void testConstructor() {
@@ -171,7 +166,7 @@ public class DateFormatUtilsTest {
         testUTC("09:11:12Z", DateFormatUtils.ISO_TIME_NO_T_TIME_ZONE_FORMAT.getPattern());
     }
 
-    @SystemDefaults(locale="en")
+    @DefaultLocale(language = "en")
     @Test
     public void testSMTP() {
         TimeZone timeZone = TimeZone.getTimeZone("GMT-3");
@@ -192,14 +187,14 @@ public class DateFormatUtilsTest {
         DateFormatUtils.ISO_DATETIME_TIME_ZONE_FORMAT.parse(date);
     }
 
-    @SystemDefaults(timezone="UTC")
+    @DefaultTimeZone("UTC")
     @Test
     public void testLang530() throws ParseException {
         final Date d = new Date();
         final String isoDateStr = DateFormatUtils.ISO_DATETIME_TIME_ZONE_FORMAT.format(d);
         final Date d2 = DateUtils.parseDate(isoDateStr, DateFormatUtils.ISO_DATETIME_TIME_ZONE_FORMAT.getPattern());
         // the format loses milliseconds so have to reintroduce them
-        assertEquals("Date not equal to itself ISO formatted and parsed", d.getTime(), d2.getTime() + d.getTime() % 1000);
+        assertEquals(d.getTime(), d2.getTime() + d.getTime() % 1000, "Date not equal to itself ISO formatted and parsed");
     }
 
     /**
@@ -218,29 +213,29 @@ public class DateFormatUtilsTest {
         // Long.
         {
             final String value = DateFormatUtils.format(cal.getTimeInMillis(), DateFormatUtils.ISO_DATETIME_TIME_ZONE_FORMAT.getPattern(), TimeZone.getTimeZone("Europe/Paris"));
-            assertEquals("long", "2009-10-16T08:42:16+02:00", value);
+            assertEquals("2009-10-16T08:42:16+02:00", value, "long");
         }
         {
             final String value = DateFormatUtils.format(cal.getTimeInMillis(), DateFormatUtils.ISO_DATETIME_TIME_ZONE_FORMAT.getPattern(), TimeZone.getTimeZone("Asia/Kolkata"));
-            assertEquals("long", "2009-10-16T12:12:16+05:30", value);
+            assertEquals("2009-10-16T12:12:16+05:30", value, "long");
         }
         {
             final String value = DateFormatUtils.format(cal.getTimeInMillis(), DateFormatUtils.ISO_DATETIME_TIME_ZONE_FORMAT.getPattern(), TimeZone.getTimeZone("Europe/London"));
-            assertEquals("long", "2009-10-16T07:42:16+01:00", value);
+            assertEquals("2009-10-16T07:42:16+01:00", value, "long");
         }
 
         // Calendar.
         {
             final String value = DateFormatUtils.format(cal, DateFormatUtils.ISO_DATETIME_TIME_ZONE_FORMAT.getPattern(), TimeZone.getTimeZone("Europe/Paris"));
-            assertEquals("calendar", "2009-10-16T08:42:16+02:00", value);
+            assertEquals("2009-10-16T08:42:16+02:00", value, "calendar");
         }
         {
             final String value = DateFormatUtils.format(cal, DateFormatUtils.ISO_DATETIME_TIME_ZONE_FORMAT.getPattern(), TimeZone.getTimeZone("Asia/Kolkata"));
-            assertEquals("calendar", "2009-10-16T12:12:16+05:30", value);
+            assertEquals("2009-10-16T12:12:16+05:30", value, "calendar");
         }
         {
             final String value = DateFormatUtils.format(cal, DateFormatUtils.ISO_DATETIME_TIME_ZONE_FORMAT.getPattern(), TimeZone.getTimeZone("Europe/London"));
-            assertEquals("calendar", "2009-10-16T07:42:16+01:00", value);
+            assertEquals("2009-10-16T07:42:16+01:00", value, "calendar");
         }
     }
 }

--- a/src/test/java/org/apache/commons/lang3/time/DateUtilsFragmentTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/DateUtilsFragmentTest.java
@@ -16,11 +16,11 @@
  */
 package org.apache.commons.lang3.time;
 
-import org.junit.Test;
-import org.junit.Before;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import java.util.Calendar;
 import java.util.Date;
 
@@ -37,7 +37,7 @@ public class DateUtilsFragmentTest {
     private Calendar aCalendar;
 
 
-    @Before
+    @BeforeEach
     public void setUp() {
         aCalendar = Calendar.getInstance();
         aCalendar.set(2005, months, days, hours, minutes, seconds);

--- a/src/test/java/org/apache/commons/lang3/time/DateUtilsRoundingTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/DateUtilsRoundingTest.java
@@ -16,11 +16,11 @@
  */
 package org.apache.commons.lang3.time;
 
-import org.junit.Test;
-import org.junit.Before;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
@@ -58,7 +58,7 @@ public class DateUtilsRoundingTest {
     FastDateFormat fdf = DateFormatUtils.ISO_DATETIME_FORMAT;
 
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
 
         dateTimeParser = new SimpleDateFormat("MMM dd, yyyy H:mm:ss.SSS", Locale.ENGLISH);
@@ -665,9 +665,9 @@ public class DateUtilsRoundingTest {
         final Date nextTruncateDate = DateUtils.addMilliseconds(lastTruncateDate, 1);
 
         //Date-comparison
-        assertEquals("Truncating "+ fdf.format(truncatedDate) +" as Date with CalendarField-value "+ calendarField +" must return itself", truncatedDate, DateUtils.truncate(truncatedDate, calendarField));
+        assertEquals(truncatedDate, DateUtils.truncate(truncatedDate, calendarField), "Truncating "+ fdf.format(truncatedDate) +" as Date with CalendarField-value "+ calendarField +" must return itself");
         assertEquals(truncatedDate, DateUtils.truncate(lastTruncateDate, calendarField));
-        assertFalse(fdf.format(lastTruncateDate) +" is not an extreme when truncating as Date with CalendarField-value "+ calendarField, truncatedDate.equals(DateUtils.truncate(nextTruncateDate, calendarField)));
+        assertFalse(truncatedDate.equals(DateUtils.truncate(nextTruncateDate, calendarField)), fdf.format(lastTruncateDate) +" is not an extreme when truncating as Date with CalendarField-value "+ calendarField);
 
         //Calendar-initiations
         Calendar truncatedCalendar, lastTruncateCalendar, nextTruncateCalendar;
@@ -679,17 +679,17 @@ public class DateUtilsRoundingTest {
         nextTruncateCalendar.setTime(nextTruncateDate);
 
         //Calendar-comparison
-        assertEquals("Truncating "+ fdf.format(truncatedCalendar) +" as Calendar with CalendarField-value "+ calendarField +" must return itself", truncatedCalendar, DateUtils.truncate(truncatedCalendar, calendarField));
+        assertEquals(truncatedCalendar, DateUtils.truncate(truncatedCalendar, calendarField), "Truncating "+ fdf.format(truncatedCalendar) +" as Calendar with CalendarField-value "+ calendarField +" must return itself");
         assertEquals(truncatedCalendar, DateUtils.truncate(lastTruncateCalendar, calendarField));
-        assertFalse(fdf.format(lastTruncateCalendar) +" is not an extreme when truncating as Calendar with CalendarField-value "+ calendarField, truncatedCalendar.equals(DateUtils.truncate(nextTruncateCalendar, calendarField)));
+        assertFalse(truncatedCalendar.equals(DateUtils.truncate(nextTruncateCalendar, calendarField)), fdf.format(lastTruncateCalendar) +" is not an extreme when truncating as Calendar with CalendarField-value "+ calendarField);
 
         //Object-comparison
-        assertEquals("Truncating "+ fdf.format(truncatedDate) +" as Date cast to Object with CalendarField-value "+ calendarField +" must return itself as Date", truncatedDate, DateUtils.truncate((Object) truncatedDate, calendarField));
+        assertEquals(truncatedDate, DateUtils.truncate((Object) truncatedDate, calendarField), "Truncating "+ fdf.format(truncatedDate) +" as Date cast to Object with CalendarField-value "+ calendarField +" must return itself as Date");
         assertEquals(truncatedDate, DateUtils.truncate((Object) lastTruncateDate, calendarField));
-        assertFalse(fdf.format(lastTruncateDate) +" is not an extreme when truncating as Date cast to Object with CalendarField-value "+ calendarField, truncatedDate.equals(DateUtils.truncate((Object) nextTruncateDate, calendarField)));
-        assertEquals("Truncating "+ fdf.format(truncatedCalendar) +" as Calendar cast to Object with CalendarField-value "+ calendarField +" must return itself as Date", truncatedDate, DateUtils.truncate((Object) truncatedCalendar, calendarField));
+        assertFalse(truncatedDate.equals(DateUtils.truncate((Object) nextTruncateDate, calendarField)), fdf.format(lastTruncateDate) +" is not an extreme when truncating as Date cast to Object with CalendarField-value "+ calendarField);
+        assertEquals(truncatedDate, DateUtils.truncate((Object) truncatedCalendar, calendarField), "Truncating "+ fdf.format(truncatedCalendar) +" as Calendar cast to Object with CalendarField-value "+ calendarField +" must return itself as Date");
         assertEquals(truncatedDate, DateUtils.truncate((Object) lastTruncateCalendar, calendarField));
-        assertFalse(fdf.format(lastTruncateCalendar) +" is not an extreme when truncating as Calendar cast to Object with CalendarField-value "+ calendarField, truncatedDate.equals(DateUtils.truncate((Object) nextTruncateCalendar, calendarField)));
+        assertFalse(truncatedDate.equals(DateUtils.truncate((Object) nextTruncateCalendar, calendarField)), fdf.format(lastTruncateCalendar) +" is not an extreme when truncating as Calendar cast to Object with CalendarField-value "+ calendarField);
     }
 
     /**
@@ -703,7 +703,7 @@ public class DateUtilsRoundingTest {
      * @since 3.0
      */
     protected void roundToJanuaryFirst(final Date minDate, final Date maxDate, final int calendarField) {
-        assertEquals("Rounding "+ fdf.format(januaryOneDate) +" as Date with CalendarField-value "+ calendarField +" must return itself", januaryOneDate, DateUtils.round(januaryOneDate, calendarField));
+        assertEquals(januaryOneDate, DateUtils.round(januaryOneDate, calendarField), "Rounding "+ fdf.format(januaryOneDate) +" as Date with CalendarField-value "+ calendarField +" must return itself");
         assertEquals(januaryOneDate, DateUtils.round(minDate, calendarField));
         assertEquals(januaryOneDate, DateUtils.round(maxDate, calendarField));
 
@@ -711,20 +711,20 @@ public class DateUtilsRoundingTest {
         minCalendar.setTime(minDate);
         final Calendar maxCalendar = Calendar.getInstance();
         maxCalendar.setTime(maxDate);
-        assertEquals("Rounding "+ fdf.format(januaryOneCalendar) +" as Date with CalendarField-value "+ calendarField +" must return itself", januaryOneCalendar, DateUtils.round(januaryOneCalendar, calendarField));
+        assertEquals(januaryOneCalendar, DateUtils.round(januaryOneCalendar, calendarField), "Rounding "+ fdf.format(januaryOneCalendar) +" as Date with CalendarField-value "+ calendarField +" must return itself");
         assertEquals(januaryOneCalendar, DateUtils.round(minCalendar, calendarField));
         assertEquals(januaryOneCalendar, DateUtils.round(maxCalendar, calendarField));
 
         final Date toPrevRoundDate = DateUtils.addMilliseconds(minDate, -1);
         final Date toNextRoundDate = DateUtils.addMilliseconds(maxDate, 1);
-        assertFalse(fdf.format(minDate) +" is not an lower-extreme when rounding as Date with CalendarField-value "+ calendarField, januaryOneDate.equals(DateUtils.round(toPrevRoundDate, calendarField)));
-        assertFalse(fdf.format(maxDate) +" is not an upper-extreme when rounding as Date with CalendarField-value "+ calendarField, januaryOneDate.equals(DateUtils.round(toNextRoundDate, calendarField)));
+        assertFalse(januaryOneDate.equals(DateUtils.round(toPrevRoundDate, calendarField)), fdf.format(minDate) +" is not an lower-extreme when rounding as Date with CalendarField-value "+ calendarField);
+        assertFalse(januaryOneDate.equals(DateUtils.round(toNextRoundDate, calendarField)), fdf.format(maxDate) +" is not an upper-extreme when rounding as Date with CalendarField-value "+ calendarField);
 
         final Calendar toPrevRoundCalendar = Calendar.getInstance();
         toPrevRoundCalendar.setTime(toPrevRoundDate);
         final Calendar toNextRoundCalendar = Calendar.getInstance();
         toNextRoundCalendar.setTime(toNextRoundDate);
-        assertFalse(fdf.format(minCalendar) +" is not an lower-extreme when rounding as Date with CalendarField-value "+ calendarField, januaryOneDate.equals(DateUtils.round(toPrevRoundDate, calendarField)));
-        assertFalse(fdf.format(maxCalendar) +" is not an upper-extreme when rounding as Date with CalendarField-value "+ calendarField, januaryOneDate.equals(DateUtils.round(toNextRoundDate, calendarField)));
+        assertFalse(januaryOneDate.equals(DateUtils.round(toPrevRoundDate, calendarField)), fdf.format(minCalendar) +" is not an lower-extreme when rounding as Date with CalendarField-value "+ calendarField);
+        assertFalse(januaryOneDate.equals(DateUtils.round(toNextRoundDate, calendarField)), fdf.format(maxCalendar) +" is not an upper-extreme when rounding as Date with CalendarField-value "+ calendarField);
     }
 }

--- a/src/test/java/org/apache/commons/lang3/time/DateUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/DateUtilsTest.java
@@ -16,12 +16,13 @@
  */
 package org.apache.commons.lang3.time;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
@@ -36,12 +37,10 @@ import java.util.Locale;
 import java.util.NoSuchElementException;
 import java.util.TimeZone;
 
-import org.apache.commons.lang3.test.SystemDefaults;
-import org.apache.commons.lang3.test.SystemDefaultsSwitch;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.DefaultLocale;
 
 /**
  * Unit tests {@link org.apache.commons.lang3.time.DateUtils}.
@@ -50,15 +49,12 @@ public class DateUtilsTest {
 
     private static Date BASE_DATE;
 
-    @BeforeClass
+    @BeforeAll
     public static void classSetup() {
         final GregorianCalendar cal = new GregorianCalendar(2000, 6, 5, 4, 3, 2);
         cal.set(Calendar.MILLISECOND, 1);
         BASE_DATE = cal.getTime();
     }
-
-    @Rule
-    public SystemDefaultsSwitch defaults = new SystemDefaultsSwitch();
 
     private DateFormat dateParser = null;
     private DateFormat dateTimeParser = null;
@@ -90,7 +86,7 @@ public class DateUtilsTest {
     private TimeZone zone = null;
     private TimeZone defaultZone = null;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         dateParser = new SimpleDateFormat("MMM dd, yyyy", Locale.ENGLISH);
         dateTimeParser = new SimpleDateFormat("MMM dd, yyyy H:mm:ss.SSS", Locale.ENGLISH);
@@ -173,19 +169,19 @@ public class DateUtilsTest {
         assertFalse(DateUtils.isSameDay(datea, dateb));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testIsSameDay_DateNullNull() throws Exception {
-        DateUtils.isSameDay((Date) null, null);
+    @Test
+    public void testIsSameDay_DateNullNull() {
+        assertThrows(IllegalArgumentException.class, () -> DateUtils.isSameDay((Date) null, null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testIsSameDay_DateNullNotNull() throws Exception {
-        DateUtils.isSameDay(null, new Date());
+    @Test
+    public void testIsSameDay_DateNullNotNull() {
+        assertThrows(IllegalArgumentException.class, () -> DateUtils.isSameDay(null, new Date()));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testIsSameDay_DateNotNullNull() throws Exception {
-        DateUtils.isSameDay(new Date(), null);
+    @Test
+    public void testIsSameDay_DateNotNullNull() {
+        assertThrows(IllegalArgumentException.class, () -> DateUtils.isSameDay(new Date(), null));
     }
 
     //-----------------------------------------------------------------------
@@ -202,19 +198,19 @@ public class DateUtilsTest {
         assertFalse(DateUtils.isSameDay(cala, calb));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testIsSameDay_CalNullNull() throws Exception {
-        DateUtils.isSameDay((Calendar) null, null);
+    @Test
+    public void testIsSameDay_CalNullNull() {
+        assertThrows(IllegalArgumentException.class, () -> DateUtils.isSameDay((Calendar) null, null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testIsSameDay_CalNullNotNull() throws Exception {
-        DateUtils.isSameDay(null, Calendar.getInstance());
+    @Test
+    public void testIsSameDay_CalNullNotNull() {
+        assertThrows(IllegalArgumentException.class, () -> DateUtils.isSameDay(null, Calendar.getInstance()));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testIsSameDay_CalNotNullNull() throws Exception {
-        DateUtils.isSameDay(Calendar.getInstance(), null);
+    @Test
+    public void testIsSameDay_CalNotNullNull() {
+        assertThrows(IllegalArgumentException.class, () -> DateUtils.isSameDay(Calendar.getInstance(), null));
     }
 
     //-----------------------------------------------------------------------
@@ -231,19 +227,19 @@ public class DateUtilsTest {
         assertFalse(DateUtils.isSameInstant(datea, dateb));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testIsSameInstant_DateNullNull() throws Exception {
-        DateUtils.isSameInstant((Date) null, null);
+    @Test
+    public void testIsSameInstant_DateNullNull() {
+        assertThrows(IllegalArgumentException.class, () -> DateUtils.isSameInstant((Date) null, null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testIsSameInstant_DateNullNotNull() throws Exception {
-        DateUtils.isSameInstant(null, new Date());
+    @Test
+    public void testIsSameInstant_DateNullNotNull() {
+        assertThrows(IllegalArgumentException.class, () -> DateUtils.isSameInstant(null, new Date()));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testIsSameInstant_DateNotNullNull() throws Exception {
-        DateUtils.isSameInstant(new Date(), null);
+    @Test
+    public void testIsSameInstant_DateNotNullNull() {
+        assertThrows(IllegalArgumentException.class, () -> DateUtils.isSameInstant(new Date(), null));
     }
 
     //-----------------------------------------------------------------------
@@ -261,19 +257,19 @@ public class DateUtilsTest {
         assertTrue(DateUtils.isSameInstant(cala, calb));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testIsSameInstant_CalNullNull() throws Exception {
-        DateUtils.isSameInstant((Calendar) null, null);
+    @Test
+    public void testIsSameInstant_CalNullNull() {
+        assertThrows(IllegalArgumentException.class, () -> DateUtils.isSameInstant((Calendar) null, null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testIsSameInstant_CalNullNotNull() throws Exception {
-        DateUtils.isSameInstant(null, Calendar.getInstance());
+    @Test
+    public void testIsSameInstant_CalNullNotNull() {
+        assertThrows(IllegalArgumentException.class, () -> DateUtils.isSameInstant(null, Calendar.getInstance()));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testIsSameInstant_CalNotNullNull() throws Exception {
-        DateUtils.isSameInstant(Calendar.getInstance(), null);
+    @Test
+    public void testIsSameInstant_CalNotNullNull() {
+        assertThrows(IllegalArgumentException.class, () -> DateUtils.isSameInstant(Calendar.getInstance(), null));
     }
 
     //-----------------------------------------------------------------------
@@ -293,25 +289,25 @@ public class DateUtilsTest {
         cald.set(2004, Calendar.JULY, 9, 16, 0, 0);
         calc.set(Calendar.MILLISECOND, 0);
         cald.set(Calendar.MILLISECOND, 0);
-        assertFalse("LANG-677", DateUtils.isSameLocalTime(calc, cald));
+        assertFalse(DateUtils.isSameLocalTime(calc, cald), "LANG-677");
 
         calb.set(2004, Calendar.JULY, 9, 11, 45, 0);
         assertFalse(DateUtils.isSameLocalTime(cala, calb));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testIsSameLocalTime_CalNullNull() throws Exception {
-        DateUtils.isSameLocalTime(null, null);
+    @Test
+    public void testIsSameLocalTime_CalNullNull() {
+        assertThrows(IllegalArgumentException.class, () -> DateUtils.isSameLocalTime(null, null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testIsSameLocalTime_CalNullNotNull() throws Exception {
-        DateUtils.isSameLocalTime(null, Calendar.getInstance());
+    @Test
+    public void testIsSameLocalTime_CalNullNotNull() {
+        assertThrows(IllegalArgumentException.class, () -> DateUtils.isSameLocalTime(null, Calendar.getInstance()));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testIsSameLocalTime_CalNotNullNull() throws Exception {
-        DateUtils.isSameLocalTime(Calendar.getInstance(), null);
+    @Test
+    public void testIsSameLocalTime_CalNotNullNull() {
+        assertThrows(IllegalArgumentException.class, () -> DateUtils.isSameLocalTime(Calendar.getInstance(), null));
     }
 
     //-----------------------------------------------------------------------
@@ -332,32 +328,32 @@ public class DateUtilsTest {
         assertEquals(cal.getTime(), date);
     }
 
-    @Test(expected = ParseException.class)
-    public void testParseDate_NoDateString() throws Exception {
+    @Test
+    public void testParseDate_NoDateString() {
         final String[] parsers = new String[] {"yyyy'-'DDD", "yyyy'-'MM'-'dd", "yyyyMMdd"};
-        DateUtils.parseDate("PURPLE", parsers);
+        assertThrows(ParseException.class, () -> DateUtils.parseDate("PURPLE", parsers));
     }
 
-    @Test(expected = ParseException.class)
-    public void testParseDate_InvalidDateString() throws Exception {
+    @Test
+    public void testParseDate_InvalidDateString() {
         final String[] parsers = new String[] {"yyyy'-'DDD", "yyyy'-'MM'-'dd", "yyyyMMdd"};
-        DateUtils.parseDate("197212AB", parsers);
+        assertThrows(ParseException.class, () -> DateUtils.parseDate("197212AB", parsers));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testParseDate_Null() throws Exception {
+    @Test
+    public void testParseDate_Null() {
         final String[] parsers = new String[] {"yyyy'-'DDD", "yyyy'-'MM'-'dd", "yyyyMMdd"};
-        DateUtils.parseDate(null, parsers);
+        assertThrows(IllegalArgumentException.class, () -> DateUtils.parseDate(null, parsers));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testParse_NullParsers() throws Exception {
-        DateUtils.parseDate("19721203", (String[]) null);
+    @Test
+    public void testParse_NullParsers() {
+        assertThrows(IllegalArgumentException.class, () -> DateUtils.parseDate("19721203", (String[]) null));
     }
 
-    @Test(expected = ParseException.class)
-    public void testParse_EmptyParsers() throws Exception {
-        DateUtils.parseDate("19721203");
+    @Test
+    public void testParse_EmptyParsers() {
+        assertThrows(ParseException.class, () -> DateUtils.parseDate("19721203"));
     }
 
     // LANG-486
@@ -689,7 +685,7 @@ public class DateUtilsTest {
     //-----------------------------------------------------------------------
     @Test
     public void testToCalendar() {
-        assertEquals("Failed to convert to a Calendar and back", date1, DateUtils.toCalendar(date1).getTime());
+        assertEquals(date1, DateUtils.toCalendar(date1).getTime(), "Failed to convert to a Calendar and back");
         try {
             DateUtils.toCalendar(null);
             fail("Expected NullPointerException to be thrown");
@@ -699,29 +695,29 @@ public class DateUtilsTest {
     }
 
     //-----------------------------------------------------------------------
-    @Test(expected=NullPointerException.class)
+    @Test
     public void testToCalendarWithDateNull() {
-        DateUtils.toCalendar(null, zone);
+        assertThrows(NullPointerException.class, () -> DateUtils.toCalendar(null, zone));
     }
 
     //-----------------------------------------------------------------------
-    @Test(expected=NullPointerException.class)
+    @Test
     public void testToCalendarWithTimeZoneNull() {
-        DateUtils.toCalendar(date1, null);
+        assertThrows(NullPointerException.class, () -> DateUtils.toCalendar(date1, null));
     }
 
     //-----------------------------------------------------------------------
     @Test
     public void testToCalendarWithDateAndTimeZoneNotNull() {
         final Calendar c = DateUtils.toCalendar(date2, defaultZone);
-        assertEquals("Convert Date and TimeZone to a Calendar, but failed to get the Date back", date2, c.getTime());
-        assertEquals("Convert Date and TimeZone to a Calendar, but failed to get the TimeZone back", defaultZone, c.getTimeZone());
+        assertEquals(date2, c.getTime(), "Convert Date and TimeZone to a Calendar, but failed to get the Date back");
+        assertEquals(defaultZone, c.getTimeZone(), "Convert Date and TimeZone to a Calendar, but failed to get the TimeZone back");
     }
 
     //-----------------------------------------------------------------------
-    @Test(expected=NullPointerException.class)
+    @Test
     public void testToCalendarWithDateAndTimeZoneNull() {
-        DateUtils.toCalendar(null, null);
+        assertThrows(NullPointerException.class, () -> DateUtils.toCalendar(null, null));
     }
 
     //-----------------------------------------------------------------------
@@ -733,127 +729,127 @@ public class DateUtilsTest {
     @Test
     public void testRound() throws Exception {
         // tests for public static Date round(Date date, int field)
-        assertEquals("round year-1 failed",
-                dateParser.parse("January 1, 2002"),
-                DateUtils.round(date1, Calendar.YEAR));
-        assertEquals("round year-2 failed",
-                dateParser.parse("January 1, 2002"),
-                DateUtils.round(date2, Calendar.YEAR));
-        assertEquals("round month-1 failed",
-                dateParser.parse("February 1, 2002"),
-                DateUtils.round(date1, Calendar.MONTH));
-        assertEquals("round month-2 failed",
-                dateParser.parse("December 1, 2001"),
-                DateUtils.round(date2, Calendar.MONTH));
-        assertEquals("round semimonth-0 failed",
-                dateParser.parse("February 1, 2002"),
-                DateUtils.round(date0, DateUtils.SEMI_MONTH));
-        assertEquals("round semimonth-1 failed",
-                dateParser.parse("February 16, 2002"),
-                DateUtils.round(date1, DateUtils.SEMI_MONTH));
-        assertEquals("round semimonth-2 failed",
-                dateParser.parse("November 16, 2001"),
-                DateUtils.round(date2, DateUtils.SEMI_MONTH));
+        assertEquals(dateParser.parse("January 1, 2002"),
+                DateUtils.round(date1, Calendar.YEAR),
+                "round year-1 failed");
+        assertEquals(dateParser.parse("January 1, 2002"),
+                DateUtils.round(date2, Calendar.YEAR),
+                "round year-2 failed");
+        assertEquals(dateParser.parse("February 1, 2002"),
+                DateUtils.round(date1, Calendar.MONTH),
+                "round month-1 failed");
+        assertEquals(dateParser.parse("December 1, 2001"),
+                DateUtils.round(date2, Calendar.MONTH),
+                "round month-2 failed");
+        assertEquals(dateParser.parse("February 1, 2002"),
+                DateUtils.round(date0, DateUtils.SEMI_MONTH),
+                "round semimonth-0 failed");
+        assertEquals(dateParser.parse("February 16, 2002"),
+                DateUtils.round(date1, DateUtils.SEMI_MONTH),
+                "round semimonth-1 failed");
+        assertEquals(dateParser.parse("November 16, 2001"),
+                DateUtils.round(date2, DateUtils.SEMI_MONTH),
+                "round semimonth-2 failed");
 
 
-        assertEquals("round date-1 failed",
-                dateParser.parse("February 13, 2002"),
-                DateUtils.round(date1, Calendar.DATE));
-        assertEquals("round date-2 failed",
-                dateParser.parse("November 18, 2001"),
-                DateUtils.round(date2, Calendar.DATE));
-        assertEquals("round hour-1 failed",
-                dateTimeParser.parse("February 12, 2002 13:00:00.000"),
-                DateUtils.round(date1, Calendar.HOUR));
-        assertEquals("round hour-2 failed",
-                dateTimeParser.parse("November 18, 2001 1:00:00.000"),
-                DateUtils.round(date2, Calendar.HOUR));
-        assertEquals("round minute-1 failed",
-                dateTimeParser.parse("February 12, 2002 12:35:00.000"),
-                DateUtils.round(date1, Calendar.MINUTE));
-        assertEquals("round minute-2 failed",
-                dateTimeParser.parse("November 18, 2001 1:23:00.000"),
-                DateUtils.round(date2, Calendar.MINUTE));
-        assertEquals("round second-1 failed",
-                dateTimeParser.parse("February 12, 2002 12:34:57.000"),
-                DateUtils.round(date1, Calendar.SECOND));
-        assertEquals("round second-2 failed",
-                dateTimeParser.parse("November 18, 2001 1:23:11.000"),
-                DateUtils.round(date2, Calendar.SECOND));
-        assertEquals("round ampm-1 failed",
-                dateTimeParser.parse("February 3, 2002 00:00:00.000"),
-                DateUtils.round(dateAmPm1, Calendar.AM_PM));
-        assertEquals("round ampm-2 failed",
-                dateTimeParser.parse("February 3, 2002 12:00:00.000"),
-                DateUtils.round(dateAmPm2, Calendar.AM_PM));
-        assertEquals("round ampm-3 failed",
-                dateTimeParser.parse("February 3, 2002 12:00:00.000"),
-                DateUtils.round(dateAmPm3, Calendar.AM_PM));
-        assertEquals("round ampm-4 failed",
-                dateTimeParser.parse("February 4, 2002 00:00:00.000"),
-                DateUtils.round(dateAmPm4, Calendar.AM_PM));
+        assertEquals(dateParser.parse("February 13, 2002"),
+                DateUtils.round(date1, Calendar.DATE),
+                "round date-1 failed");
+        assertEquals(dateParser.parse("November 18, 2001"),
+                DateUtils.round(date2, Calendar.DATE),
+                "round date-2 failed");
+        assertEquals(dateTimeParser.parse("February 12, 2002 13:00:00.000"),
+                DateUtils.round(date1, Calendar.HOUR),
+                "round hour-1 failed");
+        assertEquals(dateTimeParser.parse("November 18, 2001 1:00:00.000"),
+                DateUtils.round(date2, Calendar.HOUR),
+                "round hour-2 failed");
+        assertEquals(dateTimeParser.parse("February 12, 2002 12:35:00.000"),
+                DateUtils.round(date1, Calendar.MINUTE),
+                "round minute-1 failed");
+        assertEquals(dateTimeParser.parse("November 18, 2001 1:23:00.000"),
+                DateUtils.round(date2, Calendar.MINUTE),
+                "round minute-2 failed");
+        assertEquals(dateTimeParser.parse("February 12, 2002 12:34:57.000"),
+                DateUtils.round(date1, Calendar.SECOND),
+                "round second-1 failed");
+        assertEquals(dateTimeParser.parse("November 18, 2001 1:23:11.000"),
+                DateUtils.round(date2, Calendar.SECOND),
+                "round second-2 failed");
+        assertEquals(dateTimeParser.parse("February 3, 2002 00:00:00.000"),
+                DateUtils.round(dateAmPm1, Calendar.AM_PM),
+                "round ampm-1 failed");
+        assertEquals(dateTimeParser.parse("February 3, 2002 12:00:00.000"),
+                DateUtils.round(dateAmPm2, Calendar.AM_PM),
+                "round ampm-2 failed");
+        assertEquals(dateTimeParser.parse("February 3, 2002 12:00:00.000"),
+                DateUtils.round(dateAmPm3, Calendar.AM_PM),
+                "round ampm-3 failed");
+        assertEquals(dateTimeParser.parse("February 4, 2002 00:00:00.000"),
+                DateUtils.round(dateAmPm4, Calendar.AM_PM),
+                "round ampm-4 failed");
 
         // tests for public static Date round(Object date, int field)
-        assertEquals("round year-1 failed",
-                dateParser.parse("January 1, 2002"),
-                DateUtils.round((Object) date1, Calendar.YEAR));
-        assertEquals("round year-2 failed",
-                dateParser.parse("January 1, 2002"),
-                DateUtils.round((Object) date2, Calendar.YEAR));
-        assertEquals("round month-1 failed",
-                dateParser.parse("February 1, 2002"),
-                DateUtils.round((Object) date1, Calendar.MONTH));
-        assertEquals("round month-2 failed",
-                dateParser.parse("December 1, 2001"),
-                DateUtils.round((Object) date2, Calendar.MONTH));
-        assertEquals("round semimonth-1 failed",
-                dateParser.parse("February 16, 2002"),
-                DateUtils.round((Object) date1, DateUtils.SEMI_MONTH));
-        assertEquals("round semimonth-2 failed",
-                dateParser.parse("November 16, 2001"),
-                DateUtils.round((Object) date2, DateUtils.SEMI_MONTH));
-        assertEquals("round date-1 failed",
-                dateParser.parse("February 13, 2002"),
-                DateUtils.round((Object) date1, Calendar.DATE));
-        assertEquals("round date-2 failed",
-                dateParser.parse("November 18, 2001"),
-                DateUtils.round((Object) date2, Calendar.DATE));
-        assertEquals("round hour-1 failed",
-                dateTimeParser.parse("February 12, 2002 13:00:00.000"),
-                DateUtils.round((Object) date1, Calendar.HOUR));
-        assertEquals("round hour-2 failed",
-                dateTimeParser.parse("November 18, 2001 1:00:00.000"),
-                DateUtils.round((Object) date2, Calendar.HOUR));
-        assertEquals("round minute-1 failed",
-                dateTimeParser.parse("February 12, 2002 12:35:00.000"),
-                DateUtils.round((Object) date1, Calendar.MINUTE));
-        assertEquals("round minute-2 failed",
-                dateTimeParser.parse("November 18, 2001 1:23:00.000"),
-                DateUtils.round((Object) date2, Calendar.MINUTE));
-        assertEquals("round second-1 failed",
-                dateTimeParser.parse("February 12, 2002 12:34:57.000"),
-                DateUtils.round((Object) date1, Calendar.SECOND));
-        assertEquals("round second-2 failed",
-                dateTimeParser.parse("November 18, 2001 1:23:11.000"),
-                DateUtils.round((Object) date2, Calendar.SECOND));
-        assertEquals("round calendar second-1 failed",
-                dateTimeParser.parse("February 12, 2002 12:34:57.000"),
-                DateUtils.round((Object) cal1, Calendar.SECOND));
-        assertEquals("round calendar second-2 failed",
-                dateTimeParser.parse("November 18, 2001 1:23:11.000"),
-                DateUtils.round((Object) cal2, Calendar.SECOND));
-        assertEquals("round ampm-1 failed",
-                dateTimeParser.parse("February 3, 2002 00:00:00.000"),
-                DateUtils.round((Object) dateAmPm1, Calendar.AM_PM));
-        assertEquals("round ampm-2 failed",
-                dateTimeParser.parse("February 3, 2002 12:00:00.000"),
-                DateUtils.round((Object) dateAmPm2, Calendar.AM_PM));
-        assertEquals("round ampm-3 failed",
-                dateTimeParser.parse("February 3, 2002 12:00:00.000"),
-                DateUtils.round((Object) dateAmPm3, Calendar.AM_PM));
-        assertEquals("round ampm-4 failed",
-                dateTimeParser.parse("February 4, 2002 00:00:00.000"),
-                DateUtils.round((Object) dateAmPm4, Calendar.AM_PM));
+        assertEquals(dateParser.parse("January 1, 2002"),
+                DateUtils.round((Object) date1, Calendar.YEAR),
+                "round year-1 failed");
+        assertEquals(dateParser.parse("January 1, 2002"),
+                DateUtils.round((Object) date2, Calendar.YEAR),
+                "round year-2 failed");
+        assertEquals(dateParser.parse("February 1, 2002"),
+                DateUtils.round((Object) date1, Calendar.MONTH),
+                "round month-1 failed");
+        assertEquals(dateParser.parse("December 1, 2001"),
+                DateUtils.round((Object) date2, Calendar.MONTH),
+                "round month-2 failed");
+        assertEquals(dateParser.parse("February 16, 2002"),
+                DateUtils.round((Object) date1, DateUtils.SEMI_MONTH),
+                "round semimonth-1 failed");
+        assertEquals(dateParser.parse("November 16, 2001"),
+                DateUtils.round((Object) date2, DateUtils.SEMI_MONTH),
+                "round semimonth-2 failed");
+        assertEquals(dateParser.parse("February 13, 2002"),
+                DateUtils.round((Object) date1, Calendar.DATE),
+                "round date-1 failed");
+        assertEquals(dateParser.parse("November 18, 2001"),
+                DateUtils.round((Object) date2, Calendar.DATE),
+                "round date-2 failed");
+        assertEquals(dateTimeParser.parse("February 12, 2002 13:00:00.000"),
+                DateUtils.round((Object) date1, Calendar.HOUR),
+                "round hour-1 failed");
+        assertEquals(dateTimeParser.parse("November 18, 2001 1:00:00.000"),
+                DateUtils.round((Object) date2, Calendar.HOUR),
+                "round hour-2 failed");
+        assertEquals(dateTimeParser.parse("February 12, 2002 12:35:00.000"),
+                DateUtils.round((Object) date1, Calendar.MINUTE),
+                "round minute-1 failed");
+        assertEquals(dateTimeParser.parse("November 18, 2001 1:23:00.000"),
+                DateUtils.round((Object) date2, Calendar.MINUTE),
+                "round minute-2 failed");
+        assertEquals(dateTimeParser.parse("February 12, 2002 12:34:57.000"),
+                DateUtils.round((Object) date1, Calendar.SECOND),
+                "round second-1 failed");
+        assertEquals(dateTimeParser.parse("November 18, 2001 1:23:11.000"),
+                DateUtils.round((Object) date2, Calendar.SECOND),
+                "round second-2 failed");
+        assertEquals(dateTimeParser.parse("February 12, 2002 12:34:57.000"),
+                DateUtils.round((Object) cal1, Calendar.SECOND),
+                "round calendar second-1 failed");
+        assertEquals(dateTimeParser.parse("November 18, 2001 1:23:11.000"),
+                DateUtils.round((Object) cal2, Calendar.SECOND),
+                "round calendar second-2 failed");
+        assertEquals(dateTimeParser.parse("February 3, 2002 00:00:00.000"),
+                DateUtils.round((Object) dateAmPm1, Calendar.AM_PM),
+                "round ampm-1 failed");
+        assertEquals(dateTimeParser.parse("February 3, 2002 12:00:00.000"),
+                DateUtils.round((Object) dateAmPm2, Calendar.AM_PM),
+                "round ampm-2 failed");
+        assertEquals(dateTimeParser.parse("February 3, 2002 12:00:00.000"),
+                DateUtils.round((Object) dateAmPm3, Calendar.AM_PM),
+                "round ampm-3 failed");
+        assertEquals(dateTimeParser.parse("February 4, 2002 00:00:00.000"),
+                DateUtils.round((Object) dateAmPm4, Calendar.AM_PM),
+                "round ampm-4 failed");
 
         try {
             DateUtils.round((Date) null, Calendar.SECOND);
@@ -876,73 +872,73 @@ public class DateUtilsTest {
             fail();
         } catch(final IllegalArgumentException ex) {}
 
-        assertEquals("round ampm-1 failed",
-                dateTimeParser.parse("February 3, 2002 00:00:00.000"),
-                DateUtils.round((Object) calAmPm1, Calendar.AM_PM));
-        assertEquals("round ampm-2 failed",
-                dateTimeParser.parse("February 3, 2002 12:00:00.000"),
-                DateUtils.round((Object) calAmPm2, Calendar.AM_PM));
-        assertEquals("round ampm-3 failed",
-                dateTimeParser.parse("February 3, 2002 12:00:00.000"),
-                DateUtils.round((Object) calAmPm3, Calendar.AM_PM));
-        assertEquals("round ampm-4 failed",
-                dateTimeParser.parse("February 4, 2002 00:00:00.000"),
-                DateUtils.round((Object) calAmPm4, Calendar.AM_PM));
+        assertEquals(dateTimeParser.parse("February 3, 2002 00:00:00.000"),
+                DateUtils.round((Object) calAmPm1, Calendar.AM_PM),
+                "round ampm-1 failed");
+        assertEquals(dateTimeParser.parse("February 3, 2002 12:00:00.000"),
+                DateUtils.round((Object) calAmPm2, Calendar.AM_PM),
+                "round ampm-2 failed");
+        assertEquals(dateTimeParser.parse("February 3, 2002 12:00:00.000"),
+                DateUtils.round((Object) calAmPm3, Calendar.AM_PM),
+                "round ampm-3 failed");
+        assertEquals(dateTimeParser.parse("February 4, 2002 00:00:00.000"),
+                DateUtils.round((Object) calAmPm4, Calendar.AM_PM),
+                "round ampm-4 failed");
 
         // Fix for http://issues.apache.org/bugzilla/show_bug.cgi?id=25560 / LANG-13
         // Test rounding across the beginning of daylight saving time
         try {
             TimeZone.setDefault(zone);
             dateTimeParser.setTimeZone(zone);
-            assertEquals("round MET date across DST change-over",
-                    dateTimeParser.parse("March 30, 2003 00:00:00.000"),
-                    DateUtils.round(date4, Calendar.DATE));
-            assertEquals("round MET date across DST change-over",
-                    dateTimeParser.parse("March 30, 2003 00:00:00.000"),
-                    DateUtils.round((Object) cal4, Calendar.DATE));
-            assertEquals("round MET date across DST change-over",
-                    dateTimeParser.parse("March 30, 2003 00:00:00.000"),
-                    DateUtils.round(date5, Calendar.DATE));
-            assertEquals("round MET date across DST change-over",
-                    dateTimeParser.parse("March 30, 2003 00:00:00.000"),
-                    DateUtils.round((Object) cal5, Calendar.DATE));
-            assertEquals("round MET date across DST change-over",
-                    dateTimeParser.parse("March 30, 2003 00:00:00.000"),
-                    DateUtils.round(date6, Calendar.DATE));
-            assertEquals("round MET date across DST change-over",
-                    dateTimeParser.parse("March 30, 2003 00:00:00.000"),
-                    DateUtils.round((Object) cal6, Calendar.DATE));
-            assertEquals("round MET date across DST change-over",
-                    dateTimeParser.parse("March 30, 2003 00:00:00.000"),
-                    DateUtils.round(date7, Calendar.DATE));
-            assertEquals("round MET date across DST change-over",
-                    dateTimeParser.parse("March 30, 2003 00:00:00.000"),
-                    DateUtils.round((Object) cal7, Calendar.DATE));
+            assertEquals(dateTimeParser.parse("March 30, 2003 00:00:00.000"),
+                    DateUtils.round(date4, Calendar.DATE),
+                    "round MET date across DST change-over");
+            assertEquals(dateTimeParser.parse("March 30, 2003 00:00:00.000"),
+                    DateUtils.round((Object) cal4, Calendar.DATE),
+                    "round MET date across DST change-over");
+            assertEquals(dateTimeParser.parse("March 30, 2003 00:00:00.000"),
+                    DateUtils.round(date5, Calendar.DATE),
+                    "round MET date across DST change-over");
+            assertEquals(dateTimeParser.parse("March 30, 2003 00:00:00.000"),
+                    DateUtils.round((Object) cal5, Calendar.DATE),
+                    "round MET date across DST change-over");
+            assertEquals(dateTimeParser.parse("March 30, 2003 00:00:00.000"),
+                    DateUtils.round(date6, Calendar.DATE),
+                    "round MET date across DST change-over");
+            assertEquals(dateTimeParser.parse("March 30, 2003 00:00:00.000"),
+                    DateUtils.round((Object) cal6, Calendar.DATE),
+                    "round MET date across DST change-over");
+            assertEquals(dateTimeParser.parse("March 30, 2003 00:00:00.000"),
+                    DateUtils.round(date7, Calendar.DATE),
+                    "round MET date across DST change-over");
+            assertEquals(dateTimeParser.parse("March 30, 2003 00:00:00.000"),
+                    DateUtils.round((Object) cal7, Calendar.DATE),
+                    "round MET date across DST change-over");
 
-            assertEquals("round MET date across DST change-over",
-                    dateTimeParser.parse("March 30, 2003 01:00:00.000"),
-                    DateUtils.round(date4, Calendar.HOUR_OF_DAY));
-            assertEquals("round MET date across DST change-over",
-                    dateTimeParser.parse("March 30, 2003 01:00:00.000"),
-                    DateUtils.round((Object) cal4, Calendar.HOUR_OF_DAY));
-            assertEquals("round MET date across DST change-over",
-                    dateTimeParser.parse("March 30, 2003 03:00:00.000"),
-                    DateUtils.round(date5, Calendar.HOUR_OF_DAY));
-            assertEquals("round MET date across DST change-over",
-                    dateTimeParser.parse("March 30, 2003 03:00:00.000"),
-                    DateUtils.round((Object) cal5, Calendar.HOUR_OF_DAY));
-            assertEquals("round MET date across DST change-over",
-                    dateTimeParser.parse("March 30, 2003 03:00:00.000"),
-                    DateUtils.round(date6, Calendar.HOUR_OF_DAY));
-            assertEquals("round MET date across DST change-over",
-                    dateTimeParser.parse("March 30, 2003 03:00:00.000"),
-                    DateUtils.round((Object) cal6, Calendar.HOUR_OF_DAY));
-            assertEquals("round MET date across DST change-over",
-                    dateTimeParser.parse("March 30, 2003 04:00:00.000"),
-                    DateUtils.round(date7, Calendar.HOUR_OF_DAY));
-            assertEquals("round MET date across DST change-over",
-                    dateTimeParser.parse("March 30, 2003 04:00:00.000"),
-                    DateUtils.round((Object) cal7, Calendar.HOUR_OF_DAY));
+            assertEquals(dateTimeParser.parse("March 30, 2003 01:00:00.000"),
+                    DateUtils.round(date4, Calendar.HOUR_OF_DAY),
+                    "round MET date across DST change-over");
+            assertEquals(dateTimeParser.parse("March 30, 2003 01:00:00.000"),
+                    DateUtils.round((Object) cal4, Calendar.HOUR_OF_DAY),
+                    "round MET date across DST change-over");
+            assertEquals(dateTimeParser.parse("March 30, 2003 03:00:00.000"),
+                    DateUtils.round(date5, Calendar.HOUR_OF_DAY),
+                    "round MET date across DST change-over");
+            assertEquals(dateTimeParser.parse("March 30, 2003 03:00:00.000"),
+                    DateUtils.round((Object) cal5, Calendar.HOUR_OF_DAY),
+                    "round MET date across DST change-over");
+            assertEquals(dateTimeParser.parse("March 30, 2003 03:00:00.000"),
+                    DateUtils.round(date6, Calendar.HOUR_OF_DAY),
+                    "round MET date across DST change-over");
+            assertEquals(dateTimeParser.parse("March 30, 2003 03:00:00.000"),
+                    DateUtils.round((Object) cal6, Calendar.HOUR_OF_DAY),
+                    "round MET date across DST change-over");
+            assertEquals(dateTimeParser.parse("March 30, 2003 04:00:00.000"),
+                    DateUtils.round(date7, Calendar.HOUR_OF_DAY),
+                    "round MET date across DST change-over");
+            assertEquals(dateTimeParser.parse("March 30, 2003 04:00:00.000"),
+                    DateUtils.round((Object) cal7, Calendar.HOUR_OF_DAY),
+                    "round MET date across DST change-over");
         } finally {
             TimeZone.setDefault(defaultZone);
             dateTimeParser.setTimeZone(defaultZone);
@@ -960,56 +956,56 @@ public class DateUtilsTest {
         final Calendar testCalendar = Calendar.getInstance();
         testCalendar.set(2007, Calendar.JULY, 2, 8, 8, 50);
         Date date = testCalendar.getTime();
-        assertEquals("Minute Round Up Failed",
-                     dateTimeParser.parse("July 2, 2007 08:09:00.000"),
-                     DateUtils.round(date, Calendar.MINUTE));
+        assertEquals(dateTimeParser.parse("July 2, 2007 08:09:00.000"),
+                DateUtils.round(date, Calendar.MINUTE),
+                "Minute Round Up Failed");
 
         testCalendar.set(2007, Calendar.JULY, 2, 8, 8, 20);
         date = testCalendar.getTime();
-        assertEquals("Minute No Round Failed",
-                     dateTimeParser.parse("July 2, 2007 08:08:00.000"),
-                     DateUtils.round(date, Calendar.MINUTE));
+        assertEquals(dateTimeParser.parse("July 2, 2007 08:08:00.000"),
+                DateUtils.round(date, Calendar.MINUTE),
+                "Minute No Round Failed");
 
         testCalendar.set(2007, Calendar.JULY, 2, 8, 8, 50);
         testCalendar.set(Calendar.MILLISECOND, 600);
         date = testCalendar.getTime();
 
-        assertEquals("Second Round Up with 600 Milli Seconds Failed",
-                     dateTimeParser.parse("July 2, 2007 08:08:51.000"),
-                     DateUtils.round(date, Calendar.SECOND));
+        assertEquals(dateTimeParser.parse("July 2, 2007 08:08:51.000"),
+                DateUtils.round(date, Calendar.SECOND),
+                "Second Round Up with 600 Milli Seconds Failed");
 
         testCalendar.set(2007, Calendar.JULY, 2, 8, 8, 50);
         testCalendar.set(Calendar.MILLISECOND, 200);
         date = testCalendar.getTime();
-        assertEquals("Second Round Down with 200 Milli Seconds Failed",
-                     dateTimeParser.parse("July 2, 2007 08:08:50.000"),
-                     DateUtils.round(date, Calendar.SECOND));
+        assertEquals(dateTimeParser.parse("July 2, 2007 08:08:50.000"),
+                DateUtils.round(date, Calendar.SECOND),
+                "Second Round Down with 200 Milli Seconds Failed");
 
         testCalendar.set(2007, Calendar.JULY, 2, 8, 8, 20);
         testCalendar.set(Calendar.MILLISECOND, 600);
         date = testCalendar.getTime();
-        assertEquals("Second Round Up with 200 Milli Seconds Failed",
-                     dateTimeParser.parse("July 2, 2007 08:08:21.000"),
-                     DateUtils.round(date, Calendar.SECOND));
+        assertEquals(dateTimeParser.parse("July 2, 2007 08:08:21.000"),
+                DateUtils.round(date, Calendar.SECOND),
+                "Second Round Up with 200 Milli Seconds Failed");
 
         testCalendar.set(2007, Calendar.JULY, 2, 8, 8, 20);
         testCalendar.set(Calendar.MILLISECOND, 200);
         date = testCalendar.getTime();
-        assertEquals("Second Round Down with 200 Milli Seconds Failed",
-                     dateTimeParser.parse("July 2, 2007 08:08:20.000"),
-                     DateUtils.round(date, Calendar.SECOND));
+        assertEquals(dateTimeParser.parse("July 2, 2007 08:08:20.000"),
+                DateUtils.round(date, Calendar.SECOND),
+                "Second Round Down with 200 Milli Seconds Failed");
 
         testCalendar.set(2007, Calendar.JULY, 2, 8, 8, 50);
         date = testCalendar.getTime();
-        assertEquals("Hour Round Down Failed",
-                     dateTimeParser.parse("July 2, 2007 08:00:00.000"),
-                     DateUtils.round(date, Calendar.HOUR));
+        assertEquals(dateTimeParser.parse("July 2, 2007 08:00:00.000"),
+                DateUtils.round(date, Calendar.HOUR),
+                "Hour Round Down Failed");
 
         testCalendar.set(2007, Calendar.JULY, 2, 8, 31, 50);
         date = testCalendar.getTime();
-        assertEquals("Hour Round Up Failed",
-                     dateTimeParser.parse("July 2, 2007 09:00:00.000"),
-                     DateUtils.round(date, Calendar.HOUR));
+        assertEquals(dateTimeParser.parse("July 2, 2007 09:00:00.000"),
+                DateUtils.round(date, Calendar.HOUR),
+                "Hour Round Up Failed");
     }
 
     /**
@@ -1020,136 +1016,136 @@ public class DateUtilsTest {
     @Test
     public void testTruncate() throws Exception {
         // tests public static Date truncate(Date date, int field)
-        assertEquals("truncate year-1 failed",
-                dateParser.parse("January 1, 2002"),
-                DateUtils.truncate(date1, Calendar.YEAR));
-        assertEquals("truncate year-2 failed",
-                dateParser.parse("January 1, 2001"),
-                DateUtils.truncate(date2, Calendar.YEAR));
-        assertEquals("truncate month-1 failed",
-                dateParser.parse("February 1, 2002"),
-                DateUtils.truncate(date1, Calendar.MONTH));
-        assertEquals("truncate month-2 failed",
-                dateParser.parse("November 1, 2001"),
-                DateUtils.truncate(date2, Calendar.MONTH));
-        assertEquals("truncate semimonth-1 failed",
-                dateParser.parse("February 1, 2002"),
-                DateUtils.truncate(date1, DateUtils.SEMI_MONTH));
-        assertEquals("truncate semimonth-2 failed",
-                dateParser.parse("November 16, 2001"),
-                DateUtils.truncate(date2, DateUtils.SEMI_MONTH));
-        assertEquals("truncate date-1 failed",
-                dateParser.parse("February 12, 2002"),
-                DateUtils.truncate(date1, Calendar.DATE));
-        assertEquals("truncate date-2 failed",
-                dateParser.parse("November 18, 2001"),
-                DateUtils.truncate(date2, Calendar.DATE));
-        assertEquals("truncate hour-1 failed",
-                dateTimeParser.parse("February 12, 2002 12:00:00.000"),
-                DateUtils.truncate(date1, Calendar.HOUR));
-        assertEquals("truncate hour-2 failed",
-                dateTimeParser.parse("November 18, 2001 1:00:00.000"),
-                DateUtils.truncate(date2, Calendar.HOUR));
-        assertEquals("truncate minute-1 failed",
-                dateTimeParser.parse("February 12, 2002 12:34:00.000"),
-                DateUtils.truncate(date1, Calendar.MINUTE));
-        assertEquals("truncate minute-2 failed",
-                dateTimeParser.parse("November 18, 2001 1:23:00.000"),
-                DateUtils.truncate(date2, Calendar.MINUTE));
-        assertEquals("truncate second-1 failed",
-                dateTimeParser.parse("February 12, 2002 12:34:56.000"),
-                DateUtils.truncate(date1, Calendar.SECOND));
-        assertEquals("truncate second-2 failed",
-                dateTimeParser.parse("November 18, 2001 1:23:11.000"),
-                DateUtils.truncate(date2, Calendar.SECOND));
-        assertEquals("truncate ampm-1 failed",
-                dateTimeParser.parse("February 3, 2002 00:00:00.000"),
-                DateUtils.truncate(dateAmPm1, Calendar.AM_PM));
-        assertEquals("truncate ampm-2 failed",
-                dateTimeParser.parse("February 3, 2002 00:00:00.000"),
-                DateUtils.truncate(dateAmPm2, Calendar.AM_PM));
-        assertEquals("truncate ampm-3 failed",
-                dateTimeParser.parse("February 3, 2002 12:00:00.000"),
-                DateUtils.truncate(dateAmPm3, Calendar.AM_PM));
-        assertEquals("truncate ampm-4 failed",
-                dateTimeParser.parse("February 3, 2002 12:00:00.000"),
-                DateUtils.truncate(dateAmPm4, Calendar.AM_PM));
+        assertEquals(dateParser.parse("January 1, 2002"),
+                DateUtils.truncate(date1, Calendar.YEAR),
+                "truncate year-1 failed");
+        assertEquals(dateParser.parse("January 1, 2001"),
+                DateUtils.truncate(date2, Calendar.YEAR),
+                "truncate year-2 failed");
+        assertEquals(dateParser.parse("February 1, 2002"),
+                DateUtils.truncate(date1, Calendar.MONTH),
+                "truncate month-1 failed");
+        assertEquals(dateParser.parse("November 1, 2001"),
+                DateUtils.truncate(date2, Calendar.MONTH),
+                "truncate month-2 failed");
+        assertEquals(dateParser.parse("February 1, 2002"),
+                DateUtils.truncate(date1, DateUtils.SEMI_MONTH),
+                "truncate semimonth-1 failed");
+        assertEquals(dateParser.parse("November 16, 2001"),
+                DateUtils.truncate(date2, DateUtils.SEMI_MONTH),
+                "truncate semimonth-2 failed");
+        assertEquals(dateParser.parse("February 12, 2002"),
+                DateUtils.truncate(date1, Calendar.DATE),
+                "truncate date-1 failed");
+        assertEquals(dateParser.parse("November 18, 2001"),
+                DateUtils.truncate(date2, Calendar.DATE),
+                "truncate date-2 failed");
+        assertEquals(dateTimeParser.parse("February 12, 2002 12:00:00.000"),
+                DateUtils.truncate(date1, Calendar.HOUR),
+                "truncate hour-1 failed");
+        assertEquals(dateTimeParser.parse("November 18, 2001 1:00:00.000"),
+                DateUtils.truncate(date2, Calendar.HOUR),
+                "truncate hour-2 failed");
+        assertEquals(dateTimeParser.parse("February 12, 2002 12:34:00.000"),
+                DateUtils.truncate(date1, Calendar.MINUTE),
+                "truncate minute-1 failed");
+        assertEquals(dateTimeParser.parse("November 18, 2001 1:23:00.000"),
+                DateUtils.truncate(date2, Calendar.MINUTE),
+                "truncate minute-2 failed");
+        assertEquals(dateTimeParser.parse("February 12, 2002 12:34:56.000"),
+                DateUtils.truncate(date1, Calendar.SECOND),
+                "truncate second-1 failed");
+        assertEquals(dateTimeParser.parse("November 18, 2001 1:23:11.000"),
+                DateUtils.truncate(date2, Calendar.SECOND),
+                "truncate second-2 failed");
+        assertEquals(dateTimeParser.parse("February 3, 2002 00:00:00.000"),
+                DateUtils.truncate(dateAmPm1, Calendar.AM_PM),
+                "truncate ampm-1 failed");
+        assertEquals(dateTimeParser.parse("February 3, 2002 00:00:00.000"),
+                DateUtils.truncate(dateAmPm2, Calendar.AM_PM),
+                "truncate ampm-2 failed");
+        assertEquals(dateTimeParser.parse("February 3, 2002 12:00:00.000"),
+                DateUtils.truncate(dateAmPm3, Calendar.AM_PM),
+                "truncate ampm-3 failed");
+        assertEquals(dateTimeParser.parse("February 3, 2002 12:00:00.000"),
+                DateUtils.truncate(dateAmPm4, Calendar.AM_PM),
+                "truncate ampm-4 failed");
 
         // tests public static Date truncate(Object date, int field)
-        assertEquals("truncate year-1 failed",
-                dateParser.parse("January 1, 2002"),
-                DateUtils.truncate((Object) date1, Calendar.YEAR));
-        assertEquals("truncate year-2 failed",
-                dateParser.parse("January 1, 2001"),
-                DateUtils.truncate((Object) date2, Calendar.YEAR));
-        assertEquals("truncate month-1 failed",
-                dateParser.parse("February 1, 2002"),
-                DateUtils.truncate((Object) date1, Calendar.MONTH));
-        assertEquals("truncate month-2 failed",
-                dateParser.parse("November 1, 2001"),
-                DateUtils.truncate((Object) date2, Calendar.MONTH));
-        assertEquals("truncate semimonth-1 failed",
-                dateParser.parse("February 1, 2002"),
-                DateUtils.truncate((Object) date1, DateUtils.SEMI_MONTH));
-        assertEquals("truncate semimonth-2 failed",
-                dateParser.parse("November 16, 2001"),
-                DateUtils.truncate((Object) date2, DateUtils.SEMI_MONTH));
-        assertEquals("truncate date-1 failed",
-                dateParser.parse("February 12, 2002"),
-                DateUtils.truncate((Object) date1, Calendar.DATE));
-        assertEquals("truncate date-2 failed",
-                dateParser.parse("November 18, 2001"),
-                DateUtils.truncate((Object) date2, Calendar.DATE));
-        assertEquals("truncate hour-1 failed",
-                dateTimeParser.parse("February 12, 2002 12:00:00.000"),
-                DateUtils.truncate((Object) date1, Calendar.HOUR));
-        assertEquals("truncate hour-2 failed",
-                dateTimeParser.parse("November 18, 2001 1:00:00.000"),
-                DateUtils.truncate((Object) date2, Calendar.HOUR));
-        assertEquals("truncate minute-1 failed",
-                dateTimeParser.parse("February 12, 2002 12:34:00.000"),
-                DateUtils.truncate((Object) date1, Calendar.MINUTE));
-        assertEquals("truncate minute-2 failed",
-                dateTimeParser.parse("November 18, 2001 1:23:00.000"),
-                DateUtils.truncate((Object) date2, Calendar.MINUTE));
-        assertEquals("truncate second-1 failed",
-                dateTimeParser.parse("February 12, 2002 12:34:56.000"),
-                DateUtils.truncate((Object) date1, Calendar.SECOND));
-        assertEquals("truncate second-2 failed",
-                dateTimeParser.parse("November 18, 2001 1:23:11.000"),
-                DateUtils.truncate((Object) date2, Calendar.SECOND));
-        assertEquals("truncate ampm-1 failed",
-                dateTimeParser.parse("February 3, 2002 00:00:00.000"),
-                DateUtils.truncate((Object) dateAmPm1, Calendar.AM_PM));
-        assertEquals("truncate ampm-2 failed",
-                dateTimeParser.parse("February 3, 2002 00:00:00.000"),
-                DateUtils.truncate((Object) dateAmPm2, Calendar.AM_PM));
-        assertEquals("truncate ampm-3 failed",
-                dateTimeParser.parse("February 3, 2002 12:00:00.000"),
-                DateUtils.truncate((Object) dateAmPm3, Calendar.AM_PM));
-        assertEquals("truncate ampm-4 failed",
-                dateTimeParser.parse("February 3, 2002 12:00:00.000"),
-                DateUtils.truncate((Object) dateAmPm4, Calendar.AM_PM));
+        assertEquals(dateParser.parse("January 1, 2002"),
+                DateUtils.truncate((Object) date1, Calendar.YEAR),
+                "truncate year-1 failed");
+        assertEquals(dateParser.parse("January 1, 2001"),
+                DateUtils.truncate((Object) date2, Calendar.YEAR),
+                "truncate year-2 failed");
+        assertEquals(dateParser.parse("February 1, 2002"),
+                DateUtils.truncate((Object) date1, Calendar.MONTH),
+                "truncate month-1 failed");
+        assertEquals(dateParser.parse("November 1, 2001"),
+                DateUtils.truncate((Object) date2, Calendar.MONTH),
+                "truncate month-2 failed");
+        assertEquals(dateParser.parse("February 1, 2002"),
+                DateUtils.truncate((Object) date1, DateUtils.SEMI_MONTH),
+                "truncate semimonth-1 failed");
+        assertEquals(dateParser.parse("November 16, 2001"),
+                DateUtils.truncate((Object) date2, DateUtils.SEMI_MONTH),
+                "truncate semimonth-2 failed");
+        assertEquals(dateParser.parse("February 12, 2002"),
+                DateUtils.truncate((Object) date1, Calendar.DATE),
+                "truncate date-1 failed");
+        assertEquals(dateParser.parse("November 18, 2001"),
+                DateUtils.truncate((Object) date2, Calendar.DATE),
+                "truncate date-2 failed");
+        assertEquals(dateTimeParser.parse("February 12, 2002 12:00:00.000"),
+                DateUtils.truncate((Object) date1, Calendar.HOUR),
+                "truncate hour-1 failed");
+        assertEquals(dateTimeParser.parse("November 18, 2001 1:00:00.000"),
+                DateUtils.truncate((Object) date2, Calendar.HOUR),
+                "truncate hour-2 failed");
+        assertEquals(dateTimeParser.parse("February 12, 2002 12:34:00.000"),
+                DateUtils.truncate((Object) date1, Calendar.MINUTE),
+                "truncate minute-1 failed");
+        assertEquals(dateTimeParser.parse("November 18, 2001 1:23:00.000"),
+                DateUtils.truncate((Object) date2, Calendar.MINUTE),
+                "truncate minute-2 failed");
+        assertEquals(dateTimeParser.parse("February 12, 2002 12:34:56.000"),
+                DateUtils.truncate((Object) date1, Calendar.SECOND),
+                "truncate second-1 failed");
+        assertEquals(dateTimeParser.parse("November 18, 2001 1:23:11.000"),
+                DateUtils.truncate((Object) date2, Calendar.SECOND),
+                "truncate second-2 failed");
+        assertEquals(dateTimeParser.parse("February 3, 2002 00:00:00.000"),
+                DateUtils.truncate((Object) dateAmPm1, Calendar.AM_PM),
+                "truncate ampm-1 failed");
+        assertEquals(dateTimeParser.parse("February 3, 2002 00:00:00.000"),
+                DateUtils.truncate((Object) dateAmPm2, Calendar.AM_PM),
+                "truncate ampm-2 failed");
+        assertEquals(dateTimeParser.parse("February 3, 2002 12:00:00.000"),
+                DateUtils.truncate((Object) dateAmPm3, Calendar.AM_PM),
+                "truncate ampm-3 failed");
+        assertEquals(dateTimeParser.parse("February 3, 2002 12:00:00.000"),
+                DateUtils.truncate((Object) dateAmPm4, Calendar.AM_PM),
+                "truncate ampm-4 failed");
 
-        assertEquals("truncate calendar second-1 failed",
-                dateTimeParser.parse("February 12, 2002 12:34:56.000"),
-                DateUtils.truncate((Object) cal1, Calendar.SECOND));
-        assertEquals("truncate calendar second-2 failed",
-                dateTimeParser.parse("November 18, 2001 1:23:11.000"),
-                DateUtils.truncate((Object) cal2, Calendar.SECOND));
+        assertEquals(dateTimeParser.parse("February 12, 2002 12:34:56.000"),
+                DateUtils.truncate((Object) cal1, Calendar.SECOND),
+                "truncate calendar second-1 failed");
+        assertEquals(dateTimeParser.parse("November 18, 2001 1:23:11.000"),
+                DateUtils.truncate((Object) cal2, Calendar.SECOND),
+                "truncate calendar second-2 failed");
 
-        assertEquals("truncate ampm-1 failed",
-                dateTimeParser.parse("February 3, 2002 00:00:00.000"),
-                DateUtils.truncate((Object) calAmPm1, Calendar.AM_PM));
-        assertEquals("truncate ampm-2 failed",
-                dateTimeParser.parse("February 3, 2002 00:00:00.000"),
-                DateUtils.truncate((Object) calAmPm2, Calendar.AM_PM));
-        assertEquals("truncate ampm-3 failed",
-                dateTimeParser.parse("February 3, 2002 12:00:00.000"),
-                DateUtils.truncate((Object) calAmPm3, Calendar.AM_PM));
-        assertEquals("truncate ampm-4 failed",
-                dateTimeParser.parse("February 3, 2002 12:00:00.000"),
-                DateUtils.truncate((Object) calAmPm4, Calendar.AM_PM));
+        assertEquals(dateTimeParser.parse("February 3, 2002 00:00:00.000"),
+                DateUtils.truncate((Object) calAmPm1, Calendar.AM_PM),
+                "truncate ampm-1 failed");
+        assertEquals(dateTimeParser.parse("February 3, 2002 00:00:00.000"),
+                DateUtils.truncate((Object) calAmPm2, Calendar.AM_PM),
+                "truncate ampm-2 failed");
+        assertEquals(dateTimeParser.parse("February 3, 2002 12:00:00.000"),
+                DateUtils.truncate((Object) calAmPm3, Calendar.AM_PM),
+                "truncate ampm-3 failed");
+        assertEquals(dateTimeParser.parse("February 3, 2002 12:00:00.000"),
+                DateUtils.truncate((Object) calAmPm4, Calendar.AM_PM),
+                "truncate ampm-4 failed");
 
         try {
             DateUtils.truncate((Date) null, Calendar.SECOND);
@@ -1173,19 +1169,19 @@ public class DateUtilsTest {
         try {
             TimeZone.setDefault(zone);
             dateTimeParser.setTimeZone(zone);
-            assertEquals("truncate MET date across DST change-over",
-                    dateTimeParser.parse("March 30, 2003 00:00:00.000"),
-                    DateUtils.truncate(date3, Calendar.DATE));
-            assertEquals("truncate MET date across DST change-over",
-                    dateTimeParser.parse("March 30, 2003 00:00:00.000"),
-                    DateUtils.truncate((Object) cal3, Calendar.DATE));
+            assertEquals(dateTimeParser.parse("March 30, 2003 00:00:00.000"),
+                    DateUtils.truncate(date3, Calendar.DATE),
+                    "truncate MET date across DST change-over");
+            assertEquals(dateTimeParser.parse("March 30, 2003 00:00:00.000"),
+                    DateUtils.truncate((Object) cal3, Calendar.DATE),
+                    "truncate MET date across DST change-over");
             // Test truncate across end of daylight saving time
-            assertEquals("truncate MET date across DST change-over",
-                    dateTimeParser.parse("October 26, 2003 00:00:00.000"),
-                    DateUtils.truncate(date8, Calendar.DATE));
-            assertEquals("truncate MET date across DST change-over",
-                    dateTimeParser.parse("October 26, 2003 00:00:00.000"),
-                    DateUtils.truncate((Object) cal8, Calendar.DATE));
+            assertEquals(dateTimeParser.parse("October 26, 2003 00:00:00.000"),
+                    DateUtils.truncate(date8, Calendar.DATE),
+                    "truncate MET date across DST change-over");
+            assertEquals(dateTimeParser.parse("October 26, 2003 00:00:00.000"),
+                    DateUtils.truncate((Object) cal8, Calendar.DATE),
+                    "truncate MET date across DST change-over");
         } finally {
             TimeZone.setDefault(defaultZone);
             dateTimeParser.setTimeZone(defaultZone);
@@ -1232,55 +1228,55 @@ public class DateUtilsTest {
             final Date oct31_01_02_03MDT = new Date(oct31_01_02MDT.getTime() + 3000L);    // + 3 seconds
             final Date oct31_01_02_03_04MDT = new Date(oct31_01_02_03MDT.getTime() + 4L);       // + 4 milliseconds
 
-            assertEquals("Check 00:00:00.000", "2004-10-31 00:00:00.000 -06:00", format.format(oct31MDT));
-            assertEquals("Check 01:00:00.000", "2004-10-31 01:00:00.000 -06:00", format.format(oct31_01MDT));
-            assertEquals("Check 01:02:00.000", "2004-10-31 01:02:00.000 -06:00", format.format(oct31_01_02MDT));
-            assertEquals("Check 01:02:03.000", "2004-10-31 01:02:03.000 -06:00", format.format(oct31_01_02_03MDT));
-            assertEquals("Check 01:02:03.004", "2004-10-31 01:02:03.004 -06:00", format.format(oct31_01_02_03_04MDT));
+            assertEquals("2004-10-31 00:00:00.000 -06:00", format.format(oct31MDT), "Check 00:00:00.000");
+            assertEquals("2004-10-31 01:00:00.000 -06:00", format.format(oct31_01MDT), "Check 01:00:00.000");
+            assertEquals("2004-10-31 01:02:00.000 -06:00", format.format(oct31_01_02MDT), "Check 01:02:00.000");
+            assertEquals("2004-10-31 01:02:03.000 -06:00", format.format(oct31_01_02_03MDT), "Check 01:02:03.000");
+            assertEquals("2004-10-31 01:02:03.004 -06:00", format.format(oct31_01_02_03_04MDT), "Check 01:02:03.004");
 
             // ------- Demonstrate Problem -------
             final Calendar gval = Calendar.getInstance();
             gval.setTime(new Date(oct31_01MDT.getTime()));
             gval.set(Calendar.MINUTE, gval.get(Calendar.MINUTE)); // set minutes to the same value
-            assertEquals("Demonstrate Problem", gval.getTime().getTime(), oct31_01MDT.getTime() + 3600000L);
+            assertEquals(gval.getTime().getTime(), oct31_01MDT.getTime() + 3600000L, "Demonstrate Problem");
 
             // ---------- Test Truncate ----------
-            assertEquals("Truncate Calendar.MILLISECOND",
-                    oct31_01_02_03_04MDT, DateUtils.truncate(oct31_01_02_03_04MDT, Calendar.MILLISECOND));
+            assertEquals(oct31_01_02_03_04MDT, DateUtils.truncate(oct31_01_02_03_04MDT, Calendar.MILLISECOND),
+                    "Truncate Calendar.MILLISECOND");
 
-            assertEquals("Truncate Calendar.SECOND",
-                    oct31_01_02_03MDT, DateUtils.truncate(oct31_01_02_03_04MDT, Calendar.SECOND));
+            assertEquals(oct31_01_02_03MDT, DateUtils.truncate(oct31_01_02_03_04MDT, Calendar.SECOND),
+                    "Truncate Calendar.SECOND");
 
-            assertEquals("Truncate Calendar.MINUTE",
-                    oct31_01_02MDT, DateUtils.truncate(oct31_01_02_03_04MDT, Calendar.MINUTE));
+            assertEquals(oct31_01_02MDT, DateUtils.truncate(oct31_01_02_03_04MDT, Calendar.MINUTE),
+                    "Truncate Calendar.MINUTE");
 
-            assertEquals("Truncate Calendar.HOUR_OF_DAY",
-                    oct31_01MDT, DateUtils.truncate(oct31_01_02_03_04MDT, Calendar.HOUR_OF_DAY));
+            assertEquals(oct31_01MDT, DateUtils.truncate(oct31_01_02_03_04MDT, Calendar.HOUR_OF_DAY),
+                    "Truncate Calendar.HOUR_OF_DAY");
 
-            assertEquals("Truncate Calendar.HOUR",
-                    oct31_01MDT, DateUtils.truncate(oct31_01_02_03_04MDT, Calendar.HOUR));
+            assertEquals(oct31_01MDT, DateUtils.truncate(oct31_01_02_03_04MDT, Calendar.HOUR),
+                    "Truncate Calendar.HOUR");
 
-            assertEquals("Truncate Calendar.DATE",
-                    oct31MDT, DateUtils.truncate(oct31_01_02_03_04MDT, Calendar.DATE));
+            assertEquals(oct31MDT, DateUtils.truncate(oct31_01_02_03_04MDT, Calendar.DATE),
+                    "Truncate Calendar.DATE");
 
             // ---------- Test Round (down) ----------
-            assertEquals("Round Calendar.MILLISECOND",
-                    oct31_01_02_03_04MDT, DateUtils.round(oct31_01_02_03_04MDT, Calendar.MILLISECOND));
+            assertEquals(oct31_01_02_03_04MDT, DateUtils.round(oct31_01_02_03_04MDT, Calendar.MILLISECOND),
+                    "Round Calendar.MILLISECOND");
 
-            assertEquals("Round Calendar.SECOND",
-                    oct31_01_02_03MDT, DateUtils.round(oct31_01_02_03_04MDT, Calendar.SECOND));
+            assertEquals(oct31_01_02_03MDT, DateUtils.round(oct31_01_02_03_04MDT, Calendar.SECOND),
+                    "Round Calendar.SECOND");
 
-            assertEquals("Round Calendar.MINUTE",
-                    oct31_01_02MDT, DateUtils.round(oct31_01_02_03_04MDT, Calendar.MINUTE));
+            assertEquals(oct31_01_02MDT, DateUtils.round(oct31_01_02_03_04MDT, Calendar.MINUTE),
+                    "Round Calendar.MINUTE");
 
-            assertEquals("Round Calendar.HOUR_OF_DAY",
-                    oct31_01MDT, DateUtils.round(oct31_01_02_03_04MDT, Calendar.HOUR_OF_DAY));
+            assertEquals(oct31_01MDT, DateUtils.round(oct31_01_02_03_04MDT, Calendar.HOUR_OF_DAY),
+                    "Round Calendar.HOUR_OF_DAY");
 
-            assertEquals("Round Calendar.HOUR",
-                    oct31_01MDT, DateUtils.round(oct31_01_02_03_04MDT, Calendar.HOUR));
+            assertEquals(oct31_01MDT, DateUtils.round(oct31_01_02_03_04MDT, Calendar.HOUR),
+                    "Round Calendar.HOUR");
 
-            assertEquals("Round Calendar.DATE",
-                    oct31MDT, DateUtils.round(oct31_01_02_03_04MDT, Calendar.DATE));
+            assertEquals(oct31MDT, DateUtils.round(oct31_01_02_03_04MDT, Calendar.DATE),
+                    "Round Calendar.DATE");
         } finally {
             // restore default time zone
             TimeZone.setDefault(defaultZone);
@@ -1295,7 +1291,7 @@ public class DateUtilsTest {
         final String isoDateStr = DateFormatUtils.ISO_DATETIME_TIME_ZONE_FORMAT.format(d);
         final Date d2 = DateUtils.parseDate(isoDateStr, DateFormatUtils.ISO_DATETIME_TIME_ZONE_FORMAT.getPattern());
         // the format loses milliseconds so have to reintroduce them
-        assertEquals("Date not equal to itself ISO formatted and parsed", d.getTime(), d2.getTime() + d.getTime() % 1000);
+        assertEquals(d.getTime(), d2.getTime() + d.getTime() % 1000, "Date not equal to itself ISO formatted and parsed");
     }
 
     /**
@@ -1306,148 +1302,148 @@ public class DateUtilsTest {
     @Test
     public void testCeil() throws Exception {
         // test javadoc
-        assertEquals("ceiling javadoc-1 failed",
-                dateTimeParser.parse("March 28, 2002 14:00:00.000"),
+        assertEquals(dateTimeParser.parse("March 28, 2002 14:00:00.000"),
                 DateUtils.ceiling(
-                    dateTimeParser.parse("March 28, 2002 13:45:01.231"),
-                Calendar.HOUR));
-        assertEquals("ceiling javadoc-2 failed",
-                dateTimeParser.parse("April 1, 2002 00:00:00.000"),
+                            dateTimeParser.parse("March 28, 2002 13:45:01.231"),
+                        Calendar.HOUR),
+                "ceiling javadoc-1 failed");
+        assertEquals(dateTimeParser.parse("April 1, 2002 00:00:00.000"),
                 DateUtils.ceiling(
-                    dateTimeParser.parse("March 28, 2002 13:45:01.231"),
-                Calendar.MONTH));
+                            dateTimeParser.parse("March 28, 2002 13:45:01.231"),
+                        Calendar.MONTH),
+                "ceiling javadoc-2 failed");
 
         // tests public static Date ceiling(Date date, int field)
-        assertEquals("ceiling year-1 failed",
-                dateParser.parse("January 1, 2003"),
-                DateUtils.ceiling(date1, Calendar.YEAR));
-        assertEquals("ceiling year-2 failed",
-                dateParser.parse("January 1, 2002"),
-                DateUtils.ceiling(date2, Calendar.YEAR));
-        assertEquals("ceiling month-1 failed",
-                dateParser.parse("March 1, 2002"),
-                DateUtils.ceiling(date1, Calendar.MONTH));
-        assertEquals("ceiling month-2 failed",
-                dateParser.parse("December 1, 2001"),
-                DateUtils.ceiling(date2, Calendar.MONTH));
-        assertEquals("ceiling semimonth-1 failed",
-                dateParser.parse("February 16, 2002"),
-                DateUtils.ceiling(date1, DateUtils.SEMI_MONTH));
-        assertEquals("ceiling semimonth-2 failed",
-                dateParser.parse("December 1, 2001"),
-                DateUtils.ceiling(date2, DateUtils.SEMI_MONTH));
-        assertEquals("ceiling date-1 failed",
-                dateParser.parse("February 13, 2002"),
-                DateUtils.ceiling(date1, Calendar.DATE));
-        assertEquals("ceiling date-2 failed",
-                dateParser.parse("November 19, 2001"),
-                DateUtils.ceiling(date2, Calendar.DATE));
-        assertEquals("ceiling hour-1 failed",
-                dateTimeParser.parse("February 12, 2002 13:00:00.000"),
-                DateUtils.ceiling(date1, Calendar.HOUR));
-        assertEquals("ceiling hour-2 failed",
-                dateTimeParser.parse("November 18, 2001 2:00:00.000"),
-                DateUtils.ceiling(date2, Calendar.HOUR));
-        assertEquals("ceiling minute-1 failed",
-                dateTimeParser.parse("February 12, 2002 12:35:00.000"),
-                DateUtils.ceiling(date1, Calendar.MINUTE));
-        assertEquals("ceiling minute-2 failed",
-                dateTimeParser.parse("November 18, 2001 1:24:00.000"),
-                DateUtils.ceiling(date2, Calendar.MINUTE));
-        assertEquals("ceiling second-1 failed",
-                dateTimeParser.parse("February 12, 2002 12:34:57.000"),
-                DateUtils.ceiling(date1, Calendar.SECOND));
-        assertEquals("ceiling second-2 failed",
-                dateTimeParser.parse("November 18, 2001 1:23:12.000"),
-                DateUtils.ceiling(date2, Calendar.SECOND));
-        assertEquals("ceiling ampm-1 failed",
-                dateTimeParser.parse("February 3, 2002 12:00:00.000"),
-                DateUtils.ceiling(dateAmPm1, Calendar.AM_PM));
-        assertEquals("ceiling ampm-2 failed",
-                dateTimeParser.parse("February 3, 2002 12:00:00.000"),
-                DateUtils.ceiling(dateAmPm2, Calendar.AM_PM));
-        assertEquals("ceiling ampm-3 failed",
-                dateTimeParser.parse("February 4, 2002 00:00:00.000"),
-                DateUtils.ceiling(dateAmPm3, Calendar.AM_PM));
-        assertEquals("ceiling ampm-4 failed",
-                dateTimeParser.parse("February 4, 2002 00:00:00.000"),
-                DateUtils.ceiling(dateAmPm4, Calendar.AM_PM));
+        assertEquals(dateParser.parse("January 1, 2003"),
+                DateUtils.ceiling(date1, Calendar.YEAR),
+                "ceiling year-1 failed");
+        assertEquals(dateParser.parse("January 1, 2002"),
+                DateUtils.ceiling(date2, Calendar.YEAR),
+                "ceiling year-2 failed");
+        assertEquals(dateParser.parse("March 1, 2002"),
+                DateUtils.ceiling(date1, Calendar.MONTH),
+                "ceiling month-1 failed");
+        assertEquals(dateParser.parse("December 1, 2001"),
+                DateUtils.ceiling(date2, Calendar.MONTH),
+                "ceiling month-2 failed");
+        assertEquals(dateParser.parse("February 16, 2002"),
+                DateUtils.ceiling(date1, DateUtils.SEMI_MONTH),
+                "ceiling semimonth-1 failed");
+        assertEquals(dateParser.parse("December 1, 2001"),
+                DateUtils.ceiling(date2, DateUtils.SEMI_MONTH),
+                "ceiling semimonth-2 failed");
+        assertEquals(dateParser.parse("February 13, 2002"),
+                DateUtils.ceiling(date1, Calendar.DATE),
+                "ceiling date-1 failed");
+        assertEquals(dateParser.parse("November 19, 2001"),
+                DateUtils.ceiling(date2, Calendar.DATE),
+                "ceiling date-2 failed");
+        assertEquals(dateTimeParser.parse("February 12, 2002 13:00:00.000"),
+                DateUtils.ceiling(date1, Calendar.HOUR),
+                "ceiling hour-1 failed");
+        assertEquals(dateTimeParser.parse("November 18, 2001 2:00:00.000"),
+                DateUtils.ceiling(date2, Calendar.HOUR),
+                "ceiling hour-2 failed");
+        assertEquals(dateTimeParser.parse("February 12, 2002 12:35:00.000"),
+                DateUtils.ceiling(date1, Calendar.MINUTE),
+                "ceiling minute-1 failed");
+        assertEquals(dateTimeParser.parse("November 18, 2001 1:24:00.000"),
+                DateUtils.ceiling(date2, Calendar.MINUTE),
+                "ceiling minute-2 failed");
+        assertEquals(dateTimeParser.parse("February 12, 2002 12:34:57.000"),
+                DateUtils.ceiling(date1, Calendar.SECOND),
+                "ceiling second-1 failed");
+        assertEquals(dateTimeParser.parse("November 18, 2001 1:23:12.000"),
+                DateUtils.ceiling(date2, Calendar.SECOND),
+                "ceiling second-2 failed");
+        assertEquals(dateTimeParser.parse("February 3, 2002 12:00:00.000"),
+                DateUtils.ceiling(dateAmPm1, Calendar.AM_PM),
+                "ceiling ampm-1 failed");
+        assertEquals(dateTimeParser.parse("February 3, 2002 12:00:00.000"),
+                DateUtils.ceiling(dateAmPm2, Calendar.AM_PM),
+                "ceiling ampm-2 failed");
+        assertEquals(dateTimeParser.parse("February 4, 2002 00:00:00.000"),
+                DateUtils.ceiling(dateAmPm3, Calendar.AM_PM),
+                "ceiling ampm-3 failed");
+        assertEquals(dateTimeParser.parse("February 4, 2002 00:00:00.000"),
+                DateUtils.ceiling(dateAmPm4, Calendar.AM_PM),
+                "ceiling ampm-4 failed");
 
      // tests public static Date ceiling(Object date, int field)
-        assertEquals("ceiling year-1 failed",
-                dateParser.parse("January 1, 2003"),
-                DateUtils.ceiling((Object) date1, Calendar.YEAR));
-        assertEquals("ceiling year-2 failed",
-                dateParser.parse("January 1, 2002"),
-                DateUtils.ceiling((Object) date2, Calendar.YEAR));
-        assertEquals("ceiling month-1 failed",
-                dateParser.parse("March 1, 2002"),
-                DateUtils.ceiling((Object) date1, Calendar.MONTH));
-        assertEquals("ceiling month-2 failed",
-                dateParser.parse("December 1, 2001"),
-                DateUtils.ceiling((Object) date2, Calendar.MONTH));
-        assertEquals("ceiling semimonth-1 failed",
-                dateParser.parse("February 16, 2002"),
-                DateUtils.ceiling((Object) date1, DateUtils.SEMI_MONTH));
-        assertEquals("ceiling semimonth-2 failed",
-                dateParser.parse("December 1, 2001"),
-                DateUtils.ceiling((Object) date2, DateUtils.SEMI_MONTH));
-        assertEquals("ceiling date-1 failed",
-                dateParser.parse("February 13, 2002"),
-                DateUtils.ceiling((Object) date1, Calendar.DATE));
-        assertEquals("ceiling date-2 failed",
-                dateParser.parse("November 19, 2001"),
-                DateUtils.ceiling((Object) date2, Calendar.DATE));
-        assertEquals("ceiling hour-1 failed",
-                dateTimeParser.parse("February 12, 2002 13:00:00.000"),
-                DateUtils.ceiling((Object) date1, Calendar.HOUR));
-        assertEquals("ceiling hour-2 failed",
-                dateTimeParser.parse("November 18, 2001 2:00:00.000"),
-                DateUtils.ceiling((Object) date2, Calendar.HOUR));
-        assertEquals("ceiling minute-1 failed",
-                dateTimeParser.parse("February 12, 2002 12:35:00.000"),
-                DateUtils.ceiling((Object) date1, Calendar.MINUTE));
-        assertEquals("ceiling minute-2 failed",
-                dateTimeParser.parse("November 18, 2001 1:24:00.000"),
-                DateUtils.ceiling((Object) date2, Calendar.MINUTE));
-        assertEquals("ceiling second-1 failed",
-                dateTimeParser.parse("February 12, 2002 12:34:57.000"),
-                DateUtils.ceiling((Object) date1, Calendar.SECOND));
-        assertEquals("ceiling second-2 failed",
-                dateTimeParser.parse("November 18, 2001 1:23:12.000"),
-                DateUtils.ceiling((Object) date2, Calendar.SECOND));
-        assertEquals("ceiling ampm-1 failed",
-                dateTimeParser.parse("February 3, 2002 12:00:00.000"),
-                DateUtils.ceiling((Object) dateAmPm1, Calendar.AM_PM));
-        assertEquals("ceiling ampm-2 failed",
-                dateTimeParser.parse("February 3, 2002 12:00:00.000"),
-                DateUtils.ceiling((Object) dateAmPm2, Calendar.AM_PM));
-        assertEquals("ceiling ampm-3 failed",
-                dateTimeParser.parse("February 4, 2002 00:00:00.000"),
-                DateUtils.ceiling((Object) dateAmPm3, Calendar.AM_PM));
-        assertEquals("ceiling ampm-4 failed",
-                dateTimeParser.parse("February 4, 2002 00:00:00.000"),
-                DateUtils.ceiling((Object) dateAmPm4, Calendar.AM_PM));
+        assertEquals(dateParser.parse("January 1, 2003"),
+                DateUtils.ceiling((Object) date1, Calendar.YEAR),
+                "ceiling year-1 failed");
+        assertEquals(dateParser.parse("January 1, 2002"),
+                DateUtils.ceiling((Object) date2, Calendar.YEAR),
+                "ceiling year-2 failed");
+        assertEquals(dateParser.parse("March 1, 2002"),
+                DateUtils.ceiling((Object) date1, Calendar.MONTH),
+                "ceiling month-1 failed");
+        assertEquals(dateParser.parse("December 1, 2001"),
+                DateUtils.ceiling((Object) date2, Calendar.MONTH),
+                "ceiling month-2 failed");
+        assertEquals(dateParser.parse("February 16, 2002"),
+                DateUtils.ceiling((Object) date1, DateUtils.SEMI_MONTH),
+                "ceiling semimonth-1 failed");
+        assertEquals(dateParser.parse("December 1, 2001"),
+                DateUtils.ceiling((Object) date2, DateUtils.SEMI_MONTH),
+                "ceiling semimonth-2 failed");
+        assertEquals(dateParser.parse("February 13, 2002"),
+                DateUtils.ceiling((Object) date1, Calendar.DATE),
+                "ceiling date-1 failed");
+        assertEquals(dateParser.parse("November 19, 2001"),
+                DateUtils.ceiling((Object) date2, Calendar.DATE),
+                "ceiling date-2 failed");
+        assertEquals(dateTimeParser.parse("February 12, 2002 13:00:00.000"),
+                DateUtils.ceiling((Object) date1, Calendar.HOUR),
+                "ceiling hour-1 failed");
+        assertEquals(dateTimeParser.parse("November 18, 2001 2:00:00.000"),
+                DateUtils.ceiling((Object) date2, Calendar.HOUR),
+                "ceiling hour-2 failed");
+        assertEquals(dateTimeParser.parse("February 12, 2002 12:35:00.000"),
+                DateUtils.ceiling((Object) date1, Calendar.MINUTE),
+                "ceiling minute-1 failed");
+        assertEquals(dateTimeParser.parse("November 18, 2001 1:24:00.000"),
+                DateUtils.ceiling((Object) date2, Calendar.MINUTE),
+                "ceiling minute-2 failed");
+        assertEquals(dateTimeParser.parse("February 12, 2002 12:34:57.000"),
+                DateUtils.ceiling((Object) date1, Calendar.SECOND),
+                "ceiling second-1 failed");
+        assertEquals(dateTimeParser.parse("November 18, 2001 1:23:12.000"),
+                DateUtils.ceiling((Object) date2, Calendar.SECOND),
+                "ceiling second-2 failed");
+        assertEquals(dateTimeParser.parse("February 3, 2002 12:00:00.000"),
+                DateUtils.ceiling((Object) dateAmPm1, Calendar.AM_PM),
+                "ceiling ampm-1 failed");
+        assertEquals(dateTimeParser.parse("February 3, 2002 12:00:00.000"),
+                DateUtils.ceiling((Object) dateAmPm2, Calendar.AM_PM),
+                "ceiling ampm-2 failed");
+        assertEquals(dateTimeParser.parse("February 4, 2002 00:00:00.000"),
+                DateUtils.ceiling((Object) dateAmPm3, Calendar.AM_PM),
+                "ceiling ampm-3 failed");
+        assertEquals(dateTimeParser.parse("February 4, 2002 00:00:00.000"),
+                DateUtils.ceiling((Object) dateAmPm4, Calendar.AM_PM),
+                "ceiling ampm-4 failed");
 
-        assertEquals("ceiling calendar second-1 failed",
-                dateTimeParser.parse("February 12, 2002 12:34:57.000"),
-                DateUtils.ceiling((Object) cal1, Calendar.SECOND));
-        assertEquals("ceiling calendar second-2 failed",
-                dateTimeParser.parse("November 18, 2001 1:23:12.000"),
-                DateUtils.ceiling((Object) cal2, Calendar.SECOND));
+        assertEquals(dateTimeParser.parse("February 12, 2002 12:34:57.000"),
+                DateUtils.ceiling((Object) cal1, Calendar.SECOND),
+                "ceiling calendar second-1 failed");
+        assertEquals(dateTimeParser.parse("November 18, 2001 1:23:12.000"),
+                DateUtils.ceiling((Object) cal2, Calendar.SECOND),
+                "ceiling calendar second-2 failed");
 
-        assertEquals("ceiling ampm-1 failed",
-                dateTimeParser.parse("February 3, 2002 12:00:00.000"),
-                DateUtils.ceiling((Object) calAmPm1, Calendar.AM_PM));
-        assertEquals("ceiling ampm-2 failed",
-                dateTimeParser.parse("February 3, 2002 12:00:00.000"),
-                DateUtils.ceiling((Object) calAmPm2, Calendar.AM_PM));
-        assertEquals("ceiling ampm-3 failed",
-                dateTimeParser.parse("February 4, 2002 00:00:00.000"),
-                DateUtils.ceiling((Object) calAmPm3, Calendar.AM_PM));
-        assertEquals("ceiling ampm-4 failed",
-                dateTimeParser.parse("February 4, 2002 00:00:00.000"),
-                DateUtils.ceiling((Object) calAmPm4, Calendar.AM_PM));
+        assertEquals(dateTimeParser.parse("February 3, 2002 12:00:00.000"),
+                DateUtils.ceiling((Object) calAmPm1, Calendar.AM_PM),
+                "ceiling ampm-1 failed");
+        assertEquals(dateTimeParser.parse("February 3, 2002 12:00:00.000"),
+                DateUtils.ceiling((Object) calAmPm2, Calendar.AM_PM),
+                "ceiling ampm-2 failed");
+        assertEquals(dateTimeParser.parse("February 4, 2002 00:00:00.000"),
+                DateUtils.ceiling((Object) calAmPm3, Calendar.AM_PM),
+                "ceiling ampm-3 failed");
+        assertEquals(dateTimeParser.parse("February 4, 2002 00:00:00.000"),
+                DateUtils.ceiling((Object) calAmPm4, Calendar.AM_PM),
+                "ceiling ampm-4 failed");
 
         try {
             DateUtils.ceiling((Date) null, Calendar.SECOND);
@@ -1477,55 +1473,55 @@ public class DateUtilsTest {
             TimeZone.setDefault(zone);
             dateTimeParser.setTimeZone(zone);
 
-            assertEquals("ceiling MET date across DST change-over",
-                    dateTimeParser.parse("March 31, 2003 00:00:00.000"),
-                    DateUtils.ceiling(date4, Calendar.DATE));
-            assertEquals("ceiling MET date across DST change-over",
-                    dateTimeParser.parse("March 31, 2003 00:00:00.000"),
-                    DateUtils.ceiling((Object) cal4, Calendar.DATE));
-            assertEquals("ceiling MET date across DST change-over",
-                    dateTimeParser.parse("March 31, 2003 00:00:00.000"),
-                    DateUtils.ceiling(date5, Calendar.DATE));
-            assertEquals("ceiling MET date across DST change-over",
-                    dateTimeParser.parse("March 31, 2003 00:00:00.000"),
-                    DateUtils.ceiling((Object) cal5, Calendar.DATE));
-            assertEquals("ceiling MET date across DST change-over",
-                    dateTimeParser.parse("March 31, 2003 00:00:00.000"),
-                    DateUtils.ceiling(date6, Calendar.DATE));
-            assertEquals("ceiling MET date across DST change-over",
-                    dateTimeParser.parse("March 31, 2003 00:00:00.000"),
-                    DateUtils.ceiling((Object) cal6, Calendar.DATE));
-            assertEquals("ceiling MET date across DST change-over",
-                    dateTimeParser.parse("March 31, 2003 00:00:00.000"),
-                    DateUtils.ceiling(date7, Calendar.DATE));
-            assertEquals("ceiling MET date across DST change-over",
-                    dateTimeParser.parse("March 31, 2003 00:00:00.000"),
-                    DateUtils.ceiling((Object) cal7, Calendar.DATE));
+            assertEquals(dateTimeParser.parse("March 31, 2003 00:00:00.000"),
+                    DateUtils.ceiling(date4, Calendar.DATE),
+                    "ceiling MET date across DST change-over");
+            assertEquals(dateTimeParser.parse("March 31, 2003 00:00:00.000"),
+                    DateUtils.ceiling((Object) cal4, Calendar.DATE),
+                    "ceiling MET date across DST change-over");
+            assertEquals(dateTimeParser.parse("March 31, 2003 00:00:00.000"),
+                    DateUtils.ceiling(date5, Calendar.DATE),
+                    "ceiling MET date across DST change-over");
+            assertEquals(dateTimeParser.parse("March 31, 2003 00:00:00.000"),
+                    DateUtils.ceiling((Object) cal5, Calendar.DATE),
+                    "ceiling MET date across DST change-over");
+            assertEquals(dateTimeParser.parse("March 31, 2003 00:00:00.000"),
+                    DateUtils.ceiling(date6, Calendar.DATE),
+                    "ceiling MET date across DST change-over");
+            assertEquals(dateTimeParser.parse("March 31, 2003 00:00:00.000"),
+                    DateUtils.ceiling((Object) cal6, Calendar.DATE),
+                    "ceiling MET date across DST change-over");
+            assertEquals(dateTimeParser.parse("March 31, 2003 00:00:00.000"),
+                    DateUtils.ceiling(date7, Calendar.DATE),
+                    "ceiling MET date across DST change-over");
+            assertEquals(dateTimeParser.parse("March 31, 2003 00:00:00.000"),
+                    DateUtils.ceiling((Object) cal7, Calendar.DATE),
+                    "ceiling MET date across DST change-over");
 
-            assertEquals("ceiling MET date across DST change-over",
-                    dateTimeParser.parse("March 30, 2003 03:00:00.000"),
-                    DateUtils.ceiling(date4, Calendar.HOUR_OF_DAY));
-            assertEquals("ceiling MET date across DST change-over",
-                    dateTimeParser.parse("March 30, 2003 03:00:00.000"),
-                    DateUtils.ceiling((Object) cal4, Calendar.HOUR_OF_DAY));
-            assertEquals("ceiling MET date across DST change-over",
-                    dateTimeParser.parse("March 30, 2003 03:00:00.000"),
-                    DateUtils.ceiling(date5, Calendar.HOUR_OF_DAY));
-            assertEquals("ceiling MET date across DST change-over",
-                    dateTimeParser.parse("March 30, 2003 03:00:00.000"),
-                    DateUtils.ceiling((Object) cal5, Calendar.HOUR_OF_DAY));
-            assertEquals("ceiling MET date across DST change-over",
-                    dateTimeParser.parse("March 30, 2003 04:00:00.000"),
-                    DateUtils.ceiling(date6, Calendar.HOUR_OF_DAY));
-            assertEquals("ceiling MET date across DST change-over",
-                    dateTimeParser.parse("March 30, 2003 04:00:00.000"),
-                    DateUtils.ceiling((Object) cal6, Calendar.HOUR_OF_DAY));
-            assertEquals("ceiling MET date across DST change-over",
-                    dateTimeParser.parse("March 30, 2003 04:00:00.000"),
-                    DateUtils.ceiling(date7, Calendar.HOUR_OF_DAY));
-            assertEquals("ceiling MET date across DST change-over",
-                    dateTimeParser.parse("March 30, 2003 04:00:00.000"),
-                    DateUtils.ceiling((Object) cal7, Calendar.HOUR_OF_DAY));
+            assertEquals(dateTimeParser.parse("March 30, 2003 03:00:00.000"),
+                    DateUtils.ceiling(date4, Calendar.HOUR_OF_DAY),
+                    "ceiling MET date across DST change-over");
+            assertEquals(dateTimeParser.parse("March 30, 2003 03:00:00.000"),
+                    DateUtils.ceiling((Object) cal4, Calendar.HOUR_OF_DAY),
+                    "ceiling MET date across DST change-over");
+            assertEquals(dateTimeParser.parse("March 30, 2003 03:00:00.000"),
+                    DateUtils.ceiling(date5, Calendar.HOUR_OF_DAY),
+                    "ceiling MET date across DST change-over");
+            assertEquals(dateTimeParser.parse("March 30, 2003 03:00:00.000"),
+                    DateUtils.ceiling((Object) cal5, Calendar.HOUR_OF_DAY),
+                    "ceiling MET date across DST change-over");
+            assertEquals(dateTimeParser.parse("March 30, 2003 04:00:00.000"),
+                    DateUtils.ceiling(date6, Calendar.HOUR_OF_DAY),
+                    "ceiling MET date across DST change-over");
+            assertEquals(dateTimeParser.parse("March 30, 2003 04:00:00.000"),
+                    DateUtils.ceiling((Object) cal6, Calendar.HOUR_OF_DAY),
+                    "ceiling MET date across DST change-over");
+            assertEquals(dateTimeParser.parse("March 30, 2003 04:00:00.000"),
+                    DateUtils.ceiling(date7, Calendar.HOUR_OF_DAY),
+                    "ceiling MET date across DST change-over");
+            assertEquals(dateTimeParser.parse("March 30, 2003 04:00:00.000"),
+                    DateUtils.ceiling((Object) cal7, Calendar.HOUR_OF_DAY),
+                    "ceiling MET date across DST change-over");
 
         } finally {
             TimeZone.setDefault(defaultZone);
@@ -1655,7 +1651,7 @@ public class DateUtilsTest {
                 dateParser.parse("December 2, 2001"));
     }
 
-    @SystemDefaults(locale="en")
+    @DefaultLocale(language = "en")
     @Test
     public void testLANG799_EN_OK() throws ParseException {
         DateUtils.parseDate("Wed, 09 Apr 2008 23:55:38 GMT", "EEE, dd MMM yyyy HH:mm:ss zzz");
@@ -1663,13 +1659,13 @@ public class DateUtilsTest {
     }
 
     // Parse German date with English Locale
-    @SystemDefaults(locale="en")
-    @Test(expected = ParseException.class)
-    public void testLANG799_EN_FAIL() throws ParseException {
-        DateUtils.parseDate("Mi, 09 Apr 2008 23:55:38 GMT", "EEE, dd MMM yyyy HH:mm:ss zzz");
+    @DefaultLocale(language = "en")
+    @Test
+    public void testLANG799_EN_FAIL() {
+        assertThrows(ParseException.class, () -> DateUtils.parseDate("Mi, 09 Apr 2008 23:55:38 GMT", "EEE, dd MMM yyyy HH:mm:ss zzz"));
     }
 
-    @SystemDefaults(locale="de")
+    @DefaultLocale(language = "de")
     @Test
     public void testLANG799_DE_OK() throws ParseException {
         DateUtils.parseDate("Mi, 09 Apr 2008 23:55:38 GMT", "EEE, dd MMM yyyy HH:mm:ss zzz");
@@ -1677,14 +1673,14 @@ public class DateUtilsTest {
     }
 
     // Parse English date with German Locale
-    @SystemDefaults(locale="de")
-    @Test(expected=ParseException.class)
-    public void testLANG799_DE_FAIL() throws ParseException {
-        DateUtils.parseDate("Wed, 09 Apr 2008 23:55:38 GMT", "EEE, dd MMM yyyy HH:mm:ss zzz");
+    @DefaultLocale(language = "de")
+    @Test
+    public void testLANG799_DE_FAIL() {
+        assertThrows(ParseException.class, () -> DateUtils.parseDate("Wed, 09 Apr 2008 23:55:38 GMT", "EEE, dd MMM yyyy HH:mm:ss zzz"));
     }
 
     // Parse German date with English Locale, specifying German Locale override
-    @SystemDefaults(locale="en")
+    @DefaultLocale(language = "en")
     @Test
     public void testLANG799_EN_WITH_DE_LOCALE() throws ParseException {
         DateUtils.parseDate("Mi, 09 Apr 2008 23:55:38 GMT", Locale.GERMAN, "EEE, dd MMM yyyy HH:mm:ss zzz");
@@ -1736,7 +1732,7 @@ public class DateUtilsTest {
             assertCalendarsEquals("", last, cal, 0);
         }
 
-        assertFalse("There were " + count + " days in this iterator", count % 7 != 0);
+        assertFalse(count % 7 != 0, "There were " + count + " days in this iterator");
         assertCalendarsEquals("", end, cal, 0);
     }
 
@@ -1745,8 +1741,8 @@ public class DateUtilsTest {
      * delta is in milliseconds
      */
     private static void assertCalendarsEquals(final String message, final Calendar cal1, final Calendar cal2, final long delta) {
-        assertFalse(message + " expected " + cal1.getTime() + " but got " + cal2.getTime(),
-                Math.abs(cal1.getTime().getTime() - cal2.getTime().getTime()) > delta);
+        assertFalse(Math.abs(cal1.getTime().getTime() - cal2.getTime().getTime()) > delta,
+                message + " expected " + cal1.getTime() + " but got " + cal2.getTime());
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/time/DurationFormatUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/DurationFormatUtilsTest.java
@@ -17,18 +17,19 @@
 
 package org.apache.commons.lang3.time;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
 import java.util.Calendar;
 import java.util.TimeZone;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * TestCase for DurationFormatUtils.
@@ -156,9 +157,9 @@ public class DurationFormatUtilsTest {
         assertEquals("1 day 1 hour 1 minute 1 second", text);
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testFormatNegativeDurationWords() throws Exception {
-        DurationFormatUtils.formatDurationWords(-5000, true, true);
+    @Test
+    public void testFormatNegativeDurationWords() {
+        assertThrows(IllegalArgumentException.class, () -> DurationFormatUtils.formatDurationWords(-5000, true, true));
     }
 
     @Test
@@ -191,9 +192,9 @@ public class DurationFormatUtilsTest {
         assertEquals("01:02:12.789", DurationFormatUtils.formatDurationHMS(time));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testFormatNegativeDurationHMS() throws Exception {
-        DurationFormatUtils.formatDurationHMS(-5000);
+    @Test
+    public void testFormatNegativeDurationHMS() {
+        assertThrows(IllegalArgumentException.class, () -> DurationFormatUtils.formatDurationHMS(-5000));
     }
 
     @Test
@@ -205,9 +206,9 @@ public class DurationFormatUtilsTest {
         assertEquals("P0Y0M0DT0H1M15.321S", DurationFormatUtils.formatDurationISO(75321L));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testFormatNegativeDurationISO() throws Exception {
-        DurationFormatUtils.formatDurationISO(-5000);
+    @Test
+    public void testFormatNegativeDurationISO() {
+        assertThrows(IllegalArgumentException.class, () -> DurationFormatUtils.formatDurationISO(-5000));
     }
 
     @Test
@@ -248,9 +249,9 @@ public class DurationFormatUtilsTest {
         assertEquals("0 0 " + days, DurationFormatUtils.formatDuration(duration, "y M d"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testFormatNegativeDuration() throws Exception {
-        DurationFormatUtils.formatDuration(-5000, "S", true);
+    @Test
+    public void testFormatNegativeDuration() {
+        assertThrows(IllegalArgumentException.class, () -> DurationFormatUtils.formatDuration(-5000, "S", true));
     }
 
     @SuppressWarnings("deprecation")
@@ -282,9 +283,9 @@ public class DurationFormatUtilsTest {
         // assertEquals("P1Y2M3DT10H30M", text);
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testFormatPeriodISOStartGreaterEnd() throws Exception {
-        DurationFormatUtils.formatPeriodISO(5000, 2000);
+    @Test
+    public void testFormatPeriodISOStartGreaterEnd() {
+        assertThrows(IllegalArgumentException.class, () -> DurationFormatUtils.formatPeriodISO(5000, 2000));
     }
 
     @Test
@@ -348,9 +349,9 @@ public class DurationFormatUtilsTest {
         assertEquals("048", DurationFormatUtils.formatPeriod(time1970, time, "MMM"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testFormatPeriodeStartGreaterEnd() throws Exception {
-        DurationFormatUtils.formatPeriod(5000, 2500, "yy/MM");
+    @Test
+    public void testFormatPeriodeStartGreaterEnd() {
+        assertThrows(IllegalArgumentException.class, () -> DurationFormatUtils.formatPeriod(5000, 2500, "yy/MM"));
     }
 
     @Test
@@ -396,13 +397,13 @@ public class DurationFormatUtilsTest {
 
         // test failures in equals
         final DurationFormatUtils.Token token = new DurationFormatUtils.Token(DurationFormatUtils.y, 4);
-        assertFalse("Token equal to non-Token class. ", token.equals(new Object()));
-        assertFalse("Token equal to Token with wrong value class. ", token.equals(new DurationFormatUtils.Token(
-                new Object())));
-        assertFalse("Token equal to Token with different count. ", token.equals(new DurationFormatUtils.Token(
-                DurationFormatUtils.y, 1)));
+        assertFalse(token.equals(new Object()), "Token equal to non-Token class. ");
+        assertFalse(token.equals(new DurationFormatUtils.Token(new Object())),
+                "Token equal to Token with wrong value class. ");
+        assertFalse(token.equals(new DurationFormatUtils.Token(DurationFormatUtils.y, 1)),
+                "Token equal to Token with different count. ");
         final DurationFormatUtils.Token numToken = new DurationFormatUtils.Token(Integer.valueOf(1), 4);
-        assertTrue("Token with Number value not equal to itself. ", numToken.equals(numToken));
+        assertTrue(numToken.equals(numToken), "Token with Number value not equal to itself. ");
     }
 
 
@@ -575,9 +576,9 @@ public class DurationFormatUtilsTest {
         //bruteForce(1996, 1, 29, "M", Calendar.MONTH);  // this will fail
     }
 
-    @Test(expected=IllegalArgumentException.class)
+    @Test
     public void testLANG981() { // unmatched quote char in lexx
-        DurationFormatUtils.lexx("'yMdHms''S");
+        assertThrows(IllegalArgumentException.class, () -> DurationFormatUtils.lexx("'yMdHms''S"));
     }
 
     private static final int FOUR_YEARS = 365 * 3 + 366;
@@ -624,7 +625,7 @@ public class DurationFormatUtilsTest {
         if (message == null) {
             assertEquals(expected, result);
         } else {
-            assertEquals(message, expected, result);
+            assertEquals(expected, result, message);
         }
     }
 

--- a/src/test/java/org/apache/commons/lang3/time/FastDateFormatTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/FastDateFormatTest.java
@@ -16,12 +16,12 @@
  */
 package org.apache.commons.lang3.time;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.text.FieldPosition;
 import java.text.Format;
@@ -36,10 +36,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLongArray;
 
-import org.apache.commons.lang3.test.SystemDefaults;
-import org.apache.commons.lang3.test.SystemDefaultsSwitch;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.DefaultLocale;
+import org.junitpioneer.jupiter.DefaultTimeZone;
 
 /**
  * Unit tests {@link org.apache.commons.lang3.time.FastDateFormat}.
@@ -47,10 +46,6 @@ import org.junit.Test;
  * @since 2.0
  */
 public class FastDateFormatTest {
-
-    @Rule
-    public SystemDefaultsSwitch defaults = new SystemDefaultsSwitch();
-
     /*
      * Only the cache methods need to be tested here.
      * The print methods are tested by {@link FastDateFormat_PrinterTest}
@@ -76,7 +71,8 @@ public class FastDateFormatTest {
         assertEquals(TimeZone.getDefault(), format2.getTimeZone());
     }
 
-    @SystemDefaults(timezone="America/New_York", locale="en_US")
+    @DefaultLocale(language = "en", country = "US")
+    @DefaultTimeZone("America/New_York")
     @Test
     public void test_getInstance_String_TimeZone() {
 
@@ -96,7 +92,7 @@ public class FastDateFormatTest {
         assertNotSame(format4, format6);
     }
 
-    @SystemDefaults(locale="en_US")
+    @DefaultLocale(language = "en", country = "US")
     @Test
     public void test_getInstance_String_Locale() {
         final FastDateFormat format1 = FastDateFormat.getInstance("MM/DD/yyyy", Locale.GERMANY);
@@ -108,7 +104,7 @@ public class FastDateFormatTest {
         assertEquals(Locale.GERMANY, format1.getLocale());
     }
 
-    @SystemDefaults(locale="en_US")
+    @DefaultLocale(language = "en", country = "US")
     @Test
     public void test_changeDefault_Locale_DateInstance() {
         final FastDateFormat format1 = FastDateFormat.getDateInstance(FastDateFormat.FULL, Locale.GERMANY);
@@ -123,7 +119,7 @@ public class FastDateFormatTest {
         assertNotSame(format2, format3);
     }
 
-    @SystemDefaults(locale="en_US")
+    @DefaultLocale(language = "en", country = "US")
     @Test
     public void test_changeDefault_Locale_DateTimeInstance() {
         final FastDateFormat format1 = FastDateFormat.getDateTimeInstance(FastDateFormat.FULL, FastDateFormat.FULL, Locale.GERMANY);
@@ -138,7 +134,8 @@ public class FastDateFormatTest {
         assertNotSame(format2, format3);
     }
 
-    @SystemDefaults(locale="en_US", timezone="America/New_York")
+    @DefaultLocale(language = "en", country = "US")
+    @DefaultTimeZone("America/New_York")
     @Test
     public void test_getInstance_String_TimeZone_Locale() {
         final FastDateFormat format1 = FastDateFormat.getInstance("MM/DD/yyyy",

--- a/src/test/java/org/apache/commons/lang3/time/FastDateParserSDFTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/FastDateParserSDFTest.java
@@ -16,140 +16,131 @@
  */
 package org.apache.commons.lang3.time;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.text.ParseException;
 import java.text.ParsePosition;
 import java.text.SimpleDateFormat;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
+import java.util.stream.Stream;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Compare FastDateParser with SimpleDateFormat
  */
-@RunWith(Parameterized.class)
 public class FastDateParserSDFTest {
 
-    @Parameters(name= "{index}: {0} {1} {2}")
-    public static Collection<Object[]> data() {
-        return Arrays.asList(new Object [][]{
+    public static Stream<Arguments> data() {
+        return Stream.of(
                 // General Time zone tests
-                {"z yyyy", "GMT 2010",       Locale.UK, true}, // no offset specified, but this is allowed as a TimeZone name
-                {"z yyyy", "GMT-123 2010",   Locale.UK, false},
-                {"z yyyy", "GMT-1234 2010",  Locale.UK, false},
-                {"z yyyy", "GMT-12:34 2010", Locale.UK, true},
-                {"z yyyy", "GMT-1:23 2010",  Locale.UK, true},
+                Arguments.of("z yyyy", "GMT 2010",       Locale.UK, true), // no offset specified, but this is allowed as a TimeZone name
+                Arguments.of("z yyyy", "GMT-123 2010",   Locale.UK, false),
+                Arguments.of("z yyyy", "GMT-1234 2010",  Locale.UK, false),
+                Arguments.of("z yyyy", "GMT-12:34 2010", Locale.UK, true),
+                Arguments.of("z yyyy", "GMT-1:23 2010",  Locale.UK, true),
                 // RFC 822 tests
-                {"z yyyy", "-1234 2010",     Locale.UK, true},
-                {"z yyyy", "-12:34 2010",    Locale.UK, false},
-                {"z yyyy", "-123 2010",      Locale.UK, false},
+                Arguments.of("z yyyy", "-1234 2010",     Locale.UK, true),
+                Arguments.of("z yyyy", "-12:34 2010",    Locale.UK, false),
+                Arguments.of("z yyyy", "-123 2010",      Locale.UK, false),
                 // year tests
-                { "MM/dd/yyyy", "01/11/12",  Locale.UK, true},
-                { "MM/dd/yy", "01/11/12",    Locale.UK, true},
+                Arguments.of( "MM/dd/yyyy", "01/11/12",  Locale.UK, true),
+                Arguments.of( "MM/dd/yy", "01/11/12",    Locale.UK, true),
 
                 // LANG-1089
-                { "HH", "00",    Locale.UK, true}, // Hour in day (0-23)
-                { "KK", "00",    Locale.UK, true}, // Hour in am/pm (0-11)
-                { "hh", "00",    Locale.UK, true}, // Hour in am/pm (1-12), i.e. midday/midnight is 12, not 0
-                { "kk", "00",    Locale.UK, true}, // Hour in day (1-24), i.e. midnight is 24, not 0
+                Arguments.of( "HH", "00",    Locale.UK, true), // Hour in day (0-23)
+                Arguments.of( "KK", "00",    Locale.UK, true), // Hour in am/pm (0-11)
+                Arguments.of( "hh", "00",    Locale.UK, true), // Hour in am/pm (1-12), i.e. midday/midnight is 12, not 0
+                Arguments.of( "kk", "00",    Locale.UK, true), // Hour in day (1-24), i.e. midnight is 24, not 0
 
-                { "HH", "01",    Locale.UK, true}, // Hour in day (0-23)
-                { "KK", "01",    Locale.UK, true}, // Hour in am/pm (0-11)
-                { "hh", "01",    Locale.UK, true}, // Hour in am/pm (1-12), i.e. midday/midnight is 12, not 0
-                { "kk", "01",    Locale.UK, true}, // Hour in day (1-24), i.e. midnight is 24, not 0
+                Arguments.of( "HH", "01",    Locale.UK, true), // Hour in day (0-23)
+                Arguments.of( "KK", "01",    Locale.UK, true), // Hour in am/pm (0-11)
+                Arguments.of( "hh", "01",    Locale.UK, true), // Hour in am/pm (1-12), i.e. midday/midnight is 12, not 0
+                Arguments.of( "kk", "01",    Locale.UK, true), // Hour in day (1-24), i.e. midnight is 24, not 0
 
-                { "HH", "11",    Locale.UK, true}, // Hour in day (0-23)
-                { "KK", "11",    Locale.UK, true}, // Hour in am/pm (0-11)
-                { "hh", "11",    Locale.UK, true}, // Hour in am/pm (1-12), i.e. midday/midnight is 12, not 0
-                { "kk", "11",    Locale.UK, true}, // Hour in day (1-24), i.e. midnight is 24, not 0
+                Arguments.of( "HH", "11",    Locale.UK, true), // Hour in day (0-23)
+                Arguments.of( "KK", "11",    Locale.UK, true), // Hour in am/pm (0-11)
+                Arguments.of( "hh", "11",    Locale.UK, true), // Hour in am/pm (1-12), i.e. midday/midnight is 12, not 0
+                Arguments.of( "kk", "11",    Locale.UK, true), // Hour in day (1-24), i.e. midnight is 24, not 0
 
-                { "HH", "12",    Locale.UK, true}, // Hour in day (0-23)
-                { "KK", "12",    Locale.UK, true}, // Hour in am/pm (0-11)
-                { "hh", "12",    Locale.UK, true}, // Hour in am/pm (1-12), i.e. midday/midnight is 12, not 0
-                { "kk", "12",    Locale.UK, true}, // Hour in day (1-24), i.e. midnight is 24, not 0
+                Arguments.of( "HH", "12",    Locale.UK, true), // Hour in day (0-23)
+                Arguments.of( "KK", "12",    Locale.UK, true), // Hour in am/pm (0-11)
+                Arguments.of( "hh", "12",    Locale.UK, true), // Hour in am/pm (1-12), i.e. midday/midnight is 12, not 0
+                Arguments.of( "kk", "12",    Locale.UK, true), // Hour in day (1-24), i.e. midnight is 24, not 0
 
-                { "HH", "13",    Locale.UK, true}, // Hour in day (0-23)
-                { "KK", "13",    Locale.UK, true}, // Hour in am/pm (0-11)
-                { "hh", "13",    Locale.UK, true}, // Hour in am/pm (1-12), i.e. midday/midnight is 12, not 0
-                { "kk", "13",    Locale.UK, true}, // Hour in day (1-24), i.e. midnight is 24, not 0
+                Arguments.of( "HH", "13",    Locale.UK, true), // Hour in day (0-23)
+                Arguments.of( "KK", "13",    Locale.UK, true), // Hour in am/pm (0-11)
+                Arguments.of( "hh", "13",    Locale.UK, true), // Hour in am/pm (1-12), i.e. midday/midnight is 12, not 0
+                Arguments.of( "kk", "13",    Locale.UK, true), // Hour in day (1-24), i.e. midnight is 24, not 0
 
-                { "HH", "23",    Locale.UK, true}, // Hour in day (0-23)
-                { "KK", "23",    Locale.UK, true}, // Hour in am/pm (0-11)
-                { "hh", "23",    Locale.UK, true}, // Hour in am/pm (1-12), i.e. midday/midnight is 12, not 0
-                { "kk", "23",    Locale.UK, true}, // Hour in day (1-24), i.e. midnight is 24, not 0
+                Arguments.of( "HH", "23",    Locale.UK, true), // Hour in day (0-23)
+                Arguments.of( "KK", "23",    Locale.UK, true), // Hour in am/pm (0-11)
+                Arguments.of( "hh", "23",    Locale.UK, true), // Hour in am/pm (1-12), i.e. midday/midnight is 12, not 0
+                Arguments.of( "kk", "23",    Locale.UK, true), // Hour in day (1-24), i.e. midnight is 24, not 0
 
-                { "HH", "24",    Locale.UK, true}, // Hour in day (0-23)
-                { "KK", "24",    Locale.UK, true}, // Hour in am/pm (0-11)
-                { "hh", "24",    Locale.UK, true}, // Hour in am/pm (1-12), i.e. midday/midnight is 12, not 0
-                { "kk", "24",    Locale.UK, true}, // Hour in day (1-24), i.e. midnight is 24, not 0
+                Arguments.of( "HH", "24",    Locale.UK, true), // Hour in day (0-23)
+                Arguments.of( "KK", "24",    Locale.UK, true), // Hour in am/pm (0-11)
+                Arguments.of( "hh", "24",    Locale.UK, true), // Hour in am/pm (1-12), i.e. midday/midnight is 12, not 0
+                Arguments.of( "kk", "24",    Locale.UK, true), // Hour in day (1-24), i.e. midnight is 24, not 0
 
-                { "HH", "25",    Locale.UK, true}, // Hour in day (0-23)
-                { "KK", "25",    Locale.UK, true}, // Hour in am/pm (0-11)
-                { "hh", "25",    Locale.UK, true}, // Hour in am/pm (1-12), i.e. midday/midnight is 12, not 0
-                { "kk", "25",    Locale.UK, true}, // Hour in day (1-24), i.e. midnight is 24, not 0
+                Arguments.of( "HH", "25",    Locale.UK, true), // Hour in day (0-23)
+                Arguments.of( "KK", "25",    Locale.UK, true), // Hour in am/pm (0-11)
+                Arguments.of( "hh", "25",    Locale.UK, true), // Hour in am/pm (1-12), i.e. midday/midnight is 12, not 0
+                Arguments.of( "kk", "25",    Locale.UK, true), // Hour in day (1-24), i.e. midnight is 24, not 0
 
-                { "HH", "48",    Locale.UK, true}, // Hour in day (0-23)
-                { "KK", "48",    Locale.UK, true}, // Hour in am/pm (0-11)
-                { "hh", "48",    Locale.UK, true}, // Hour in am/pm (1-12), i.e. midday/midnight is 12, not 0
-                { "kk", "48",    Locale.UK, true}, // Hour in day (1-24), i.e. midnight is 24, not 0
-                });
+                Arguments.of( "HH", "48",    Locale.UK, true), // Hour in day (0-23)
+                Arguments.of( "KK", "48",    Locale.UK, true), // Hour in am/pm (0-11)
+                Arguments.of( "hh", "48",    Locale.UK, true), // Hour in am/pm (1-12), i.e. midday/midnight is 12, not 0
+                Arguments.of( "kk", "48",    Locale.UK, true)  // Hour in day (1-24), i.e. midnight is 24, not 0
+        );
     }
 
-    private final String format;
-    private final String input;
-    private final Locale locale;
-    private final boolean valid;
-    private final TimeZone timeZone = TimeZone.getDefault();
+    private static final TimeZone timeZone = TimeZone.getDefault();
 
-    public FastDateParserSDFTest(final String format, final String input, final Locale locale, final boolean valid) {
-        this.format = format;
-        this.input = input;
-        this.locale = locale;
-        this.valid = valid;
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testOriginal(final String format, final String input, final Locale locale, final boolean valid) {
+        checkParse(input, format, locale, valid);
     }
 
-    @Test
-    public void testOriginal() throws Exception {
-        checkParse(input);
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testOriginalPP(final String format, final String input, final Locale locale, final boolean valid) {
+        checkParsePosition(input, format, locale, valid);
     }
 
-    @Test
-    public void testOriginalPP() throws Exception {
-        checkParsePosition(input);
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testUpperCase(final String format, final String input, final Locale locale, final boolean valid) {
+        checkParse(input.toUpperCase(locale), format, locale, valid);
     }
 
-    @Test
-    public void testUpperCase() throws Exception {
-        checkParse(input.toUpperCase(locale));
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testUpperCasePP(final String format, final String input, final Locale locale, final boolean valid) {
+        checkParsePosition(input.toUpperCase(locale), format, locale, valid);
     }
 
-    @Test
-    public void testUpperCasePP() throws Exception {
-        checkParsePosition(input.toUpperCase(locale));
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testLowerCase(final String format, final String input, final Locale locale, final boolean valid) {
+        checkParse(input.toLowerCase(locale), format, locale, valid);
     }
 
-    @Test
-    public void testLowerCase() throws Exception {
-        checkParse(input.toLowerCase(locale));
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testLowerCasePP(final String format, final String input, final Locale locale, final boolean valid) {
+        checkParsePosition(input.toLowerCase(locale), format, locale, valid);
     }
 
-    @Test
-    public void testLowerCasePP() throws Exception {
-        checkParsePosition(input.toLowerCase(locale));
-    }
-
-    private void checkParse(final String formattedDate) {
+    private void checkParse(final String formattedDate, String format, Locale locale, boolean valid) {
         final SimpleDateFormat sdf = new SimpleDateFormat(format, locale);
         sdf.setTimeZone(timeZone);
         final DateParser fdf = new FastDateParser(format, timeZone, locale);
@@ -184,12 +175,12 @@ public class FastDateParserSDFTest {
             fdfE = e.getClass();
         }
         if (valid) {
-            assertEquals(locale.toString()+" "+formattedDate +"\n",expectedTime, actualTime);
+            assertEquals(expectedTime, actualTime, locale.toString()+" "+formattedDate +"\n");
         } else {
-            assertEquals(locale.toString()+" "+formattedDate + " expected same Exception ", sdfE, fdfE);
+            assertEquals(sdfE, fdfE, locale.toString()+" "+formattedDate + " expected same Exception ");
         }
     }
-    private void checkParsePosition(final String formattedDate) {
+    private void checkParsePosition(final String formattedDate, String format, Locale locale, boolean valid) {
         final SimpleDateFormat sdf = new SimpleDateFormat(format, locale);
         sdf.setTimeZone(timeZone);
         final DateParser fdf = new FastDateParser(format, timeZone, locale);
@@ -198,7 +189,7 @@ public class FastDateParserSDFTest {
         final Date expectedTime = sdf.parse(formattedDate, sdfP);
         final int sdferrorIndex = sdfP.getErrorIndex();
         if (valid) {
-            assertEquals("Expected SDF error index -1 ", -1, sdferrorIndex);
+            assertEquals(-1, sdferrorIndex, "Expected SDF error index -1 ");
             final int endIndex = sdfP.getIndex();
             final int length = formattedDate.length();
             if (endIndex != length) {
@@ -216,15 +207,15 @@ public class FastDateParserSDFTest {
         final Date actualTime = fdf.parse(formattedDate, fdfP);
         final int fdferrorIndex = fdfP.getErrorIndex();
         if (valid) {
-            assertEquals("Expected FDF error index -1 ", -1, fdferrorIndex);
+            assertEquals(-1, fdferrorIndex, "Expected FDF error index -1 ");
             final int endIndex = fdfP.getIndex();
             final int length = formattedDate.length();
-            assertEquals("Expected FDF to parse full string " + fdfP, length, endIndex);
-            assertEquals(locale.toString()+" "+formattedDate +"\n", expectedTime, actualTime);
+            assertEquals(length, endIndex, "Expected FDF to parse full string " + fdfP);
+            assertEquals(expectedTime, actualTime, locale.toString()+" "+formattedDate +"\n");
         } else {
-            assertNotEquals("Test data error: expected FDF parse to fail, but got " + actualTime, -1, fdferrorIndex);
-            assertTrue("FDF error index ("+ fdferrorIndex + ") should approximate SDF index (" + sdferrorIndex + ")",
-                    sdferrorIndex - fdferrorIndex <= 4);
+            assertNotEquals(-1, fdferrorIndex, "Test data error: expected FDF parse to fail, but got " + actualTime);
+            assertTrue(sdferrorIndex - fdferrorIndex <= 4,
+                    "FDF error index ("+ fdferrorIndex + ") should approximate SDF index (" + sdferrorIndex + ")");
         }
     }
 }

--- a/src/test/java/org/apache/commons/lang3/time/FastDateParserTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/FastDateParserTest.java
@@ -16,10 +16,11 @@
  */
 package org.apache.commons.lang3.time;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.Serializable;
 import java.text.ParseException;
@@ -34,7 +35,7 @@ import java.util.Map;
 import java.util.TimeZone;
 import org.apache.commons.lang3.LocaleUtils;
 import org.apache.commons.lang3.SerializationUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests {@link org.apache.commons.lang3.time.FastDateParser}.
@@ -224,7 +225,7 @@ public class FastDateParserTest {
         final String fmt = sdf.format(in);
         try {
             final Date out = fdp.parse(fmt);
-            assertEquals(locale.toString()+" "+in+" "+ format+ " "+tz.getID(), in, out);
+            assertEquals(in, out, locale.toString()+" "+in+" "+ format+ " "+tz.getID());
         } catch (final ParseException pe) {
             if (year >= 1868 || !locale.getCountry().equals("JP")) {// LANG-978
                 throw pe;
@@ -271,7 +272,7 @@ public class FastDateParserTest {
                 final Date expected= cal.getTime();
 
                 final Date actual = fdp.parse("2000/02/10 "+tz.getDisplayName(locale));
-                assertEquals("tz:"+tz.getID()+" locale:"+locale.getDisplayName(), expected, actual);
+                assertEquals(expected, actual, "tz:"+tz.getID()+" locale:"+locale.getDisplayName());
             }
         }
     }
@@ -385,7 +386,7 @@ public class FastDateParserTest {
     private void checkParse(final Locale locale, final SimpleDateFormat sdf, final DateParser fdf, final String formattedDate) throws ParseException {
         final Date expectedTime = sdf.parse(formattedDate);
         final Date actualTime = fdf.parse(formattedDate);
-        assertEquals(locale.toString()+" "+formattedDate +"\n",expectedTime, actualTime);
+        assertEquals(expectedTime, actualTime, locale.toString()+" "+formattedDate +"\n");
     }
 
     @Test
@@ -473,8 +474,8 @@ public class FastDateParserTest {
             }
         }
         // SDF and FDF should produce equivalent results
-        assertTrue("Should both or neither throw Exceptions", (f==null)==(s==null));
-        assertEquals("Parsed dates should be equal", dsdf, dfdp);
+        assertTrue((f==null)==(s==null), "Should both or neither throw Exceptions");
+        assertEquals(dsdf, dfdp, "Parsed dates should be equal");
     }
 
     @Test
@@ -604,9 +605,9 @@ public class FastDateParserTest {
         assertEquals(expected.getTime(), fdp.parse("14May2014"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void test1806Argument() {
-        getInstance("XXXX");
+        assertThrows(IllegalArgumentException.class, () -> getInstance("XXXX"));
     }
 
     private static Calendar initializeCalendar(final TimeZone tz) {
@@ -652,13 +653,13 @@ public class FastDateParserTest {
             final String message = trial.zone.getDisplayName()+";";
 
             DateParser parser = getInstance(formatStub+"X", trial.zone);
-            assertEquals(message+trial.one, cal.getTime().getTime(), parser.parse(dateStub+trial.one).getTime()-trial.offset);
+            assertEquals(cal.getTime().getTime(), parser.parse(dateStub+trial.one).getTime()-trial.offset, message+trial.one);
 
             parser = getInstance(formatStub+"XX", trial.zone);
-            assertEquals(message+trial.two, cal.getTime(), parser.parse(dateStub+trial.two));
+            assertEquals(cal.getTime(), parser.parse(dateStub+trial.two), message+trial.two);
 
             parser = getInstance(formatStub+"XXX", trial.zone);
-            assertEquals(message+trial.three, cal.getTime(), parser.parse(dateStub+trial.three));
+            assertEquals(cal.getTime(), parser.parse(dateStub+trial.three), message+trial.three);
         }
     }
 

--- a/src/test/java/org/apache/commons/lang3/time/FastDateParser_MoreOrLessTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/FastDateParser_MoreOrLessTest.java
@@ -16,9 +16,9 @@
  */
 package org.apache.commons.lang3.time;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.text.ParsePosition;
 import java.util.Calendar;
@@ -26,7 +26,7 @@ import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class FastDateParser_MoreOrLessTest {
 

--- a/src/test/java/org/apache/commons/lang3/time/FastDatePrinterTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/FastDatePrinterTest.java
@@ -16,9 +16,10 @@
  */
 package org.apache.commons.lang3.time;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.Serializable;
 import java.text.FieldPosition;
@@ -31,10 +32,9 @@ import java.util.Locale;
 import java.util.TimeZone;
 
 import org.apache.commons.lang3.SerializationUtils;
-import org.apache.commons.lang3.test.SystemDefaults;
-import org.apache.commons.lang3.test.SystemDefaultsSwitch;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.DefaultLocale;
+import org.junitpioneer.jupiter.DefaultTimeZone;
 
 /**
  * Unit tests {@link org.apache.commons.lang3.time.FastDatePrinter}.
@@ -76,10 +76,8 @@ public class FastDatePrinterTest {
         return new FastDatePrinter(format, timeZone, locale);
     }
 
-    @Rule
-    public SystemDefaultsSwitch defaults = new SystemDefaultsSwitch();
-
-    @SystemDefaults(timezone="America/New_York", locale="en_US")
+    @DefaultLocale(language = "en", country = "US")
+    @DefaultTimeZone("America/New_York")
     @Test
     public void testFormat() {
         final GregorianCalendar cal1 = new GregorianCalendar(2003, 0, 10, 15, 33, 20);
@@ -210,8 +208,8 @@ public class FastDatePrinterTest {
         cal.set(2009, Calendar.OCTOBER, 16, 8, 42, 16);
 
         final DatePrinter format = getInstance("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", TimeZone.getTimeZone("GMT"));
-        assertEquals("dateTime", "2009-10-16T16:42:16.000Z", format.format(cal.getTime()));
-        assertEquals("dateTime", "2009-10-16T16:42:16.000Z", format.format(cal));
+        assertEquals("2009-10-16T16:42:16.000Z", format.format(cal.getTime()), "dateTime");
+        assertEquals("2009-10-16T16:42:16.000Z", format.format(cal), "dateTime");
     }
 
     @Test
@@ -262,7 +260,7 @@ public class FastDatePrinterTest {
         assertEquals(NEW_YORK, printer.getTimeZone());
     }
 
-    @SystemDefaults(timezone="UTC")
+    @DefaultTimeZone("UTC")
     @Test
     public void testTimeZoneAsZ() throws Exception {
         final Calendar c = Calendar.getInstance(FastTimeZone.getGmtTimeZone());
@@ -288,9 +286,9 @@ public class FastDatePrinterTest {
         return cal;
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void test1806Argument() {
-        getInstance("XXXX");
+        assertThrows(IllegalArgumentException.class, () -> getInstance("XXXX"));
     }
 
     private enum Expected1806 {
@@ -354,15 +352,15 @@ public class FastDatePrinterTest {
         // calendar fast.
         {
             final String value = FastDateFormat.getInstance("yyyy-MM-dd'T'HH:mm:ss Z", TimeZone.getTimeZone("Europe/Paris")).format(cal);
-            assertEquals("calendar", "2009-10-16T08:42:16 +0200", value);
+            assertEquals("2009-10-16T08:42:16 +0200", value, "calendar");
         }
         {
             final String value = FastDateFormat.getInstance("yyyy-MM-dd'T'HH:mm:ss Z", TimeZone.getTimeZone("Asia/Kolkata")).format(cal);
-            assertEquals("calendar", "2009-10-16T12:12:16 +0530", value);
+            assertEquals("2009-10-16T12:12:16 +0530", value, "calendar");
         }
         {
             final String value = FastDateFormat.getInstance("yyyy-MM-dd'T'HH:mm:ss Z", TimeZone.getTimeZone("Europe/London")).format(cal);
-            assertEquals("calendar", "2009-10-16T07:42:16 +0100", value);
+            assertEquals("2009-10-16T07:42:16 +0100", value, "calendar");
         }
     }
 

--- a/src/test/java/org/apache/commons/lang3/time/FastDatePrinterTimeZonesTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/FastDatePrinterTimeZonesTest.java
@@ -16,48 +16,34 @@
  */
 package org.apache.commons.lang3.time;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Calendar;
-import java.util.Collection;
-import java.util.List;
 import java.util.TimeZone;
+import java.util.stream.Stream;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public class FastDatePrinterTimeZonesTest {
 
     private static final String PATTERN = "h:mma z";
 
-    @Parameterized.Parameters
-    public static Collection<TimeZone> data() {
-        final String[] zoneIds = TimeZone.getAvailableIDs();
-        final List<TimeZone> timeZones = new ArrayList<>();
-        for (final String zoneId : zoneIds) {
-            timeZones.add(TimeZone.getTimeZone(zoneId));
-        }
-        return timeZones;
+    public static Stream<TimeZone> data() {
+        return Arrays.stream(TimeZone.getAvailableIDs()).map(TimeZone::getTimeZone);
     }
 
-    private final TimeZone timeZone;
-
-    public FastDatePrinterTimeZonesTest(final TimeZone timeZone) {
-        this.timeZone = timeZone;
-    }
-
-    @Test
-    public void testCalendarTimezoneRespected() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testCalendarTimezoneRespected(TimeZone timeZone) {
         final Calendar cal = Calendar.getInstance(timeZone);
 
         final SimpleDateFormat sdf = new SimpleDateFormat(PATTERN);
         sdf.setTimeZone(timeZone);
         final String expectedValue = sdf.format(cal.getTime());
-        final String actualValue = FastDateFormat.getInstance(PATTERN, this.timeZone).format(cal);
+        final String actualValue = FastDateFormat.getInstance(PATTERN, timeZone).format(cal);
         assertEquals(expectedValue, actualValue);
     }
 

--- a/src/test/java/org/apache/commons/lang3/time/FastTimeZoneTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/FastTimeZoneTest.java
@@ -16,9 +16,9 @@
  */
 package org.apache.commons.lang3.time;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.TimeZone;
 

--- a/src/test/java/org/apache/commons/lang3/time/GmtTimeZoneTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/GmtTimeZoneTest.java
@@ -16,19 +16,20 @@
  */
 package org.apache.commons.lang3.time;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for GmtTimeZone
  */
 public class GmtTimeZoneTest {
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void hoursOutOfRange() {
-        new GmtTimeZone(false, 24, 0);
+        assertThrows(IllegalArgumentException.class, () -> new GmtTimeZone(false, 24, 0));
     }
 
     @Test
@@ -36,9 +37,9 @@ public class GmtTimeZoneTest {
         assertEquals(23 * 60 * 60 * 1000, new GmtTimeZone(false, 23, 0).getRawOffset());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void minutesOutOfRange() {
-        new GmtTimeZone(false, 0, 60);
+        assertThrows(IllegalArgumentException.class, () -> new GmtTimeZone(false, 0, 60));
     }
 
     @Test
@@ -51,9 +52,9 @@ public class GmtTimeZoneTest {
         assertEquals(0, new GmtTimeZone(false, 0, 0).getOffset(234304));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void setRawOffset() {
-        new GmtTimeZone(false, 0, 0).setRawOffset(0);
+        assertThrows(UnsupportedOperationException.class, () -> new GmtTimeZone(false, 0, 0).setRawOffset(0));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/time/StopWatchTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/StopWatchTest.java
@@ -16,15 +16,15 @@
  */
 package org.apache.commons.lang3.time;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang3.reflect.FieldUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * TestCase for StopWatch.
@@ -109,8 +109,7 @@ public class StopWatchTest {
         watch.stop();
         final long totalTime = watch.getTime();
 
-        assertEquals("Formatted split string not the correct length",
-                splitStr.length(), 12);
+        assertEquals(splitStr.length(), 12, "Formatted split string not the correct length");
         assertTrue(splitTime >= 500);
         assertTrue(splitTime < 700);
         assertTrue(totalTime >= 1500);

--- a/src/test/java/org/apache/commons/lang3/time/WeekYearTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/WeekYearTest.java
@@ -16,58 +16,45 @@
  */
 package org.apache.commons.lang3.time;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.text.ParseException;
 import java.text.ParsePosition;
-import java.util.Arrays;
 import java.util.Calendar;
-import java.util.Collection;
 import java.util.GregorianCalendar;
 import java.util.Locale;
 import java.util.TimeZone;
+import java.util.stream.Stream;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public class WeekYearTest {
 
-    @Parameters(name = "{index}: {3}")
-    public static Collection<Object[]> data() {
-        return Arrays
-                .asList(new Object[][] {
-                    { 2005, Calendar.JANUARY, 1, "2004-W53-6" },
-                    { 2005, Calendar.JANUARY, 2, "2004-W53-7" },
-                    { 2005, Calendar.DECEMBER, 31, "2005-W52-6" },
-                    { 2007, Calendar.JANUARY, 1, "2007-W01-1" },
-                    { 2007, Calendar.DECEMBER, 30, "2007-W52-7" },
-                    { 2007, Calendar.DECEMBER, 31, "2008-W01-1" },
-                    { 2008, Calendar.JANUARY, 1, "2008-W01-2" },
-                    { 2008, Calendar.DECEMBER, 28, "2008-W52-7" },
-                    { 2008, Calendar.DECEMBER, 29, "2009-W01-1" },
-                    { 2008, Calendar.DECEMBER, 30, "2009-W01-2" },
-                    { 2008, Calendar.DECEMBER, 31, "2009-W01-3" },
-                    { 2009, Calendar.JANUARY, 1, "2009-W01-4" },
-                    { 2009, Calendar.DECEMBER, 31, "2009-W53-4" },
-                    { 2010, Calendar.JANUARY, 1, "2009-W53-5" },
-                    { 2010, Calendar.JANUARY, 2, "2009-W53-6" },
-                    { 2010, Calendar.JANUARY, 3, "2009-W53-7" }
-                });
+    public static Stream<Arguments> data() {
+        return Stream.of(
+            Arguments.of(new GregorianCalendar( 2005, Calendar.JANUARY, 1), "2004-W53-6"),
+            Arguments.of(new GregorianCalendar( 2005, Calendar.JANUARY, 2), "2004-W53-7"),
+            Arguments.of(new GregorianCalendar( 2005, Calendar.DECEMBER, 31), "2005-W52-6"),
+            Arguments.of(new GregorianCalendar( 2007, Calendar.JANUARY, 1), "2007-W01-1"),
+            Arguments.of(new GregorianCalendar( 2007, Calendar.DECEMBER, 30), "2007-W52-7"),
+            Arguments.of(new GregorianCalendar( 2007, Calendar.DECEMBER, 31), "2008-W01-1"),
+            Arguments.of(new GregorianCalendar( 2008, Calendar.JANUARY, 1), "2008-W01-2"),
+            Arguments.of(new GregorianCalendar( 2008, Calendar.DECEMBER, 28), "2008-W52-7"),
+            Arguments.of(new GregorianCalendar( 2008, Calendar.DECEMBER, 29), "2009-W01-1"),
+            Arguments.of(new GregorianCalendar( 2008, Calendar.DECEMBER, 30), "2009-W01-2"),
+            Arguments.of(new GregorianCalendar( 2008, Calendar.DECEMBER, 31), "2009-W01-3"),
+            Arguments.of(new GregorianCalendar( 2009, Calendar.JANUARY, 1), "2009-W01-4"),
+            Arguments.of(new GregorianCalendar( 2009, Calendar.DECEMBER, 31), "2009-W53-4"),
+            Arguments.of(new GregorianCalendar( 2010, Calendar.JANUARY, 1), "2009-W53-5"),
+            Arguments.of(new GregorianCalendar( 2010, Calendar.JANUARY, 2), "2009-W53-6"),
+            Arguments.of(new GregorianCalendar( 2010, Calendar.JANUARY, 3), "2009-W53-7")
+        );
     }
 
-    final Calendar vulgar;
-    final String isoForm;
-
-    public WeekYearTest(final int year, final int month, final int day, final String isoForm) {
-        vulgar = new GregorianCalendar(year, month, day);
-        this.isoForm = isoForm;
-    }
-
-    @Test
-    public void testParser() throws ParseException {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testParser(Calendar vulgar, String isoForm) {
         final DateParser parser = new FastDateParser("YYYY-'W'ww-u", TimeZone.getDefault(), Locale.getDefault());
 
         final Calendar cal = Calendar.getInstance();
@@ -79,8 +66,9 @@ public class WeekYearTest {
         assertEquals(vulgar.getTime(), cal.getTime());
     }
 
-    @Test
-    public void testPrinter() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testPrinter(Calendar vulgar, String isoForm) {
         final FastDatePrinter printer = new FastDatePrinter("YYYY-'W'ww-u", TimeZone.getDefault(), Locale.getDefault());
 
         vulgar.setMinimalDaysInFirstWeek(4);


### PR DESCRIPTION
Upgrade the tests in the `time` package to use JUnit Jupiter as part of the effort to remove the dependency on the Vintage Engine.

While most of these changes are drop-in replacements with no functional benefit, there are some non-obvious changes worth mentioning.

Unlike `org.junit.Test`, `org.junit.jupiter.api.Test` does not have an `expected` argument. Instead, an explicit call to `org.junit.jupiter.api.Assertions.assertThrows` is used.

JUnit Jupiter no longer has a concept of runners. Tests previously run with the `org.junit.runners.Parameterized` runner were rewritten to use `@ParameterizedTest` and a `@MethodSource`.

JUnit Jupiter also no longer has the concept of Rules. Usages of the `SystemDefaultsSwitch` rule and its accompanying annotates were replaced with the `@DefaultLocale` and `@DefaultTimezone` annotations that @britter contributed to [JUnit Pioneer](https://github.com/junit-pioneer/junit-pioneer), the semi-official JUnit extension project.

It's also worth noting this is a minimal patch for migrating the package's tests to Jupiter. There are several tests that can be made more elegant with Jupiter's new features, but that work is left for subsequent patches.