### PR TITLE
Test cleanup

### DIFF
--- a/src/test/java/org/apache/commons/lang3/AnnotationUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/AnnotationUtilsTest.java
@@ -24,6 +24,7 @@ import static org.apache.commons.lang3.AnnotationUtilsTest.Stooge.MOE;
 import static org.apache.commons.lang3.AnnotationUtilsTest.Stooge.SHEMP;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -484,16 +485,16 @@ public class AnnotationUtilsTest {
             final Test generated = (Test) Proxy.newProxyInstance(Thread.currentThread()
                             .getContextClassLoader(), new Class[]{Test.class},
                     generatedTestInvocationHandler);
-            assertTrue(real.equals(generated));
-            assertFalse(generated.equals(real));
+            assertEquals(real, generated);
+            assertNotEquals(generated, real);
             assertTrue(AnnotationUtils.equals(generated, real));
             assertTrue(AnnotationUtils.equals(real, generated));
 
             final Test generated2 = (Test) Proxy.newProxyInstance(Thread.currentThread()
                             .getContextClassLoader(), new Class[]{Test.class},
                     generatedTestInvocationHandler);
-            assertFalse(generated.equals(generated2));
-            assertFalse(generated2.equals(generated));
+            assertNotEquals(generated, generated2);
+            assertNotEquals(generated2, generated);
             assertTrue(AnnotationUtils.equals(generated, generated2));
             assertTrue(AnnotationUtils.equals(generated2, generated));
         });

--- a/src/test/java/org/apache/commons/lang3/ArrayUtilsAddTest.java
+++ b/src/test/java/org/apache/commons/lang3/ArrayUtilsAddTest.java
@@ -21,8 +21,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Arrays;
 
@@ -40,12 +40,9 @@ public class ArrayUtilsAddTest {
         n = ArrayUtils.addAll(new Number[]{Integer.valueOf(1)}, new Long[]{Long.valueOf(2)});
         assertEquals(2,n.length);
         assertEquals(Number.class,n.getClass().getComponentType());
-        try {
-            // Invalid - can't store Long in Integer array
-               n = ArrayUtils.addAll(new Integer[]{Integer.valueOf(1)}, new Long[]{Long.valueOf(2)});
-               fail("Should have generated IllegalArgumentException");
-        } catch (final IllegalArgumentException expected) {
-        }
+        // Invalid - can't store Long in Integer array
+        assertThrows(IllegalArgumentException.class,
+                () -> ArrayUtils.addAll(new Integer[]{Integer.valueOf(1)}, new Long[]{Long.valueOf(2)}));
     }
 
     @Test
@@ -226,25 +223,12 @@ public class ArrayUtilsAddTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void testLANG571(){
         final String[] stringArray=null;
         final String aString=null;
-        try {
-            @SuppressWarnings("unused")
-            final
-            String[] sa = ArrayUtils.add(stringArray, aString);
-            fail("Should have caused IllegalArgumentException");
-        } catch (final IllegalArgumentException iae){
-            //expected
-        }
-        try {
-            @SuppressWarnings({ "unused", "deprecation" })
-            final
-            String[] sa = ArrayUtils.add(stringArray, 0, aString);
-            fail("Should have caused IllegalArgumentException");
-        } catch (final IllegalArgumentException iae){
-            //expected
-        }
+        assertThrows(IllegalArgumentException.class, () -> ArrayUtils.add(stringArray, aString));
+        assertThrows(IllegalArgumentException.class, () -> ArrayUtils.add(stringArray, 0, aString));
     }
 
     @Test
@@ -408,36 +392,25 @@ public class ArrayUtilsAddTest {
         // boolean tests
         boolean[] booleanArray = ArrayUtils.add( null, 0, true );
         assertTrue( Arrays.equals( new boolean[] { true }, booleanArray ) );
-        try {
-            booleanArray = ArrayUtils.add( null, -1, true );
-        } catch(final IndexOutOfBoundsException e) {
-            assertEquals("Index: -1, Length: 0", e.getMessage());
-        }
+        IndexOutOfBoundsException e =
+                assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.add( null, -1, true));
+        assertEquals("Index: -1, Length: 0", e.getMessage());
         booleanArray = ArrayUtils.add( new boolean[] { true }, 0, false);
         assertTrue( Arrays.equals( new boolean[] { false, true }, booleanArray ) );
         booleanArray = ArrayUtils.add( new boolean[] { false }, 1, true);
         assertTrue( Arrays.equals( new boolean[] { false, true }, booleanArray ) );
         booleanArray = ArrayUtils.add( new boolean[] { true, false }, 1, true);
         assertTrue( Arrays.equals( new boolean[] { true, true, false }, booleanArray ) );
-        try {
-            booleanArray = ArrayUtils.add( new boolean[] { true, false }, 4, true);
-        } catch(final IndexOutOfBoundsException e) {
-            assertEquals("Index: 4, Length: 2", e.getMessage());
-        }
-        try {
-            booleanArray = ArrayUtils.add( new boolean[] { true, false }, -1, true);
-        } catch(final IndexOutOfBoundsException e) {
-            assertEquals("Index: -1, Length: 2", e.getMessage());
-        }
+        e = assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.add(new boolean[] { true, false }, 4, true));
+        assertEquals("Index: 4, Length: 2", e.getMessage());
+        e = assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.add(new boolean[] { true, false }, -1, true));
+        assertEquals("Index: -1, Length: 2", e.getMessage());
 
         // char tests
         char[] charArray = ArrayUtils.add( (char[]) null, 0, 'a' );
         assertTrue( Arrays.equals( new char[] { 'a' }, charArray ) );
-        try {
-            charArray = ArrayUtils.add( (char[]) null, -1, 'a' );
-        } catch(final IndexOutOfBoundsException e) {
-            assertEquals("Index: -1, Length: 0", e.getMessage());
-        }
+        e = assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.add( (char[]) null, -1, 'a' ));
+        assertEquals("Index: -1, Length: 0", e.getMessage());
         charArray = ArrayUtils.add( new char[] { 'a' }, 0, 'b');
         assertTrue( Arrays.equals( new char[] { 'b', 'a' }, charArray ) );
         charArray = ArrayUtils.add( new char[] { 'a', 'b' }, 0, 'c');
@@ -446,166 +419,106 @@ public class ArrayUtilsAddTest {
         assertTrue( Arrays.equals( new char[] { 'a', 'k', 'b' }, charArray ) );
         charArray = ArrayUtils.add( new char[] { 'a', 'b', 'c' }, 1, 't');
         assertTrue( Arrays.equals( new char[] { 'a', 't', 'b', 'c' }, charArray ) );
-        try {
-            charArray = ArrayUtils.add( new char[] { 'a', 'b' }, 4, 'c');
-        } catch(final IndexOutOfBoundsException e) {
-            assertEquals("Index: 4, Length: 2", e.getMessage());
-        }
-        try {
-            charArray = ArrayUtils.add( new char[] { 'a', 'b' }, -1, 'c');
-        } catch(final IndexOutOfBoundsException e) {
-            assertEquals("Index: -1, Length: 2", e.getMessage());
-        }
+        e = assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.add( new char[] { 'a', 'b' }, 4, 'c'));
+        assertEquals("Index: 4, Length: 2", e.getMessage());
+        e = assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.add( new char[] { 'a', 'b' }, -1, 'c'));
+        assertEquals("Index: -1, Length: 2", e.getMessage());
 
         // short tests
         short[] shortArray = ArrayUtils.add( new short[] { 1 }, 0, (short) 2);
         assertTrue( Arrays.equals( new short[] { 2, 1 }, shortArray ) );
-        try {
-            shortArray = ArrayUtils.add( (short[]) null, -1, (short) 2);
-        } catch(final IndexOutOfBoundsException e) {
-            assertEquals("Index: -1, Length: 0", e.getMessage());
-        }
+        e = assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.add( (short[]) null, -1, (short) 2));
+        assertEquals("Index: -1, Length: 0", e.getMessage());
         shortArray = ArrayUtils.add( new short[] { 2, 6 }, 2, (short) 10);
         assertTrue( Arrays.equals( new short[] { 2, 6, 10 }, shortArray ) );
         shortArray = ArrayUtils.add( new short[] { 2, 6 }, 0, (short) -4);
         assertTrue( Arrays.equals( new short[] { -4, 2, 6 }, shortArray ) );
         shortArray = ArrayUtils.add( new short[] { 2, 6, 3 }, 2, (short) 1);
         assertTrue( Arrays.equals( new short[] { 2, 6, 1, 3 }, shortArray ) );
-        try {
-            shortArray = ArrayUtils.add( new short[] { 2, 6 }, 4, (short) 10);
-        } catch(final IndexOutOfBoundsException e) {
-            assertEquals("Index: 4, Length: 2", e.getMessage());
-        }
-        try {
-            shortArray = ArrayUtils.add( new short[] { 2, 6 }, -1, (short) 10);
-        } catch(final IndexOutOfBoundsException e) {
-            assertEquals("Index: -1, Length: 2", e.getMessage());
-        }
+        e = assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.add( new short[] { 2, 6 }, 4, (short) 10));
+        assertEquals("Index: 4, Length: 2", e.getMessage());
+        e = assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.add( new short[] { 2, 6 }, -1, (short) 10));
+        assertEquals("Index: -1, Length: 2", e.getMessage());
 
         // byte tests
         byte[] byteArray = ArrayUtils.add( new byte[] { 1 }, 0, (byte) 2);
         assertTrue( Arrays.equals( new byte[] { 2, 1 }, byteArray ) );
-        try {
-            byteArray = ArrayUtils.add( (byte[]) null, -1, (byte) 2);
-        } catch(final IndexOutOfBoundsException e) {
-            assertEquals("Index: -1, Length: 0", e.getMessage());
-        }
+        e = assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.add( (byte[]) null, -1, (byte) 2));
+        assertEquals("Index: -1, Length: 0", e.getMessage());
         byteArray = ArrayUtils.add( new byte[] { 2, 6 }, 2, (byte) 3);
         assertTrue( Arrays.equals( new byte[] { 2, 6, 3 }, byteArray ) );
         byteArray = ArrayUtils.add( new byte[] { 2, 6 }, 0, (byte) 1);
         assertTrue( Arrays.equals( new byte[] { 1, 2, 6 }, byteArray ) );
         byteArray = ArrayUtils.add( new byte[] { 2, 6, 3 }, 2, (byte) 1);
         assertTrue( Arrays.equals( new byte[] { 2, 6, 1, 3 }, byteArray ) );
-        try {
-            byteArray = ArrayUtils.add( new byte[] { 2, 6 }, 4, (byte) 3);
-        } catch(final IndexOutOfBoundsException e) {
-            assertEquals("Index: 4, Length: 2", e.getMessage());
-        }
-        try {
-            byteArray = ArrayUtils.add( new byte[] { 2, 6 }, -1, (byte) 3);
-        } catch(final IndexOutOfBoundsException e) {
-            assertEquals("Index: -1, Length: 2", e.getMessage());
-        }
+        e = assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.add( new byte[] { 2, 6 }, 4, (byte) 3));
+        assertEquals("Index: 4, Length: 2", e.getMessage());
+        e = assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.add( new byte[] { 2, 6 }, -1, (byte) 3));
+        assertEquals("Index: -1, Length: 2", e.getMessage());
 
         // int tests
         int[] intArray = ArrayUtils.add( new int[] { 1 }, 0, 2);
         assertTrue( Arrays.equals( new int[] { 2, 1 }, intArray ) );
-        try {
-            intArray = ArrayUtils.add( (int[]) null, -1, 2);
-        } catch(final IndexOutOfBoundsException e) {
-            assertEquals("Index: -1, Length: 0", e.getMessage());
-        }
+        e = assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.add( (int[]) null, -1, 2));
+        assertEquals("Index: -1, Length: 0", e.getMessage());
         intArray = ArrayUtils.add( new int[] { 2, 6 }, 2, 10);
         assertTrue( Arrays.equals( new int[] { 2, 6, 10 }, intArray ) );
         intArray = ArrayUtils.add( new int[] { 2, 6 }, 0, -4);
         assertTrue( Arrays.equals( new int[] { -4, 2, 6 }, intArray ) );
         intArray = ArrayUtils.add( new int[] { 2, 6, 3 }, 2, 1);
         assertTrue( Arrays.equals( new int[] { 2, 6, 1, 3 }, intArray ) );
-        try {
-            intArray = ArrayUtils.add( new int[] { 2, 6 }, 4, 10);
-        } catch(final IndexOutOfBoundsException e) {
-            assertEquals("Index: 4, Length: 2", e.getMessage());
-        }
-        try {
-            intArray = ArrayUtils.add( new int[] { 2, 6 }, -1, 10);
-        } catch(final IndexOutOfBoundsException e) {
-            assertEquals("Index: -1, Length: 2", e.getMessage());
-        }
+        e = assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.add( new int[] { 2, 6 }, 4, 10));
+        assertEquals("Index: 4, Length: 2", e.getMessage());
+        e = assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.add( new int[] { 2, 6 }, -1, 10));
+        assertEquals("Index: -1, Length: 2", e.getMessage());
 
         // long tests
         long[] longArray = ArrayUtils.add( new long[] { 1L }, 0, 2L);
         assertTrue( Arrays.equals( new long[] { 2L, 1L }, longArray ) );
-        try {
-            longArray = ArrayUtils.add( (long[]) null, -1, 2L);
-        } catch(final IndexOutOfBoundsException e) {
-            assertEquals("Index: -1, Length: 0", e.getMessage());
-        }
+        e = assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.add( (long[]) null, -1, 2L));
+        assertEquals("Index: -1, Length: 0", e.getMessage());
         longArray = ArrayUtils.add( new long[] { 2L, 6L }, 2, 10L);
         assertTrue( Arrays.equals( new long[] { 2L, 6L, 10L }, longArray ) );
         longArray = ArrayUtils.add( new long[] { 2L, 6L }, 0, -4L);
         assertTrue( Arrays.equals( new long[] { -4L, 2L, 6L }, longArray ) );
         longArray = ArrayUtils.add( new long[] { 2L, 6L, 3L }, 2, 1L);
         assertTrue( Arrays.equals( new long[] { 2L, 6L, 1L, 3L }, longArray ) );
-        try {
-            longArray = ArrayUtils.add( new long[] { 2L, 6L }, 4, 10L);
-        } catch(final IndexOutOfBoundsException e) {
-            assertEquals("Index: 4, Length: 2", e.getMessage());
-        }
-        try {
-            longArray = ArrayUtils.add( new long[] { 2L, 6L }, -1, 10L);
-        } catch(final IndexOutOfBoundsException e) {
-            assertEquals("Index: -1, Length: 2", e.getMessage());
-        }
+        e = assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.add( new long[] { 2L, 6L }, 4, 10L));
+        assertEquals("Index: 4, Length: 2", e.getMessage());
+        e = assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.add( new long[] { 2L, 6L }, -1, 10L));
+        assertEquals("Index: -1, Length: 2", e.getMessage());
 
         // float tests
         float[] floatArray = ArrayUtils.add( new float[] { 1.1f }, 0, 2.2f);
         assertTrue( Arrays.equals( new float[] { 2.2f, 1.1f }, floatArray ) );
-        try {
-            floatArray = ArrayUtils.add( (float[]) null, -1, 2.2f);
-        } catch(final IndexOutOfBoundsException e) {
-            assertEquals("Index: -1, Length: 0", e.getMessage());
-        }
+        e = assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.add( (float[]) null, -1, 2.2f));
+        assertEquals("Index: -1, Length: 0", e.getMessage());
         floatArray = ArrayUtils.add( new float[] { 2.3f, 6.4f }, 2, 10.5f);
         assertTrue( Arrays.equals( new float[] { 2.3f, 6.4f, 10.5f }, floatArray ) );
         floatArray = ArrayUtils.add( new float[] { 2.6f, 6.7f }, 0, -4.8f);
         assertTrue( Arrays.equals( new float[] { -4.8f, 2.6f, 6.7f }, floatArray ) );
         floatArray = ArrayUtils.add( new float[] { 2.9f, 6.0f, 0.3f }, 2, 1.0f);
         assertTrue( Arrays.equals( new float[] { 2.9f, 6.0f, 1.0f, 0.3f }, floatArray ) );
-        try {
-            floatArray = ArrayUtils.add( new float[] { 2.3f, 6.4f }, 4, 10.5f);
-        } catch(final IndexOutOfBoundsException e) {
-            assertEquals("Index: 4, Length: 2", e.getMessage());
-        }
-        try {
-            floatArray = ArrayUtils.add( new float[] { 2.3f, 6.4f }, -1, 10.5f);
-        } catch(final IndexOutOfBoundsException e) {
-            assertEquals("Index: -1, Length: 2", e.getMessage());
-        }
+        e = assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.add( new float[] { 2.3f, 6.4f }, 4, 10.5f));
+        assertEquals("Index: 4, Length: 2", e.getMessage());
+        e = assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.add( new float[] { 2.3f, 6.4f }, -1, 10.5f));
+        assertEquals("Index: -1, Length: 2", e.getMessage());
 
         // double tests
         double[] doubleArray = ArrayUtils.add( new double[] { 1.1 }, 0, 2.2);
         assertTrue( Arrays.equals( new double[] { 2.2, 1.1 }, doubleArray ) );
-        try {
-          doubleArray = ArrayUtils.add(null, -1, 2.2);
-        } catch(final IndexOutOfBoundsException e) {
-            assertEquals("Index: -1, Length: 0", e.getMessage());
-        }
+        e = assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.add(null, -1, 2.2));
+        assertEquals("Index: -1, Length: 0", e.getMessage());
         doubleArray = ArrayUtils.add( new double[] { 2.3, 6.4 }, 2, 10.5);
         assertTrue( Arrays.equals( new double[] { 2.3, 6.4, 10.5 }, doubleArray ) );
         doubleArray = ArrayUtils.add( new double[] { 2.6, 6.7 }, 0, -4.8);
         assertTrue( Arrays.equals( new double[] { -4.8, 2.6, 6.7 }, doubleArray ) );
         doubleArray = ArrayUtils.add( new double[] { 2.9, 6.0, 0.3 }, 2, 1.0);
         assertTrue( Arrays.equals( new double[] { 2.9, 6.0, 1.0, 0.3 }, doubleArray ) );
-        try {
-            doubleArray = ArrayUtils.add( new double[] { 2.3, 6.4 }, 4, 10.5);
-        } catch(final IndexOutOfBoundsException e) {
-            assertEquals("Index: 4, Length: 2", e.getMessage());
-        }
-        try {
-            doubleArray = ArrayUtils.add( new double[] { 2.3, 6.4 }, -1, 10.5);
-        } catch(final IndexOutOfBoundsException e) {
-            assertEquals("Index: -1, Length: 2", e.getMessage());
-        }
+        e = assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.add( new double[] { 2.3, 6.4 }, 4, 10.5));
+        assertEquals("Index: 4, Length: 2", e.getMessage());
+        e = assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.add( new double[] { 2.3, 6.4 }, -1, 10.5));
+        assertEquals("Index: -1, Length: 2", e.getMessage());
     }
 
 }

--- a/src/test/java/org/apache/commons/lang3/ArrayUtilsInsertTest.java
+++ b/src/test/java/org/apache/commons/lang3/ArrayUtilsInsertTest.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Test;
 public class ArrayUtilsInsertTest {
 
     @Test
-    public void testInsertBooleans() throws Exception {
+    public void testInsertBooleans() {
         final boolean[] array = {true,false,true};
         final boolean[] values = {false,true,false};
 
@@ -55,7 +55,7 @@ public class ArrayUtilsInsertTest {
 
 
     @Test
-    public void testInsertBytes() throws Exception {
+    public void testInsertBytes() {
         final byte[] array = {1,2,3};
         final byte[] values = {4,5,6};
 
@@ -79,7 +79,7 @@ public class ArrayUtilsInsertTest {
     }
 
     @Test
-    public void testInsertChars() throws Exception {
+    public void testInsertChars() {
         final char[] array = {'a','b','c'};
         final char[] values = {'d','e','f'};
 
@@ -103,7 +103,7 @@ public class ArrayUtilsInsertTest {
     }
 
     @Test
-    public void testInsertDoubles() throws Exception {
+    public void testInsertDoubles() {
         final double[] array = {1,2,3};
         final double[] values = {4,5,6};
         final double delta = 0.000001;
@@ -128,7 +128,7 @@ public class ArrayUtilsInsertTest {
     }
 
     @Test
-    public void testInsertFloats() throws Exception {
+    public void testInsertFloats() {
         final float[] array = {1,2,3};
         final float[] values = {4,5,6};
         final float delta = 0.000001f;
@@ -153,7 +153,7 @@ public class ArrayUtilsInsertTest {
     }
 
     @Test
-    public void testInsertInts() throws Exception {
+    public void testInsertInts() {
         final int[] array = {1,2,3};
         final int[] values = {4,5,6};
 
@@ -178,7 +178,7 @@ public class ArrayUtilsInsertTest {
 
 
     @Test
-    public void testInsertLongs() throws Exception {
+    public void testInsertLongs() {
         final long[] array = {1,2,3};
         final long[] values = {4,5,6};
 
@@ -203,7 +203,7 @@ public class ArrayUtilsInsertTest {
 
 
     @Test
-    public void testInsertShorts() throws Exception {
+    public void testInsertShorts() {
         final short[] array = {1,2,3};
         final short[] values = {4,5,6};
 
@@ -228,7 +228,7 @@ public class ArrayUtilsInsertTest {
 
 
     @Test
-    public void testInsertGenericArray() throws Exception {
+    public void testInsertGenericArray() {
         final String[] array = {"a","b","c"};
         final String[] values = {"d","e","f"};
 

--- a/src/test/java/org/apache/commons/lang3/ArrayUtilsInsertTest.java
+++ b/src/test/java/org/apache/commons/lang3/ArrayUtilsInsertTest.java
@@ -18,7 +18,7 @@
 package org.apache.commons.lang3;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -36,7 +36,7 @@ public class ArrayUtilsInsertTest {
 
         final boolean[] result = ArrayUtils.insert(42, array, null);
         assertArrayEquals(array, result);
-        assertFalse(array == result);
+        assertNotSame(array, result);
 
         assertNull(ArrayUtils.insert(42, null, array));
         assertArrayEquals(new boolean[0], ArrayUtils.insert(0, new boolean[0], null));
@@ -61,7 +61,7 @@ public class ArrayUtilsInsertTest {
 
         final byte[] result = ArrayUtils.insert(42, array, null);
         assertArrayEquals(array, result);
-        assertFalse(array == result);
+        assertNotSame(array, result);
 
         assertNull(ArrayUtils.insert(42, null, array));
         assertArrayEquals(new byte[0], ArrayUtils.insert(0, new byte[0], null));
@@ -85,7 +85,7 @@ public class ArrayUtilsInsertTest {
 
         final char[] result = ArrayUtils.insert(42, array, null);
         assertArrayEquals(array, result);
-        assertFalse(array == result);
+        assertNotSame(array, result);
 
         assertNull(ArrayUtils.insert(42, null, array));
         assertArrayEquals(new char[0], ArrayUtils.insert(0, new char[0], null));
@@ -110,7 +110,7 @@ public class ArrayUtilsInsertTest {
 
         final double[] result = ArrayUtils.insert(42, array, null);
         assertArrayEquals(array, result, delta);
-        assertFalse(array == result);
+        assertNotSame(array, result);
 
         assertNull(ArrayUtils.insert(42, null, array));
         assertArrayEquals(new double[0], ArrayUtils.insert(0, new double[0], null), delta);
@@ -135,7 +135,7 @@ public class ArrayUtilsInsertTest {
 
         final float[] result = ArrayUtils.insert(42, array, null);
         assertArrayEquals(array, result, delta);
-        assertFalse(array == result);
+        assertNotSame(array, result);
 
         assertNull(ArrayUtils.insert(42, null, array));
         assertArrayEquals(new float[0], ArrayUtils.insert(0, new float[0], null), delta);
@@ -159,7 +159,7 @@ public class ArrayUtilsInsertTest {
 
         final int[] result = ArrayUtils.insert(42, array, null);
         assertArrayEquals(array, result);
-        assertFalse(array == result);
+        assertNotSame(array, result);
 
         assertNull(ArrayUtils.insert(42, null, array));
         assertArrayEquals(new int[0], ArrayUtils.insert(0, new int[0], null));
@@ -184,7 +184,7 @@ public class ArrayUtilsInsertTest {
 
         final long[] result = ArrayUtils.insert(42, array, null);
         assertArrayEquals(array, result);
-        assertFalse(array == result);
+        assertNotSame(array, result);
 
         assertNull(ArrayUtils.insert(42, null, array));
         assertArrayEquals(new long[0], ArrayUtils.insert(0, new long[0], null));
@@ -209,7 +209,7 @@ public class ArrayUtilsInsertTest {
 
         final short[] result = ArrayUtils.insert(42, array, null);
         assertArrayEquals(array, result);
-        assertFalse(array == result);
+        assertNotSame(array, result);
 
         assertNull(ArrayUtils.insert(42, null, array));
         assertArrayEquals(new short[0], ArrayUtils.insert(0, new short[0], null));
@@ -234,7 +234,7 @@ public class ArrayUtilsInsertTest {
 
         final String[] result = ArrayUtils.insert(42, array, (String[]) null);
         assertArrayEquals(array, result);
-        assertFalse(array == result);
+        assertNotSame(array, result);
 
         assertNull(ArrayUtils.insert(42, null, array));
         assertArrayEquals(new String[0], ArrayUtils.insert(0, new String[0], (String[]) null));

--- a/src/test/java/org/apache/commons/lang3/ArrayUtilsInsertTest.java
+++ b/src/test/java/org/apache/commons/lang3/ArrayUtilsInsertTest.java
@@ -20,7 +20,7 @@ package org.apache.commons.lang3;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
@@ -42,19 +42,8 @@ public class ArrayUtilsInsertTest {
         assertArrayEquals(new boolean[0], ArrayUtils.insert(0, new boolean[0], null));
         assertNull(ArrayUtils.insert(42, (boolean[]) null, null));
 
-        try {
-            ArrayUtils.insert(-1, array, array);
-            fail("Expected IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
-
-        try {
-            ArrayUtils.insert(array.length + 1, array, array);
-            fail("Expected IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.insert(-1, array, array));
+        assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.insert(array.length + 1, array, array));
 
         assertArrayEquals(new boolean[]{false,true,false,true}, ArrayUtils.insert(0, array, false));
         assertArrayEquals(new boolean[]{true,false,false,true}, ArrayUtils.insert(1, array, false));
@@ -78,19 +67,8 @@ public class ArrayUtilsInsertTest {
         assertArrayEquals(new byte[0], ArrayUtils.insert(0, new byte[0], null));
         assertNull(ArrayUtils.insert(42, (byte[]) null, null));
 
-        try {
-            ArrayUtils.insert(-1, array, array);
-            fail("Expected IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
-
-        try {
-            ArrayUtils.insert(array.length + 1, array, array);
-            fail("Expected IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.insert(-1, array, array));
+        assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.insert(array.length + 1, array, array));
 
         assertArrayEquals(new byte[]{0,1,2,3}, ArrayUtils.insert(0, array, (byte) 0));
         assertArrayEquals(new byte[]{1,0,2,3}, ArrayUtils.insert(1, array, (byte) 0));
@@ -113,19 +91,8 @@ public class ArrayUtilsInsertTest {
         assertArrayEquals(new char[0], ArrayUtils.insert(0, new char[0], null));
         assertNull(ArrayUtils.insert(42, (char[]) null, null));
 
-        try {
-            ArrayUtils.insert(-1, array, array);
-            fail("Expected IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
-
-        try {
-            ArrayUtils.insert(array.length + 1, array, array);
-            fail("Expected IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.insert(-1, array, array));
+        assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.insert(array.length + 1, array, array));
 
         assertArrayEquals(new char[]{'z','a','b','c'}, ArrayUtils.insert(0, array, 'z'));
         assertArrayEquals(new char[]{'a','z','b','c'}, ArrayUtils.insert(1, array, 'z'));
@@ -149,19 +116,8 @@ public class ArrayUtilsInsertTest {
         assertArrayEquals(new double[0], ArrayUtils.insert(0, new double[0], null), delta);
         assertNull(ArrayUtils.insert(42, (double[]) null, null));
 
-        try {
-            ArrayUtils.insert(-1, array, array);
-            fail("Expected IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
-
-        try {
-            ArrayUtils.insert(array.length + 1, array, array);
-            fail("Expected IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.insert(-1, array, array));
+        assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.insert(array.length + 1, array, array));
 
         assertArrayEquals(new double[]{0,1,2,3}, ArrayUtils.insert(0, array, 0), delta);
         assertArrayEquals(new double[]{1,0,2,3}, ArrayUtils.insert(1, array, 0), delta);
@@ -185,19 +141,8 @@ public class ArrayUtilsInsertTest {
         assertArrayEquals(new float[0], ArrayUtils.insert(0, new float[0], null), delta);
         assertNull(ArrayUtils.insert(42, (float[]) null, null));
 
-        try {
-            ArrayUtils.insert(-1, array, array);
-            fail("Expected IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
-
-        try {
-            ArrayUtils.insert(array.length + 1, array, array);
-            fail("Expected IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.insert(-1, array, array));
+        assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.insert(array.length + 1, array, array));
 
         assertArrayEquals(new float[]{0,1,2,3}, ArrayUtils.insert(0, array, 0), delta);
         assertArrayEquals(new float[]{1,0,2,3}, ArrayUtils.insert(1, array, 0), delta);
@@ -220,19 +165,8 @@ public class ArrayUtilsInsertTest {
         assertArrayEquals(new int[0], ArrayUtils.insert(0, new int[0], null));
         assertNull(ArrayUtils.insert(42, (int[]) null, null));
 
-        try {
-            ArrayUtils.insert(-1, array, array);
-            fail("Expected IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
-
-        try {
-            ArrayUtils.insert(array.length + 1, array, array);
-            fail("Expected IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.insert(-1, array, array));
+        assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.insert(array.length + 1, array, array));
 
         assertArrayEquals(new int[]{0,1,2,3}, ArrayUtils.insert(0, array, 0));
         assertArrayEquals(new int[]{1,0,2,3}, ArrayUtils.insert(1, array, 0));
@@ -256,19 +190,8 @@ public class ArrayUtilsInsertTest {
         assertArrayEquals(new long[0], ArrayUtils.insert(0, new long[0], null));
         assertNull(ArrayUtils.insert(42, (long[]) null, null));
 
-        try {
-            ArrayUtils.insert(-1, array, array);
-            fail("Expected IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
-
-        try {
-            ArrayUtils.insert(array.length + 1, array, array);
-            fail("Expected IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.insert(-1, array, array));
+        assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.insert(array.length + 1, array, array));
 
         assertArrayEquals(new long[]{0,1,2,3}, ArrayUtils.insert(0, array, 0));
         assertArrayEquals(new long[]{1,0,2,3}, ArrayUtils.insert(1, array, 0));
@@ -292,19 +215,8 @@ public class ArrayUtilsInsertTest {
         assertArrayEquals(new short[0], ArrayUtils.insert(0, new short[0], null));
         assertNull(ArrayUtils.insert(42, (short[]) null, null));
 
-        try {
-            ArrayUtils.insert(-1, array, array);
-            fail("Expected IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
-
-        try {
-            ArrayUtils.insert(array.length + 1, array, array);
-            fail("Expected IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.insert(-1, array, array));
+        assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.insert(array.length + 1, array, array));
 
         assertArrayEquals(new short[]{0,1,2,3}, ArrayUtils.insert(0, array, (short) 0));
         assertArrayEquals(new short[]{1,0,2,3}, ArrayUtils.insert(1, array, (short) 0));
@@ -328,19 +240,8 @@ public class ArrayUtilsInsertTest {
         assertArrayEquals(new String[0], ArrayUtils.insert(0, new String[0], (String[]) null));
         assertNull(ArrayUtils.insert(42, null, (String[]) null));
 
-        try {
-            ArrayUtils.insert(-1, array, array);
-            fail("Expected IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
-
-        try {
-            ArrayUtils.insert(array.length + 1, array, array);
-            fail("Expected IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.insert(-1, array, array));
+        assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.insert(array.length + 1, array, array));
 
         assertArrayEquals(new String[]{"z","a","b","c"}, ArrayUtils.insert(0, array, "z"));
         assertArrayEquals(new String[]{"a","z","b","c"}, ArrayUtils.insert(1, array, "z"));

--- a/src/test/java/org/apache/commons/lang3/ArrayUtilsRemoveTest.java
+++ b/src/test/java/org/apache/commons/lang3/ArrayUtilsRemoveTest.java
@@ -19,8 +19,8 @@ package org.apache.commons.lang3;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Arrays;
 
@@ -46,18 +46,9 @@ public class ArrayUtilsRemoveTest {
         array = ArrayUtils.remove(new Object[] {"a", "b", "c"}, 1);
         assertTrue(Arrays.equals(new Object[] {"a", "c"}, array));
         assertEquals(Object.class, array.getClass().getComponentType());
-        try {
-            ArrayUtils.remove(new Object[] {"a", "b"}, -1);
-            fail("IndexOutOfBoundsException expected");
-        } catch (final IndexOutOfBoundsException e) {}
-        try {
-            ArrayUtils.remove(new Object[] {"a", "b"}, 2);
-            fail("IndexOutOfBoundsException expected");
-        } catch (final IndexOutOfBoundsException e) {}
-        try {
-            ArrayUtils.remove((Object[]) null, 0);
-            fail("IndexOutOfBoundsException expected");
-        } catch (final IndexOutOfBoundsException e) {}
+        assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.remove(new Object[] {"a", "b"}, -1));
+        assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.remove(new Object[] {"a", "b"}, 2));
+        assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.remove((Object[]) null, 0));
     }
 
     @Test
@@ -91,18 +82,9 @@ public class ArrayUtilsRemoveTest {
         array = ArrayUtils.remove(new boolean[] {true, false, true}, 1);
         assertTrue(Arrays.equals(new boolean[] {true, true}, array));
         assertEquals(Boolean.TYPE, array.getClass().getComponentType());
-        try {
-            ArrayUtils.remove(new boolean[] {true, false}, -1);
-            fail("IndexOutOfBoundsException expected");
-        } catch (final IndexOutOfBoundsException e) {}
-        try {
-            ArrayUtils.remove(new boolean[] {true, false}, 2);
-            fail("IndexOutOfBoundsException expected");
-        } catch (final IndexOutOfBoundsException e) {}
-        try {
-            ArrayUtils.remove((boolean[]) null, 0);
-            fail("IndexOutOfBoundsException expected");
-        } catch (final IndexOutOfBoundsException e) {}
+        assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.remove(new boolean[] {true, false}, -1));
+        assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.remove(new boolean[] {true, false}, 2));
+        assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.remove((boolean[]) null, 0));
     }
 
     @Test
@@ -120,18 +102,9 @@ public class ArrayUtilsRemoveTest {
         array = ArrayUtils.remove(new byte[] {1, 2, 1}, 1);
         assertTrue(Arrays.equals(new byte[] {1, 1}, array));
         assertEquals(Byte.TYPE, array.getClass().getComponentType());
-        try {
-            ArrayUtils.remove(new byte[] {1, 2}, -1);
-            fail("IndexOutOfBoundsException expected");
-        } catch (final IndexOutOfBoundsException e) {}
-        try {
-            ArrayUtils.remove(new byte[] {1, 2}, 2);
-            fail("IndexOutOfBoundsException expected");
-        } catch (final IndexOutOfBoundsException e) {}
-        try {
-            ArrayUtils.remove((byte[]) null, 0);
-            fail("IndexOutOfBoundsException expected");
-        } catch (final IndexOutOfBoundsException e) {}
+        assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.remove(new byte[] {1, 2}, -1));
+        assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.remove(new byte[] {1, 2}, 2));
+        assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.remove((byte[]) null, 0));
     }
 
     @Test
@@ -149,18 +122,9 @@ public class ArrayUtilsRemoveTest {
         array = ArrayUtils.remove(new char[] {'a', 'b', 'c'}, 1);
         assertTrue(Arrays.equals(new char[] {'a', 'c'}, array));
         assertEquals(Character.TYPE, array.getClass().getComponentType());
-        try {
-            ArrayUtils.remove(new char[] {'a', 'b'}, -1);
-            fail("IndexOutOfBoundsException expected");
-        } catch (final IndexOutOfBoundsException e) {}
-        try {
-            ArrayUtils.remove(new char[] {'a', 'b'}, 2);
-            fail("IndexOutOfBoundsException expected");
-        } catch (final IndexOutOfBoundsException e) {}
-        try {
-            ArrayUtils.remove((char[]) null, 0);
-            fail("IndexOutOfBoundsException expected");
-        } catch (final IndexOutOfBoundsException e) {}
+        assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.remove(new char[] {'a', 'b'}, -1));
+        assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.remove(new char[] {'a', 'b'}, 2));
+        assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.remove((char[]) null, 0));
     }
 
     @Test
@@ -178,18 +142,9 @@ public class ArrayUtilsRemoveTest {
         array = ArrayUtils.remove(new double[] {1, 2, 1}, 1);
         assertTrue(Arrays.equals(new double[] {1, 1}, array));
         assertEquals(Double.TYPE, array.getClass().getComponentType());
-        try {
-            ArrayUtils.remove(new double[] {1, 2}, -1);
-            fail("IndexOutOfBoundsException expected");
-        } catch (final IndexOutOfBoundsException e) {}
-        try {
-            ArrayUtils.remove(new double[] {1, 2}, 2);
-            fail("IndexOutOfBoundsException expected");
-        } catch (final IndexOutOfBoundsException e) {}
-        try {
-            ArrayUtils.remove((double[]) null, 0);
-            fail("IndexOutOfBoundsException expected");
-        } catch (final IndexOutOfBoundsException e) {}
+        assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.remove(new double[] {1, 2}, -1));
+        assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.remove(new double[] {1, 2}, 2));
+        assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.remove((double[]) null, 0));
     }
 
     @Test
@@ -207,18 +162,9 @@ public class ArrayUtilsRemoveTest {
         array = ArrayUtils.remove(new float[] {1, 2, 1}, 1);
         assertTrue(Arrays.equals(new float[] {1, 1}, array));
         assertEquals(Float.TYPE, array.getClass().getComponentType());
-        try {
-            ArrayUtils.remove(new float[] {1, 2}, -1);
-            fail("IndexOutOfBoundsException expected");
-        } catch (final IndexOutOfBoundsException e) {}
-        try {
-            ArrayUtils.remove(new float[] {1, 2}, 2);
-            fail("IndexOutOfBoundsException expected");
-        } catch (final IndexOutOfBoundsException e) {}
-        try {
-            ArrayUtils.remove((float[]) null, 0);
-            fail("IndexOutOfBoundsException expected");
-        } catch (final IndexOutOfBoundsException e) {}
+        assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.remove(new float[] {1, 2}, -1));
+        assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.remove(new float[] {1, 2}, 2));
+        assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.remove((float[]) null, 0));
     }
 
     @Test
@@ -236,18 +182,9 @@ public class ArrayUtilsRemoveTest {
         array = ArrayUtils.remove(new int[] {1, 2, 1}, 1);
         assertTrue(Arrays.equals(new int[] {1, 1}, array));
         assertEquals(Integer.TYPE, array.getClass().getComponentType());
-        try {
-            ArrayUtils.remove(new int[] {1, 2}, -1);
-            fail("IndexOutOfBoundsException expected");
-        } catch (final IndexOutOfBoundsException e) {}
-        try {
-            ArrayUtils.remove(new int[] {1, 2}, 2);
-            fail("IndexOutOfBoundsException expected");
-        } catch (final IndexOutOfBoundsException e) {}
-        try {
-            ArrayUtils.remove((int[]) null, 0);
-            fail("IndexOutOfBoundsException expected");
-        } catch (final IndexOutOfBoundsException e) {}
+        assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.remove(new int[] {1, 2}, -1));
+        assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.remove(new int[] {1, 2}, 2));
+        assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.remove((int[]) null, 0));
     }
 
     @Test
@@ -265,18 +202,9 @@ public class ArrayUtilsRemoveTest {
         array = ArrayUtils.remove(new long[] {1, 2, 1}, 1);
         assertTrue(Arrays.equals(new long[] {1, 1}, array));
         assertEquals(Long.TYPE, array.getClass().getComponentType());
-        try {
-            ArrayUtils.remove(new long[] {1, 2}, -1);
-            fail("IndexOutOfBoundsException expected");
-        } catch (final IndexOutOfBoundsException e) {}
-        try {
-            ArrayUtils.remove(new long[] {1, 2}, 2);
-            fail("IndexOutOfBoundsException expected");
-        } catch (final IndexOutOfBoundsException e) {}
-        try {
-            ArrayUtils.remove((long[]) null, 0);
-            fail("IndexOutOfBoundsException expected");
-        } catch (final IndexOutOfBoundsException e) {}
+        assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.remove(new long[] {1, 2}, -1));
+        assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.remove(new long[] {1, 2}, 2));
+        assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.remove((long[]) null, 0));
     }
 
     @Test
@@ -294,18 +222,9 @@ public class ArrayUtilsRemoveTest {
         array = ArrayUtils.remove(new short[] {1, 2, 1}, 1);
         assertTrue(Arrays.equals(new short[] {1, 1}, array));
         assertEquals(Short.TYPE, array.getClass().getComponentType());
-        try {
-            ArrayUtils.remove(new short[] {1, 2}, -1);
-            fail("IndexOutOfBoundsException expected");
-        } catch (final IndexOutOfBoundsException e) {}
-        try {
-            ArrayUtils.remove(new short[] {1, 2}, 2);
-            fail("IndexOutOfBoundsException expected");
-        } catch (final IndexOutOfBoundsException e) {}
-        try {
-            ArrayUtils.remove((short[]) null, 0);
-            fail("IndexOutOfBoundsException expected");
-        } catch (final IndexOutOfBoundsException e) {}
+        assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.remove(new short[] {1, 2}, -1));
+        assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.remove(new short[] {1, 2}, 2));
+        assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.remove((short[]) null, 0));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/ArrayUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/ArrayUtilsTest.java
@@ -25,7 +25,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
@@ -230,21 +229,12 @@ public class ArrayUtilsTest {
         assertEquals("world", map.get("hello"));
 
         assertNull(ArrayUtils.toMap(null));
-        try {
-            ArrayUtils.toMap(new String[][]{{"foo", "bar"}, {"short"}});
-            fail("exception expected");
-        } catch (final IllegalArgumentException ex) {
-        }
-        try {
-            ArrayUtils.toMap(new Object[]{new Object[]{"foo", "bar"}, "illegal type"});
-            fail("exception expected");
-        } catch (final IllegalArgumentException ex) {
-        }
-        try {
-            ArrayUtils.toMap(new Object[]{new Object[]{"foo", "bar"}, null});
-            fail("exception expected");
-        } catch (final IllegalArgumentException ex) {
-        }
+        assertThrows(IllegalArgumentException.class, () ->
+                ArrayUtils.toMap(new String[][]{{"foo", "bar"}, {"short"}}));
+        assertThrows(IllegalArgumentException.class, () ->
+                ArrayUtils.toMap(new Object[]{new Object[]{"foo", "bar"}, "illegal type"}));
+        assertThrows(IllegalArgumentException.class, () ->
+                ArrayUtils.toMap(new Object[]{new Object[]{"foo", "bar"}, null}));
 
         map = ArrayUtils.toMap(new Object[]{new Map.Entry<Object, Object>() {
             @Override
@@ -795,11 +785,9 @@ public class ArrayUtilsTest {
                 "java.util.Date type");
         assertNotSame(java.sql.Date.class, ArrayUtils.subarray(dateArray, 1, 4).getClass().getComponentType(),
                 "java.sql.Date type");
-        try {
-            @SuppressWarnings("unused") final java.sql.Date[] dummy = (java.sql.Date[]) ArrayUtils.subarray(dateArray, 1, 3);
-            fail("Invalid downcast");
-        } catch (final ClassCastException e) {
-        }
+        assertThrows(ClassCastException.class,
+                () -> java.sql.Date[].class.cast(ArrayUtils.subarray(dateArray, 1, 3)),
+                "Invalid downcast");
     }
 
     @Test
@@ -1406,21 +1394,9 @@ public class ArrayUtilsTest {
     //-----------------------------------------------------------------------
     @Test
     public void testSameType() {
-        try {
-            ArrayUtils.isSameType(null, null);
-            fail();
-        } catch (final IllegalArgumentException ex) {
-        }
-        try {
-            ArrayUtils.isSameType(null, new Object[0]);
-            fail();
-        } catch (final IllegalArgumentException ex) {
-        }
-        try {
-            ArrayUtils.isSameType(new Object[0], null);
-            fail();
-        } catch (final IllegalArgumentException ex) {
-        }
+        assertThrows(IllegalArgumentException.class, () -> ArrayUtils.isSameType(null, null));
+        assertThrows(IllegalArgumentException.class, () -> ArrayUtils.isSameType(null, new Object[0]));
+        assertThrows(IllegalArgumentException.class, () -> ArrayUtils.isSameType(new Object[0], null));
 
         assertTrue(ArrayUtils.isSameType(new Object[0], new Object[0]));
         assertFalse(ArrayUtils.isSameType(new String[0], new Object[0]));
@@ -3901,11 +3877,7 @@ public class ArrayUtilsTest {
                 ArrayUtils.toPrimitive(new Boolean[]{Boolean.TRUE, Boolean.FALSE, Boolean.TRUE}))
         );
 
-        try {
-            ArrayUtils.toPrimitive(new Boolean[]{Boolean.TRUE, null});
-            fail();
-        } catch (final NullPointerException ex) {
-        }
+        assertThrows(NullPointerException.class, () -> ArrayUtils.toPrimitive(new Boolean[]{Boolean.TRUE, null}));
     }
 
     @Test
@@ -3952,11 +3924,8 @@ public class ArrayUtilsTest {
                         new Character(Character.MAX_VALUE), new Character('0')}))
         );
 
-        try {
-            ArrayUtils.toPrimitive(new Character[]{new Character(Character.MIN_VALUE), null});
-            fail();
-        } catch (final NullPointerException ex) {
-        }
+        assertThrows(NullPointerException.class,
+                () -> ArrayUtils.toPrimitive(new Character[]{new Character(Character.MIN_VALUE), null}));
     }
 
     @Test
@@ -4012,11 +3981,8 @@ public class ArrayUtilsTest {
                         Byte.valueOf(Byte.MAX_VALUE), Byte.valueOf((byte) 9999999)}))
         );
 
-        try {
-            ArrayUtils.toPrimitive(new Byte[]{Byte.valueOf(Byte.MIN_VALUE), null});
-            fail();
-        } catch (final NullPointerException ex) {
-        }
+        assertThrows(NullPointerException.class,
+                () -> ArrayUtils.toPrimitive(new Byte[]{Byte.valueOf(Byte.MIN_VALUE), null}));
     }
 
     @Test
@@ -4072,11 +4038,8 @@ public class ArrayUtilsTest {
                         Short.valueOf(Short.MAX_VALUE), Short.valueOf((short) 9999999)}))
         );
 
-        try {
-            ArrayUtils.toPrimitive(new Short[]{Short.valueOf(Short.MIN_VALUE), null});
-            fail();
-        } catch (final NullPointerException ex) {
-        }
+        assertThrows(NullPointerException.class,
+                () -> ArrayUtils.toPrimitive(new Short[]{Short.valueOf(Short.MIN_VALUE), null}));
     }
 
     @Test
@@ -4129,11 +4092,8 @@ public class ArrayUtilsTest {
                         Integer.valueOf(Integer.MAX_VALUE), Integer.valueOf(9999999)}))
         );
 
-        try {
-            ArrayUtils.toPrimitive(new Integer[]{Integer.valueOf(Integer.MIN_VALUE), null});
-            fail();
-        } catch (final NullPointerException ex) {
-        }
+        assertThrows(NullPointerException.class,
+                () -> ArrayUtils.toPrimitive(new Integer[]{Integer.valueOf(Integer.MIN_VALUE), null}));
     }
 
     @Test
@@ -4194,11 +4154,8 @@ public class ArrayUtilsTest {
                         Long.valueOf(Long.MAX_VALUE), Long.valueOf(9999999)}))
         );
 
-        try {
-            ArrayUtils.toPrimitive(new Long[]{Long.valueOf(Long.MIN_VALUE), null});
-            fail();
-        } catch (final NullPointerException ex) {
-        }
+        assertThrows(NullPointerException.class,
+                () -> ArrayUtils.toPrimitive(new Long[]{Long.valueOf(Long.MIN_VALUE), null}));
     }
 
     @Test
@@ -4256,11 +4213,8 @@ public class ArrayUtilsTest {
                         Float.valueOf(Float.MAX_VALUE), Float.valueOf(9999999)}))
         );
 
-        try {
-            ArrayUtils.toPrimitive(new Float[]{Float.valueOf(Float.MIN_VALUE), null});
-            fail();
-        } catch (final NullPointerException ex) {
-        }
+        assertThrows(NullPointerException.class,
+                () -> ArrayUtils.toPrimitive(new Float[]{Float.valueOf(Float.MIN_VALUE), null}));
     }
 
     @Test
@@ -4318,11 +4272,8 @@ public class ArrayUtilsTest {
                         Double.valueOf(Double.MAX_VALUE), Double.valueOf(9999999)}))
         );
 
-        try {
-            ArrayUtils.toPrimitive(new Float[]{Float.valueOf(Float.MIN_VALUE), null});
-            fail();
-        } catch (final NullPointerException ex) {
-        }
+        assertThrows(NullPointerException.class,
+                () -> ArrayUtils.toPrimitive(new Float[]{Float.valueOf(Float.MIN_VALUE), null}));
     }
 
     @Test
@@ -4565,11 +4516,7 @@ public class ArrayUtilsTest {
         assertEquals(0, ArrayUtils.getLength(emptyBooleanArray));
         assertEquals(1, ArrayUtils.getLength(notEmptyBooleanArray));
 
-        try {
-            ArrayUtils.getLength("notAnArray");
-            fail("IllegalArgumentException should have been thrown");
-        } catch (final IllegalArgumentException e) {
-        }
+        assertThrows(IllegalArgumentException.class, () -> ArrayUtils.getLength("notAnArray"));
     }
 
     @Test
@@ -4753,11 +4700,7 @@ public class ArrayUtilsTest {
         final Object[] array = new Object[]{1, 2, 3, "array", "test"};
         assertArrayEquals(new String[]{"1", "2", "3", "array", "test"}, ArrayUtils.toStringArray(array));
 
-        try {
-            ArrayUtils.toStringArray(new Object[]{null});
-            fail("NullPointerException expected!");
-        } catch (final NullPointerException expected) {
-        }
+        assertThrows(NullPointerException.class, () -> ArrayUtils.toStringArray(new Object[]{null}));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/ArrayUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/ArrayUtilsTest.java
@@ -77,17 +77,17 @@ public class ArrayUtilsTest {
     public void testHashCode() {
         final long[][] array1 = new long[][]{{2, 5}, {4, 5}};
         final long[][] array2 = new long[][]{{2, 5}, {4, 6}};
-        assertTrue(ArrayUtils.hashCode(array1) == ArrayUtils.hashCode(array1));
+        assertEquals(ArrayUtils.hashCode(array1), ArrayUtils.hashCode(array1));
         assertFalse(ArrayUtils.hashCode(array1) == ArrayUtils.hashCode(array2));
 
         final Object[] array3 = new Object[]{new String(new char[]{'A', 'B'})};
         final Object[] array4 = new Object[]{"AB"};
-        assertTrue(ArrayUtils.hashCode(array3) == ArrayUtils.hashCode(array3));
-        assertTrue(ArrayUtils.hashCode(array3) == ArrayUtils.hashCode(array4));
+        assertEquals(ArrayUtils.hashCode(array3), ArrayUtils.hashCode(array3));
+        assertEquals(ArrayUtils.hashCode(array3), ArrayUtils.hashCode(array4));
 
         final Object[] arrayA = new Object[]{new boolean[]{true, false}, new int[]{6, 7}};
         final Object[] arrayB = new Object[]{new boolean[]{true, false}, new int[]{6, 7}};
-        assertTrue(ArrayUtils.hashCode(arrayB) == ArrayUtils.hashCode(arrayA));
+        assertEquals(ArrayUtils.hashCode(arrayB), ArrayUtils.hashCode(arrayA));
     }
 
     //-----------------------------------------------------------------------
@@ -272,13 +272,13 @@ public class ArrayUtilsTest {
         Object[] original1 = new Object[0];
         Object[] cloned1 = ArrayUtils.clone(original1);
         assertTrue(Arrays.equals(original1, cloned1));
-        assertTrue(original1 != cloned1);
+        assertNotSame(original1, cloned1);
 
         final StringBuilder builder = new StringBuilder("pick");
         original1 = new Object[]{builder, "a", new String[]{"stick"}};
         cloned1 = ArrayUtils.clone(original1);
         assertTrue(Arrays.equals(original1, cloned1));
-        assertTrue(original1 != cloned1);
+        assertNotSame(original1, cloned1);
         assertSame(original1[0], cloned1[0]);
         assertSame(original1[1], cloned1[1]);
         assertSame(original1[2], cloned1[2]);
@@ -290,7 +290,7 @@ public class ArrayUtilsTest {
         final boolean[] original = new boolean[]{true, false};
         final boolean[] cloned = ArrayUtils.clone(original);
         assertTrue(Arrays.equals(original, cloned));
-        assertTrue(original != cloned);
+        assertNotSame(original, cloned);
     }
 
     @Test
@@ -299,7 +299,7 @@ public class ArrayUtilsTest {
         final long[] original = new long[]{0L, 1L};
         final long[] cloned = ArrayUtils.clone(original);
         assertTrue(Arrays.equals(original, cloned));
-        assertTrue(original != cloned);
+        assertNotSame(original, cloned);
     }
 
     @Test
@@ -308,7 +308,7 @@ public class ArrayUtilsTest {
         final int[] original = new int[]{5, 8};
         final int[] cloned = ArrayUtils.clone(original);
         assertTrue(Arrays.equals(original, cloned));
-        assertTrue(original != cloned);
+        assertNotSame(original, cloned);
     }
 
     @Test
@@ -317,7 +317,7 @@ public class ArrayUtilsTest {
         final short[] original = new short[]{1, 4};
         final short[] cloned = ArrayUtils.clone(original);
         assertTrue(Arrays.equals(original, cloned));
-        assertTrue(original != cloned);
+        assertNotSame(original, cloned);
     }
 
     @Test
@@ -326,7 +326,7 @@ public class ArrayUtilsTest {
         final char[] original = new char[]{'a', '4'};
         final char[] cloned = ArrayUtils.clone(original);
         assertTrue(Arrays.equals(original, cloned));
-        assertTrue(original != cloned);
+        assertNotSame(original, cloned);
     }
 
     @Test
@@ -335,7 +335,7 @@ public class ArrayUtilsTest {
         final byte[] original = new byte[]{1, 6};
         final byte[] cloned = ArrayUtils.clone(original);
         assertTrue(Arrays.equals(original, cloned));
-        assertTrue(original != cloned);
+        assertNotSame(original, cloned);
     }
 
     @Test
@@ -344,7 +344,7 @@ public class ArrayUtilsTest {
         final double[] original = new double[]{2.4d, 5.7d};
         final double[] cloned = ArrayUtils.clone(original);
         assertTrue(Arrays.equals(original, cloned));
-        assertTrue(original != cloned);
+        assertNotSame(original, cloned);
     }
 
     @Test
@@ -353,7 +353,7 @@ public class ArrayUtilsTest {
         final float[] original = new float[]{2.6f, 6.4f};
         final float[] cloned = ArrayUtils.clone(original);
         assertTrue(Arrays.equals(original, cloned));
-        assertTrue(original != cloned);
+        assertNotSame(original, cloned);
     }
 
     //-----------------------------------------------------------------------
@@ -365,8 +365,8 @@ public class ArrayUtilsTest {
     public void testNullToEmptyGenericNull() {
         final TestClass[] output = ArrayUtils.nullToEmpty(null, TestClass[].class);
 
-        assertTrue(output != null);
-        assertTrue(output.length == 0);
+        assertNotNull(output);
+        assertEquals(0, output.length);
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/ArrayUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/ArrayUtilsTest.java
@@ -392,12 +392,12 @@ public class ArrayUtilsTest {
     }
 
     @Test
-    public void testNullToEmptyBooleanNull() throws Exception {
+    public void testNullToEmptyBooleanNull() {
         assertEquals(ArrayUtils.EMPTY_BOOLEAN_ARRAY, ArrayUtils.nullToEmpty((boolean[]) null));
     }
 
     @Test
-    public void testNullToEmptyBooleanEmptyArray() throws Exception {
+    public void testNullToEmptyBooleanEmptyArray() {
         final boolean[] empty = new boolean[]{};
         final boolean[] result = ArrayUtils.nullToEmpty(empty);
         assertEquals(ArrayUtils.EMPTY_BOOLEAN_ARRAY, result);
@@ -411,12 +411,12 @@ public class ArrayUtilsTest {
     }
 
     @Test
-    public void testNullToEmptyLongNull() throws Exception {
+    public void testNullToEmptyLongNull() {
         assertEquals(ArrayUtils.EMPTY_LONG_ARRAY, ArrayUtils.nullToEmpty((long[]) null));
     }
 
     @Test
-    public void testNullToEmptyLongEmptyArray() throws Exception {
+    public void testNullToEmptyLongEmptyArray() {
         final long[] empty = new long[]{};
         final long[] result = ArrayUtils.nullToEmpty(empty);
         assertEquals(ArrayUtils.EMPTY_LONG_ARRAY, result);
@@ -430,12 +430,12 @@ public class ArrayUtilsTest {
     }
 
     @Test
-    public void testNullToEmptyIntNull() throws Exception {
+    public void testNullToEmptyIntNull() {
         assertEquals(ArrayUtils.EMPTY_INT_ARRAY, ArrayUtils.nullToEmpty((int[]) null));
     }
 
     @Test
-    public void testNullToEmptyIntEmptyArray() throws Exception {
+    public void testNullToEmptyIntEmptyArray() {
         final int[] empty = new int[]{};
         final int[] result = ArrayUtils.nullToEmpty(empty);
         assertEquals(ArrayUtils.EMPTY_INT_ARRAY, result);
@@ -449,12 +449,12 @@ public class ArrayUtilsTest {
     }
 
     @Test
-    public void testNullToEmptyShortNull() throws Exception {
+    public void testNullToEmptyShortNull() {
         assertEquals(ArrayUtils.EMPTY_SHORT_ARRAY, ArrayUtils.nullToEmpty((short[]) null));
     }
 
     @Test
-    public void testNullToEmptyShortEmptyArray() throws Exception {
+    public void testNullToEmptyShortEmptyArray() {
         final short[] empty = new short[]{};
         final short[] result = ArrayUtils.nullToEmpty(empty);
         assertEquals(ArrayUtils.EMPTY_SHORT_ARRAY, result);
@@ -468,12 +468,12 @@ public class ArrayUtilsTest {
     }
 
     @Test
-    public void testNullToEmptyCharNull() throws Exception {
+    public void testNullToEmptyCharNull() {
         assertEquals(ArrayUtils.EMPTY_CHAR_ARRAY, ArrayUtils.nullToEmpty((char[]) null));
     }
 
     @Test
-    public void testNullToEmptyCharEmptyArray() throws Exception {
+    public void testNullToEmptyCharEmptyArray() {
         final char[] empty = new char[]{};
         final char[] result = ArrayUtils.nullToEmpty(empty);
         assertEquals(ArrayUtils.EMPTY_CHAR_ARRAY, result);
@@ -487,12 +487,12 @@ public class ArrayUtilsTest {
     }
 
     @Test
-    public void testNullToEmptyByteNull() throws Exception {
+    public void testNullToEmptyByteNull() {
         assertEquals(ArrayUtils.EMPTY_BYTE_ARRAY, ArrayUtils.nullToEmpty((byte[]) null));
     }
 
     @Test
-    public void testNullToEmptyByteEmptyArray() throws Exception {
+    public void testNullToEmptyByteEmptyArray() {
         final byte[] empty = new byte[]{};
         final byte[] result = ArrayUtils.nullToEmpty(empty);
         assertEquals(ArrayUtils.EMPTY_BYTE_ARRAY, result);
@@ -506,12 +506,12 @@ public class ArrayUtilsTest {
     }
 
     @Test
-    public void testNullToEmptyDoubleNull() throws Exception {
+    public void testNullToEmptyDoubleNull() {
         assertEquals(ArrayUtils.EMPTY_DOUBLE_ARRAY, ArrayUtils.nullToEmpty((double[]) null));
     }
 
     @Test
-    public void testNullToEmptyDoubleEmptyArray() throws Exception {
+    public void testNullToEmptyDoubleEmptyArray() {
         final double[] empty = new double[]{};
         final double[] result = ArrayUtils.nullToEmpty(empty);
         assertEquals(ArrayUtils.EMPTY_DOUBLE_ARRAY, result);
@@ -525,12 +525,12 @@ public class ArrayUtilsTest {
     }
 
     @Test
-    public void testNullToEmptyFloatNull() throws Exception {
+    public void testNullToEmptyFloatNull() {
         assertEquals(ArrayUtils.EMPTY_FLOAT_ARRAY, ArrayUtils.nullToEmpty((float[]) null));
     }
 
     @Test
-    public void testNullToEmptyFloatEmptyArray() throws Exception {
+    public void testNullToEmptyFloatEmptyArray() {
         final float[] empty = new float[]{};
         final float[] result = ArrayUtils.nullToEmpty(empty);
         assertEquals(ArrayUtils.EMPTY_FLOAT_ARRAY, result);
@@ -544,12 +544,12 @@ public class ArrayUtilsTest {
     }
 
     @Test
-    public void testNullToEmptyObjectNull() throws Exception {
+    public void testNullToEmptyObjectNull() {
         assertArrayEquals(ArrayUtils.EMPTY_OBJECT_ARRAY, ArrayUtils.nullToEmpty((Object[]) null));
     }
 
     @Test
-    public void testNullToEmptyObjectEmptyArray() throws Exception {
+    public void testNullToEmptyObjectEmptyArray() {
         final Object[] empty = new Object[]{};
         final Object[] result = ArrayUtils.nullToEmpty(empty);
         assertArrayEquals(ArrayUtils.EMPTY_OBJECT_ARRAY, result);
@@ -563,12 +563,12 @@ public class ArrayUtilsTest {
     }
 
     @Test
-    public void testNullToEmptyClassNull() throws Exception {
+    public void testNullToEmptyClassNull() {
         assertArrayEquals(ArrayUtils.EMPTY_CLASS_ARRAY, ArrayUtils.nullToEmpty((Class<?>[]) null));
     }
 
     @Test
-    public void testNullToEmptyClassEmptyArray() throws Exception {
+    public void testNullToEmptyClassEmptyArray() {
         final Class<?>[] empty = {};
         final Class<?>[] result = ArrayUtils.nullToEmpty(empty);
         assertArrayEquals(ArrayUtils.EMPTY_CLASS_ARRAY, result);
@@ -582,12 +582,12 @@ public class ArrayUtilsTest {
     }
 
     @Test
-    public void testNullToEmptyStringNull() throws Exception {
+    public void testNullToEmptyStringNull() {
         assertArrayEquals(ArrayUtils.EMPTY_STRING_ARRAY, ArrayUtils.nullToEmpty((String[]) null));
     }
 
     @Test
-    public void testNullToEmptyStringEmptyArray() throws Exception {
+    public void testNullToEmptyStringEmptyArray() {
         final String[] empty = new String[]{};
         final String[] result = ArrayUtils.nullToEmpty(empty);
         assertArrayEquals(ArrayUtils.EMPTY_STRING_ARRAY, result);
@@ -601,12 +601,12 @@ public class ArrayUtilsTest {
     }
 
     @Test
-    public void testNullToEmptyBooleanObjectNull() throws Exception {
+    public void testNullToEmptyBooleanObjectNull() {
         assertArrayEquals(ArrayUtils.EMPTY_BOOLEAN_OBJECT_ARRAY, ArrayUtils.nullToEmpty((Boolean[]) null));
     }
 
     @Test
-    public void testNullToEmptyBooleanObjectEmptyArray() throws Exception {
+    public void testNullToEmptyBooleanObjectEmptyArray() {
         final Boolean[] empty = new Boolean[]{};
         final Boolean[] result = ArrayUtils.nullToEmpty(empty);
         assertArrayEquals(ArrayUtils.EMPTY_BOOLEAN_OBJECT_ARRAY, result);
@@ -620,12 +620,12 @@ public class ArrayUtilsTest {
     }
 
     @Test
-    public void testNullToEmptyLongObjectNull() throws Exception {
+    public void testNullToEmptyLongObjectNull() {
         assertArrayEquals(ArrayUtils.EMPTY_LONG_OBJECT_ARRAY, ArrayUtils.nullToEmpty((Long[]) null));
     }
 
     @Test
-    public void testNullToEmptyLongObjectEmptyArray() throws Exception {
+    public void testNullToEmptyLongObjectEmptyArray() {
         final Long[] empty = new Long[]{};
         final Long[] result = ArrayUtils.nullToEmpty(empty);
         assertArrayEquals(ArrayUtils.EMPTY_LONG_OBJECT_ARRAY, result);
@@ -639,12 +639,12 @@ public class ArrayUtilsTest {
     }
 
     @Test
-    public void testNullToEmptyIntObjectNull() throws Exception {
+    public void testNullToEmptyIntObjectNull() {
         assertArrayEquals(ArrayUtils.EMPTY_INTEGER_OBJECT_ARRAY, ArrayUtils.nullToEmpty((Integer[]) null));
     }
 
     @Test
-    public void testNullToEmptyIntObjectEmptyArray() throws Exception {
+    public void testNullToEmptyIntObjectEmptyArray() {
         final Integer[] empty = new Integer[]{};
         final Integer[] result = ArrayUtils.nullToEmpty(empty);
         assertArrayEquals(ArrayUtils.EMPTY_INTEGER_OBJECT_ARRAY, result);
@@ -658,12 +658,12 @@ public class ArrayUtilsTest {
     }
 
     @Test
-    public void testNullToEmptyShortObjectNull() throws Exception {
+    public void testNullToEmptyShortObjectNull() {
         assertArrayEquals(ArrayUtils.EMPTY_SHORT_OBJECT_ARRAY, ArrayUtils.nullToEmpty((Short[]) null));
     }
 
     @Test
-    public void testNullToEmptyShortObjectEmptyArray() throws Exception {
+    public void testNullToEmptyShortObjectEmptyArray() {
         final Short[] empty = new Short[]{};
         final Short[] result = ArrayUtils.nullToEmpty(empty);
         assertArrayEquals(ArrayUtils.EMPTY_SHORT_OBJECT_ARRAY, result);
@@ -677,12 +677,12 @@ public class ArrayUtilsTest {
     }
 
     @Test
-    public void testNUllToEmptyCharObjectNull() throws Exception {
+    public void testNUllToEmptyCharObjectNull() {
         assertArrayEquals(ArrayUtils.EMPTY_CHARACTER_OBJECT_ARRAY, ArrayUtils.nullToEmpty((Character[]) null));
     }
 
     @Test
-    public void testNullToEmptyCharObjectEmptyArray() throws Exception {
+    public void testNullToEmptyCharObjectEmptyArray() {
         final Character[] empty = new Character[]{};
         final Character[] result = ArrayUtils.nullToEmpty(empty);
         assertArrayEquals(ArrayUtils.EMPTY_CHARACTER_OBJECT_ARRAY, result);
@@ -696,12 +696,12 @@ public class ArrayUtilsTest {
     }
 
     @Test
-    public void testNullToEmptyByteObjectNull() throws Exception {
+    public void testNullToEmptyByteObjectNull() {
         assertArrayEquals(ArrayUtils.EMPTY_BYTE_OBJECT_ARRAY, ArrayUtils.nullToEmpty((Byte[]) null));
     }
 
     @Test
-    public void testNullToEmptyByteObjectEmptyArray() throws Exception {
+    public void testNullToEmptyByteObjectEmptyArray() {
         final Byte[] empty = new Byte[]{};
         final Byte[] result = ArrayUtils.nullToEmpty(empty);
         assertArrayEquals(ArrayUtils.EMPTY_BYTE_OBJECT_ARRAY, result);
@@ -715,12 +715,12 @@ public class ArrayUtilsTest {
     }
 
     @Test
-    public void testNullToEmptyDoubleObjectNull() throws Exception {
+    public void testNullToEmptyDoubleObjectNull() {
         assertArrayEquals(ArrayUtils.EMPTY_DOUBLE_OBJECT_ARRAY, ArrayUtils.nullToEmpty((Double[]) null));
     }
 
     @Test
-    public void testNullToEmptyDoubleObjectEmptyArray() throws Exception {
+    public void testNullToEmptyDoubleObjectEmptyArray() {
         final Double[] empty = new Double[]{};
         final Double[] result = ArrayUtils.nullToEmpty(empty);
         assertArrayEquals(ArrayUtils.EMPTY_DOUBLE_OBJECT_ARRAY, result);
@@ -734,12 +734,12 @@ public class ArrayUtilsTest {
     }
 
     @Test
-    public void testNullToEmptyFloatObjectNull() throws Exception {
+    public void testNullToEmptyFloatObjectNull() {
         assertArrayEquals(ArrayUtils.EMPTY_FLOAT_OBJECT_ARRAY, ArrayUtils.nullToEmpty((Float[]) null));
     }
 
     @Test
-    public void testNullToEmptyFloatObjectEmptyArray() throws Exception {
+    public void testNullToEmptyFloatObjectEmptyArray() {
         final Float[] empty = new Float[]{};
         final Float[] result = ArrayUtils.nullToEmpty(empty);
         assertArrayEquals(ArrayUtils.EMPTY_FLOAT_OBJECT_ARRAY, result);

--- a/src/test/java/org/apache/commons/lang3/BooleanUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/BooleanUtilsTest.java
@@ -1009,8 +1009,8 @@ public class BooleanUtilsTest {
     @Test
     public void testCompare(){
         assertTrue(BooleanUtils.compare(true, false) > 0);
-        assertTrue(BooleanUtils.compare(true, true) == 0);
-        assertTrue(BooleanUtils.compare(false, false) == 0);
+        assertEquals(0, BooleanUtils.compare(true, true));
+        assertEquals(0, BooleanUtils.compare(false, false));
         assertTrue(BooleanUtils.compare(false, true) < 0);
     }
 

--- a/src/test/java/org/apache/commons/lang3/CharEncodingTest.java
+++ b/src/test/java/org/apache/commons/lang3/CharEncodingTest.java
@@ -73,7 +73,7 @@ public class CharEncodingTest  {
     }
 
     @Test
-    public void testStandardCharsetsEquality() throws Exception {
+    public void testStandardCharsetsEquality() {
         assertEquals(StandardCharsets.ISO_8859_1.name(), CharEncoding.ISO_8859_1);
         assertEquals(StandardCharsets.US_ASCII.name(), CharEncoding.US_ASCII);
         assertEquals(StandardCharsets.UTF_8.name(), CharEncoding.UTF_8);

--- a/src/test/java/org/apache/commons/lang3/CharRangeTest.java
+++ b/src/test/java/org/apache/commons/lang3/CharRangeTest.java
@@ -20,6 +20,7 @@ package org.apache.commons.lang3;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -123,21 +124,21 @@ public class CharRangeTest  {
         final CharRange rangeae = CharRange.isIn('a', 'e');
         final CharRange rangenotbf = CharRange.isIn('b', 'f');
 
-        assertFalse(rangea.equals(null));
+        assertNotEquals(null, rangea);
 
-        assertTrue(rangea.equals(rangea));
-        assertTrue(rangea.equals(CharRange.is('a')));
-        assertTrue(rangeae.equals(rangeae));
-        assertTrue(rangeae.equals(CharRange.isIn('a', 'e')));
-        assertTrue(rangenotbf.equals(rangenotbf));
-        assertTrue(rangenotbf.equals(CharRange.isIn('b', 'f')));
+        assertEquals(rangea, rangea);
+        assertEquals(rangea, CharRange.is('a'));
+        assertEquals(rangeae, rangeae);
+        assertEquals(rangeae, CharRange.isIn('a', 'e'));
+        assertEquals(rangenotbf, rangenotbf);
+        assertEquals(rangenotbf, CharRange.isIn('b', 'f'));
 
-        assertFalse(rangea.equals(rangeae));
-        assertFalse(rangea.equals(rangenotbf));
-        assertFalse(rangeae.equals(rangea));
-        assertFalse(rangeae.equals(rangenotbf));
-        assertFalse(rangenotbf.equals(rangea));
-        assertFalse(rangenotbf.equals(rangeae));
+        assertNotEquals(rangea, rangeae);
+        assertNotEquals(rangea, rangenotbf);
+        assertNotEquals(rangeae, rangea);
+        assertNotEquals(rangeae, rangenotbf);
+        assertNotEquals(rangenotbf, rangea);
+        assertNotEquals(rangenotbf, rangeae);
     }
 
     @Test
@@ -146,12 +147,12 @@ public class CharRangeTest  {
         final CharRange rangeae = CharRange.isIn('a', 'e');
         final CharRange rangenotbf = CharRange.isIn('b', 'f');
 
-        assertTrue(rangea.hashCode() == rangea.hashCode());
-        assertTrue(rangea.hashCode() == CharRange.is('a').hashCode());
-        assertTrue(rangeae.hashCode() == rangeae.hashCode());
-        assertTrue(rangeae.hashCode() == CharRange.isIn('a', 'e').hashCode());
-        assertTrue(rangenotbf.hashCode() == rangenotbf.hashCode());
-        assertTrue(rangenotbf.hashCode() == CharRange.isIn('b', 'f').hashCode());
+        assertEquals(rangea.hashCode(), rangea.hashCode());
+        assertEquals(rangea.hashCode(), CharRange.is('a').hashCode());
+        assertEquals(rangeae.hashCode(), rangeae.hashCode());
+        assertEquals(rangeae.hashCode(), CharRange.isIn('a', 'e').hashCode());
+        assertEquals(rangenotbf.hashCode(), rangenotbf.hashCode());
+        assertEquals(rangenotbf.hashCode(), CharRange.isIn('b', 'f').hashCode());
 
         assertFalse(rangea.hashCode() == rangeae.hashCode());
         assertFalse(rangea.hashCode() == rangenotbf.hashCode());

--- a/src/test/java/org/apache/commons/lang3/CharRangeTest.java
+++ b/src/test/java/org/apache/commons/lang3/CharRangeTest.java
@@ -23,7 +23,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.lang.reflect.Modifier;
 import java.util.Iterator;
@@ -311,13 +310,8 @@ public class CharRangeTest  {
     @Test
     public void testContainsNullArg() {
         final CharRange range = CharRange.is('a');
-        try {
-            @SuppressWarnings("unused")
-            final
-            boolean contains = range.contains(null);
-        } catch(final IllegalArgumentException e) {
-            assertEquals("The Range must not be null", e.getMessage());
-        }
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> range.contains(null));
+        assertEquals("The Range must not be null", e.getMessage());
     }
 
     @Test
@@ -355,36 +349,21 @@ public class CharRangeTest  {
         final Iterator<Character> emptySetIt = emptySet.iterator();
         assertNotNull(emptySetIt);
         assertFalse(emptySetIt.hasNext());
-        try {
-            emptySetIt.next();
-            fail("Should throw NoSuchElementException");
-        } catch (final NoSuchElementException e) {
-            assertTrue(true);
-        }
+        assertThrows(NoSuchElementException.class, emptySetIt::next);
 
         final Iterator<Character> notFirstIt = notFirst.iterator();
         assertNotNull(notFirstIt);
         assertTrue(notFirstIt.hasNext());
         assertEquals(Character.valueOf((char) 0), notFirstIt.next());
         assertFalse(notFirstIt.hasNext());
-        try {
-            notFirstIt.next();
-            fail("Should throw NoSuchElementException");
-        } catch (final NoSuchElementException e) {
-            assertTrue(true);
-        }
+        assertThrows(NoSuchElementException.class, notFirstIt::next);
 
         final Iterator<Character> notLastIt = notLast.iterator();
         assertNotNull(notLastIt);
         assertTrue(notLastIt.hasNext());
         assertEquals(Character.valueOf(Character.MAX_VALUE), notLastIt.next());
         assertFalse(notLastIt.hasNext());
-        try {
-            notLastIt.next();
-            fail("Should throw NoSuchElementException");
-        } catch (final NoSuchElementException e) {
-            assertTrue(true);
-        }
+        assertThrows(NoSuchElementException.class, notLastIt::next);
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/apache/commons/lang3/CharSequenceUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/CharSequenceUtilsTest.java
@@ -179,7 +179,7 @@ public class CharSequenceUtilsTest {
 
 
     @Test
-    public void testToCharArray() throws Exception {
+    public void testToCharArray() {
         final StringBuilder builder = new StringBuilder("abcdefg");
         final char[] expected = builder.toString().toCharArray();
         assertArrayEquals(expected, CharSequenceUtils.toCharArray(builder));

--- a/src/test/java/org/apache/commons/lang3/CharSequenceUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/CharSequenceUtilsTest.java
@@ -23,7 +23,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
@@ -83,7 +82,7 @@ public class CharSequenceUtilsTest {
         final int ooffset;
         final int len;
         final boolean expected;
-        final Class<?> throwable;
+        final Class<? extends Throwable> throwable;
         TestData(final String source, final boolean ignoreCase, final int toffset,
                 final String other, final int ooffset, final int len, final boolean expected){
             this.source = source;
@@ -96,7 +95,7 @@ public class CharSequenceUtilsTest {
             this.throwable = null;
         }
         TestData(final String source, final boolean ignoreCase, final int toffset,
-                final String other, final int ooffset, final int len, final Class<?> throwable){
+                final String other, final int ooffset, final int len, final Class<? extends Throwable> throwable){
             this.source = source;
             this.ignoreCase = ignoreCase;
             this.toffset = toffset;
@@ -145,14 +144,7 @@ public class CharSequenceUtilsTest {
 
         void run(final TestData data, final String id) {
             if (data.throwable != null) {
-                try {
-                    invoke();
-                    fail(id + " Expected " + data.throwable);
-                } catch (final Exception e) {
-                    if (!e.getClass().equals(data.throwable)) {
-                        fail(id + " Expected " + data.throwable + " got " + e.getClass());
-                    }
-                }
+                assertThrows(data.throwable, this::invoke, id + " Expected " + data.throwable);
             } else {
                 final boolean stringCheck = invoke();
                 assertEquals(data.expected, stringCheck, id + " Failed test " + data);

--- a/src/test/java/org/apache/commons/lang3/CharSetTest.java
+++ b/src/test/java/org/apache/commons/lang3/CharSetTest.java
@@ -466,7 +466,7 @@ public class CharSetTest  {
     }
 
     @Test
-    public void testJavadocExamples() throws Exception {
+    public void testJavadocExamples() {
         assertFalse(CharSet.getInstance("^a-c").contains('a'));
         assertTrue(CharSet.getInstance("^a-c").contains('d'));
         assertTrue(CharSet.getInstance("^^a-c").contains('a'));

--- a/src/test/java/org/apache/commons/lang3/CharSetTest.java
+++ b/src/test/java/org/apache/commons/lang3/CharSetTest.java
@@ -20,6 +20,7 @@ package org.apache.commons.lang3;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -349,22 +350,22 @@ public class CharSetTest  {
         final CharSet notatoc = CharSet.getInstance("^a-c");
         final CharSet notatoc2 = CharSet.getInstance("^a-c");
 
-        assertFalse(abc.equals(null));
+        assertNotEquals(null, abc);
 
-        assertTrue(abc.equals(abc));
-        assertTrue(abc.equals(abc2));
-        assertFalse(abc.equals(atoc));
-        assertFalse(abc.equals(notatoc));
+        assertEquals(abc, abc);
+        assertEquals(abc, abc2);
+        assertNotEquals(abc, atoc);
+        assertNotEquals(abc, notatoc);
 
-        assertFalse(atoc.equals(abc));
-        assertTrue(atoc.equals(atoc));
-        assertTrue(atoc.equals(atoc2));
-        assertFalse(atoc.equals(notatoc));
+        assertNotEquals(atoc, abc);
+        assertEquals(atoc, atoc);
+        assertEquals(atoc, atoc2);
+        assertNotEquals(atoc, notatoc);
 
-        assertFalse(notatoc.equals(abc));
-        assertFalse(notatoc.equals(atoc));
-        assertTrue(notatoc.equals(notatoc));
-        assertTrue(notatoc.equals(notatoc2));
+        assertNotEquals(notatoc, abc);
+        assertNotEquals(notatoc, atoc);
+        assertEquals(notatoc, notatoc);
+        assertEquals(notatoc, notatoc2);
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/CharUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/CharUtilsTest.java
@@ -21,8 +21,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
@@ -199,10 +199,7 @@ public class CharUtilsTest {
     public void testToChar_Character() {
         assertEquals('A', CharUtils.toChar(CHARACTER_A));
         assertEquals('B', CharUtils.toChar(CHARACTER_B));
-        try {
-            CharUtils.toChar((Character) null);
-            fail("An IllegalArgumentException should have been thrown");
-        } catch (final IllegalArgumentException ex) {}
+        assertThrows(IllegalArgumentException.class, () -> CharUtils.toChar((Character) null));
     }
 
     @Test
@@ -216,14 +213,8 @@ public class CharUtilsTest {
     public void testToChar_String() {
         assertEquals('A', CharUtils.toChar("A"));
         assertEquals('B', CharUtils.toChar("BA"));
-        try {
-            CharUtils.toChar((String) null);
-            fail("An IllegalArgumentException should have been thrown");
-        } catch (final IllegalArgumentException ex) {}
-        try {
-            CharUtils.toChar("");
-            fail("An IllegalArgumentException should have been thrown");
-        } catch (final IllegalArgumentException ex) {}
+        assertThrows(IllegalArgumentException.class, () -> CharUtils.toChar((String) null));
+        assertThrows(IllegalArgumentException.class, () -> CharUtils.toChar(""));
     }
 
     @Test
@@ -278,10 +269,7 @@ public class CharUtilsTest {
         assertEquals(7, CharUtils.toIntValue('7'));
         assertEquals(8, CharUtils.toIntValue('8'));
         assertEquals(9, CharUtils.toIntValue('9'));
-        try {
-            CharUtils.toIntValue('a');
-            fail("An IllegalArgumentException should have been thrown");
-        } catch (final IllegalArgumentException ex) {}
+        assertThrows(IllegalArgumentException.class, () -> CharUtils.toIntValue('a'));
     }
 
     @Test
@@ -295,14 +283,8 @@ public class CharUtilsTest {
     public void testToIntValue_Character() {
         assertEquals(0, CharUtils.toIntValue(new Character('0')));
         assertEquals(3, CharUtils.toIntValue(new Character('3')));
-        try {
-            CharUtils.toIntValue(null);
-            fail("An IllegalArgumentException should have been thrown");
-        } catch (final IllegalArgumentException ex) {}
-        try {
-            CharUtils.toIntValue(CHARACTER_A);
-            fail("An IllegalArgumentException should have been thrown");
-        } catch (final IllegalArgumentException ex) {}
+        assertThrows(IllegalArgumentException.class, () -> CharUtils.toIntValue(null));
+        assertThrows(IllegalArgumentException.class, () -> CharUtils.toIntValue(CHARACTER_A));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/CharUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/CharUtilsTest.java
@@ -19,6 +19,7 @@ package org.apache.commons.lang3;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -41,7 +42,7 @@ public class CharUtilsTest {
     @Test
     public void testCompare() {
         assertTrue(CharUtils.compare('a', 'b') < 0);
-        assertTrue(CharUtils.compare('c', 'c') == 0);
+        assertEquals(0, CharUtils.compare('c', 'c'));
         assertTrue(CharUtils.compare('c', 'a') > 0);
     }
 
@@ -241,7 +242,7 @@ public class CharUtilsTest {
             final Character ch = CharUtils.toCharacterObject((char) i);
             final Character ch2 = CharUtils.toCharacterObject((char) i);
             assertEquals(ch, ch2);
-            assertTrue(ch != ch2);
+            assertNotSame(ch, ch2);
             assertEquals(i, ch.charValue());
             assertEquals(i, ch2.charValue());
         }
@@ -311,7 +312,7 @@ public class CharUtilsTest {
             final String str = CharUtils.toString((char) i);
             final String str2 = CharUtils.toString((char) i);
             assertEquals(str, str2);
-            assertTrue(str != str2);
+            assertNotSame(str, str2);
             assertEquals(1, str.length());
             assertEquals(i, str.charAt(0));
             assertEquals(1, str2.length());

--- a/src/test/java/org/apache/commons/lang3/ClassPathUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/ClassPathUtilsTest.java
@@ -53,7 +53,7 @@ public class ClassPathUtilsTest {
     }
 
     @Test
-    public void testToFullyQualifiedNameClassString() throws Exception {
+    public void testToFullyQualifiedNameClassString() {
         final String expected = "org.apache.commons.lang3.Test.properties";
         final String actual = ClassPathUtils.toFullyQualifiedName(ClassPathUtils.class, "Test.properties");
 
@@ -73,7 +73,7 @@ public class ClassPathUtilsTest {
     }
 
     @Test
-    public void testToFullyQualifiedNamePackageString() throws Exception {
+    public void testToFullyQualifiedNamePackageString() {
         final String expected = "org.apache.commons.lang3.Test.properties";
         final String actual = ClassPathUtils.toFullyQualifiedName(ClassPathUtils.class.getPackage(), "Test.properties");
 
@@ -92,7 +92,7 @@ public class ClassPathUtilsTest {
     }
 
     @Test
-    public void testToFullyQualifiedPathClass() throws Exception {
+    public void testToFullyQualifiedPathClass() {
         final String expected = "org/apache/commons/lang3/Test.properties";
         final String actual = ClassPathUtils.toFullyQualifiedPath(ClassPathUtils.class, "Test.properties");
 
@@ -112,7 +112,7 @@ public class ClassPathUtilsTest {
     }
 
     @Test
-    public void testToFullyQualifiedPathPackage() throws Exception {
+    public void testToFullyQualifiedPathPackage() {
         final String expected = "org/apache/commons/lang3/Test.properties";
         final String actual = ClassPathUtils.toFullyQualifiedPath(ClassPathUtils.class.getPackage(), "Test.properties");
 

--- a/src/test/java/org/apache/commons/lang3/ClassUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/ClassUtilsTest.java
@@ -663,7 +663,7 @@ public class ClassUtilsTest  {
         assertEquals("Inner", ClassUtils.getSimpleName(new Inner(), "<null>"));
         assertEquals("String", ClassUtils.getSimpleName("hello", "<null>"));
         assertEquals("<null>", ClassUtils.getSimpleName(null, "<null>"));
-        assertEquals(null, ClassUtils.getSimpleName(null, null));
+        assertNull(ClassUtils.getSimpleName(null, null));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/ClassUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/ClassUtilsTest.java
@@ -25,7 +25,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
@@ -97,13 +96,10 @@ public class ClassUtilsTest  {
         assertGetClassThrowsException( className, ClassNotFoundException.class );
     }
 
-    private void assertGetClassThrowsException( final String className, final Class<?> exceptionType ) throws Exception {
-        try {
-            ClassUtils.getClass( className );
-            fail( "ClassUtils.getClass() should fail with an exception of type " + exceptionType.getName() + " when given class name \"" + className + "\"." );
-        } catch( final Exception e ) {
-            assertTrue( exceptionType.isAssignableFrom( e.getClass() ) );
-        }
+    private void assertGetClassThrowsException(final String className, final Class<? extends Exception> exceptionType) {
+        assertThrows(exceptionType,
+                () -> ClassUtils.getClass(className),
+                "ClassUtils.getClass() should fail with an exception of type " + exceptionType.getName() + " when given class name \"" + className + "\"." );
     }
 
     private void assertGetClassThrowsNullPointerException( final String className ) throws Exception {
@@ -128,12 +124,9 @@ public class ClassUtilsTest  {
         @SuppressWarnings("unchecked") // test what happens when non-generic code adds wrong type of element
         final List<Object> olist = (List<Object>) (List<?>) list;
         olist.add(new Object());
-        try {
-            ClassUtils.convertClassesToClassNames(list);
-            fail("Should not have been able to convert list");
-        } catch (final ClassCastException expected) {
-            // empty
-    }
+        assertThrows(ClassCastException.class,
+                () -> ClassUtils.convertClassesToClassNames(list),
+                "Should not have been able to convert list");
         assertNull(ClassUtils.convertClassesToClassNames(null));
     }
 
@@ -156,12 +149,9 @@ public class ClassUtilsTest  {
         @SuppressWarnings("unchecked") // test what happens when non-generic code adds wrong type of element
         final List<Object> olist = (List<Object>) (List<?>) list;
         olist.add(new Object());
-        try {
-            ClassUtils.convertClassNamesToClasses(list);
-            fail("Should not have been able to convert list");
-        } catch (final ClassCastException expected) {
-            // empty
-        }
+        assertThrows(ClassCastException.class,
+                () -> ClassUtils.convertClassNamesToClasses(list),
+                "Should not have been able to convert list");
         assertNull(ClassUtils.convertClassNamesToClasses(null));
     }
 
@@ -1208,17 +1198,12 @@ public class ClassUtilsTest  {
         // Tests with Collections$UnmodifiableSet
         final Set<?> set = Collections.unmodifiableSet(new HashSet<>());
         final Method isEmptyMethod = ClassUtils.getPublicMethod(set.getClass(), "isEmpty");
-            assertTrue(Modifier.isPublic(isEmptyMethod.getDeclaringClass().getModifiers()));
-
-        try {
-            isEmptyMethod.invoke(set);
-        } catch(final java.lang.IllegalAccessException iae) {
-            fail("Should not have thrown IllegalAccessException");
-        }
+        assertTrue(Modifier.isPublic(isEmptyMethod.getDeclaringClass().getModifiers()));
+        assertTrue((Boolean) isEmptyMethod.invoke(set));
 
         // Tests with a public Class
         final Method toStringMethod = ClassUtils.getPublicMethod(Object.class, "toString");
-            assertEquals(Object.class.getMethod("toString", new Class[0]), toStringMethod);
+        assertEquals(Object.class.getMethod("toString", new Class[0]), toStringMethod);
     }
 
     @Test
@@ -1370,12 +1355,7 @@ public class ClassUtilsTest  {
         // Tests with Collections$UnmodifiableSet
         final Set<?> set = Collections.unmodifiableSet(new HashSet<>());
         final Method isEmptyMethod = set.getClass().getMethod("isEmpty");
-        try {
-            isEmptyMethod.invoke(set);
-            fail("Failed to throw IllegalAccessException as expected");
-        } catch(final IllegalAccessException iae) {
-            // expected
-        }
+        assertThrows(IllegalAccessException.class, () -> isEmptyMethod.invoke(set));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/ClassUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/ClassUtilsTest.java
@@ -92,7 +92,7 @@ public class ClassUtilsTest  {
         assertEquals( c, ClassUtils.getClass( c.getName() ) );
     }
 
-    private void assertGetClassThrowsClassNotFound( final String className ) throws Exception {
+    private void assertGetClassThrowsClassNotFound( final String className ) {
         assertGetClassThrowsException( className, ClassNotFoundException.class );
     }
 
@@ -102,7 +102,7 @@ public class ClassUtilsTest  {
                 "ClassUtils.getClass() should fail with an exception of type " + exceptionType.getName() + " when given class name \"" + className + "\"." );
     }
 
-    private void assertGetClassThrowsNullPointerException( final String className ) throws Exception {
+    private void assertGetClassThrowsNullPointerException( final String className ) {
         assertGetClassThrowsException( className, NullPointerException.class );
     }
 
@@ -667,7 +667,7 @@ public class ClassUtilsTest  {
     }
 
     @Test
-    public void test_isAssignable() throws Exception {
+    public void test_isAssignable() {
         assertFalse(ClassUtils.isAssignable((Class<?>) null, null));
         assertFalse(ClassUtils.isAssignable(String.class, null));
 
@@ -693,7 +693,7 @@ public class ClassUtilsTest  {
     }
 
     @Test
-    public void test_isAssignable_Autoboxing() throws Exception {
+    public void test_isAssignable_Autoboxing() {
         assertFalse(ClassUtils.isAssignable((Class<?>) null, null, true));
         assertFalse(ClassUtils.isAssignable(String.class, null, true));
 
@@ -718,7 +718,7 @@ public class ClassUtilsTest  {
 
     // -------------------------------------------------------------------------
     @Test
-    public void test_isAssignable_ClassArray_ClassArray() throws Exception {
+    public void test_isAssignable_ClassArray_ClassArray() {
         final Class<?>[] array2 = new Class[] {Object.class, Object.class};
         final Class<?>[] array1 = new Class[] {Object.class};
         final Class<?>[] array1s = new Class[] {String.class};
@@ -746,7 +746,7 @@ public class ClassUtilsTest  {
     }
 
     @Test
-    public void test_isAssignable_ClassArray_ClassArray_Autoboxing() throws Exception {
+    public void test_isAssignable_ClassArray_ClassArray_Autoboxing() {
         final Class<?>[] array2 = new Class[] {Object.class, Object.class};
         final Class<?>[] array1 = new Class[] {Object.class};
         final Class<?>[] array1s = new Class[] {String.class};
@@ -774,7 +774,7 @@ public class ClassUtilsTest  {
     }
 
     @Test
-    public void test_isAssignable_ClassArray_ClassArray_NoAutoboxing() throws Exception {
+    public void test_isAssignable_ClassArray_ClassArray_NoAutoboxing() {
         final Class<?>[] array2 = new Class[] {Object.class, Object.class};
         final Class<?>[] array1 = new Class[] {Object.class};
         final Class<?>[] array1s = new Class[] {String.class};
@@ -802,7 +802,7 @@ public class ClassUtilsTest  {
     }
 
     @Test
-    public void test_isAssignable_DefaultUnboxing_Widening() throws Exception {
+    public void test_isAssignable_DefaultUnboxing_Widening() {
         // test byte conversions
         assertFalse(ClassUtils.isAssignable(Byte.class, Character.TYPE), "byte -> char");
         assertTrue(ClassUtils.isAssignable(Byte.class, Byte.TYPE), "byte -> byte");
@@ -885,7 +885,7 @@ public class ClassUtilsTest  {
     }
 
     @Test
-    public void test_isAssignable_NoAutoboxing() throws Exception {
+    public void test_isAssignable_NoAutoboxing() {
         assertFalse(ClassUtils.isAssignable((Class<?>) null, null, false));
         assertFalse(ClassUtils.isAssignable(String.class, null, false));
 
@@ -909,7 +909,7 @@ public class ClassUtilsTest  {
     }
 
     @Test
-    public void test_isAssignable_Unboxing_Widening() throws Exception {
+    public void test_isAssignable_Unboxing_Widening() {
         // test byte conversions
         assertFalse(ClassUtils.isAssignable(Byte.class, Character.TYPE, true), "byte -> char");
         assertTrue(ClassUtils.isAssignable(Byte.class, Byte.TYPE, true), "byte -> byte");
@@ -992,7 +992,7 @@ public class ClassUtilsTest  {
     }
 
     @Test
-    public void test_isAssignable_Widening() throws Exception {
+    public void test_isAssignable_Widening() {
         // test byte conversions
         assertFalse(ClassUtils.isAssignable(Byte.TYPE, Character.TYPE), "byte -> char");
         assertTrue(ClassUtils.isAssignable(Byte.TYPE, Byte.TYPE), "byte -> byte");

--- a/src/test/java/org/apache/commons/lang3/ConversionTest.java
+++ b/src/test/java/org/apache/commons/lang3/ConversionTest.java
@@ -105,49 +105,49 @@ public class ConversionTest {
      */
     @Test
     public void testHexDigitToBinary() {
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{false, false, false, false}, Conversion.hexDigitToBinary('0'));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{true, false, false, false}, Conversion.hexDigitToBinary('1'));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{false, true, false, false}, Conversion.hexDigitToBinary('2'));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{true, true, false, false}, Conversion.hexDigitToBinary('3'));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{false, false, true, false}, Conversion.hexDigitToBinary('4'));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{true, false, true, false}, Conversion.hexDigitToBinary('5'));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{false, true, true, false}, Conversion.hexDigitToBinary('6'));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{true, true, true, false}, Conversion.hexDigitToBinary('7'));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{false, false, false, true}, Conversion.hexDigitToBinary('8'));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{true, false, false, true}, Conversion.hexDigitToBinary('9'));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{false, true, false, true}, Conversion.hexDigitToBinary('A'));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{false, true, false, true}, Conversion.hexDigitToBinary('a'));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{true, true, false, true}, Conversion.hexDigitToBinary('B'));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{true, true, false, true}, Conversion.hexDigitToBinary('b'));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{false, false, true, true}, Conversion.hexDigitToBinary('C'));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{false, false, true, true}, Conversion.hexDigitToBinary('c'));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{true, false, true, true}, Conversion.hexDigitToBinary('D'));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{true, false, true, true}, Conversion.hexDigitToBinary('d'));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{false, true, true, true}, Conversion.hexDigitToBinary('E'));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{false, true, true, true}, Conversion.hexDigitToBinary('e'));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{true, true, true, true}, Conversion.hexDigitToBinary('F'));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{true, true, true, true}, Conversion.hexDigitToBinary('f'));
         try {
             Conversion.hexDigitToBinary('G');
@@ -162,49 +162,49 @@ public class ConversionTest {
      */
     @Test
     public void testHexDigitMsb0ToBinary() {
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{false, false, false, false}, Conversion.hexDigitMsb0ToBinary('0'));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{false, false, false, true}, Conversion.hexDigitMsb0ToBinary('1'));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{false, false, true, false}, Conversion.hexDigitMsb0ToBinary('2'));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{false, false, true, true}, Conversion.hexDigitMsb0ToBinary('3'));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{false, true, false, false}, Conversion.hexDigitMsb0ToBinary('4'));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{false, true, false, true}, Conversion.hexDigitMsb0ToBinary('5'));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{false, true, true, false}, Conversion.hexDigitMsb0ToBinary('6'));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{false, true, true, true}, Conversion.hexDigitMsb0ToBinary('7'));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{true, false, false, false}, Conversion.hexDigitMsb0ToBinary('8'));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{true, false, false, true}, Conversion.hexDigitMsb0ToBinary('9'));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{true, false, true, false}, Conversion.hexDigitMsb0ToBinary('A'));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{true, false, true, false}, Conversion.hexDigitMsb0ToBinary('a'));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{true, false, true, true}, Conversion.hexDigitMsb0ToBinary('B'));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{true, false, true, true}, Conversion.hexDigitMsb0ToBinary('b'));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{true, true, false, false}, Conversion.hexDigitMsb0ToBinary('C'));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{true, true, false, false}, Conversion.hexDigitMsb0ToBinary('c'));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{true, true, false, true}, Conversion.hexDigitMsb0ToBinary('D'));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{true, true, false, true}, Conversion.hexDigitMsb0ToBinary('d'));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{true, true, true, false}, Conversion.hexDigitMsb0ToBinary('E'));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{true, true, true, false}, Conversion.hexDigitMsb0ToBinary('e'));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{true, true, true, true}, Conversion.hexDigitMsb0ToBinary('F'));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{true, true, true, true}, Conversion.hexDigitMsb0ToBinary('f'));
         try {
             Conversion.hexDigitMsb0ToBinary('G');
@@ -517,24 +517,6 @@ public class ConversionTest {
         }
         final String out = sb.toString();
         return out.substring(0, out.length() - 1);
-    }
-
-    // org.junit.jupiter.api.Assertions(boolean[], boolean[]) does not exist in JUnit 4.2
-    static void assertBinaryEquals(final boolean[] expected, final boolean[] actual) {
-        assertEquals(expected.length, actual.length);
-        for (int i = 0; i < expected.length; i++ ) {
-            try {
-                assertEquals(expected[i], actual[i]);
-            } catch (final Throwable e) {
-                final String msg = "Mismatch at index "
-                    + i
-                    + " between:\n"
-                    + dbgPrint(expected)
-                    + " and\n"
-                    + dbgPrint(actual);
-                fail(msg + "\n" + e.getMessage());
-            }
-        }
     }
 
     /**
@@ -1451,20 +1433,20 @@ public class ConversionTest {
      */
     @Test
     public void testLongToBinary() {
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{},
             Conversion.longToBinary(0x0000000000000000L, 0, new boolean[]{}, 0, 0));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{},
             Conversion.longToBinary(0x0000000000000000L, 100, new boolean[]{}, 0, 0));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{},
             Conversion.longToBinary(0x0000000000000000L, 0, new boolean[]{}, 100, 0));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[69],
             Conversion.longToBinary(0x1234567890ABCDEFL, 0, new boolean[69], 0, 0));
 
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{
                 true, false, false, false, false, false, false, false, false, false, false,
                 false, false, false, false, false, false, false, false, false, false, false,
@@ -1474,7 +1456,7 @@ public class ConversionTest {
                 false, false, false, false, false, false, false, false, false, false, false,
                 false, false, false},
             Conversion.longToBinary(0x1234567890ABCDEFL, 0, new boolean[69], 0, 1));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{
                 true, true, false, false, false, false, false, false, false, false, false,
                 false, false, false, false, false, false, false, false, false, false, false,
@@ -1484,7 +1466,7 @@ public class ConversionTest {
                 false, false, false, false, false, false, false, false, false, false, false,
                 false, false, false},
             Conversion.longToBinary(0x1234567890ABCDEFL, 0, new boolean[69], 0, 2));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{
                 true, true, true, false, false, false, false, false, false, false, false,
                 false, false, false, false, false, false, false, false, false, false, false,
@@ -1494,7 +1476,7 @@ public class ConversionTest {
                 false, false, false, false, false, false, false, false, false, false, false,
                 false, false, false},
             Conversion.longToBinary(0x1234567890ABCDEFL, 0, new boolean[69], 0, 3));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{
                 true, true, true, true, false, true, true, true, true, false, true, true,
                 false, false, true, true, true, true, false, true, false, true, false, true,
@@ -1503,7 +1485,7 @@ public class ConversionTest {
                 false, false, false, true, false, true, true, false, false, false, true, false,
                 false, true, false, false, false, false, false, false, false, false},
             Conversion.longToBinary(0x1234567890ABCDEFL, 0, new boolean[69], 0, 63));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{
                 true, true, true, true, false, true, true, true, true, false, true, true,
                 false, false, true, true, true, true, false, true, false, true, false, true,
@@ -1512,7 +1494,7 @@ public class ConversionTest {
                 false, false, false, true, false, true, true, false, false, false, true, false,
                 false, true, false, false, false, false, false, false, false, false},
             Conversion.longToBinary(0x1234567890ABCDEFL, 0, new boolean[69], 0, 64));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{
                 false, false, true, false, false, false, false, false, false, false, false,
                 false, false, false, false, false, false, false, false, false, false, false,
@@ -1522,7 +1504,7 @@ public class ConversionTest {
                 false, false, false, false, false, false, false, false, false, false, false,
                 false, false, false},
             Conversion.longToBinary(0x1234567890ABCDEFL, 0, new boolean[69], 2, 1));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{
                 false, false, true, true, true, true, false, true, true, true, true, false,
                 true, true, false, false, true, true, true, true, false, true, false, true,
@@ -1531,7 +1513,7 @@ public class ConversionTest {
                 false, true, false, false, false, true, false, true, true, false, false, false,
                 true, false, false, true, false, false, false, false, false, false},
             Conversion.longToBinary(0x1234567890ABCDEFL, 0, new boolean[69], 2, 64));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{
                 true, true, true, false, true, true, true, true, false, true, true, false,
                 false, true, true, true, true, false, true, false, true, false, true, false,
@@ -1540,7 +1522,7 @@ public class ConversionTest {
                 false, true, false, true, true, false, false, false, true, false, false, true,
                 false, false, false, false, false, false, false, false, false},
             Conversion.longToBinary(0x1234567890ABCDEFL, 1, new boolean[69], 0, 63));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{
                 true, true, false, true, true, true, true, false, true, true, false, false,
                 true, true, true, true, false, true, false, true, false, true, false, false,
@@ -1550,7 +1532,7 @@ public class ConversionTest {
                 false, false, false, false, false, false, false, false, false},
             Conversion.longToBinary(0x1234567890ABCDEFL, 2, new boolean[69], 0, 62));
 
-        // assertBinaryEquals(new boolean[]{false,false,false, true, true, false, true, true,
+        // assertArrayEquals(new boolean[]{false,false,false, true, true, false, true, true,
         // true, true, false, true, true, false, false, true, true, true, true, false, true,
         // false, true, false, true, false, false, false, false, true, false, false, true,
         // false, false, false, true, true, true, true, false, false, true, true, false, true,
@@ -1558,7 +1540,7 @@ public class ConversionTest {
         // false, false, true, false, false, false
         // ,false,false,false,false},Conversion.longToBinary(0x1234567890ABCDEFL, 2,new
         // boolean[69], 3, 63));//rejected by assertion
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{
                 false, false, false, true, true, false, true, true, true, true, false, true,
                 true, false, false, true, true, true, true, false, true, false, true, false,
@@ -1574,71 +1556,71 @@ public class ConversionTest {
      */
     @Test
     public void testIntToBinary() {
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{}, Conversion.intToBinary(0x00000000, 0, new boolean[]{}, 0, 0));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{}, Conversion.intToBinary(0x00000000, 100, new boolean[]{}, 0, 0));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{}, Conversion.intToBinary(0x00000000, 0, new boolean[]{}, 100, 0));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[69], Conversion.intToBinary(0x90ABCDEF, 0, new boolean[69], 0, 0));
-        assertBinaryEquals(new boolean[]{
+        assertArrayEquals(new boolean[]{
             true, false, false, false, false, false, false, false, false, false, false, false,
             false, false, false, false, false, false, false, false, false, false, false, false,
             false, false, false, false, false, false, false, false, false, false, false, false,
             false}, Conversion.intToBinary(0x90ABCDEF, 0, new boolean[37], 0, 1));
-        assertBinaryEquals(new boolean[]{
+        assertArrayEquals(new boolean[]{
             true, true, false, false, false, false, false, false, false, false, false, false,
             false, false, false, false, false, false, false, false, false, false, false, false,
             false, false, false, false, false, false, false, false, false, false, false, false,
             false}, Conversion.intToBinary(0x90ABCDEF, 0, new boolean[37], 0, 2));
-        assertBinaryEquals(new boolean[]{
+        assertArrayEquals(new boolean[]{
             true, true, true, false, false, false, false, false, false, false, false, false,
             false, false, false, false, false, false, false, false, false, false, false, false,
             false, false, false, false, false, false, false, false, false, false, false, false,
             false}, Conversion.intToBinary(0x90ABCDEF, 0, new boolean[37], 0, 3));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{
                 true, true, true, true, false, true, true, true, true, false, true, true,
                 false, false, true, true, true, true, false, true, false, true, false, true,
                 false, false, false, false, true, false, false, false, false, false, false,
                 false, false}, Conversion.intToBinary(0x90ABCDEF, 0, new boolean[37], 0, 31));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{
                 true, true, true, true, false, true, true, true, true, false, true, true,
                 false, false, true, true, true, true, false, true, false, true, false, true,
                 false, false, false, false, true, false, false, true, false, false, false,
                 false, false}, Conversion.intToBinary(0x90ABCDEF, 0, new boolean[37], 0, 32));
-        assertBinaryEquals(new boolean[]{
+        assertArrayEquals(new boolean[]{
             false, false, true, false, false, false, false, false, false, false, false, false,
             false, false, false, false, false, false, false, false, false, false, false, false,
             false, false, false, false, false, false, false, false, false, false, false, false,
             false}, Conversion.intToBinary(0x90ABCDEF, 0, new boolean[37], 2, 1));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{
                 false, false, true, true, true, true, false, true, true, true, true, false,
                 true, true, false, false, true, true, true, true, false, true, false, true,
                 false, true, false, false, false, false, true, false, false, true, false,
                 false, false}, Conversion.intToBinary(0x90ABCDEF, 0, new boolean[37], 2, 32));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{
                 true, true, true, false, true, true, true, true, false, true, true, false,
                 false, true, true, true, true, false, true, false, true, false, true, false,
                 false, false, false, true, false, false, true, false, false, false, false,
                 false, false}, Conversion.intToBinary(0x90ABCDEF, 1, new boolean[37], 0, 31));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{
                 true, true, false, true, true, true, true, false, true, true, false, false,
                 true, true, true, true, false, true, false, true, false, true, false, false,
                 false, false, true, false, false, true, false, false, false, false, false,
                 false, false}, Conversion.intToBinary(0x90ABCDEF, 2, new boolean[37], 0, 30));
-        // assertBinaryEquals(new boolean[]{false, false, false, true, true, false, true,
+        // assertArrayEquals(new boolean[]{false, false, false, true, true, false, true,
         // true,
         // true, true, false, true, true, false, false, true, true, true, true, false, true,
         // false, true, false, true, false, false, false, false, true, false, false, false,
         // false, false, false, false},Conversion.intToBinary(0x90ABCDEF, 2,new boolean[37],
         // 3,31));//rejected by assertion
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{
                 false, false, false, true, true, false, true, true, true, true, false, true,
                 true, false, false, true, true, true, true, false, true, false, true, false,
@@ -1651,57 +1633,57 @@ public class ConversionTest {
      */
     @Test
     public void testShortToBinary() {
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{}, Conversion.shortToBinary((short)0x0000, 0, new boolean[]{}, 0, 0));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{},
             Conversion.shortToBinary((short)0x0000, 100, new boolean[]{}, 0, 0));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{},
             Conversion.shortToBinary((short)0x0000, 0, new boolean[]{}, 100, 0));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[69], Conversion.shortToBinary((short)0xCDEF, 0, new boolean[69], 0, 0));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{
                 true, false, false, false, false, false, false, false, false, false, false,
                 false, false, false, false, false, false, false, false, false, false},
             Conversion.shortToBinary((short)0xCDEF, 0, new boolean[21], 0, 1));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{
                 true, true, false, false, false, false, false, false, false, false, false,
                 false, false, false, false, false, false, false, false, false, false},
             Conversion.shortToBinary((short)0xCDEF, 0, new boolean[21], 0, 2));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{
                 true, true, true, false, false, false, false, false, false, false, false,
                 false, false, false, false, false, false, false, false, false, false},
             Conversion.shortToBinary((short)0xCDEF, 0, new boolean[21], 0, 3));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{
                 true, true, true, true, false, true, true, true, true, false, true, true,
                 false, false, true, false, false, false, false, false, false},
             Conversion.shortToBinary((short)0xCDEF, 0, new boolean[21], 0, 15));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{
                 true, true, true, true, false, true, true, true, true, false, true, true,
                 false, false, true, true, false, false, false, false, false},
             Conversion.shortToBinary((short)0xCDEF, 0, new boolean[21], 0, 16));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{
                 false, false, true, false, false, false, false, false, false, false, false,
                 false, false, false, false, false, false, false, false, false, false},
             Conversion.shortToBinary((short)0xCDEF, 0, new boolean[21], 2, 1));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{
                 false, false, true, true, true, true, false, true, true, true, true, false,
                 true, true, false, false, true, true, false, false, false},
             Conversion.shortToBinary((short)0xCDEF, 0, new boolean[21], 2, 16));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{
                 true, true, true, false, true, true, true, true, false, true, true, false,
                 false, true, true, false, false, false, false, false, false},
             Conversion.shortToBinary((short)0xCDEF, 1, new boolean[21], 0, 15));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{
                 true, true, false, true, true, true, true, false, true, true, false, false,
                 true, true, false, false, false, false, false, false, false},
@@ -1711,7 +1693,7 @@ public class ConversionTest {
         // false},Conversion.shortToBinary((short)0xCDEF, 2,new boolean[21],
         // 3,15));//rejected by
         // assertion
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{
                 false, false, false, true, true, false, true, true, true, true, false, true,
                 true, false, false, true, true, false, false, false, false},
@@ -1723,45 +1705,45 @@ public class ConversionTest {
      */
     @Test
     public void testByteToBinary() {
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{}, Conversion.byteToBinary((byte)0x00, 0, new boolean[]{}, 0, 0));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{}, Conversion.byteToBinary((byte)0x00, 100, new boolean[]{}, 0, 0));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[]{}, Conversion.byteToBinary((byte)0x00, 0, new boolean[]{}, 100, 0));
-        assertBinaryEquals(
+        assertArrayEquals(
             new boolean[69], Conversion.byteToBinary((byte)0xEF, 0, new boolean[69], 0, 0));
-        assertBinaryEquals(new boolean[]{
+        assertArrayEquals(new boolean[]{
             true, false, false, false, false, false, false, false, false, false, false, false,
             false}, Conversion.byteToBinary((byte)0x95, 0, new boolean[13], 0, 1));
-        assertBinaryEquals(new boolean[]{
+        assertArrayEquals(new boolean[]{
             true, false, false, false, false, false, false, false, false, false, false, false,
             false}, Conversion.byteToBinary((byte)0x95, 0, new boolean[13], 0, 2));
-        assertBinaryEquals(new boolean[]{
+        assertArrayEquals(new boolean[]{
             true, false, true, false, false, false, false, false, false, false, false, false,
             false}, Conversion.byteToBinary((byte)0x95, 0, new boolean[13], 0, 3));
-        assertBinaryEquals(new boolean[]{
+        assertArrayEquals(new boolean[]{
             true, false, true, false, true, false, false, false, false, false, false, false,
             false}, Conversion.byteToBinary((byte)0x95, 0, new boolean[13], 0, 7));
-        assertBinaryEquals(new boolean[]{
+        assertArrayEquals(new boolean[]{
             true, false, true, false, true, false, false, true, false, false, false, false,
             false}, Conversion.byteToBinary((byte)0x95, 0, new boolean[13], 0, 8));
-        assertBinaryEquals(new boolean[]{
+        assertArrayEquals(new boolean[]{
             false, false, true, false, false, false, false, false, false, false, false, false,
             false}, Conversion.byteToBinary((byte)0x95, 0, new boolean[13], 2, 1));
-        assertBinaryEquals(new boolean[]{
+        assertArrayEquals(new boolean[]{
             false, false, true, false, true, false, true, false, false, true, false, false,
             false}, Conversion.byteToBinary((byte)0x95, 0, new boolean[13], 2, 8));
-        assertBinaryEquals(new boolean[]{
+        assertArrayEquals(new boolean[]{
             false, true, false, true, false, false, true, false, false, false, false, false,
             false}, Conversion.byteToBinary((byte)0x95, 1, new boolean[13], 0, 7));
-        assertBinaryEquals(new boolean[]{
+        assertArrayEquals(new boolean[]{
             true, false, true, false, false, true, false, false, false, false, false, false,
             false}, Conversion.byteToBinary((byte)0x95, 2, new boolean[13], 0, 6));
         // assertArrayEquals(new boolean[]{false, false, false, true, true, false, true, true,
         // false, false, false, false, false},Conversion.byteToBinary((byte)0x95, 2,new
         // boolean[13], 3, 7));//rejected by assertion
-        assertBinaryEquals(new boolean[]{
+        assertArrayEquals(new boolean[]{
             false, false, false, true, false, true, false, false, true, false, false, false,
             false}, Conversion.byteToBinary((byte)0x95, 2, new boolean[13], 3, 6));
     }

--- a/src/test/java/org/apache/commons/lang3/ConversionTest.java
+++ b/src/test/java/org/apache/commons/lang3/ConversionTest.java
@@ -18,7 +18,7 @@ package org.apache.commons.lang3;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.UUID;
 
@@ -57,12 +57,7 @@ public class ConversionTest {
         assertEquals(14, Conversion.hexDigitToInt('e'));
         assertEquals(15, Conversion.hexDigitToInt('F'));
         assertEquals(15, Conversion.hexDigitToInt('f'));
-        try {
-            Conversion.hexDigitToInt('G');
-            fail("Thrown " + IllegalArgumentException.class.getName() + " expected");
-        } catch (final IllegalArgumentException e) {
-            // OK
-        }
+        assertThrows(IllegalArgumentException.class, () -> Conversion.hexDigitToInt('G'));
     }
 
     /**
@@ -92,12 +87,7 @@ public class ConversionTest {
         assertEquals(0x7, Conversion.hexDigitMsb0ToInt('e'));
         assertEquals(0xF, Conversion.hexDigitMsb0ToInt('F'));
         assertEquals(0xF, Conversion.hexDigitMsb0ToInt('f'));
-        try {
-            Conversion.hexDigitMsb0ToInt('G');
-            fail("Thrown " + IllegalArgumentException.class.getName() + " expected");
-        } catch (final IllegalArgumentException e) {
-            // OK
-        }
+        assertThrows(IllegalArgumentException.class, () -> Conversion.hexDigitMsb0ToInt('G'));
     }
 
     /**
@@ -149,12 +139,7 @@ public class ConversionTest {
             new boolean[]{true, true, true, true}, Conversion.hexDigitToBinary('F'));
         assertArrayEquals(
             new boolean[]{true, true, true, true}, Conversion.hexDigitToBinary('f'));
-        try {
-            Conversion.hexDigitToBinary('G');
-            fail("Thrown " + IllegalArgumentException.class.getName() + " expected");
-        } catch (final IllegalArgumentException e) {
-            // OK
-        }
+        assertThrows(IllegalArgumentException.class, () -> Conversion.hexDigitToBinary('G'));
     }
 
     /**
@@ -206,12 +191,7 @@ public class ConversionTest {
             new boolean[]{true, true, true, true}, Conversion.hexDigitMsb0ToBinary('F'));
         assertArrayEquals(
             new boolean[]{true, true, true, true}, Conversion.hexDigitMsb0ToBinary('f'));
-        try {
-            Conversion.hexDigitMsb0ToBinary('G');
-            fail("Thrown " + IllegalArgumentException.class.getName() + " expected");
-        } catch (final IllegalArgumentException e) {
-            // OK
-        }
+        assertThrows(IllegalArgumentException.class, () -> Conversion.hexDigitMsb0ToBinary('G'));
     }
 
     /**
@@ -239,12 +219,7 @@ public class ConversionTest {
         assertEquals('1', Conversion.binaryToHexDigit(new boolean[]{true}));
         assertEquals(
             'f', Conversion.binaryToHexDigit(new boolean[]{true, true, true, true, true}));
-        try {
-            Conversion.binaryToHexDigit(new boolean[]{});
-            fail("Thrown " + IllegalArgumentException.class.getName() + " expected");
-        } catch (final IllegalArgumentException e) {
-            // OK
-        }
+        assertThrows(IllegalArgumentException.class, () -> Conversion.binaryToHexDigit(new boolean[]{}));
     }
 
     /**
@@ -308,12 +283,7 @@ public class ConversionTest {
             'e', Conversion.binaryToHexDigitMsb0_4bits(new boolean[]{true, true, true, false}));
         assertEquals(
             'f', Conversion.binaryToHexDigitMsb0_4bits(new boolean[]{true, true, true, true}));
-        try {
-            Conversion.binaryToHexDigitMsb0_4bits(new boolean[]{});
-            fail("Thrown " + IllegalArgumentException.class.getName() + " expected");
-        } catch (final IllegalArgumentException e) {
-            // OK
-        }
+        assertThrows(IllegalArgumentException.class, () -> Conversion.binaryToHexDigitMsb0_4bits(new boolean[]{}));
     }
 
     /**
@@ -393,12 +363,7 @@ public class ConversionTest {
             Conversion.binaryBeMsb0ToHexDigit(new boolean[]{
                 true, false, false, false, false, false, false, false, false, false, false,
                 false, false, true, false, false}));
-        try {
-            Conversion.binaryBeMsb0ToHexDigit(new boolean[]{});
-            fail("Thrown " + IllegalArgumentException.class.getName() + " expected");
-        } catch (final IllegalArgumentException e) {
-            // OK
-        }
+        assertThrows(IllegalArgumentException.class, () -> Conversion.binaryBeMsb0ToHexDigit(new boolean[]{}));
     }
 
     /**
@@ -469,12 +434,7 @@ public class ConversionTest {
         assertEquals('d', Conversion.intToHexDigit(13));
         assertEquals('e', Conversion.intToHexDigit(14));
         assertEquals('f', Conversion.intToHexDigit(15));
-        try {
-            Conversion.intToHexDigit(16);
-            fail("Thrown " + IllegalArgumentException.class.getName() + " expected");
-        } catch (final IllegalArgumentException e) {
-            // OK
-        }
+        assertThrows(IllegalArgumentException.class, () -> Conversion.intToHexDigit(16));
     }
 
     /**
@@ -498,12 +458,7 @@ public class ConversionTest {
         assertEquals('b', Conversion.intToHexDigitMsb0(13));
         assertEquals('7', Conversion.intToHexDigitMsb0(14));
         assertEquals('f', Conversion.intToHexDigitMsb0(15));
-        try {
-            Conversion.intToHexDigitMsb0(16);
-            fail("Thrown " + IllegalArgumentException.class.getName() + " expected");
-        } catch (final IllegalArgumentException e) {
-            // OK
-        }
+        assertThrows(IllegalArgumentException.class, () -> Conversion.intToHexDigitMsb0(16));
     }
 
     static String dbgPrint(final boolean[] src) {
@@ -1276,12 +1231,7 @@ public class ConversionTest {
             Conversion.longToHex(0x1234567890ABCDEFL, 4, "ffffffffffffffffffffffff", 3, 15));
         assertEquals(
             "fedcba0987654321", Conversion.longToHex(0x1234567890ABCDEFL, 0, "", 0, 16));
-        try {
-            Conversion.longToHex(0x1234567890ABCDEFL, 0, "", 1, 8);
-            fail("Thrown " + StringIndexOutOfBoundsException.class.getName() + " expected");
-        } catch (final StringIndexOutOfBoundsException e) {
-            // OK
-        }
+        assertThrows(StringIndexOutOfBoundsException.class, () -> Conversion.longToHex(0x1234567890ABCDEFL, 0, "", 1, 8));
     }
 
     /**
@@ -1340,12 +1290,7 @@ public class ConversionTest {
             "fffedcba09ffffffffffffff",
             Conversion.intToHex(0x90ABCDEF, 4, "ffffffffffffffffffffffff", 3, 7));
         assertEquals("fedcba09", Conversion.intToHex(0x90ABCDEF, 0, "", 0, 8));
-        try {
-            Conversion.intToHex(0x90ABCDEF, 0, "", 1, 8);
-            fail("Thrown " + StringIndexOutOfBoundsException.class.getName() + " expected");
-        } catch (final StringIndexOutOfBoundsException e) {
-            // OK
-        }
+        assertThrows(StringIndexOutOfBoundsException.class, () -> Conversion.intToHex(0x90ABCDEF, 0, "", 1, 8));
     }
 
     /**
@@ -1392,12 +1337,7 @@ public class ConversionTest {
             "fffedcffffffffffffffffff",
             Conversion.shortToHex((short)0xCDEF, 4, "ffffffffffffffffffffffff", 3, 3));
         assertEquals("fedc", Conversion.shortToHex((short)0xCDEF, 0, "", 0, 4));
-        try {
-            Conversion.shortToHex((short)0xCDEF, 0, "", 1, 4);
-            fail("Thrown " + StringIndexOutOfBoundsException.class.getName() + " expected");
-        } catch (final StringIndexOutOfBoundsException e) {
-            // OK
-        }
+        assertThrows(StringIndexOutOfBoundsException.class, () -> Conversion.shortToHex((short)0xCDEF, 0, "", 1, 4));
     }
 
     /**
@@ -1420,12 +1360,7 @@ public class ConversionTest {
         // assertion
         assertEquals("000e0", Conversion.byteToHex((byte)0xEF, 4, "00000", 3, 1));
         assertEquals("fe", Conversion.byteToHex((byte)0xEF, 0, "", 0, 2));
-        try {
-            Conversion.byteToHex((byte)0xEF, 0, "", 1, 2);
-            fail("Thrown " + StringIndexOutOfBoundsException.class.getName() + " expected");
-        } catch (final StringIndexOutOfBoundsException e) {
-            // OK
-        }
+        assertThrows(StringIndexOutOfBoundsException.class, () -> Conversion.byteToHex((byte)0xEF, 0, "", 1, 2));
     }
 
     /**

--- a/src/test/java/org/apache/commons/lang3/LocaleUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/LocaleUtilsTest.java
@@ -37,6 +37,8 @@ import java.util.Set;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Unit tests for {@link LocaleUtils}.
@@ -561,41 +563,29 @@ public class LocaleUtilsTest  {
         }
     }
 
-    @Test
-    public void testParseAllLocales() {
-        final Locale[] locales = Locale.getAvailableLocales();
-        int failures = 0;
-        for (final Locale l : locales) {
-            // Check if it's possible to recreate the Locale using just the standard constructor
-            final Locale locale = new Locale(l.getLanguage(), l.getCountry(), l.getVariant());
-            if (l.equals(locale)) { // it is possible for LocaleUtils.toLocale to handle these Locales
-                String str = l.toString();
-                // Look for the script/extension suffix
-                int suff = str.indexOf("_#");
-                if (suff == - 1) {
-                    suff = str.indexOf("#");
-                }
-                if (suff >= 0) { // we have a suffix
-                    try {
-                        LocaleUtils.toLocale(str); // should cause IAE
-                        System.out.println("Should not have parsed: " + str);
-                        failures++;
-                        continue; // try next Locale
-                    } catch (final IllegalArgumentException iae) {
-                        // expected; try without suffix
-                        str = str.substring(0, suff);
-                    }
-                }
-                final Locale loc = LocaleUtils.toLocale(str);
-                if (!l.equals(loc)) {
-                    System.out.println("Failed to parse: " + str);
-                    failures++;
+    @ParameterizedTest
+    @MethodSource("java.util.Locale#getAvailableLocales")
+    public void testParseAllLocales(Locale l) {
+        // Check if it's possible to recreate the Locale using just the standard constructor
+        final Locale locale = new Locale(l.getLanguage(), l.getCountry(), l.getVariant());
+        if (l.equals(locale)) { // it is possible for LocaleUtils.toLocale to handle these Locales
+            String str = l.toString();
+            // Look for the script/extension suffix
+            int suff = str.indexOf("_#");
+            if (suff == - 1) {
+                suff = str.indexOf("#");
+            }
+            if (suff >= 0) { // we have a suffix
+                try {
+                    LocaleUtils.toLocale(str); // should cause IAE
+                    fail("Should not have parsed: " + str);
+                } catch (final IllegalArgumentException iae) {
+                    // expected; try without suffix
+                    str = str.substring(0, suff);
                 }
             }
-        }
-        if (failures > 0) {
-            fail("Failed "+failures+" test(s)");
+            final Locale loc = LocaleUtils.toLocale(str);
+            assertEquals(l, loc);
         }
     }
-
 }

--- a/src/test/java/org/apache/commons/lang3/LocaleUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/LocaleUtilsTest.java
@@ -24,7 +24,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
@@ -394,10 +393,7 @@ public class LocaleUtilsTest  {
                     break;
                 }
             }
-            if (!found) {
-                fail("Could not find language: " + language
-                        + " for country: " + country);
-            }
+            assertTrue(found, "Could not find language: " + language + " for country: " + country);
         }
         assertUnmodifiableCollection(list);
     }
@@ -445,10 +441,7 @@ public class LocaleUtilsTest  {
                     break;
                 }
             }
-            if (!found) {
-                fail("Could not find language: " + country
-                        + " for country: " + language);
-            }
+            assertTrue(found, "Could not find language: " + country + " for country: " + language);
         }
         assertUnmodifiableCollection(list);
     }

--- a/src/test/java/org/apache/commons/lang3/LocaleUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/LocaleUtilsTest.java
@@ -54,7 +54,7 @@ public class LocaleUtilsTest  {
     private static final Locale LOCALE_QQ_ZZ = new Locale("qq", "ZZ");
 
     @BeforeEach
-    public void setUp() throws Exception {
+    public void setUp() {
         // Testing #LANG-304. Must be called before availableLocaleSet is called.
         LocaleUtils.isAvailableLocale(Locale.getDefault());
     }

--- a/src/test/java/org/apache/commons/lang3/LocaleUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/LocaleUtilsTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -138,32 +139,13 @@ public class LocaleUtilsTest  {
         // LANG-941: JDK 8 introduced the empty locale as one of the default locales
         assertValidToLocale("");
 
-        try {
-            LocaleUtils.toLocale("Us");
-            fail("Should fail if not lowercase");
-        } catch (final IllegalArgumentException iae) {}
-        try {
-            LocaleUtils.toLocale("US");
-            fail("Should fail if not lowercase");
-        } catch (final IllegalArgumentException iae) {}
-        try {
-            LocaleUtils.toLocale("uS");
-            fail("Should fail if not lowercase");
-        } catch (final IllegalArgumentException iae) {}
-        try {
-            LocaleUtils.toLocale("u#");
-            fail("Should fail if not lowercase");
-        } catch (final IllegalArgumentException iae) {}
-
-        try {
-            LocaleUtils.toLocale("u");
-            fail("Must be 2 chars if less than 5");
-        } catch (final IllegalArgumentException iae) {}
-
-        try {
-            LocaleUtils.toLocale("uu_U");
-            fail("Must be 2 chars if less than 5");
-        } catch (final IllegalArgumentException iae) {}
+        assertThrows(IllegalArgumentException.class, () -> LocaleUtils.toLocale("Us"), "Should fail if not lowercase");
+        assertThrows(IllegalArgumentException.class, () -> LocaleUtils.toLocale("uS"), "Should fail if not lowercase");
+        assertThrows(IllegalArgumentException.class, () -> LocaleUtils.toLocale("u#"), "Should fail if not lowercase");
+        assertThrows(
+                IllegalArgumentException.class, () -> LocaleUtils.toLocale("u"), "Must be 2 chars if less than 5");
+        assertThrows(
+                IllegalArgumentException.class, () -> LocaleUtils.toLocale("uu_U"), "Must be 2 chars if less than 5");
     }
 
     /**
@@ -175,30 +157,28 @@ public class LocaleUtilsTest  {
         //valid though doesn't exist
         assertValidToLocale("us_ZH", "us", "ZH");
 
-        try {
-            LocaleUtils.toLocale("us-EN");
-            fail("Should fail as not underscore");
-        } catch (final IllegalArgumentException iae) {}
-        try {
-            LocaleUtils.toLocale("us_En");
-            fail("Should fail second part not uppercase");
-        } catch (final IllegalArgumentException iae) {}
-        try {
-            LocaleUtils.toLocale("us_en");
-            fail("Should fail second part not uppercase");
-        } catch (final IllegalArgumentException iae) {}
-        try {
-            LocaleUtils.toLocale("us_eN");
-            fail("Should fail second part not uppercase");
-        } catch (final IllegalArgumentException iae) {}
-        try {
-            LocaleUtils.toLocale("uS_EN");
-            fail("Should fail first part not lowercase");
-        } catch (final IllegalArgumentException iae) {}
-        try {
-            LocaleUtils.toLocale("us_E3");
-            fail("Should fail second part not uppercase");
-        } catch (final IllegalArgumentException iae) {}
+        assertThrows(
+                IllegalArgumentException.class, () -> LocaleUtils.toLocale("us-EN"), "Should fail as not underscore");
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> LocaleUtils.toLocale("us_En"),
+                "Should fail second part not uppercase");
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> LocaleUtils.toLocale("us_en"),
+                "Should fail second part not uppercase");
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> LocaleUtils.toLocale("us_eN"),
+                "Should fail second part not uppercase");
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> LocaleUtils.toLocale("uS_EN"),
+                "Should fail first part not lowercase");
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> LocaleUtils.toLocale("us_E3"),
+                "Should fail second part not uppercase");
     }
 
     /**
@@ -217,14 +197,10 @@ public class LocaleUtilsTest  {
             assertValidToLocale("us_EN_SFsafdFDsdfF", "us", "EN", "SFSAFDFDSDFF");
         }
 
-        try {
-            LocaleUtils.toLocale("us_EN-a");
-            fail("Should fail as not underscore");
-        } catch (final IllegalArgumentException iae) {}
-        try {
-            LocaleUtils.toLocale("uu_UU_");
-            fail("Must be 3, 5 or 7+ in length");
-        } catch (final IllegalArgumentException iae) {}
+        assertThrows(
+                IllegalArgumentException.class, () -> LocaleUtils.toLocale("us_EN-a"), "Should fail as not underscore");
+        assertThrows(
+                IllegalArgumentException.class, () -> LocaleUtils.toLocale("uu_UU_"), "Must be 3, 5 or 7+ in length");
     }
 
     //-----------------------------------------------------------------------
@@ -492,10 +468,7 @@ public class LocaleUtilsTest  {
      * @param coll  the collection to check
      */
     private static void assertUnmodifiableCollection(final Collection<?> coll) {
-        try {
-            coll.add(null);
-            fail();
-        } catch (final UnsupportedOperationException ex) {}
+        assertThrows(UnsupportedOperationException.class, () -> coll.add(null));
     }
 
     /**
@@ -526,41 +499,34 @@ public class LocaleUtilsTest  {
         assertValidToLocale("_GB", "", "GB", "");
         assertValidToLocale("_GB_P", "", "GB", "P");
         assertValidToLocale("_GB_POSIX", "", "GB", "POSIX");
-        try {
-            LocaleUtils.toLocale("_G");
-            fail("Must be at least 3 chars if starts with underscore");
-        } catch (final IllegalArgumentException iae) {
-        }
-        try {
-            LocaleUtils.toLocale("_Gb");
-            fail("Must be uppercase if starts with underscore");
-        } catch (final IllegalArgumentException iae) {
-        }
-        try {
-            LocaleUtils.toLocale("_gB");
-            fail("Must be uppercase if starts with underscore");
-        } catch (final IllegalArgumentException iae) {
-        }
-        try {
-            LocaleUtils.toLocale("_1B");
-            fail("Must be letter if starts with underscore");
-        } catch (final IllegalArgumentException iae) {
-        }
-        try {
-            LocaleUtils.toLocale("_G1");
-            fail("Must be letter if starts with underscore");
-        } catch (final IllegalArgumentException iae) {
-        }
-        try {
-            LocaleUtils.toLocale("_GB_");
-            fail("Must be at least 5 chars if starts with underscore");
-        } catch (final IllegalArgumentException iae) {
-        }
-        try {
-            LocaleUtils.toLocale("_GBAP");
-            fail("Must have underscore after the country if starts with underscore and is at least 5 chars");
-        } catch (final IllegalArgumentException iae) {
-        }
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> LocaleUtils.toLocale("_G"),
+                "Must be at least 3 chars if starts with underscore");
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> LocaleUtils.toLocale("_Gb"),
+                "Must be uppercase if starts with underscore");
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> LocaleUtils.toLocale("_gB"),
+                "Must be uppercase if starts with underscore");
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> LocaleUtils.toLocale("_1B"),
+                "Must be letter if starts with underscore");
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> LocaleUtils.toLocale("_G1"),
+                "Must be letter if starts with underscore");
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> LocaleUtils.toLocale("_GB_"),
+                "Must be at least 5 chars if starts with underscore");
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> LocaleUtils.toLocale("_GBAP"),
+                "Must have underscore after the country if starts with underscore and is at least 5 chars");
     }
 
     @ParameterizedTest
@@ -569,22 +535,19 @@ public class LocaleUtilsTest  {
         // Check if it's possible to recreate the Locale using just the standard constructor
         final Locale locale = new Locale(l.getLanguage(), l.getCountry(), l.getVariant());
         if (l.equals(locale)) { // it is possible for LocaleUtils.toLocale to handle these Locales
-            String str = l.toString();
+            final String str = l.toString();
             // Look for the script/extension suffix
             int suff = str.indexOf("_#");
             if (suff == - 1) {
                 suff = str.indexOf("#");
             }
+            String localeStr = str;
             if (suff >= 0) { // we have a suffix
-                try {
-                    LocaleUtils.toLocale(str); // should cause IAE
-                    fail("Should not have parsed: " + str);
-                } catch (final IllegalArgumentException iae) {
-                    // expected; try without suffix
-                    str = str.substring(0, suff);
-                }
+                assertThrows(IllegalArgumentException.class, () -> LocaleUtils.toLocale(str));
+                // try without suffix
+                localeStr = str.substring(0, suff);
             }
-            final Locale loc = LocaleUtils.toLocale(str);
+            final Locale loc = LocaleUtils.toLocale(localeStr);
             assertEquals(l, loc);
         }
     }

--- a/src/test/java/org/apache/commons/lang3/ObjectUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/ObjectUtilsTest.java
@@ -24,7 +24,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.lang.reflect.Constructor;
@@ -227,16 +226,8 @@ public class ObjectUtilsTest {
         ObjectUtils.identityToString(buffer, i);
         assertEquals(expected, buffer.toString());
 
-        try {
-            ObjectUtils.identityToString((StringBuffer)null, "tmp");
-            fail("NullPointerException expected");
-        } catch(final NullPointerException npe) {
-        }
-        try {
-            ObjectUtils.identityToString(new StringBuffer(), null);
-            fail("NullPointerException expected");
-        } catch(final NullPointerException npe) {
-        }
+        assertThrows(NullPointerException.class, () -> ObjectUtils.identityToString((StringBuffer)null, "tmp"));
+        assertThrows(NullPointerException.class, () -> ObjectUtils.identityToString(new StringBuffer(), null));
     }
 
     @Test
@@ -281,20 +272,12 @@ public class ObjectUtilsTest {
 
     @Test
     public void testIdentityToStringStringBuilderNullValue() {
-        try {
-            ObjectUtils.identityToString(new StringBuilder(), null);
-            fail("NullPointerException expected");
-        } catch(final NullPointerException npe) {
-        }
+        assertThrows(NullPointerException.class, () -> ObjectUtils.identityToString(new StringBuilder(), null));
     }
 
     @Test
     public  void testIdentityToStringStringBuilderNullStringBuilder() {
-        try {
-            ObjectUtils.identityToString((StringBuilder)null, "tmp");
-            fail("NullPointerException expected");
-        } catch(final NullPointerException npe) {
-        }
+        assertThrows(NullPointerException.class, () -> ObjectUtils.identityToString((StringBuilder)null, "tmp"));
     }
 
     @Test
@@ -306,47 +289,25 @@ public class ObjectUtilsTest {
         ObjectUtils.identityToString(builder, i);
         assertEquals(expected, builder.toString());
 
-        try {
-            ObjectUtils.identityToString((StrBuilder)null, "tmp");
-            fail("NullPointerException expected");
-        } catch(final NullPointerException npe) {
-        }
+        assertThrows(NullPointerException.class, () -> ObjectUtils.identityToString((StrBuilder)null, "tmp"));
 
-        try {
-            ObjectUtils.identityToString(new StrBuilder(), null);
-            fail("NullPointerException expected");
-        } catch(final NullPointerException npe) {
-        }
+        assertThrows(NullPointerException.class, () -> ObjectUtils.identityToString(new StrBuilder(), null));
     }
 
     @Test
-    public void testIdentityToStringAppendable() {
+    public void testIdentityToStringAppendable() throws IOException {
         final Integer i = Integer.valueOf(121);
         final String expected = "java.lang.Integer@" + Integer.toHexString(System.identityHashCode(i));
 
-        try {
-            final Appendable appendable = new StringBuilder();
-            ObjectUtils.identityToString(appendable, i);
-            assertEquals(expected, appendable.toString());
-        } catch(final IOException ex) {
-            fail("IOException unexpected");
-        }
+        final Appendable appendable = new StringBuilder();
+        ObjectUtils.identityToString(appendable, i);
+        assertEquals(expected, appendable.toString());
 
-        try {
-            ObjectUtils.identityToString((Appendable)null, "tmp");
-            fail("NullPointerException expected");
-        } catch(final NullPointerException expectedException) {
-        } catch(final IOException ex) {
-          fail("IOException unexpected");
-        }
+        assertThrows(NullPointerException.class, () -> ObjectUtils.identityToString((Appendable)null, "tmp"));
 
-        try {
-            ObjectUtils.identityToString((Appendable)(new StringBuilder()), null);
-            fail("NullPointerException expected");
-        } catch(final NullPointerException expectedException) {
-        } catch(final IOException ex) {
-          fail("IOException unexpected");
-        }
+        assertThrows(
+                NullPointerException.class,
+                () -> ObjectUtils.identityToString((Appendable)(new StringBuilder()), null));
     }
 
     @Test
@@ -641,32 +602,22 @@ public class ObjectUtilsTest {
         assertTrue(1.0f == MAGIC_FLOAT);
         assertTrue(1.0 == MAGIC_DOUBLE);
         assertEquals("abc", MAGIC_STRING);
-
-        try {
-            ObjectUtils.CONST_BYTE(-129);
-            fail("CONST_BYTE(-129): IllegalArgumentException should have been thrown.");
-        } catch (final IllegalArgumentException iae) {
-
-        }
-        try {
-            ObjectUtils.CONST_BYTE(128);
-            fail("CONST_BYTE(128): IllegalArgumentException should have been thrown.");
-        } catch (final IllegalArgumentException iae) {
-
-        }
-        try {
-            ObjectUtils.CONST_SHORT(-32769);
-            fail("CONST_SHORT(-32769): IllegalArgumentException should have been thrown.");
-        } catch (final IllegalArgumentException iae) {
-
-        }
-        try {
-            ObjectUtils.CONST_BYTE(32768);
-            fail("CONST_SHORT(32768): IllegalArgumentException should have been thrown.");
-        } catch (final IllegalArgumentException iae) {
-
-        }
-
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> ObjectUtils.CONST_BYTE(-129),
+                "CONST_BYTE(-129): IllegalArgumentException should have been thrown.");
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> ObjectUtils.CONST_BYTE(128),
+                "CONST_BYTE(128): IllegalArgumentException should have been thrown.");
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> ObjectUtils.CONST_SHORT(-32769),
+                "CONST_SHORT(-32769): IllegalArgumentException should have been thrown.");
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> ObjectUtils.CONST_BYTE(32768),
+                "CONST_SHORT(32768): IllegalArgumentException should have been thrown.");
     }
 
     /**

--- a/src/test/java/org/apache/commons/lang3/RandomStringUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/RandomStringUtilsTest.java
@@ -200,10 +200,9 @@ public class RandomStringUtilsTest {
             }
         }
         for (int i = 0; i < testChars.length; i++) {
-            if (!found[i]) {
-                fail("alphanumeric character not generated in 1000 attempts: "
-                   + testChars[i] +" -- repeated failures indicate a problem ");
-            }
+            assertTrue(found[i],
+                    "alphanumeric character not generated in 1000 attempts: " +
+                            testChars[i] + " -- repeated failures indicate a problem ");
         }
     }
 
@@ -224,10 +223,9 @@ public class RandomStringUtilsTest {
             }
         }
         for (int i = 0; i < testChars.length; i++) {
-            if (!found[i]) {
-                fail("digit not generated in 1000 attempts: "
-                   + testChars[i] +" -- repeated failures indicate a problem ");
-            }
+            assertTrue(found[i],
+                    "digit not generated in 1000 attempts: " + testChars[i] +
+                            " -- repeated failures indicate a problem ");
         }
     }
 
@@ -248,10 +246,9 @@ public class RandomStringUtilsTest {
             }
         }
         for (int i = 0; i < testChars.length; i++) {
-            if (!found[i]) {
-                fail("alphanumeric character not generated in 1000 attempts: "
-                   + testChars[i] +" -- repeated failures indicate a problem ");
-            }
+            assertTrue(found[i],
+                    "alphanumeric character not generated in 1000 attempts: " + testChars[i] +
+                            " -- repeated failures indicate a problem ");
         }
     }
 
@@ -272,11 +269,9 @@ public class RandomStringUtilsTest {
             }
         }
         for (int i = 0; i < testChars.length; i++) {
-            if (!found[i]) {
-                fail("ascii character not generated in 1000 attempts: "
-                + (int) testChars[i] +
-                 " -- repeated failures indicate a problem");
-            }
+            assertTrue(found[i],
+                    "ascii character not generated in 1000 attempts: " + (int) testChars[i] +
+                            " -- repeated failures indicate a problem");
         }
     }
 

--- a/src/test/java/org/apache/commons/lang3/RandomStringUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/RandomStringUtilsTest.java
@@ -501,11 +501,9 @@ public class RandomStringUtilsTest {
      * Test for LANG-1286. Creates situation where old code would
      * overflow a char and result in a code point outside the specified
      * range.
-     *
-     * @throws Exception
      */
     @Test
-    public void testCharOverflow() throws Exception {
+    public void testCharOverflow() {
         final int start = Character.MAX_VALUE;
         final int end = Integer.MAX_VALUE;
 

--- a/src/test/java/org/apache/commons/lang3/RandomStringUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/RandomStringUtilsTest.java
@@ -24,6 +24,7 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -157,63 +158,29 @@ public class RandomStringUtilsTest {
 
     @Test
     public void testLANG807() {
-        try {
-            RandomStringUtils.random(3,5,5,false,false);
-            fail("Expected IllegalArgumentException");
-        } catch (final IllegalArgumentException ex) { // distinguish from Random#nextInt message
-            final String msg = ex.getMessage();
-            assertTrue(msg.contains("start"), "Message (" + msg + ") must contain 'start'");
-            assertTrue(msg.contains("end"), "Message (" + msg + ") must contain 'end'");
-        }
+        IllegalArgumentException ex =
+                assertThrows(IllegalArgumentException.class, () -> RandomStringUtils.random(3,5,5,false,false));
+        final String msg = ex.getMessage();
+        assertTrue(msg.contains("start"), "Message (" + msg + ") must contain 'start'");
+        assertTrue(msg.contains("end"), "Message (" + msg + ") must contain 'end'");
     }
 
     @Test
     public void testExceptions() {
         final char[] DUMMY = new char[]{'a'}; // valid char array
-        try {
-            RandomStringUtils.random(-1);
-            fail();
-        } catch (final IllegalArgumentException ex) {}
-        try {
-            RandomStringUtils.random(-1, true, true);
-            fail();
-        } catch (final IllegalArgumentException ex) {}
-        try {
-            RandomStringUtils.random(-1, DUMMY);
-            fail();
-        } catch (final IllegalArgumentException ex) {}
-        try {
-            RandomStringUtils.random(1, new char[0]); // must not provide empty array => IAE
-            fail();
-        } catch (final IllegalArgumentException ex) {}
-        try {
-            RandomStringUtils.random(-1, "");
-            fail();
-        } catch (final IllegalArgumentException ex) {}
-        try {
-            RandomStringUtils.random(-1, (String)null);
-            fail();
-        } catch (final IllegalArgumentException ex) {}
-        try {
-            RandomStringUtils.random(-1, 'a', 'z', false, false);
-            fail();
-        } catch (final IllegalArgumentException ex) {}
-        try {
-            RandomStringUtils.random(-1, 'a', 'z', false, false, DUMMY);
-            fail();
-        } catch (final IllegalArgumentException ex) {}
-        try {
-            RandomStringUtils.random(-1, 'a', 'z', false, false, DUMMY, new Random());
-            fail();
-        } catch (final IllegalArgumentException ex) {}
-        try {
-            RandomStringUtils.random(8, 32, 48, false, true);
-            fail();
-        } catch (final IllegalArgumentException ex) {}
-        try {
-            RandomStringUtils.random(8, 32, 65, true, false);
-            fail();
-        } catch (final IllegalArgumentException ex) {}
+        assertThrows(IllegalArgumentException.class, () -> RandomStringUtils.random(-1));
+        assertThrows(IllegalArgumentException.class, () -> RandomStringUtils.random(-1, true, true));
+        assertThrows(IllegalArgumentException.class, () -> RandomStringUtils.random(-1, DUMMY));
+        assertThrows(IllegalArgumentException.class, () -> RandomStringUtils.random(1, new char[0]));
+        assertThrows(IllegalArgumentException.class, () -> RandomStringUtils.random(-1, ""));
+        assertThrows(IllegalArgumentException.class, () -> RandomStringUtils.random(-1, (String) null));
+        assertThrows(IllegalArgumentException.class, () -> RandomStringUtils.random(-1, 'a', 'z', false, false));
+        assertThrows(IllegalArgumentException.class, () -> RandomStringUtils.random(-1, 'a', 'z', false, false, DUMMY));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> RandomStringUtils.random(-1, 'a', 'z', false, false, DUMMY, new Random()));
+        assertThrows(IllegalArgumentException.class, () -> RandomStringUtils.random(8, 32, 48, false, true));
+        assertThrows(IllegalArgumentException.class, () -> RandomStringUtils.random(8, 32, 65, true, false));
     }
 
     /**

--- a/src/test/java/org/apache/commons/lang3/RangeTest.java
+++ b/src/test/java/org/apache/commons/lang3/RangeTest.java
@@ -23,7 +23,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Comparator;
 
@@ -254,12 +253,7 @@ public class RangeTest {
 
     @Test
     public void testElementCompareTo() {
-        try {
-            intRange.elementCompareTo(null);
-            fail("NullPointerException should have been thrown");
-        } catch (final NullPointerException npe) {
-            // expected
-        }
+        assertThrows(NullPointerException.class, () -> intRange.elementCompareTo(null));
 
         assertEquals(-1, intRange.elementCompareTo(5));
         assertEquals(0, intRange.elementCompareTo(10));

--- a/src/test/java/org/apache/commons/lang3/RangeTest.java
+++ b/src/test/java/org/apache/commons/lang3/RangeTest.java
@@ -19,6 +19,7 @@ package org.apache.commons.lang3;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -147,12 +148,12 @@ public class RangeTest {
         assertEquals(byteRange, byteRange);
         assertEquals(byteRange, byteRange2);
         assertEquals(byteRange2, byteRange2);
-        assertTrue(byteRange.equals(byteRange));
-        assertTrue(byteRange2.equals(byteRange2));
-        assertTrue(byteRange3.equals(byteRange3));
-        assertFalse(byteRange2.equals(byteRange3));
-        assertFalse(byteRange2.equals(null));
-        assertFalse(byteRange2.equals("Ni!"));
+        assertEquals(byteRange, byteRange);
+        assertEquals(byteRange2, byteRange2);
+        assertEquals(byteRange3, byteRange3);
+        assertNotEquals(byteRange2, byteRange3);
+        assertNotEquals(null, byteRange2);
+        assertNotEquals("Ni!", byteRange2);
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/RegExUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/RegExUtilsTest.java
@@ -18,7 +18,7 @@ package org.apache.commons.lang3;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
@@ -64,12 +64,10 @@ public class RegExUtilsTest {
         assertEquals("AB", RegExUtils.removeAll("A<__>\n<__>B", "(?s)<.*>"));
         assertEquals("ABC123", RegExUtils.removeAll("ABCabc123abc", "[a-z]"));
 
-        try {
-            RegExUtils.removeAll("any", "{badRegexSyntax}");
-            fail("RegExUtils.removeAll expecting PatternSyntaxException");
-        } catch (final PatternSyntaxException ex) {
-            // empty
-        }
+        assertThrows(
+                PatternSyntaxException.class,
+                () -> RegExUtils.removeAll("any", "{badRegexSyntax}"),
+                "RegExUtils.removeAll expecting PatternSyntaxException");
     }
 
     @Test
@@ -103,12 +101,10 @@ public class RegExUtilsTest {
         assertEquals("ABCbc123", RegExUtils.removeFirst("ABCabc123", "[a-z]"));
         assertEquals("ABC123abc", RegExUtils.removeFirst("ABCabc123abc", "[a-z]+"));
 
-        try {
-            RegExUtils.removeFirst("any", "{badRegexSyntax}");
-            fail("RegExUtils.removeFirst expecting PatternSyntaxException");
-        } catch (final PatternSyntaxException ex) {
-            // empty
-        }
+        assertThrows(
+                PatternSyntaxException.class,
+                () -> RegExUtils.removeFirst("any", "{badRegexSyntax}"),
+                "RegExUtils.removeFirst expecting PatternSyntaxException");
     }
 
     @Test
@@ -174,12 +170,10 @@ public class RegExUtilsTest {
         assertEquals("ABC123", RegExUtils.replaceAll("ABCabc123", "[^A-Z0-9]+", ""));
         assertEquals("Lorem_ipsum_dolor_sit", RegExUtils.replaceAll("Lorem ipsum  dolor   sit", "( +)([a-z]+)", "_$2"));
 
-        try {
-            RegExUtils.replaceAll("any", "{badRegexSyntax}", "");
-            fail("RegExUtils.replaceAll expecting PatternSyntaxException");
-        } catch (final PatternSyntaxException ex) {
-            // empty
-        }
+        assertThrows(
+                PatternSyntaxException.class,
+                () -> RegExUtils.replaceAll("any", "{badRegexSyntax}", ""),
+                "RegExUtils.replaceAll expecting PatternSyntaxException");
     }
 
     @Test
@@ -225,12 +219,10 @@ public class RegExUtilsTest {
         assertEquals("Lorem_ipsum  dolor   sit",
                 RegExUtils.replaceFirst("Lorem ipsum  dolor   sit", "( +)([a-z]+)", "_$2"));
 
-        try {
-            RegExUtils.replaceFirst("any", "{badRegexSyntax}", "");
-            fail("RegExUtils.replaceFirst expecting PatternSyntaxException");
-        } catch (final PatternSyntaxException ex) {
-            // empty
-        }
+        assertThrows(
+                PatternSyntaxException.class,
+                () -> RegExUtils.replaceFirst("any", "{badRegexSyntax}", ""),
+                "RegExUtils.replaceFirst expecting PatternSyntaxException");
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/SerializationUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/SerializationUtilsTest.java
@@ -159,11 +159,9 @@ public class SerializationUtilsTest {
                 throw new IOException(SERIALIZE_IO_EXCEPTION_MESSAGE);
             }
         };
-        try {
-            SerializationUtils.serialize(iMap, streamTest);
-        } catch(final SerializationException e) {
-            assertEquals("java.io.IOException: " + SERIALIZE_IO_EXCEPTION_MESSAGE, e.getMessage());
-        }
+        SerializationException e =
+                assertThrows(SerializationException.class, () -> SerializationUtils.serialize(iMap, streamTest));
+        assertEquals("java.io.IOException: " + SERIALIZE_IO_EXCEPTION_MESSAGE, e.getMessage());
     }
 
     //-----------------------------------------------------------------------
@@ -234,13 +232,9 @@ public class SerializationUtilsTest {
         oos.close();
 
         final ByteArrayInputStream inTest = new ByteArrayInputStream(streamReal.toByteArray());
-        try {
-            @SuppressWarnings("unused")
-            final
-            Object test = SerializationUtils.deserialize(inTest);
-        } catch(final SerializationException se) {
-            assertEquals("java.lang.ClassNotFoundException: " + CLASS_NOT_FOUND_MESSAGE, se.getMessage());
-        }
+        SerializationException se =
+                assertThrows(SerializationException.class, () -> SerializationUtils.deserialize(inTest));
+        assertEquals("java.lang.ClassNotFoundException: " + CLASS_NOT_FOUND_MESSAGE, se.getMessage());
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/SerializationUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/SerializationUtilsTest.java
@@ -150,7 +150,7 @@ public class SerializationUtilsTest {
     }
 
     @Test
-    public void testSerializeIOException() throws Exception {
+    public void testSerializeIOException() {
         // forces an IOException when the ObjectOutputStream is created, to test not closing the stream
         // in the finally block
         final OutputStream streamTest = new OutputStream() {
@@ -328,7 +328,7 @@ public class SerializationUtilsTest {
     //-----------------------------------------------------------------------
 
     @Test
-    public void testClone() throws Exception {
+    public void testClone() {
         final Object test = SerializationUtils.clone(iMap);
         assertNotNull(test);
         assertTrue(test instanceof HashMap<?,?>);
@@ -342,7 +342,7 @@ public class SerializationUtilsTest {
     }
 
     @Test
-    public void testCloneNull() throws Exception {
+    public void testCloneNull() {
         final Object test = SerializationUtils.clone(null);
         assertNull(test);
     }

--- a/src/test/java/org/apache/commons/lang3/StringEscapeUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringEscapeUtilsTest.java
@@ -22,7 +22,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.io.StringWriter;
@@ -57,20 +56,8 @@ public class StringEscapeUtilsTest {
     @Test
     public void testEscapeJava() throws IOException {
         assertNull(StringEscapeUtils.escapeJava(null));
-        try {
-            StringEscapeUtils.ESCAPE_JAVA.translate(null, null);
-            fail();
-        } catch (final IOException ex) {
-            fail();
-        } catch (final IllegalArgumentException ex) {
-        }
-        try {
-            StringEscapeUtils.ESCAPE_JAVA.translate("", null);
-            fail();
-        } catch (final IOException ex) {
-            fail();
-        } catch (final IllegalArgumentException ex) {
-        }
+        assertThrows(IllegalArgumentException.class, () -> StringEscapeUtils.ESCAPE_JAVA.translate(null, null));
+        assertThrows(IllegalArgumentException.class, () -> StringEscapeUtils.ESCAPE_JAVA.translate("", null));
 
         assertEscapeJava("empty string", "", "");
         assertEscapeJava(FOO, FOO);
@@ -126,25 +113,9 @@ public class StringEscapeUtilsTest {
     @Test
     public void testUnescapeJava() throws IOException {
         assertNull(StringEscapeUtils.unescapeJava(null));
-        try {
-            StringEscapeUtils.UNESCAPE_JAVA.translate(null, null);
-            fail();
-        } catch (final IOException ex) {
-            fail();
-        } catch (final IllegalArgumentException ex) {
-        }
-        try {
-            StringEscapeUtils.UNESCAPE_JAVA.translate("", null);
-            fail();
-        } catch (final IOException ex) {
-            fail();
-        } catch (final IllegalArgumentException ex) {
-        }
-        try {
-            StringEscapeUtils.unescapeJava("\\u02-3");
-            fail();
-        } catch (final RuntimeException ex) {
-        }
+        assertThrows(IllegalArgumentException.class, () -> StringEscapeUtils.UNESCAPE_JAVA.translate(null, null));
+        assertThrows(IllegalArgumentException.class, () -> StringEscapeUtils.UNESCAPE_JAVA.translate("", null));
+        assertThrows(RuntimeException.class, () -> StringEscapeUtils.unescapeJava("\\u02-3"));
 
         assertUnescapeJava("", "");
         assertUnescapeJava("test", "test");
@@ -182,20 +153,8 @@ public class StringEscapeUtilsTest {
     @Test
     public void testEscapeEcmaScript() {
         assertNull(StringEscapeUtils.escapeEcmaScript(null));
-        try {
-            StringEscapeUtils.ESCAPE_ECMASCRIPT.translate(null, null);
-            fail();
-        } catch (final IOException ex) {
-            fail();
-        } catch (final IllegalArgumentException ex) {
-        }
-        try {
-            StringEscapeUtils.ESCAPE_ECMASCRIPT.translate("", null);
-            fail();
-        } catch (final IOException ex) {
-            fail();
-        } catch (final IllegalArgumentException ex) {
-        }
+        assertThrows(IllegalArgumentException.class, () -> StringEscapeUtils.ESCAPE_ECMASCRIPT.translate(null, null));
+        assertThrows(IllegalArgumentException.class, () -> StringEscapeUtils.ESCAPE_ECMASCRIPT.translate("", null));
 
         assertEquals("He didn\\'t say, \\\"stop!\\\"", StringEscapeUtils.escapeEcmaScript("He didn't say, \"stop!\""));
         assertEquals("document.getElementById(\\\"test\\\").value = \\'<script>alert(\\'aaa\\');<\\/script>\\';",
@@ -205,20 +164,8 @@ public class StringEscapeUtilsTest {
     @Test
     public void testUnescapeEcmaScript() {
         assertNull(StringEscapeUtils.escapeEcmaScript(null));
-        try {
-            StringEscapeUtils.UNESCAPE_ECMASCRIPT.translate(null, null);
-            fail();
-        } catch (final IOException ex) {
-            fail();
-        } catch (final IllegalArgumentException ex) {
-        }
-        try {
-            StringEscapeUtils.UNESCAPE_ECMASCRIPT.translate("", null);
-            fail();
-        } catch (final IOException ex) {
-            fail();
-        } catch (final IllegalArgumentException ex) {
-        }
+        assertThrows(IllegalArgumentException.class, () -> StringEscapeUtils.UNESCAPE_ECMASCRIPT.translate(null, null));
+        assertThrows(IllegalArgumentException.class, () -> StringEscapeUtils.UNESCAPE_ECMASCRIPT.translate("", null));
 
         assertEquals("He didn't say, \"stop!\"", StringEscapeUtils.unescapeEcmaScript("He didn\\'t say, \\\"stop!\\\""));
         assertEquals("document.getElementById(\"test\").value = '<script>alert('aaa');</script>';",
@@ -244,24 +191,21 @@ public class StringEscapeUtilsTest {
     };
 
     @Test
-    public void testEscapeHtml() {
+    public void testEscapeHtml() throws IOException {
         for (final String[] element : HTML_ESCAPES) {
             final String message = element[0];
             final String expected = element[1];
             final String original = element[2];
             assertEquals(expected, StringEscapeUtils.escapeHtml4(original), message);
             final StringWriter sw = new StringWriter();
-            try {
-                StringEscapeUtils.ESCAPE_HTML4.translate(original, sw);
-            } catch (final IOException e) {
-            }
+            StringEscapeUtils.ESCAPE_HTML4.translate(original, sw);
             final String actual = original == null ? null : sw.toString();
             assertEquals(expected, actual, message);
         }
     }
 
     @Test
-    public void testUnescapeHtml4() {
+    public void testUnescapeHtml4() throws IOException {
         for (final String[] element : HTML_ESCAPES) {
             final String message = element[0];
             final String expected = element[2];
@@ -269,10 +213,7 @@ public class StringEscapeUtilsTest {
             assertEquals(expected, StringEscapeUtils.unescapeHtml4(original), message);
 
             final StringWriter sw = new StringWriter();
-            try {
-                StringEscapeUtils.UNESCAPE_HTML4.translate(original, sw);
-            } catch (final IOException e) {
-            }
+            StringEscapeUtils.UNESCAPE_HTML4.translate(original, sw);
             final String actual = original == null ? null : sw.toString();
             assertEquals(expected, actual, message);
         }
@@ -337,17 +278,11 @@ public class StringEscapeUtilsTest {
         assertNull(StringEscapeUtils.unescapeXml(null));
 
         StringWriter sw = new StringWriter();
-        try {
-            StringEscapeUtils.ESCAPE_XML.translate("<abc>", sw);
-        } catch (final IOException e) {
-        }
+        StringEscapeUtils.ESCAPE_XML.translate("<abc>", sw);
         assertEquals("&lt;abc&gt;", sw.toString(), "XML was escaped incorrectly");
 
         sw = new StringWriter();
-        try {
-            StringEscapeUtils.UNESCAPE_XML.translate("&lt;abc&gt;", sw);
-        } catch (final IOException e) {
-        }
+        StringEscapeUtils.UNESCAPE_XML.translate("&lt;abc&gt;", sw);
         assertEquals("<abc>", sw.toString(), "XML was unescaped incorrectly");
     }
 
@@ -481,14 +416,10 @@ public class StringEscapeUtilsTest {
         checkCsvEscapeWriter("", "");
     }
 
-    private void checkCsvEscapeWriter(final String expected, final String value) {
-        try {
-            final StringWriter writer = new StringWriter();
-            StringEscapeUtils.ESCAPE_CSV.translate(value, writer);
-            assertEquals(expected, writer.toString());
-        } catch (final IOException e) {
-            fail("Threw: " + e);
-        }
+    private void checkCsvEscapeWriter(final String expected, final String value) throws IOException {
+        final StringWriter writer = new StringWriter();
+        StringEscapeUtils.ESCAPE_CSV.translate(value, writer);
+        assertEquals(expected, writer.toString());
     }
 
     @Test
@@ -525,14 +456,10 @@ public class StringEscapeUtilsTest {
         checkCsvUnescapeWriter("\"foo.bar\"",        "\"foo.bar\"");
     }
 
-    private void checkCsvUnescapeWriter(final String expected, final String value) {
-        try {
-            final StringWriter writer = new StringWriter();
-            StringEscapeUtils.UNESCAPE_CSV.translate(value, writer);
-            assertEquals(expected, writer.toString());
-        } catch (final IOException e) {
-            fail("Threw: " + e);
-        }
+    private void checkCsvUnescapeWriter(final String expected, final String value) throws IOException {
+        final StringWriter writer = new StringWriter();
+        StringEscapeUtils.UNESCAPE_CSV.translate(value, writer);
+        assertEquals(expected, writer.toString());
     }
 
     @Test
@@ -622,20 +549,8 @@ public class StringEscapeUtilsTest {
     @Test
     public void testEscapeJson() {
         assertNull(StringEscapeUtils.escapeJson(null));
-        try {
-            StringEscapeUtils.ESCAPE_JSON.translate(null, null);
-            fail();
-        } catch (final IOException ex) {
-            fail();
-        } catch (final IllegalArgumentException ex) {
-        }
-        try {
-            StringEscapeUtils.ESCAPE_JSON.translate("", null);
-            fail();
-        } catch (final IOException ex) {
-            fail();
-        } catch (final IllegalArgumentException ex) {
-        }
+        assertThrows(IllegalArgumentException.class, () -> StringEscapeUtils.ESCAPE_JSON.translate(null, null));
+        assertThrows(IllegalArgumentException.class, () -> StringEscapeUtils.ESCAPE_JSON.translate("", null));
 
         assertEquals("He didn't say, \\\"stop!\\\"", StringEscapeUtils.escapeJson("He didn't say, \"stop!\""));
 
@@ -648,20 +563,8 @@ public class StringEscapeUtilsTest {
     @Test
     public void testUnescapeJson() {
         assertNull(StringEscapeUtils.unescapeJson(null));
-        try {
-            StringEscapeUtils.UNESCAPE_JSON.translate(null, null);
-            fail();
-        } catch (final IOException ex) {
-            fail();
-        } catch (final IllegalArgumentException ex) {
-        }
-        try {
-            StringEscapeUtils.UNESCAPE_JSON.translate("", null);
-            fail();
-        } catch (final IOException ex) {
-            fail();
-        } catch (final IllegalArgumentException ex) {
-        }
+        assertThrows(IllegalArgumentException.class, () -> StringEscapeUtils.UNESCAPE_JSON.translate(null, null));
+        assertThrows(IllegalArgumentException.class, () -> StringEscapeUtils.UNESCAPE_JSON.translate("", null));
 
         assertEquals("He didn't say, \"stop!\"", StringEscapeUtils.unescapeJson("He didn't say, \\\"stop!\\\""));
 

--- a/src/test/java/org/apache/commons/lang3/StringEscapeUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringEscapeUtilsTest.java
@@ -245,12 +245,12 @@ public class StringEscapeUtilsTest {
     }
 
     @Test
-    public void testUnescapeUnknownEntity() throws Exception {
+    public void testUnescapeUnknownEntity() {
         assertEquals("&zzzz;", StringEscapeUtils.unescapeHtml4("&zzzz;"));
     }
 
     @Test
-    public void testEscapeHtmlVersions() throws Exception {
+    public void testEscapeHtmlVersions() {
         assertEquals("&Beta;", StringEscapeUtils.escapeHtml4("\u0392"));
         assertEquals("\u0392", StringEscapeUtils.unescapeHtml4("&Beta;"));
 
@@ -287,7 +287,7 @@ public class StringEscapeUtilsTest {
     }
 
     @Test
-    public void testEscapeXml10() throws Exception {
+    public void testEscapeXml10() {
         assertEquals("a&lt;b&gt;c&quot;d&apos;e&amp;f", StringEscapeUtils.escapeXml10("a<b>c\"d'e&f"));
         assertEquals("a\tb\rc\nd", StringEscapeUtils.escapeXml10("a\tb\rc\nd"), "XML 1.0 should not escape \t \n \r");
         assertEquals("ab", StringEscapeUtils.escapeXml10("a\u0000\u0001\u0008\u000b\u000c\u000e\u001fb"),
@@ -302,7 +302,7 @@ public class StringEscapeUtilsTest {
     }
 
     @Test
-    public void testEscapeXml11() throws Exception {
+    public void testEscapeXml11() {
         assertEquals("a&lt;b&gt;c&quot;d&apos;e&amp;f", StringEscapeUtils.escapeXml11("a<b>c\"d'e&f"));
         assertEquals("a\tb\rc\nd", StringEscapeUtils.escapeXml11("a\tb\rc\nd"), "XML 1.1 should not escape \t \n \r");
         assertEquals("ab", StringEscapeUtils.escapeXml11("a\u0000b"), "XML 1.1 should omit #x0");
@@ -393,7 +393,7 @@ public class StringEscapeUtilsTest {
     }
 
     @Test
-    public void testEscapeCsvString() throws Exception {
+    public void testEscapeCsvString() {
         assertEquals("foo.bar",            StringEscapeUtils.escapeCsv("foo.bar"));
         assertEquals("\"foo,bar\"",        StringEscapeUtils.escapeCsv("foo,bar"));
         assertEquals("\"foo\nbar\"",       StringEscapeUtils.escapeCsv("foo\nbar"));
@@ -429,7 +429,7 @@ public class StringEscapeUtilsTest {
     }
 
     @Test
-    public void testUnescapeCsvString() throws Exception {
+    public void testUnescapeCsvString() {
         assertEquals("foo.bar",              StringEscapeUtils.unescapeCsv("foo.bar"));
         assertEquals("foo,bar",              StringEscapeUtils.unescapeCsv("\"foo,bar\""));
         assertEquals("foo\nbar",             StringEscapeUtils.unescapeCsv("\"foo\nbar\""));

--- a/src/test/java/org/apache/commons/lang3/StringUtilsEqualsIndexOfTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringUtilsEqualsIndexOfTest.java
@@ -200,10 +200,10 @@ public class StringUtilsEqualsIndexOfTest  {
     //-----------------------------------------------------------------------
     @Test
     public void testCompare_StringString() {
-        assertTrue(StringUtils.compare(null, null) == 0);
+        assertEquals(0, StringUtils.compare(null, null));
         assertTrue(StringUtils.compare(null, "a") < 0);
         assertTrue(StringUtils.compare("a", null) > 0);
-        assertTrue(StringUtils.compare("abc", "abc") == 0);
+        assertEquals(0, StringUtils.compare("abc", "abc"));
         assertTrue(StringUtils.compare("a", "b") < 0);
         assertTrue(StringUtils.compare("b", "a") > 0);
         assertTrue(StringUtils.compare("a", "B") > 0);
@@ -215,12 +215,12 @@ public class StringUtilsEqualsIndexOfTest  {
 
     @Test
     public void testCompare_StringStringBoolean() {
-        assertTrue(StringUtils.compare(null, null, false) == 0);
+        assertEquals(0, StringUtils.compare(null, null, false));
         assertTrue(StringUtils.compare(null, "a", true) < 0);
         assertTrue(StringUtils.compare(null, "a", false) > 0);
         assertTrue(StringUtils.compare("a", null, true) > 0);
         assertTrue(StringUtils.compare("a", null, false) < 0);
-        assertTrue(StringUtils.compare("abc", "abc", false) == 0);
+        assertEquals(0, StringUtils.compare("abc", "abc", false));
         assertTrue(StringUtils.compare("a", "b", false) < 0);
         assertTrue(StringUtils.compare("b", "a", false) > 0);
         assertTrue(StringUtils.compare("a", "B", false) > 0);
@@ -232,11 +232,11 @@ public class StringUtilsEqualsIndexOfTest  {
 
     @Test
     public void testCompareIgnoreCase_StringString() {
-        assertTrue(StringUtils.compareIgnoreCase(null, null) == 0);
+        assertEquals(0, StringUtils.compareIgnoreCase(null, null));
         assertTrue(StringUtils.compareIgnoreCase(null, "a") < 0);
         assertTrue(StringUtils.compareIgnoreCase("a", null) > 0);
-        assertTrue(StringUtils.compareIgnoreCase("abc", "abc") == 0);
-        assertTrue(StringUtils.compareIgnoreCase("abc", "ABC") == 0);
+        assertEquals(0, StringUtils.compareIgnoreCase("abc", "abc"));
+        assertEquals(0, StringUtils.compareIgnoreCase("abc", "ABC"));
         assertTrue(StringUtils.compareIgnoreCase("a", "b") < 0);
         assertTrue(StringUtils.compareIgnoreCase("b", "a") > 0);
         assertTrue(StringUtils.compareIgnoreCase("a", "B") < 0);
@@ -249,13 +249,13 @@ public class StringUtilsEqualsIndexOfTest  {
 
     @Test
     public void testCompareIgnoreCase_StringStringBoolean() {
-        assertTrue(StringUtils.compareIgnoreCase(null, null, false) == 0);
+        assertEquals(0, StringUtils.compareIgnoreCase(null, null, false));
         assertTrue(StringUtils.compareIgnoreCase(null, "a", true) < 0);
         assertTrue(StringUtils.compareIgnoreCase(null, "a", false) > 0);
         assertTrue(StringUtils.compareIgnoreCase("a", null, true) > 0);
         assertTrue(StringUtils.compareIgnoreCase("a", null, false) < 0);
-        assertTrue(StringUtils.compareIgnoreCase("abc", "abc", false) == 0);
-        assertTrue(StringUtils.compareIgnoreCase("abc", "ABC", false) == 0);
+        assertEquals(0, StringUtils.compareIgnoreCase("abc", "abc", false));
+        assertEquals(0, StringUtils.compareIgnoreCase("abc", "ABC", false));
         assertTrue(StringUtils.compareIgnoreCase("a", "b", false) < 0);
         assertTrue(StringUtils.compareIgnoreCase("b", "a", false) > 0);
         assertTrue(StringUtils.compareIgnoreCase("a", "B", false) < 0);

--- a/src/test/java/org/apache/commons/lang3/StringUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringUtilsTest.java
@@ -1653,9 +1653,9 @@ public class StringUtilsTest {
         assertEquals("", StringUtils.chomp("", "foo"), "chomp(String, String) failed");
         assertEquals("", StringUtils.chomp("", null), "chomp(String, String) failed");
         assertEquals("", StringUtils.chomp("", ""), "chomp(String, String) failed");
-        assertEquals(null, StringUtils.chomp(null, "foo"), "chomp(String, String) failed");
-        assertEquals(null, StringUtils.chomp(null, null), "chomp(String, String) failed");
-        assertEquals(null, StringUtils.chomp(null, ""), "chomp(String, String) failed");
+        assertNull(StringUtils.chomp(null, "foo"), "chomp(String, String) failed");
+        assertNull(StringUtils.chomp(null, null), "chomp(String, String) failed");
+        assertNull(StringUtils.chomp(null, ""), "chomp(String, String) failed");
         assertEquals("", StringUtils.chomp("foo", "foo"), "chomp(String, String) failed");
         assertEquals(" ", StringUtils.chomp(" foo", "foo"), "chomp(String, String) failed");
         assertEquals("foo ", StringUtils.chomp("foo ", "foo"), "chomp(String, String) failed");
@@ -2920,14 +2920,14 @@ public class StringUtilsTest {
      */
     @Test
     public void testAppendIfMissing() {
-        assertEquals(null, StringUtils.appendIfMissing(null, null), "appendIfMissing(null,null)");
+        assertNull(StringUtils.appendIfMissing(null, null), "appendIfMissing(null,null)");
         assertEquals("abc", StringUtils.appendIfMissing("abc", null), "appendIfMissing(abc,null)");
         assertEquals("xyz", StringUtils.appendIfMissing("", "xyz"), "appendIfMissing(\"\",xyz)");
         assertEquals("abcxyz", StringUtils.appendIfMissing("abc", "xyz"), "appendIfMissing(abc,xyz)");
         assertEquals("abcxyz", StringUtils.appendIfMissing("abcxyz", "xyz"), "appendIfMissing(abcxyz,xyz)");
         assertEquals("aXYZxyz", StringUtils.appendIfMissing("aXYZ", "xyz"), "appendIfMissing(aXYZ,xyz)");
 
-        assertEquals(null, StringUtils.appendIfMissing(null, null, (CharSequence[]) null), "appendIfMissing(null,null,null)");
+        assertNull(StringUtils.appendIfMissing(null, null, (CharSequence[]) null), "appendIfMissing(null,null,null)");
         assertEquals("abc", StringUtils.appendIfMissing("abc", null, (CharSequence[]) null), "appendIfMissing(abc,null,null)");
         assertEquals("xyz", StringUtils.appendIfMissing("", "xyz", (CharSequence[]) null), "appendIfMissing(\"\",xyz,null))");
         assertEquals("abcxyz", StringUtils.appendIfMissing("abc", "xyz", new CharSequence[]{null}), "appendIfMissing(abc,xyz,{null})");
@@ -2944,14 +2944,14 @@ public class StringUtilsTest {
      */
     @Test
     public void testAppendIfMissingIgnoreCase() {
-        assertEquals(null, StringUtils.appendIfMissingIgnoreCase(null, null), "appendIfMissingIgnoreCase(null,null)");
+        assertNull(StringUtils.appendIfMissingIgnoreCase(null, null), "appendIfMissingIgnoreCase(null,null)");
         assertEquals("abc", StringUtils.appendIfMissingIgnoreCase("abc", null), "appendIfMissingIgnoreCase(abc,null)");
         assertEquals("xyz", StringUtils.appendIfMissingIgnoreCase("", "xyz"), "appendIfMissingIgnoreCase(\"\",xyz)");
         assertEquals("abcxyz", StringUtils.appendIfMissingIgnoreCase("abc", "xyz"), "appendIfMissingIgnoreCase(abc,xyz)");
         assertEquals("abcxyz", StringUtils.appendIfMissingIgnoreCase("abcxyz", "xyz"), "appendIfMissingIgnoreCase(abcxyz,xyz)");
         assertEquals("abcXYZ", StringUtils.appendIfMissingIgnoreCase("abcXYZ", "xyz"), "appendIfMissingIgnoreCase(abcXYZ,xyz)");
 
-        assertEquals(null, StringUtils.appendIfMissingIgnoreCase(null, null, (CharSequence[]) null), "appendIfMissingIgnoreCase(null,null,null)");
+        assertNull(StringUtils.appendIfMissingIgnoreCase(null, null, (CharSequence[]) null), "appendIfMissingIgnoreCase(null,null,null)");
         assertEquals("abc", StringUtils.appendIfMissingIgnoreCase("abc", null, (CharSequence[]) null), "appendIfMissingIgnoreCase(abc,null,null)");
         assertEquals("xyz", StringUtils.appendIfMissingIgnoreCase("", "xyz", (CharSequence[]) null), "appendIfMissingIgnoreCase(\"\",xyz,null)");
         assertEquals("abcxyz", StringUtils.appendIfMissingIgnoreCase("abc", "xyz", new CharSequence[]{null}), "appendIfMissingIgnoreCase(abc,xyz,{null})");
@@ -2968,14 +2968,14 @@ public class StringUtilsTest {
      */
     @Test
     public void testPrependIfMissing() {
-        assertEquals(null, StringUtils.prependIfMissing(null, null), "prependIfMissing(null,null)");
+        assertNull(StringUtils.prependIfMissing(null, null), "prependIfMissing(null,null)");
         assertEquals("abc", StringUtils.prependIfMissing("abc", null), "prependIfMissing(abc,null)");
         assertEquals("xyz", StringUtils.prependIfMissing("", "xyz"), "prependIfMissing(\"\",xyz)");
         assertEquals("xyzabc", StringUtils.prependIfMissing("abc", "xyz"), "prependIfMissing(abc,xyz)");
         assertEquals("xyzabc", StringUtils.prependIfMissing("xyzabc", "xyz"), "prependIfMissing(xyzabc,xyz)");
         assertEquals("xyzXYZabc", StringUtils.prependIfMissing("XYZabc", "xyz"), "prependIfMissing(XYZabc,xyz)");
 
-        assertEquals(null, StringUtils.prependIfMissing(null, null, (CharSequence[]) null), "prependIfMissing(null,null null)");
+        assertNull(StringUtils.prependIfMissing(null, null, (CharSequence[]) null), "prependIfMissing(null,null null)");
         assertEquals("abc", StringUtils.prependIfMissing("abc", null, (CharSequence[]) null), "prependIfMissing(abc,null,null)");
         assertEquals("xyz", StringUtils.prependIfMissing("", "xyz", (CharSequence[]) null), "prependIfMissing(\"\",xyz,null)");
         assertEquals("xyzabc", StringUtils.prependIfMissing("abc", "xyz", new CharSequence[]{null}), "prependIfMissing(abc,xyz,{null})");
@@ -2992,14 +2992,14 @@ public class StringUtilsTest {
      */
     @Test
     public void testPrependIfMissingIgnoreCase() {
-        assertEquals(null, StringUtils.prependIfMissingIgnoreCase(null, null), "prependIfMissingIgnoreCase(null,null)");
+        assertNull(StringUtils.prependIfMissingIgnoreCase(null, null), "prependIfMissingIgnoreCase(null,null)");
         assertEquals("abc", StringUtils.prependIfMissingIgnoreCase("abc", null), "prependIfMissingIgnoreCase(abc,null)");
         assertEquals("xyz", StringUtils.prependIfMissingIgnoreCase("", "xyz"), "prependIfMissingIgnoreCase(\"\",xyz)");
         assertEquals("xyzabc", StringUtils.prependIfMissingIgnoreCase("abc", "xyz"), "prependIfMissingIgnoreCase(abc,xyz)");
         assertEquals("xyzabc", StringUtils.prependIfMissingIgnoreCase("xyzabc", "xyz"), "prependIfMissingIgnoreCase(xyzabc,xyz)");
         assertEquals("XYZabc", StringUtils.prependIfMissingIgnoreCase("XYZabc", "xyz"), "prependIfMissingIgnoreCase(XYZabc,xyz)");
 
-        assertEquals(null, StringUtils.prependIfMissingIgnoreCase(null, null, (CharSequence[]) null), "prependIfMissingIgnoreCase(null,null null)");
+        assertNull(StringUtils.prependIfMissingIgnoreCase(null, null, (CharSequence[]) null), "prependIfMissingIgnoreCase(null,null null)");
         assertEquals("abc", StringUtils.prependIfMissingIgnoreCase("abc", null, (CharSequence[]) null), "prependIfMissingIgnoreCase(abc,null,null)");
         assertEquals("xyz", StringUtils.prependIfMissingIgnoreCase("", "xyz", (CharSequence[]) null), "prependIfMissingIgnoreCase(\"\",xyz,null)");
         assertEquals("xyzabc", StringUtils.prependIfMissingIgnoreCase("abc", "xyz", new CharSequence[]{null}), "prependIfMissingIgnoreCase(abc,xyz,{null})");

--- a/src/test/java/org/apache/commons/lang3/StringUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringUtilsTest.java
@@ -2442,7 +2442,7 @@ public class StringUtilsTest {
     }
 
     @Test
-    public void testGetFuzzyDistance() throws Exception {
+    public void testGetFuzzyDistance() {
         assertEquals(0, StringUtils.getFuzzyDistance("", "", Locale.ENGLISH));
         assertEquals(0, StringUtils.getFuzzyDistance("Workshop", "b", Locale.ENGLISH));
         assertEquals(1, StringUtils.getFuzzyDistance("Room", "o", Locale.ENGLISH));
@@ -2884,7 +2884,7 @@ public class StringUtilsTest {
     }
 
     @Test
-    public void testEscapeSurrogatePairs() throws Exception {
+    public void testEscapeSurrogatePairs() {
         assertEquals("\uD83D\uDE30", StringEscapeUtils.escapeCsv("\uD83D\uDE30"));
         // Examples from https://en.wikipedia.org/wiki/UTF-16
         assertEquals("\uD800\uDC00", StringEscapeUtils.escapeCsv("\uD800\uDC00"));
@@ -2905,7 +2905,7 @@ public class StringUtilsTest {
     }
 
     @Test
-    public void testUnescapeSurrogatePairs() throws Exception {
+    public void testUnescapeSurrogatePairs() {
         assertEquals("\uD83D\uDE30", StringEscapeUtils.unescapeCsv("\uD83D\uDE30"));
         // Examples from https://en.wikipedia.org/wiki/UTF-16
         assertEquals("\uD800\uDC00", StringEscapeUtils.unescapeCsv("\uD800\uDC00"));
@@ -3145,7 +3145,7 @@ public class StringUtilsTest {
     }
 
     @Test
-    public void testToCodePoints() throws Exception {
+    public void testToCodePoints() {
         final int orphanedHighSurrogate = 0xD801;
         final int orphanedLowSurrogate = 0xDC00;
         final int supplementary = 0x2070E;

--- a/src/test/java/org/apache/commons/lang3/StringUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringUtilsTest.java
@@ -24,7 +24,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Constructor;
@@ -2849,18 +2848,16 @@ public class StringUtilsTest {
                 // don't actively test for that.
                 final Class<?>[] params = m.getParameterTypes();
                 if (params.length > 0 && (params[0] == CharSequence.class || params[0] == CharSequence[].class)) {
-                    if (!ArrayUtils.contains(excludeMethods, methodStr)) {
-                        fail("The method \"" + methodStr + "\" appears to be mutable in spirit and therefore must not accept a CharSequence");
-                    }
+                    assertTrue(!ArrayUtils.contains(excludeMethods, methodStr),
+                            "The method \"" + methodStr + "\" appears to be mutable in spirit and therefore must not accept a CharSequence");
                 }
             } else {
                 // Assume this is immutable in spirit and ensure the first parameter is not String.
                 // As above, it may be something other than CharSequence.
                 final Class<?>[] params = m.getParameterTypes();
                 if (params.length > 0 && (params[0] == String.class || params[0] == String[].class)) {
-                    if (!ArrayUtils.contains(excludeMethods, methodStr)) {
-                        fail("The method \"" + methodStr + "\" appears to be immutable in spirit and therefore must not accept a String");
-                    }
+                    assertTrue(ArrayUtils.contains(excludeMethods, methodStr),
+                            "The method \"" + methodStr + "\" appears to be immutable in spirit and therefore must not accept a String");
                 }
             }
         }

--- a/src/test/java/org/apache/commons/lang3/StringUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringUtilsTest.java
@@ -1273,12 +1273,10 @@ public class StringUtilsTest {
         assertEquals("Lorem_ipsum_dolor_sit",
                      StringUtils.replaceAll("Lorem ipsum  dolor   sit", "( +)([a-z]+)", "_$2"));
 
-        try {
-            StringUtils.replaceAll("any", "{badRegexSyntax}", "");
-            fail("StringUtils.replaceAll expecting PatternSyntaxException");
-        } catch (final PatternSyntaxException ex) {
-            // empty
-        }
+        assertThrows(
+                PatternSyntaxException.class,
+                () -> StringUtils.replaceAll("any", "{badRegexSyntax}", ""),
+                "StringUtils.replaceAll expecting PatternSyntaxException");
     }
 
     @Test
@@ -1302,12 +1300,10 @@ public class StringUtilsTest {
         assertEquals("Lorem_ipsum  dolor   sit",
                      StringUtils.replaceFirst("Lorem ipsum  dolor   sit", "( +)([a-z]+)", "_$2"));
 
-        try {
-            StringUtils.replaceFirst("any", "{badRegexSyntax}", "");
-            fail("StringUtils.replaceFirst expecting PatternSyntaxException");
-        } catch (final PatternSyntaxException ex) {
-            // empty
-        }
+        assertThrows(
+                PatternSyntaxException.class,
+                () -> StringUtils.replaceFirst("any", "{badRegexSyntax}", ""),
+                "StringUtils.replaceFirst expecting PatternSyntaxException");
     }
 
     @Test
@@ -1450,12 +1446,10 @@ public class StringUtilsTest {
         assertEquals(StringUtils.replaceEach("aba", new String[]{"a"}, new String[]{null}), "aba");
         assertEquals(StringUtils.replaceEach("aba", new String[]{"a", "b"}, new String[]{"c", null}), "cbc");
 
-        try {
-            StringUtils.replaceEach("abba", new String[]{"a"}, new String[]{"b", "a"});
-            fail("StringUtils.replaceEach(String, String[], String[]) expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException ex) {
-            // expected
-        }
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> StringUtils.replaceEach("abba", new String[]{"a"}, new String[]{"b", "a"}),
+                "StringUtils.replaceEach(String, String[], String[]) expecting IllegalArgumentException");
     }
 
     /**
@@ -1476,11 +1470,10 @@ public class StringUtilsTest {
         assertEquals(StringUtils.replaceEachRepeatedly("abcde", new String[]{"ab", "d"}, new String[]{"w", "t"}), "wcte");
         assertEquals(StringUtils.replaceEachRepeatedly("abcde", new String[]{"ab", "d"}, new String[]{"d", "t"}), "tcte");
 
-        try {
-            StringUtils.replaceEachRepeatedly("abcde", new String[]{"ab", "d"}, new String[]{"d", "ab"});
-            fail("Should be a circular reference");
-        } catch (final IllegalStateException e) {
-        }
+        assertThrows(
+                IllegalStateException.class,
+                () -> StringUtils.replaceEachRepeatedly("abcde", new String[]{"ab", "d"}, new String[]{"d", "ab"}),
+                "Should be a circular reference");
 
         //JAVADOC TESTS END
     }
@@ -1981,12 +1974,10 @@ public class StringUtilsTest {
         assertEquals("a...", StringUtils.abbreviate("abcdefg", 4));
         assertEquals("", StringUtils.abbreviate("", 4));
 
-        try {
-            StringUtils.abbreviate("abc", 3);
-            fail("StringUtils.abbreviate expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException expected) {
-            // empty
-        }
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> StringUtils.abbreviate("abc", 3),
+                "StringUtils.abbreviate expecting IllegalArgumentException");
     }
 
     @Test
@@ -2008,14 +1999,10 @@ public class StringUtilsTest {
         assertEquals("abc.", StringUtils.abbreviate("abcdefg", ".", 4));
         assertEquals("", StringUtils.abbreviate("", 4));
 
-        try {
-            @SuppressWarnings("unused")
-            final
-            String res = StringUtils.abbreviate("abcdefghij", "...", 3);
-            fail("StringUtils.abbreviate expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException ex) {
-            // empty
-        }
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> StringUtils.abbreviate("abcdefghij", "...", 3),
+                "StringUtils.abbreviate expecting IllegalArgumentException");
     }
 
     @Test
@@ -2024,19 +2011,14 @@ public class StringUtilsTest {
         assertEquals("", StringUtils.abbreviate("", 0, 10));
         assertEquals("", StringUtils.abbreviate("", 2, 10));
 
-        try {
-            StringUtils.abbreviate("abcdefghij", 0, 3);
-            fail("StringUtils.abbreviate expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException expected) {
-            // empty
-        }
-        try {
-            StringUtils.abbreviate("abcdefghij", 5, 6);
-            fail("StringUtils.abbreviate expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException expected) {
-            // empty
-        }
-
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> StringUtils.abbreviate("abcdefghij", 0, 3),
+                "StringUtils.abbreviate expecting IllegalArgumentException");
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> StringUtils.abbreviate("abcdefghij", 5, 6),
+                "StringUtils.abbreviate expecting IllegalArgumentException");
 
         final String raspberry = "raspberry peach";
         assertEquals("raspberry peach", StringUtils.abbreviate(raspberry, 11, 15));
@@ -2084,18 +2066,14 @@ public class StringUtilsTest {
         assertEquals("", StringUtils.abbreviate("", null, 0, 10));
         assertEquals("", StringUtils.abbreviate("", "...", 2, 10));
 
-        try {
-            StringUtils.abbreviate("abcdefghij", "::", 0, 2);
-            fail("StringUtils.abbreviate expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException expected) {
-            // empty
-        }
-        try {
-            StringUtils.abbreviate("abcdefghij", "!!!", 5, 6);
-            fail("StringUtils.abbreviate expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException expected) {
-            // empty
-        }
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> StringUtils.abbreviate("abcdefghij", "::", 0, 2),
+                "StringUtils.abbreviate expecting IllegalArgumentException");
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> StringUtils.abbreviate("abcdefghij", "!!!", 5, 6),
+                "StringUtils.abbreviate expecting IllegalArgumentException");
 
         final String raspberry = "raspberry peach";
         assertEquals("raspberry peach", StringUtils.abbreviate(raspberry, "--", 12, 15));
@@ -2181,47 +2159,31 @@ public class StringUtilsTest {
     @Test
     public void testTruncate_StringInt() {
         assertNull(StringUtils.truncate(null, 12));
-        try {
-            StringUtils.truncate(null, -1);
-            fail("maxWith cannot be negative");
-        } catch (final Exception e) {
-            assertTrue(e instanceof IllegalArgumentException);
-        }
-        try {
-            StringUtils.truncate(null, -10);
-            fail("maxWith cannot be negative");
-        } catch (final Exception e) {
-            assertTrue(e instanceof IllegalArgumentException);
-        }
-        try {
-            StringUtils.truncate(null, Integer.MIN_VALUE);
-            fail("maxWith cannot be negative");
-        } catch (final Exception e) {
-            assertTrue(e instanceof IllegalArgumentException);
-        }
+        assertThrows(
+                IllegalArgumentException.class, () -> StringUtils.truncate(null, -1), "maxWith cannot be negative");
+        assertThrows(
+                IllegalArgumentException.class, () -> StringUtils.truncate(null, -10), "maxWith cannot be negative");
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> StringUtils.truncate(null, Integer.MIN_VALUE),
+                "maxWith cannot be negative");
         assertEquals("", StringUtils.truncate("", 10));
         assertEquals("", StringUtils.truncate("", 10));
         assertEquals("abc", StringUtils.truncate("abcdefghij", 3));
         assertEquals("abcdef", StringUtils.truncate("abcdefghij", 6));
         assertEquals("", StringUtils.truncate("abcdefghij", 0));
-        try {
-            StringUtils.truncate("abcdefghij", -1);
-            fail("maxWith cannot be negative");
-        } catch (final Exception e) {
-            assertTrue(e instanceof IllegalArgumentException);
-        }
-        try {
-            StringUtils.truncate("abcdefghij", -100);
-            fail("maxWith cannot be negative");
-        } catch (final Exception e) {
-            assertTrue(e instanceof IllegalArgumentException);
-        }
-        try {
-            StringUtils.truncate("abcdefghij", Integer.MIN_VALUE);
-            fail("maxWith cannot be negative");
-        } catch (final Exception e) {
-            assertTrue(e instanceof IllegalArgumentException);
-        }
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> StringUtils.truncate("abcdefghij", -1),
+                "maxWith cannot be negative");
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> StringUtils.truncate("abcdefghij", -100),
+                "maxWith cannot be negative");
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> StringUtils.truncate("abcdefghij", Integer.MIN_VALUE),
+                "maxWith cannot be negative");
         assertEquals("abcdefghij", StringUtils.truncate("abcdefghijklmno", 10));
         assertEquals("abcdefghijklmno", StringUtils.truncate("abcdefghijklmno", Integer.MAX_VALUE));
         assertEquals("abcde", StringUtils.truncate("abcdefghijklmno", 5));
@@ -2231,108 +2193,74 @@ public class StringUtilsTest {
     @Test
     public void testTruncate_StringIntInt() {
         assertNull(StringUtils.truncate(null, 0, 12));
-        try {
-            StringUtils.truncate(null, -1, 0);
-            fail("maxWith cannot be negative");
-        } catch (final Exception e) {
-            assertTrue(e instanceof IllegalArgumentException);
-        }
-        try {
-            StringUtils.truncate(null, -10, -4);
-            fail("maxWith cannot be negative");
-        } catch (final Exception e) {
-            assertTrue(e instanceof IllegalArgumentException);
-        }
-        try {
-            StringUtils.truncate(null, Integer.MIN_VALUE, Integer.MIN_VALUE);
-            fail("maxWith cannot be negative");
-        } catch (final Exception e) {
-            assertTrue(e instanceof IllegalArgumentException);
-        }
+        assertThrows(
+                IllegalArgumentException.class, () -> StringUtils.truncate(null, -1, 0), "maxWith cannot be negative");
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> StringUtils.truncate(null, -10, -4),
+                "maxWith cannot be negative");
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> StringUtils.truncate(null, Integer.MIN_VALUE, Integer.MIN_VALUE),
+                "maxWith cannot be negative");
         assertNull(StringUtils.truncate(null, 10, 12));
         assertEquals("", StringUtils.truncate("", 0, 10));
         assertEquals("", StringUtils.truncate("", 2, 10));
         assertEquals("abc", StringUtils.truncate("abcdefghij", 0, 3));
         assertEquals("fghij", StringUtils.truncate("abcdefghij", 5, 6));
         assertEquals("", StringUtils.truncate("abcdefghij", 0, 0));
-        try {
-            StringUtils.truncate("abcdefghij", 0, -1);
-            fail("maxWith cannot be negative");
-        } catch (final Exception e) {
-            assertTrue(e instanceof IllegalArgumentException);
-        }
-        try {
-            StringUtils.truncate("abcdefghij", 0, -10);
-            fail("maxWith cannot be negative");
-        } catch (final Exception e) {
-            assertTrue(e instanceof IllegalArgumentException);
-        }
-        try {
-            StringUtils.truncate("abcdefghij", 0, -100);
-            fail("maxWith cannot be negative");
-        } catch (final Exception e) {
-            assertTrue(e instanceof IllegalArgumentException);
-        }
-        try {
-            StringUtils.truncate("abcdefghij", 1, -100);
-            fail("maxWith cannot be negative");
-        } catch (final Exception e) {
-            assertTrue(e instanceof IllegalArgumentException);
-        }
-        try {
-            StringUtils.truncate("abcdefghij", 0, Integer.MIN_VALUE);
-            fail("maxWith cannot be negative");
-        } catch (final Exception e) {
-            assertTrue(e instanceof IllegalArgumentException);
-        }
-        try {
-            StringUtils.truncate("abcdefghij", -1, 0);
-            fail("offset cannot be negative");
-        } catch (final Exception e) {
-            assertTrue(e instanceof IllegalArgumentException);
-        }
-        try {
-            StringUtils.truncate("abcdefghij", -10, 0);
-            fail("offset cannot be negative");
-        } catch (final Exception e) {
-            assertTrue(e instanceof IllegalArgumentException);
-        }
-        try {
-            StringUtils.truncate("abcdefghij", -100, 1);
-            fail("offset cannot be negative");
-        } catch (final Exception e) {
-            assertTrue(e instanceof IllegalArgumentException);
-        }
-        try {
-            StringUtils.truncate("abcdefghij", Integer.MIN_VALUE, 0);
-            fail("offset cannot be negative");
-        } catch (final Exception e) {
-            assertTrue(e instanceof IllegalArgumentException);
-        }
-        try {
-            StringUtils.truncate("abcdefghij", -1, -1);
-            fail("offset cannot be negative");
-        } catch (final Exception e) {
-            assertTrue(e instanceof IllegalArgumentException);
-        }
-        try {
-            StringUtils.truncate("abcdefghij", -10, -10);
-            fail("offset cannot be negative");
-        } catch (final Exception e) {
-            assertTrue(e instanceof IllegalArgumentException);
-        }
-        try {
-            StringUtils.truncate("abcdefghij", -100, -100);
-            fail("offset  cannot be negative");
-        } catch (final Exception e) {
-            assertTrue(e instanceof IllegalArgumentException);
-        }
-        try {
-            StringUtils.truncate("abcdefghij", Integer.MIN_VALUE, Integer.MIN_VALUE);
-            fail("offset  cannot be negative");
-        } catch (final Exception e) {
-            assertTrue(e instanceof IllegalArgumentException);
-        }
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> StringUtils.truncate("abcdefghij", 0, -1),
+                "maxWith cannot be negative");
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> StringUtils.truncate("abcdefghij", 0, -10),
+                "maxWith cannot be negative");
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> StringUtils.truncate("abcdefghij", 0, -100),
+                "maxWith cannot be negative");
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> StringUtils.truncate("abcdefghij", 1, -100),
+                "maxWith cannot be negative");
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> StringUtils.truncate("abcdefghij", 0, Integer.MIN_VALUE),
+                "maxWith cannot be negative");
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> StringUtils.truncate("abcdefghij", -1, 0),
+                "offset cannot be negative");
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> StringUtils.truncate("abcdefghij", -10, 0),
+                "offset cannot be negative");
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> StringUtils.truncate("abcdefghij", -100, 1),
+                "offset cannot be negative");
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> StringUtils.truncate("abcdefghij", Integer.MIN_VALUE, 0),
+                "offset cannot be negative");
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> StringUtils.truncate("abcdefghij", -1, -1),
+                "offset cannot be negative");
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> StringUtils.truncate("abcdefghij", -10, -10),
+                "offset cannot be negative");
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> StringUtils.truncate("abcdefghij", -100, -100),
+                "offset  cannot be negative");
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> StringUtils.truncate("abcdefghij", Integer.MIN_VALUE, Integer.MIN_VALUE),
+                "offset  cannot be negative");
         final String raspberry = "raspberry peach";
         assertEquals("peach", StringUtils.truncate(raspberry, 10, 15));
         assertEquals("abcdefghij", StringUtils.truncate("abcdefghijklmno", 0, 10));
@@ -2795,12 +2723,10 @@ public class StringUtilsTest {
         assertEquals("AB", StringUtils.removeAll("A<__>\n<__>B", "(?s)<.*>"));
         assertEquals("ABC123", StringUtils.removeAll("ABCabc123abc", "[a-z]"));
 
-        try {
-            StringUtils.removeAll("any", "{badRegexSyntax}");
-            fail("StringUtils.removeAll expecting PatternSyntaxException");
-        } catch (final PatternSyntaxException ex) {
-            // empty
-        }
+        assertThrows(
+                PatternSyntaxException.class,
+                () -> StringUtils.removeAll("any", "{badRegexSyntax}"),
+                "StringUtils.removeAll expecting PatternSyntaxException");
     }
 
     @Test
@@ -2818,12 +2744,10 @@ public class StringUtilsTest {
         assertEquals("ABCbc123", StringUtils.removeFirst("ABCabc123", "[a-z]"));
         assertEquals("ABC123abc", StringUtils.removeFirst("ABCabc123abc", "[a-z]+"));
 
-        try {
-            StringUtils.removeFirst("any", "{badRegexSyntax}");
-            fail("StringUtils.removeFirst expecting PatternSyntaxException");
-        } catch (final PatternSyntaxException ex) {
-            // empty
-        }
+        assertThrows(
+                PatternSyntaxException.class,
+                () -> StringUtils.removeFirst("any", "{badRegexSyntax}"),
+                "StringUtils.removeFirst expecting PatternSyntaxException");
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/SystemUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/SystemUtilsTest.java
@@ -420,7 +420,7 @@ public class SystemUtilsTest {
     }
 
     @Test
-    public void testIsJavaVersionAtLeast() throws Exception {
+    public void testIsJavaVersionAtLeast() {
         if (SystemUtils.IS_JAVA_1_7) {
             assertTrue(SystemUtils.isJavaVersionAtLeast(JAVA_1_1));
             assertTrue(SystemUtils.isJavaVersionAtLeast(JAVA_1_2));
@@ -524,7 +524,7 @@ public class SystemUtilsTest {
     }
 
     @Test
-    public void testOsVersionMatches() throws Exception {
+    public void testOsVersionMatches() {
         String osVersion = null;
         assertFalse(SystemUtils.isOSVersionMatch(osVersion, "10.1"));
 

--- a/src/test/java/org/apache/commons/lang3/ThreadUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/ThreadUtilsTest.java
@@ -108,17 +108,17 @@ public class ThreadUtilsTest {
     }
 
     @Test
-    public void testNoThread() throws InterruptedException {
+    public void testNoThread() {
         assertEquals(0, ThreadUtils.findThreadsByName("some_thread_which_does_not_exist_18762ZucTT").size());
     }
 
     @Test
-    public void testNoThreadGroup() throws InterruptedException {
+    public void testNoThreadGroup() {
         assertEquals(0, ThreadUtils.findThreadGroupsByName("some_thread_group_which_does_not_exist_18762ZucTTII").size());
     }
 
     @Test
-    public void testSystemThreadGroupExists() throws InterruptedException {
+    public void testSystemThreadGroupExists() {
         final ThreadGroup systemThreadGroup = ThreadUtils.getSystemThreadGroup();
         assertNotNull(systemThreadGroup);
         assertNull(systemThreadGroup.getParent());
@@ -126,12 +126,12 @@ public class ThreadUtilsTest {
     }
 
     @Test
-    public void testAtLeastOneThreadExists() throws InterruptedException {
+    public void testAtLeastOneThreadExists() {
         assertTrue(ThreadUtils.getAllThreads().size() > 0);
     }
 
     @Test
-    public void testAtLeastOneThreadGroupsExists() throws InterruptedException {
+    public void testAtLeastOneThreadGroupsExists() {
         assertTrue(ThreadUtils.getAllThreadGroups().size() > 0);
     }
 
@@ -278,7 +278,7 @@ public class ThreadUtilsTest {
     }
 
     @Test
-    public void testConstructor() throws InterruptedException {
+    public void testConstructor() {
         assertNotNull(new ThreadUtils());
         final Constructor<?>[] cons = ThreadUtils.class.getDeclaredConstructors();
         assertEquals(1, cons.length);

--- a/src/test/java/org/apache/commons/lang3/builder/CompareToBuilderTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/CompareToBuilderTest.java
@@ -101,8 +101,8 @@ public class CompareToBuilderTest {
     public void testReflectionCompare() {
         final TestObject o1 = new TestObject(4);
         final TestObject o2 = new TestObject(4);
-        assertTrue(CompareToBuilder.reflectionCompare(o1, o1) == 0);
-        assertTrue(CompareToBuilder.reflectionCompare(o1, o2) == 0);
+        assertEquals(0, CompareToBuilder.reflectionCompare(o1, o1));
+        assertEquals(0, CompareToBuilder.reflectionCompare(o1, o2));
         o2.setA(5);
         assertTrue(CompareToBuilder.reflectionCompare(o1, o2) < 0);
         assertTrue(CompareToBuilder.reflectionCompare(o2, o1) > 0);
@@ -166,9 +166,9 @@ public class CompareToBuilderTest {
     }
 
     private void assertXYZCompareOrder(final Object x, final Object y, final Object z, final boolean testTransients, final String[] excludeFields) {
-        assertTrue(0 == CompareToBuilder.reflectionCompare(x, x, testTransients, null, excludeFields));
-        assertTrue(0 == CompareToBuilder.reflectionCompare(y, y, testTransients, null, excludeFields));
-        assertTrue(0 == CompareToBuilder.reflectionCompare(z, z, testTransients, null, excludeFields));
+        assertEquals(0, CompareToBuilder.reflectionCompare(x, x, testTransients, null, excludeFields));
+        assertEquals(0, CompareToBuilder.reflectionCompare(y, y, testTransients, null, excludeFields));
+        assertEquals(0, CompareToBuilder.reflectionCompare(z, z, testTransients, null, excludeFields));
 
         assertTrue(0 > CompareToBuilder.reflectionCompare(x, y, testTransients, null, excludeFields));
         assertTrue(0 > CompareToBuilder.reflectionCompare(x, z, testTransients, null, excludeFields));
@@ -214,7 +214,7 @@ public class CompareToBuilderTest {
     private void assertReflectionCompareContract(final Object x, final Object y, final Object z, final boolean testTransients, final String[] excludeFields) {
 
         // signum
-        assertTrue(reflectionCompareSignum(x, y, testTransients, excludeFields) == -reflectionCompareSignum(y, x, testTransients, excludeFields));
+        assertEquals(reflectionCompareSignum(x, y, testTransients, excludeFields), -reflectionCompareSignum(y, x, testTransients, excludeFields));
 
         // transitive
         if (CompareToBuilder.reflectionCompare(x, y, testTransients, null, excludeFields) > 0
@@ -224,7 +224,7 @@ public class CompareToBuilderTest {
 
         // un-named
         if (CompareToBuilder.reflectionCompare(x, y, testTransients, null, excludeFields) == 0) {
-            assertTrue(reflectionCompareSignum(x, z, testTransients, excludeFields) == -reflectionCompareSignum(y, z, testTransients, excludeFields));
+            assertEquals(reflectionCompareSignum(x, z, testTransients, excludeFields), -reflectionCompareSignum(y, z, testTransients, excludeFields));
         }
 
         // strongly recommended but not strictly required
@@ -249,7 +249,7 @@ public class CompareToBuilderTest {
     public void testAppendSuper() {
         final TestObject o1 = new TestObject(4);
         final TestObject o2 = new TestObject(5);
-        assertTrue(new CompareToBuilder().appendSuper(0).append(o1, o1).toComparison() == 0);
+        assertEquals(0, new CompareToBuilder().appendSuper(0).append(o1, o1).toComparison());
         assertTrue(new CompareToBuilder().appendSuper(0).append(o1, o2).toComparison() < 0);
         assertTrue(new CompareToBuilder().appendSuper(0).append(o2, o1).toComparison() > 0);
 
@@ -264,14 +264,14 @@ public class CompareToBuilderTest {
     public void testObject() {
         final TestObject o1 = new TestObject(4);
         final TestObject o2 = new TestObject(4);
-        assertTrue(new CompareToBuilder().append(o1, o1).toComparison() == 0);
-        assertTrue(new CompareToBuilder().append(o1, o2).toComparison() == 0);
+        assertEquals(0, new CompareToBuilder().append(o1, o1).toComparison());
+        assertEquals(0, new CompareToBuilder().append(o1, o2).toComparison());
         o2.setA(5);
         assertTrue(new CompareToBuilder().append(o1, o2).toComparison() < 0);
         assertTrue(new CompareToBuilder().append(o2, o1).toComparison() > 0);
 
         assertTrue(new CompareToBuilder().append(o1, null).toComparison() > 0);
-        assertTrue(new CompareToBuilder().append((Object) null, null).toComparison() == 0);
+        assertEquals(0, new CompareToBuilder().append((Object) null, null).toComparison());
         assertTrue(new CompareToBuilder().append(null, o1).toComparison() < 0);
     }
 
@@ -301,17 +301,17 @@ public class CompareToBuilderTest {
     public void testObjectComparator() {
         final String o1 = "Fred";
         String o2 = "Fred";
-        assertTrue(new CompareToBuilder().append(o1, o1, String.CASE_INSENSITIVE_ORDER).toComparison() == 0);
-        assertTrue(new CompareToBuilder().append(o1, o2, String.CASE_INSENSITIVE_ORDER).toComparison() == 0);
+        assertEquals(0, new CompareToBuilder().append(o1, o1, String.CASE_INSENSITIVE_ORDER).toComparison());
+        assertEquals(0, new CompareToBuilder().append(o1, o2, String.CASE_INSENSITIVE_ORDER).toComparison());
         o2 = "FRED";
-        assertTrue(new CompareToBuilder().append(o1, o2, String.CASE_INSENSITIVE_ORDER).toComparison() == 0);
-        assertTrue(new CompareToBuilder().append(o2, o1, String.CASE_INSENSITIVE_ORDER).toComparison() == 0);
+        assertEquals(0, new CompareToBuilder().append(o1, o2, String.CASE_INSENSITIVE_ORDER).toComparison());
+        assertEquals(0, new CompareToBuilder().append(o2, o1, String.CASE_INSENSITIVE_ORDER).toComparison());
         o2 = "FREDA";
         assertTrue(new CompareToBuilder().append(o1, o2, String.CASE_INSENSITIVE_ORDER).toComparison() < 0);
         assertTrue(new CompareToBuilder().append(o2, o1, String.CASE_INSENSITIVE_ORDER).toComparison() > 0);
 
         assertTrue(new CompareToBuilder().append(o1, null, String.CASE_INSENSITIVE_ORDER).toComparison() > 0);
-        assertTrue(new CompareToBuilder().append(null, null, String.CASE_INSENSITIVE_ORDER).toComparison() == 0);
+        assertEquals(0, new CompareToBuilder().append(null, null, String.CASE_INSENSITIVE_ORDER).toComparison());
         assertTrue(new CompareToBuilder().append(null, o1, String.CASE_INSENSITIVE_ORDER).toComparison() < 0);
     }
 
@@ -319,14 +319,14 @@ public class CompareToBuilderTest {
     public void testObjectComparatorNull() {
         final String o1 = "Fred";
         String o2 = "Fred";
-        assertTrue(new CompareToBuilder().append(o1, o1, null).toComparison() == 0);
-        assertTrue(new CompareToBuilder().append(o1, o2, null).toComparison() == 0);
+        assertEquals(0, new CompareToBuilder().append(o1, o1, null).toComparison());
+        assertEquals(0, new CompareToBuilder().append(o1, o2, null).toComparison());
         o2 = "Zebra";
         assertTrue(new CompareToBuilder().append(o1, o2, null).toComparison() < 0);
         assertTrue(new CompareToBuilder().append(o2, o1, null).toComparison() > 0);
 
         assertTrue(new CompareToBuilder().append(o1, null, null).toComparison() > 0);
-        assertTrue(new CompareToBuilder().append(null, null, null).toComparison() == 0);
+        assertEquals(0, new CompareToBuilder().append(null, null, null).toComparison());
         assertTrue(new CompareToBuilder().append(null, o1, null).toComparison() < 0);
     }
 
@@ -334,7 +334,7 @@ public class CompareToBuilderTest {
     public void testLong() {
         final long o1 = 1L;
         final long o2 = 2L;
-        assertTrue(new CompareToBuilder().append(o1, o1).toComparison() == 0);
+        assertEquals(0, new CompareToBuilder().append(o1, o1).toComparison());
         assertTrue(new CompareToBuilder().append(o1, o2).toComparison() < 0);
         assertTrue(new CompareToBuilder().append(o2, o1).toComparison() > 0);
         assertTrue(new CompareToBuilder().append(o1, Long.MAX_VALUE).toComparison() < 0);
@@ -347,7 +347,7 @@ public class CompareToBuilderTest {
     public void testInt() {
         final int o1 = 1;
         final int o2 = 2;
-        assertTrue(new CompareToBuilder().append(o1, o1).toComparison() == 0);
+        assertEquals(0, new CompareToBuilder().append(o1, o1).toComparison());
         assertTrue(new CompareToBuilder().append(o1, o2).toComparison() < 0);
         assertTrue(new CompareToBuilder().append(o2, o1).toComparison() > 0);
         assertTrue(new CompareToBuilder().append(o1, Integer.MAX_VALUE).toComparison() < 0);
@@ -360,7 +360,7 @@ public class CompareToBuilderTest {
     public void testShort() {
         final short o1 = 1;
         final short o2 = 2;
-        assertTrue(new CompareToBuilder().append(o1, o1).toComparison() == 0);
+        assertEquals(0, new CompareToBuilder().append(o1, o1).toComparison());
         assertTrue(new CompareToBuilder().append(o1, o2).toComparison() < 0);
         assertTrue(new CompareToBuilder().append(o2, o1).toComparison() > 0);
         assertTrue(new CompareToBuilder().append(o1, Short.MAX_VALUE).toComparison() < 0);
@@ -373,7 +373,7 @@ public class CompareToBuilderTest {
     public void testChar() {
         final char o1 = 1;
         final char o2 = 2;
-        assertTrue(new CompareToBuilder().append(o1, o1).toComparison() == 0);
+        assertEquals(0, new CompareToBuilder().append(o1, o1).toComparison());
         assertTrue(new CompareToBuilder().append(o1, o2).toComparison() < 0);
         assertTrue(new CompareToBuilder().append(o2, o1).toComparison() > 0);
         assertTrue(new CompareToBuilder().append(o1, Character.MAX_VALUE).toComparison() < 0);
@@ -386,7 +386,7 @@ public class CompareToBuilderTest {
     public void testByte() {
         final byte o1 = 1;
         final byte o2 = 2;
-        assertTrue(new CompareToBuilder().append(o1, o1).toComparison() == 0);
+        assertEquals(0, new CompareToBuilder().append(o1, o1).toComparison());
         assertTrue(new CompareToBuilder().append(o1, o2).toComparison() < 0);
         assertTrue(new CompareToBuilder().append(o2, o1).toComparison() > 0);
         assertTrue(new CompareToBuilder().append(o1, Byte.MAX_VALUE).toComparison() < 0);
@@ -399,14 +399,14 @@ public class CompareToBuilderTest {
     public void testDouble() {
         final double o1 = 1;
         final double o2 = 2;
-        assertTrue(new CompareToBuilder().append(o1, o1).toComparison() == 0);
+        assertEquals(0, new CompareToBuilder().append(o1, o1).toComparison());
         assertTrue(new CompareToBuilder().append(o1, o2).toComparison() < 0);
         assertTrue(new CompareToBuilder().append(o2, o1).toComparison() > 0);
         assertTrue(new CompareToBuilder().append(o1, Double.MAX_VALUE).toComparison() < 0);
         assertTrue(new CompareToBuilder().append(Double.MAX_VALUE, o1).toComparison() > 0);
         assertTrue(new CompareToBuilder().append(o1, Double.MIN_VALUE).toComparison() > 0);
         assertTrue(new CompareToBuilder().append(Double.MIN_VALUE, o1).toComparison() < 0);
-        assertTrue(new CompareToBuilder().append(Double.NaN, Double.NaN).toComparison() == 0);
+        assertEquals(0, new CompareToBuilder().append(Double.NaN, Double.NaN).toComparison());
         assertTrue(new CompareToBuilder().append(Double.NaN, Double.MAX_VALUE).toComparison() > 0);
         assertTrue(new CompareToBuilder().append(Double.POSITIVE_INFINITY, Double.MAX_VALUE).toComparison() > 0);
         assertTrue(new CompareToBuilder().append(Double.NEGATIVE_INFINITY, Double.MIN_VALUE).toComparison() < 0);
@@ -420,14 +420,14 @@ public class CompareToBuilderTest {
     public void testFloat() {
         final float o1 = 1;
         final float o2 = 2;
-        assertTrue(new CompareToBuilder().append(o1, o1).toComparison() == 0);
+        assertEquals(0, new CompareToBuilder().append(o1, o1).toComparison());
         assertTrue(new CompareToBuilder().append(o1, o2).toComparison() < 0);
         assertTrue(new CompareToBuilder().append(o2, o1).toComparison() > 0);
         assertTrue(new CompareToBuilder().append(o1, Float.MAX_VALUE).toComparison() < 0);
         assertTrue(new CompareToBuilder().append(Float.MAX_VALUE, o1).toComparison() > 0);
         assertTrue(new CompareToBuilder().append(o1, Float.MIN_VALUE).toComparison() > 0);
         assertTrue(new CompareToBuilder().append(Float.MIN_VALUE, o1).toComparison() < 0);
-        assertTrue(new CompareToBuilder().append(Float.NaN, Float.NaN).toComparison() == 0);
+        assertEquals(0, new CompareToBuilder().append(Float.NaN, Float.NaN).toComparison());
         assertTrue(new CompareToBuilder().append(Float.NaN, Float.MAX_VALUE).toComparison() > 0);
         assertTrue(new CompareToBuilder().append(Float.POSITIVE_INFINITY, Float.MAX_VALUE).toComparison() > 0);
         assertTrue(new CompareToBuilder().append(Float.NEGATIVE_INFINITY, Float.MIN_VALUE).toComparison() < 0);
@@ -441,8 +441,8 @@ public class CompareToBuilderTest {
     public void testBoolean() {
         final boolean o1 = true;
         final boolean o2 = false;
-        assertTrue(new CompareToBuilder().append(o1, o1).toComparison() == 0);
-        assertTrue(new CompareToBuilder().append(o2, o2).toComparison() == 0);
+        assertEquals(0, new CompareToBuilder().append(o1, o1).toComparison());
+        assertEquals(0, new CompareToBuilder().append(o2, o2).toComparison());
         assertTrue(new CompareToBuilder().append(o1, o2).toComparison() > 0);
         assertTrue(new CompareToBuilder().append(o2, o1).toComparison() < 0);
     }
@@ -460,8 +460,8 @@ public class CompareToBuilderTest {
         obj3[1] = new TestObject(5);
         obj3[2] = new TestObject(6);
 
-        assertTrue(new CompareToBuilder().append(obj1, obj1).toComparison() == 0);
-        assertTrue(new CompareToBuilder().append(obj1, obj2).toComparison() == 0);
+        assertEquals(0, new CompareToBuilder().append(obj1, obj1).toComparison());
+        assertEquals(0, new CompareToBuilder().append(obj1, obj2).toComparison());
         assertTrue(new CompareToBuilder().append(obj1, obj3).toComparison() < 0);
         assertTrue(new CompareToBuilder().append(obj3, obj1).toComparison() > 0);
 
@@ -470,7 +470,7 @@ public class CompareToBuilderTest {
         assertTrue(new CompareToBuilder().append(obj2, obj1).toComparison() < 0);
 
         assertTrue(new CompareToBuilder().append(obj1, null).toComparison() > 0);
-        assertTrue(new CompareToBuilder().append((Object[]) null, null).toComparison() == 0);
+        assertEquals(0, new CompareToBuilder().append((Object[]) null, null).toComparison());
         assertTrue(new CompareToBuilder().append(null, obj1).toComparison() < 0);
     }
 
@@ -487,8 +487,8 @@ public class CompareToBuilderTest {
         obj3[1] = 6L;
         obj3[2] = 7L;
 
-        assertTrue(new CompareToBuilder().append(obj1, obj1).toComparison() == 0);
-        assertTrue(new CompareToBuilder().append(obj1, obj2).toComparison() == 0);
+        assertEquals(0, new CompareToBuilder().append(obj1, obj1).toComparison());
+        assertEquals(0, new CompareToBuilder().append(obj1, obj2).toComparison());
         assertTrue(new CompareToBuilder().append(obj1, obj3).toComparison() < 0);
         assertTrue(new CompareToBuilder().append(obj3, obj1).toComparison() > 0);
 
@@ -497,7 +497,7 @@ public class CompareToBuilderTest {
         assertTrue(new CompareToBuilder().append(obj2, obj1).toComparison() < 0);
 
         assertTrue(new CompareToBuilder().append(obj1, null).toComparison() > 0);
-        assertTrue(new CompareToBuilder().append((long[]) null, null).toComparison() == 0);
+        assertEquals(0, new CompareToBuilder().append((long[]) null, null).toComparison());
         assertTrue(new CompareToBuilder().append(null, obj1).toComparison() < 0);
     }
 
@@ -514,8 +514,8 @@ public class CompareToBuilderTest {
         obj3[1] = 6;
         obj3[2] = 7;
 
-        assertTrue(new CompareToBuilder().append(obj1, obj1).toComparison() == 0);
-        assertTrue(new CompareToBuilder().append(obj1, obj2).toComparison() == 0);
+        assertEquals(0, new CompareToBuilder().append(obj1, obj1).toComparison());
+        assertEquals(0, new CompareToBuilder().append(obj1, obj2).toComparison());
         assertTrue(new CompareToBuilder().append(obj1, obj3).toComparison() < 0);
         assertTrue(new CompareToBuilder().append(obj3, obj1).toComparison() > 0);
 
@@ -524,7 +524,7 @@ public class CompareToBuilderTest {
         assertTrue(new CompareToBuilder().append(obj2, obj1).toComparison() < 0);
 
         assertTrue(new CompareToBuilder().append(obj1, null).toComparison() > 0);
-        assertTrue(new CompareToBuilder().append((int[]) null, null).toComparison() == 0);
+        assertEquals(0, new CompareToBuilder().append((int[]) null, null).toComparison());
         assertTrue(new CompareToBuilder().append(null, obj1).toComparison() < 0);
     }
 
@@ -541,8 +541,8 @@ public class CompareToBuilderTest {
         obj3[1] = 6;
         obj3[2] = 7;
 
-        assertTrue(new CompareToBuilder().append(obj1, obj1).toComparison() == 0);
-        assertTrue(new CompareToBuilder().append(obj1, obj2).toComparison() == 0);
+        assertEquals(0, new CompareToBuilder().append(obj1, obj1).toComparison());
+        assertEquals(0, new CompareToBuilder().append(obj1, obj2).toComparison());
         assertTrue(new CompareToBuilder().append(obj1, obj3).toComparison() < 0);
         assertTrue(new CompareToBuilder().append(obj3, obj1).toComparison() > 0);
 
@@ -551,7 +551,7 @@ public class CompareToBuilderTest {
         assertTrue(new CompareToBuilder().append(obj2, obj1).toComparison() < 0);
 
         assertTrue(new CompareToBuilder().append(obj1, null).toComparison() > 0);
-        assertTrue(new CompareToBuilder().append((short[]) null, null).toComparison() == 0);
+        assertEquals(0, new CompareToBuilder().append((short[]) null, null).toComparison());
         assertTrue(new CompareToBuilder().append(null, obj1).toComparison() < 0);
     }
 
@@ -568,8 +568,8 @@ public class CompareToBuilderTest {
         obj3[1] = 6;
         obj3[2] = 7;
 
-        assertTrue(new CompareToBuilder().append(obj1, obj1).toComparison() == 0);
-        assertTrue(new CompareToBuilder().append(obj1, obj2).toComparison() == 0);
+        assertEquals(0, new CompareToBuilder().append(obj1, obj1).toComparison());
+        assertEquals(0, new CompareToBuilder().append(obj1, obj2).toComparison());
         assertTrue(new CompareToBuilder().append(obj1, obj3).toComparison() < 0);
         assertTrue(new CompareToBuilder().append(obj3, obj1).toComparison() > 0);
 
@@ -578,7 +578,7 @@ public class CompareToBuilderTest {
         assertTrue(new CompareToBuilder().append(obj2, obj1).toComparison() < 0);
 
         assertTrue(new CompareToBuilder().append(obj1, null).toComparison() > 0);
-        assertTrue(new CompareToBuilder().append((char[]) null, null).toComparison() == 0);
+        assertEquals(0, new CompareToBuilder().append((char[]) null, null).toComparison());
         assertTrue(new CompareToBuilder().append(null, obj1).toComparison() < 0);
     }
 
@@ -595,8 +595,8 @@ public class CompareToBuilderTest {
         obj3[1] = 6;
         obj3[2] = 7;
 
-        assertTrue(new CompareToBuilder().append(obj1, obj1).toComparison() == 0);
-        assertTrue(new CompareToBuilder().append(obj1, obj2).toComparison() == 0);
+        assertEquals(0, new CompareToBuilder().append(obj1, obj1).toComparison());
+        assertEquals(0, new CompareToBuilder().append(obj1, obj2).toComparison());
         assertTrue(new CompareToBuilder().append(obj1, obj3).toComparison() < 0);
         assertTrue(new CompareToBuilder().append(obj3, obj1).toComparison() > 0);
 
@@ -605,7 +605,7 @@ public class CompareToBuilderTest {
         assertTrue(new CompareToBuilder().append(obj2, obj1).toComparison() < 0);
 
         assertTrue(new CompareToBuilder().append(obj1, null).toComparison() > 0);
-        assertTrue(new CompareToBuilder().append((byte[]) null, null).toComparison() == 0);
+        assertEquals(0, new CompareToBuilder().append((byte[]) null, null).toComparison());
         assertTrue(new CompareToBuilder().append(null, obj1).toComparison() < 0);
     }
 
@@ -622,8 +622,8 @@ public class CompareToBuilderTest {
         obj3[1] = 6;
         obj3[2] = 7;
 
-        assertTrue(new CompareToBuilder().append(obj1, obj1).toComparison() == 0);
-        assertTrue(new CompareToBuilder().append(obj1, obj2).toComparison() == 0);
+        assertEquals(0, new CompareToBuilder().append(obj1, obj1).toComparison());
+        assertEquals(0, new CompareToBuilder().append(obj1, obj2).toComparison());
         assertTrue(new CompareToBuilder().append(obj1, obj3).toComparison() < 0);
         assertTrue(new CompareToBuilder().append(obj3, obj1).toComparison() > 0);
 
@@ -632,7 +632,7 @@ public class CompareToBuilderTest {
         assertTrue(new CompareToBuilder().append(obj2, obj1).toComparison() < 0);
 
         assertTrue(new CompareToBuilder().append(obj1, null).toComparison() > 0);
-        assertTrue(new CompareToBuilder().append((double[]) null, null).toComparison() == 0);
+        assertEquals(0, new CompareToBuilder().append((double[]) null, null).toComparison());
         assertTrue(new CompareToBuilder().append(null, obj1).toComparison() < 0);
     }
 
@@ -649,8 +649,8 @@ public class CompareToBuilderTest {
         obj3[1] = 6;
         obj3[2] = 7;
 
-        assertTrue(new CompareToBuilder().append(obj1, obj1).toComparison() == 0);
-        assertTrue(new CompareToBuilder().append(obj1, obj2).toComparison() == 0);
+        assertEquals(0, new CompareToBuilder().append(obj1, obj1).toComparison());
+        assertEquals(0, new CompareToBuilder().append(obj1, obj2).toComparison());
         assertTrue(new CompareToBuilder().append(obj1, obj3).toComparison() < 0);
         assertTrue(new CompareToBuilder().append(obj3, obj1).toComparison() > 0);
 
@@ -659,7 +659,7 @@ public class CompareToBuilderTest {
         assertTrue(new CompareToBuilder().append(obj2, obj1).toComparison() < 0);
 
         assertTrue(new CompareToBuilder().append(obj1, null).toComparison() > 0);
-        assertTrue(new CompareToBuilder().append((float[]) null, null).toComparison() == 0);
+        assertEquals(0, new CompareToBuilder().append((float[]) null, null).toComparison());
         assertTrue(new CompareToBuilder().append(null, obj1).toComparison() < 0);
     }
 
@@ -676,8 +676,8 @@ public class CompareToBuilderTest {
         obj3[1] = false;
         obj3[2] = true;
 
-        assertTrue(new CompareToBuilder().append(obj1, obj1).toComparison() == 0);
-        assertTrue(new CompareToBuilder().append(obj1, obj2).toComparison() == 0);
+        assertEquals(0, new CompareToBuilder().append(obj1, obj1).toComparison());
+        assertEquals(0, new CompareToBuilder().append(obj1, obj2).toComparison());
         assertTrue(new CompareToBuilder().append(obj1, obj3).toComparison() < 0);
         assertTrue(new CompareToBuilder().append(obj3, obj1).toComparison() > 0);
 
@@ -686,7 +686,7 @@ public class CompareToBuilderTest {
         assertTrue(new CompareToBuilder().append(obj2, obj1).toComparison() < 0);
 
         assertTrue(new CompareToBuilder().append(obj1, null).toComparison() > 0);
-        assertTrue(new CompareToBuilder().append((boolean[]) null, null).toComparison() == 0);
+        assertEquals(0, new CompareToBuilder().append((boolean[]) null, null).toComparison());
         assertTrue(new CompareToBuilder().append(null, obj1).toComparison() < 0);
     }
 
@@ -705,8 +705,8 @@ public class CompareToBuilderTest {
         array3[1][2] = 100;
         array3[1][2] = 100;
 
-        assertTrue(new CompareToBuilder().append(array1, array1).toComparison() == 0);
-        assertTrue(new CompareToBuilder().append(array1, array2).toComparison() == 0);
+        assertEquals(0, new CompareToBuilder().append(array1, array1).toComparison());
+        assertEquals(0, new CompareToBuilder().append(array1, array2).toComparison());
         assertTrue(new CompareToBuilder().append(array1, array3).toComparison() < 0);
         assertTrue(new CompareToBuilder().append(array3, array1).toComparison() > 0);
         array1[1][1] = 200;
@@ -729,8 +729,8 @@ public class CompareToBuilderTest {
         array3[1][2] = 100;
         array3[1][2] = 100;
 
-        assertTrue(new CompareToBuilder().append(array1, array1).toComparison() == 0);
-        assertTrue(new CompareToBuilder().append(array1, array2).toComparison() == 0);
+        assertEquals(0, new CompareToBuilder().append(array1, array1).toComparison());
+        assertEquals(0, new CompareToBuilder().append(array1, array2).toComparison());
         assertTrue(new CompareToBuilder().append(array1, array3).toComparison() < 0);
         assertTrue(new CompareToBuilder().append(array3, array1).toComparison() > 0);
         array1[1][1] = 200;
@@ -753,8 +753,8 @@ public class CompareToBuilderTest {
         array3[1][2] = 100;
         array3[1][2] = 100;
 
-        assertTrue(new CompareToBuilder().append(array1, array1).toComparison() == 0);
-        assertTrue(new CompareToBuilder().append(array1, array2).toComparison() == 0);
+        assertEquals(0, new CompareToBuilder().append(array1, array1).toComparison());
+        assertEquals(0, new CompareToBuilder().append(array1, array2).toComparison());
         assertTrue(new CompareToBuilder().append(array1, array3).toComparison() < 0);
         assertTrue(new CompareToBuilder().append(array3, array1).toComparison() > 0);
         array1[1][1] = 200;
@@ -777,8 +777,8 @@ public class CompareToBuilderTest {
         array3[1][2] = 100;
         array3[1][2] = 100;
 
-        assertTrue(new CompareToBuilder().append(array1, array1).toComparison() == 0);
-        assertTrue(new CompareToBuilder().append(array1, array2).toComparison() == 0);
+        assertEquals(0, new CompareToBuilder().append(array1, array1).toComparison());
+        assertEquals(0, new CompareToBuilder().append(array1, array2).toComparison());
         assertTrue(new CompareToBuilder().append(array1, array3).toComparison() < 0);
         assertTrue(new CompareToBuilder().append(array3, array1).toComparison() > 0);
         array1[1][1] = 200;
@@ -801,8 +801,8 @@ public class CompareToBuilderTest {
         array3[1][2] = 100;
         array3[1][2] = 100;
 
-        assertTrue(new CompareToBuilder().append(array1, array1).toComparison() == 0);
-        assertTrue(new CompareToBuilder().append(array1, array2).toComparison() == 0);
+        assertEquals(0, new CompareToBuilder().append(array1, array1).toComparison());
+        assertEquals(0, new CompareToBuilder().append(array1, array2).toComparison());
         assertTrue(new CompareToBuilder().append(array1, array3).toComparison() < 0);
         assertTrue(new CompareToBuilder().append(array3, array1).toComparison() > 0);
         array1[1][1] = 127;
@@ -825,8 +825,8 @@ public class CompareToBuilderTest {
         array3[1][2] = 100;
         array3[1][2] = 100;
 
-        assertTrue(new CompareToBuilder().append(array1, array1).toComparison() == 0);
-        assertTrue(new CompareToBuilder().append(array1, array2).toComparison() == 0);
+        assertEquals(0, new CompareToBuilder().append(array1, array1).toComparison());
+        assertEquals(0, new CompareToBuilder().append(array1, array2).toComparison());
         assertTrue(new CompareToBuilder().append(array1, array3).toComparison() < 0);
         assertTrue(new CompareToBuilder().append(array3, array1).toComparison() > 0);
         array1[1][1] = 127;
@@ -849,8 +849,8 @@ public class CompareToBuilderTest {
         array3[1][2] = 100;
         array3[1][2] = 100;
 
-        assertTrue(new CompareToBuilder().append(array1, array1).toComparison() == 0);
-        assertTrue(new CompareToBuilder().append(array1, array2).toComparison() == 0);
+        assertEquals(0, new CompareToBuilder().append(array1, array1).toComparison());
+        assertEquals(0, new CompareToBuilder().append(array1, array2).toComparison());
         assertTrue(new CompareToBuilder().append(array1, array3).toComparison() < 0);
         assertTrue(new CompareToBuilder().append(array3, array1).toComparison() > 0);
         array1[1][1] = 127;
@@ -873,8 +873,8 @@ public class CompareToBuilderTest {
         array3[1][2] = false;
         array3[1][2] = false;
 
-        assertTrue(new CompareToBuilder().append(array1, array1).toComparison() == 0);
-        assertTrue(new CompareToBuilder().append(array1, array2).toComparison() == 0);
+        assertEquals(0, new CompareToBuilder().append(array1, array1).toComparison());
+        assertEquals(0, new CompareToBuilder().append(array1, array2).toComparison());
         assertTrue(new CompareToBuilder().append(array1, array3).toComparison() < 0);
         assertTrue(new CompareToBuilder().append(array3, array1).toComparison() > 0);
         array1[1][1] = true;
@@ -901,8 +901,8 @@ public class CompareToBuilderTest {
         array3[1][2] = 100;
 
 
-        assertTrue(new CompareToBuilder().append(array1, array1).toComparison() == 0);
-        assertTrue(new CompareToBuilder().append(array1, array2).toComparison() == 0);
+        assertEquals(0, new CompareToBuilder().append(array1, array1).toComparison());
+        assertEquals(0, new CompareToBuilder().append(array1, array2).toComparison());
         assertTrue(new CompareToBuilder().append(array1, array3).toComparison() < 0);
         assertTrue(new CompareToBuilder().append(array3, array1).toComparison() > 0);
         array1[1][1] = 200;
@@ -927,8 +927,8 @@ public class CompareToBuilderTest {
         }
         ((long[]) array3[0])[2] = 1;
         ((long[]) array3[1])[2] = 1;
-        assertTrue(new CompareToBuilder().append(array1, array1).toComparison() == 0);
-        assertTrue(new CompareToBuilder().append(array1, array2).toComparison() == 0);
+        assertEquals(0, new CompareToBuilder().append(array1, array1).toComparison());
+        assertEquals(0, new CompareToBuilder().append(array1, array2).toComparison());
         assertTrue(new CompareToBuilder().append(array1, array3).toComparison() < 0);
         assertTrue(new CompareToBuilder().append(array3, array1).toComparison() > 0);
         ((long[]) array1[1])[1] = 200;
@@ -953,8 +953,8 @@ public class CompareToBuilderTest {
         final Object obj2 = array2;
         final Object obj3 = array3;
 
-        assertTrue(new CompareToBuilder().append(obj1, obj1).toComparison() == 0);
-        assertTrue(new CompareToBuilder().append(obj1, obj2).toComparison() == 0);
+        assertEquals(0, new CompareToBuilder().append(obj1, obj1).toComparison());
+        assertEquals(0, new CompareToBuilder().append(obj1, obj2).toComparison());
         assertTrue(new CompareToBuilder().append(obj1, obj3).toComparison() < 0);
         assertTrue(new CompareToBuilder().append(obj3, obj1).toComparison() > 0);
 
@@ -978,8 +978,8 @@ public class CompareToBuilderTest {
         final Object obj1 = array1;
         final Object obj2 = array2;
         final Object obj3 = array3;
-        assertTrue(new CompareToBuilder().append(obj1, obj1).toComparison() == 0);
-        assertTrue(new CompareToBuilder().append(obj1, obj2).toComparison() == 0);
+        assertEquals(0, new CompareToBuilder().append(obj1, obj1).toComparison());
+        assertEquals(0, new CompareToBuilder().append(obj1, obj2).toComparison());
         assertTrue(new CompareToBuilder().append(obj1, obj3).toComparison() < 0);
         assertTrue(new CompareToBuilder().append(obj3, obj1).toComparison() > 0);
 
@@ -1003,8 +1003,8 @@ public class CompareToBuilderTest {
         final Object obj1 = array1;
         final Object obj2 = array2;
         final Object obj3 = array3;
-        assertTrue(new CompareToBuilder().append(obj1, obj1).toComparison() == 0);
-        assertTrue(new CompareToBuilder().append(obj1, obj2).toComparison() == 0);
+        assertEquals(0, new CompareToBuilder().append(obj1, obj1).toComparison());
+        assertEquals(0, new CompareToBuilder().append(obj1, obj2).toComparison());
         assertTrue(new CompareToBuilder().append(obj1, obj3).toComparison() < 0);
         assertTrue(new CompareToBuilder().append(obj3, obj1).toComparison() > 0);
 
@@ -1028,8 +1028,8 @@ public class CompareToBuilderTest {
         final Object obj1 = array1;
         final Object obj2 = array2;
         final Object obj3 = array3;
-        assertTrue(new CompareToBuilder().append(obj1, obj1).toComparison() == 0);
-        assertTrue(new CompareToBuilder().append(obj1, obj2).toComparison() == 0);
+        assertEquals(0, new CompareToBuilder().append(obj1, obj1).toComparison());
+        assertEquals(0, new CompareToBuilder().append(obj1, obj2).toComparison());
         assertTrue(new CompareToBuilder().append(obj1, obj3).toComparison() < 0);
         assertTrue(new CompareToBuilder().append(obj3, obj1).toComparison() > 0);
 
@@ -1053,8 +1053,8 @@ public class CompareToBuilderTest {
         final Object obj1 = array1;
         final Object obj2 = array2;
         final Object obj3 = array3;
-        assertTrue(new CompareToBuilder().append(obj1, obj1).toComparison() == 0);
-        assertTrue(new CompareToBuilder().append(obj1, obj2).toComparison() == 0);
+        assertEquals(0, new CompareToBuilder().append(obj1, obj1).toComparison());
+        assertEquals(0, new CompareToBuilder().append(obj1, obj2).toComparison());
         assertTrue(new CompareToBuilder().append(obj1, obj3).toComparison() < 0);
         assertTrue(new CompareToBuilder().append(obj3, obj1).toComparison() > 0);
 
@@ -1078,8 +1078,8 @@ public class CompareToBuilderTest {
         final Object obj1 = array1;
         final Object obj2 = array2;
         final Object obj3 = array3;
-        assertTrue(new CompareToBuilder().append(obj1, obj1).toComparison() == 0);
-        assertTrue(new CompareToBuilder().append(obj1, obj2).toComparison() == 0);
+        assertEquals(0, new CompareToBuilder().append(obj1, obj1).toComparison());
+        assertEquals(0, new CompareToBuilder().append(obj1, obj2).toComparison());
         assertTrue(new CompareToBuilder().append(obj1, obj3).toComparison() < 0);
         assertTrue(new CompareToBuilder().append(obj3, obj1).toComparison() > 0);
 
@@ -1103,8 +1103,8 @@ public class CompareToBuilderTest {
         final Object obj1 = array1;
         final Object obj2 = array2;
         final Object obj3 = array3;
-        assertTrue(new CompareToBuilder().append(obj1, obj1).toComparison() == 0);
-        assertTrue(new CompareToBuilder().append(obj1, obj2).toComparison() == 0);
+        assertEquals(0, new CompareToBuilder().append(obj1, obj1).toComparison());
+        assertEquals(0, new CompareToBuilder().append(obj1, obj2).toComparison());
         assertTrue(new CompareToBuilder().append(obj1, obj3).toComparison() < 0);
         assertTrue(new CompareToBuilder().append(obj3, obj1).toComparison() > 0);
 
@@ -1128,8 +1128,8 @@ public class CompareToBuilderTest {
         final Object obj1 = array1;
         final Object obj2 = array2;
         final Object obj3 = array3;
-        assertTrue(new CompareToBuilder().append(obj1, obj1).toComparison() == 0);
-        assertTrue(new CompareToBuilder().append(obj1, obj2).toComparison() == 0);
+        assertEquals(0, new CompareToBuilder().append(obj1, obj1).toComparison());
+        assertEquals(0, new CompareToBuilder().append(obj1, obj2).toComparison());
         assertTrue(new CompareToBuilder().append(obj1, obj3).toComparison() < 0);
         assertTrue(new CompareToBuilder().append(obj3, obj1).toComparison() > 0);
 
@@ -1153,8 +1153,8 @@ public class CompareToBuilderTest {
         final Object obj1 = array1;
         final Object obj2 = array2;
         final Object obj3 = array3;
-        assertTrue(new CompareToBuilder().append(obj1, obj1).toComparison() == 0);
-        assertTrue(new CompareToBuilder().append(obj1, obj2).toComparison() == 0);
+        assertEquals(0, new CompareToBuilder().append(obj1, obj1).toComparison());
+        assertEquals(0, new CompareToBuilder().append(obj1, obj2).toComparison());
         assertTrue(new CompareToBuilder().append(obj1, obj3).toComparison() < 0);
         assertTrue(new CompareToBuilder().append(obj3, obj1).toComparison() > 0);
 

--- a/src/test/java/org/apache/commons/lang3/builder/DefaultToStringStyleTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/DefaultToStringStyleTest.java
@@ -35,12 +35,12 @@ public class DefaultToStringStyleTest {
     private final String baseStr = base.getClass().getName() + "@" + Integer.toHexString(System.identityHashCode(base));
 
     @BeforeEach
-    public void setUp() throws Exception {
+    public void setUp() {
         ToStringBuilder.setDefaultStyle(ToStringStyle.DEFAULT_STYLE);
     }
 
     @AfterEach
-    public void tearDown() throws Exception {
+    public void tearDown() {
         ToStringBuilder.setDefaultStyle(ToStringStyle.DEFAULT_STYLE);
     }
 

--- a/src/test/java/org/apache/commons/lang3/builder/DiffBuilderTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/DiffBuilderTest.java
@@ -107,7 +107,7 @@ public class DiffBuilderTest {
     }
 
     @Test
-    public void testBooleanArray() throws Exception {
+    public void testBooleanArray() {
         final TypeTestClass class1 = new TypeTestClass();
         final TypeTestClass class2 = new TypeTestClass();
         class2.booleanArrayField = new boolean[] {false, false};
@@ -134,7 +134,7 @@ public class DiffBuilderTest {
     }
 
     @Test
-    public void testByteArray() throws Exception {
+    public void testByteArray() {
         final TypeTestClass class1 = new TypeTestClass();
         final TypeTestClass class2 = new TypeTestClass();
         class2.byteArrayField= new byte[] {0x01, 0x02};
@@ -161,7 +161,7 @@ public class DiffBuilderTest {
 
 
     @Test
-    public void testCharArray() throws Exception {
+    public void testCharArray() {
         final TypeTestClass class1 = new TypeTestClass();
         final TypeTestClass class2 = new TypeTestClass();
         class2.charArrayField = new char[] {'f', 'o', 'o'};
@@ -189,7 +189,7 @@ public class DiffBuilderTest {
 
 
     @Test
-    public void testDoubleArray() throws Exception {
+    public void testDoubleArray() {
         final TypeTestClass class1 = new TypeTestClass();
         final TypeTestClass class2 = new TypeTestClass();
         class2.doubleArrayField = new double[] {3.0, 2.9, 2.8};
@@ -216,7 +216,7 @@ public class DiffBuilderTest {
 
 
     @Test
-    public void testFloatArray() throws Exception {
+    public void testFloatArray() {
         final TypeTestClass class1 = new TypeTestClass();
         final TypeTestClass class2 = new TypeTestClass();
         class2.floatArrayField = new float[] {3.0F, 2.9F, 2.8F};
@@ -244,7 +244,7 @@ public class DiffBuilderTest {
 
 
     @Test
-    public void testIntArray() throws Exception {
+    public void testIntArray() {
         final TypeTestClass class1 = new TypeTestClass();
         final TypeTestClass class2 = new TypeTestClass();
         class2.intArrayField = new int[] {3, 2, 1};
@@ -271,7 +271,7 @@ public class DiffBuilderTest {
 
 
     @Test
-    public void testLongArray() throws Exception {
+    public void testLongArray() {
         final TypeTestClass class1 = new TypeTestClass();
         final TypeTestClass class2 = new TypeTestClass();
         class2.longArrayField = new long[] {3L, 2L, 1L};
@@ -298,7 +298,7 @@ public class DiffBuilderTest {
 
 
     @Test
-    public void testShortArray() throws Exception {
+    public void testShortArray() {
         final TypeTestClass class1 = new TypeTestClass();
         final TypeTestClass class2 = new TypeTestClass();
         class2.shortArrayField = new short[] {3, 2, 1};
@@ -312,7 +312,7 @@ public class DiffBuilderTest {
     }
 
     @Test
-    public void testObject() throws Exception {
+    public void testObject() {
         final TypeTestClass class1 = new TypeTestClass();
         final TypeTestClass class2 = new TypeTestClass();
         class2.objectField = "Some string";
@@ -327,7 +327,7 @@ public class DiffBuilderTest {
      * Test that "left" and "right" are the same instance and are equal.
      */
     @Test
-    public void testObjectsSameAndEqual() throws Exception {
+    public void testObjectsSameAndEqual() {
         final Integer sameObject = 1;
         final TypeTestClass left = new TypeTestClass();
         left.objectField = sameObject;
@@ -344,7 +344,7 @@ public class DiffBuilderTest {
      * Test that "left" and "right" are the same instance but are equal.
      */
     @Test
-    public void testObjectsNotSameButEqual() throws Exception {
+    public void testObjectsNotSameButEqual() {
         final TypeTestClass left = new TypeTestClass();
         left.objectField = new Integer(1);
         final TypeTestClass right = new TypeTestClass();
@@ -360,7 +360,7 @@ public class DiffBuilderTest {
      * Test that "left" and "right" are not the same instance and are not equal.
      */
     @Test
-    public void testObjectsNotSameNorEqual() throws Exception {
+    public void testObjectsNotSameNorEqual() {
         final TypeTestClass left = new TypeTestClass();
         left.objectField = 4;
         final TypeTestClass right = new TypeTestClass();
@@ -373,7 +373,7 @@ public class DiffBuilderTest {
     }
 
     @Test
-    public void testObjectArray() throws Exception {
+    public void testObjectArray() {
         final TypeTestClass class1 = new TypeTestClass();
         final TypeTestClass class2 = new TypeTestClass();
         class2.objectArrayField = new Object[] {"string", 1, 2};
@@ -385,7 +385,7 @@ public class DiffBuilderTest {
     }
 
     @Test
-    public void testObjectArrayEqual() throws Exception {
+    public void testObjectArrayEqual() {
         final TypeTestClass class1 = new TypeTestClass();
         final TypeTestClass class2 = new TypeTestClass();
         class1.objectArrayField = new Object[] {"string", 1, 2};
@@ -396,7 +396,7 @@ public class DiffBuilderTest {
 
 
     @Test
-    public void testByteArrayEqualAsObject() throws Exception {
+    public void testByteArrayEqualAsObject() {
         final DiffResult list = new DiffBuilder("String1", "String2", SHORT_STYLE)
             .append("foo", new boolean[] {false}, new boolean[] {false})
             .append("foo", new byte[] {0x01}, new byte[] {0x01})

--- a/src/test/java/org/apache/commons/lang3/builder/DiffBuilderTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/DiffBuilderTest.java
@@ -20,9 +20,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.hamcrest.Matcher;
@@ -333,8 +334,8 @@ public class DiffBuilderTest {
         left.objectField = sameObject;
         final TypeTestClass right = new TypeTestClass();
         right.objectField = sameObject;
-        assertTrue(left.objectField == right.objectField);
-        assertTrue(left.objectField.equals(right.objectField));
+        assertSame(left.objectField, right.objectField);
+        assertEquals(left.objectField, right.objectField);
 
         final DiffResult list = left.diff(right);
         assertEquals(0, list.getNumberOfDiffs());
@@ -349,8 +350,8 @@ public class DiffBuilderTest {
         left.objectField = new Integer(1);
         final TypeTestClass right = new TypeTestClass();
         right.objectField = new Integer(1);
-        assertFalse(left.objectField == right.objectField);
-        assertTrue(left.objectField.equals(right.objectField));
+        assertNotSame(left.objectField, right.objectField);
+        assertEquals(left.objectField, right.objectField);
 
         final DiffResult list = left.diff(right);
         assertEquals(0, list.getNumberOfDiffs());
@@ -365,8 +366,8 @@ public class DiffBuilderTest {
         left.objectField = 4;
         final TypeTestClass right = new TypeTestClass();
         right.objectField = 100;
-        assertFalse(left.objectField == right.objectField);
-        assertFalse(left.objectField.equals(right.objectField));
+        assertNotSame(left.objectField, right.objectField);
+        assertNotEquals(left.objectField, right.objectField);
 
         final DiffResult list = left.diff(right);
         assertEquals(1, list.getNumberOfDiffs());

--- a/src/test/java/org/apache/commons/lang3/builder/DiffResultTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/DiffResultTest.java
@@ -118,7 +118,7 @@ public class DiffResultTest {
     @Test
     public void testNullLhs() {
         assertThrows(IllegalArgumentException.class,
-            () ->  new DiffResult(null, SIMPLE_FALSE, SIMPLE_TRUE.diff(SIMPLE_FALSE).getDiffs(), SHORT_STYLE));
+            () -> new DiffResult(null, SIMPLE_FALSE, SIMPLE_TRUE.diff(SIMPLE_FALSE).getDiffs(), SHORT_STYLE));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/builder/DiffResultTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/DiffResultTest.java
@@ -99,7 +99,7 @@ public class DiffResultTest {
     @Test
     public void testToStringSpecifyStyleOutput() {
         final DiffResult list = SIMPLE_FALSE.diff(SIMPLE_TRUE);
-        assertTrue(list.getToStringStyle().equals(SHORT_STYLE));
+        assertEquals(list.getToStringStyle(), SHORT_STYLE);
 
         final String lhsString = new ToStringBuilder(SIMPLE_FALSE,
                 ToStringStyle.MULTI_LINE_STYLE).append(

--- a/src/test/java/org/apache/commons/lang3/builder/EqualsBuilderTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/EqualsBuilderTest.java
@@ -1222,7 +1222,7 @@ public class EqualsBuilderTest {
     }
 
     @Test
-    public void testReflectionEqualsExcludeFields() throws Exception {
+    public void testReflectionEqualsExcludeFields() {
         final TestObjectWithMultipleFields x1 = new TestObjectWithMultipleFields(1, 2, 3);
         final TestObjectWithMultipleFields x2 = new TestObjectWithMultipleFields(1, 3, 4);
 
@@ -1311,7 +1311,7 @@ public class EqualsBuilderTest {
     }
 
     @Test
-    public void testReflectionArrays() throws Exception {
+    public void testReflectionArrays() {
 
         final TestObject one = new TestObject(1);
         final TestObject two = new TestObject(2);

--- a/src/test/java/org/apache/commons/lang3/builder/EqualsBuilderTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/EqualsBuilderTest.java
@@ -18,6 +18,7 @@ package org.apache.commons.lang3.builder;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -1198,10 +1199,10 @@ public class EqualsBuilderTest {
         assertTrue(Arrays.equals(x, y));
         assertTrue(Arrays.equals(y, x));
         // real tests:
-        assertTrue(x[0].equals(x[0]));
-        assertTrue(y[0].equals(y[0]));
-        assertTrue(x[0].equals(y[0]));
-        assertTrue(y[0].equals(x[0]));
+        assertEquals(x[0], x[0]);
+        assertEquals(y[0], y[0]);
+        assertEquals(x[0], y[0]);
+        assertEquals(y[0], x[0]);
         assertTrue(new EqualsBuilder().append(x, x).isEquals());
         assertTrue(new EqualsBuilder().append(y, y).isEquals());
         assertTrue(new EqualsBuilder().append(x, y).isEquals());
@@ -1282,11 +1283,11 @@ public class EqualsBuilderTest {
         x3.setObjectReference(refX3);
         refX3.setObjectReference(x3);
 
-        assertTrue(x1.equals(x2));
+        assertEquals(x1, x2);
         assertNull(EqualsBuilder.getRegistry());
-        assertFalse(x1.equals(x3));
+        assertNotEquals(x1, x3);
         assertNull(EqualsBuilder.getRegistry());
-        assertFalse(x2.equals(x3));
+        assertNotEquals(x2, x3);
         assertNull(EqualsBuilder.getRegistry());
     }
 

--- a/src/test/java/org/apache/commons/lang3/builder/HashCodeBuilderTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/HashCodeBuilderTest.java
@@ -487,7 +487,7 @@ public class HashCodeBuilderTest {
     }
 
     @Test
-    public void testReflectionHashCodeExcludeFields() throws Exception {
+    public void testReflectionHashCodeExcludeFields() {
         final TestObjectWithMultipleFields x = new TestObjectWithMultipleFields(1, 2, 3);
 
         assertEquals(((17 * 37 + 1) * 37 + 2) * 37 + 3, HashCodeBuilder.reflectionHashCode(x));

--- a/src/test/java/org/apache/commons/lang3/builder/JsonToStringStyleTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/JsonToStringStyleTest.java
@@ -36,12 +36,12 @@ public class JsonToStringStyleTest {
     private final Integer base = Integer.valueOf(5);
 
     @BeforeEach
-    public void setUp() throws Exception {
+    public void setUp() {
         ToStringBuilder.setDefaultStyle(ToStringStyle.JSON_STYLE);
     }
 
     @AfterEach
-    public void tearDown() throws Exception {
+    public void tearDown() {
         ToStringBuilder.setDefaultStyle(ToStringStyle.DEFAULT_STYLE);
     }
 

--- a/src/test/java/org/apache/commons/lang3/builder/JsonToStringStyleTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/JsonToStringStyleTest.java
@@ -17,7 +17,7 @@
 package org.apache.commons.lang3.builder;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -91,11 +91,7 @@ public class JsonToStringStyleTest {
 
     @Test
     public void testChar() {
-        try {
-            new ToStringBuilder(base).append('A').toString();
-            fail("Should have generated UnsupportedOperationException");
-        } catch (final UnsupportedOperationException e) {
-        }
+        assertThrows(UnsupportedOperationException.class, () -> new ToStringBuilder(base).append('A').toString());
 
         assertEquals("{\"a\":\"A\"}", new ToStringBuilder(base).append("a", 'A')
                 .toString());
@@ -108,11 +104,7 @@ public class JsonToStringStyleTest {
         final Date now = new Date();
         final Date afterNow = new Date(System.currentTimeMillis() + 1);
 
-        try {
-            new ToStringBuilder(base).append(now).toString();
-            fail("Should have generated UnsupportedOperationException");
-        } catch (final UnsupportedOperationException e) {
-        }
+        assertThrows(UnsupportedOperationException.class, () -> new ToStringBuilder(base).append(now).toString());
 
         assertEquals("{\"now\":\"" + now.toString() +"\"}", new ToStringBuilder(base).append("now", now)
                 .toString());
@@ -126,17 +118,10 @@ public class JsonToStringStyleTest {
         final Integer i3 = Integer.valueOf(3);
         final Integer i4 = Integer.valueOf(4);
 
-        try {
-            new ToStringBuilder(base).append((Object) null).toString();
-            fail("Should have generated UnsupportedOperationException");
-        } catch (final UnsupportedOperationException e) {
-        }
+        assertThrows(
+                UnsupportedOperationException.class, () -> new ToStringBuilder(base).append((Object) null).toString());
 
-        try {
-            new ToStringBuilder(base).append(i3).toString();
-            fail("Should have generated UnsupportedOperationException");
-        } catch (final UnsupportedOperationException e) {
-        }
+        assertThrows(UnsupportedOperationException.class, () -> new ToStringBuilder(base).append(i3).toString());
 
         assertEquals("{\"a\":null}",
                 new ToStringBuilder(base).append("a", (Object) null).toString());
@@ -146,63 +131,48 @@ public class JsonToStringStyleTest {
                 new ToStringBuilder(base).append("a", i3).append("b", i4)
                         .toString());
 
-        try {
-            new ToStringBuilder(base).append("a", i3, false).toString();
-            fail("Should have generated UnsupportedOperationException");
-        } catch (final UnsupportedOperationException e) {
-        }
+        assertThrows(
+                UnsupportedOperationException.class, () -> new ToStringBuilder(base).append("a", i3, false).toString());
 
-        try {
-            new ToStringBuilder(base).append("a", new ArrayList<>(), false).toString();
-            fail("Should have generated UnsupportedOperationException");
-        } catch (final UnsupportedOperationException e) {
-        }
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> new ToStringBuilder(base).append("a", new ArrayList<>(), false).toString());
 
         assertEquals(
                 "{\"a\":[]}",
                 new ToStringBuilder(base).append("a", new ArrayList<>(),
                         true).toString());
 
-        try {
-            new ToStringBuilder(base).append("a", new HashMap<>(), false).toString();
-            fail("Should have generated UnsupportedOperationException");
-        } catch (final UnsupportedOperationException e) {
-        }
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> new ToStringBuilder(base).append("a", new HashMap<>(), false).toString());
 
         assertEquals(
                 "{\"a\":{}}",
                 new ToStringBuilder(base).append("a",
                         new HashMap<>(), true).toString());
 
-        try {
-            new ToStringBuilder(base).append("a", (Object) new String[0], false).toString();
-            fail("Should have generated UnsupportedOperationException");
-        } catch (final UnsupportedOperationException e) {
-        }
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> new ToStringBuilder(base).append("a", (Object) new String[0], false).toString());
 
         assertEquals(
                 "{\"a\":[]}",
                 new ToStringBuilder(base).append("a", (Object) new String[0],
                         true).toString());
 
-        try {
-            new ToStringBuilder(base).append("a", (Object) new int[]{1, 2, 3}, false).toString();
-            fail("Should have generated UnsupportedOperationException");
-        } catch (final UnsupportedOperationException e) {
-        }
-
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> new ToStringBuilder(base).append("a", (Object) new int[]{1, 2, 3}, false).toString());
 
         assertEquals(
                 "{\"a\":[1,2,3]}",
                 new ToStringBuilder(base).append("a",
                         (Object) new int[]{1, 2, 3}, true).toString());
 
-        try {
-            new ToStringBuilder(base).append("a", (Object) new String[]{"v", "x", "y", "z"}, false).toString();
-            fail("Should have generated UnsupportedOperationException");
-        } catch (final UnsupportedOperationException e) {
-        }
-
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> new ToStringBuilder(base).append("a", (Object) new String[]{"v", "x", "y", "z"}, false).toString());
 
         assertEquals(
                 "{\"a\":[\"v\",\"x\",\"y\",\"z\"]}",
@@ -252,12 +222,7 @@ public class JsonToStringStyleTest {
 
     @Test
     public void testLong() {
-
-        try {
-            new ToStringBuilder(base).append(3L).toString();
-            fail("Should have generated UnsupportedOperationException");
-        } catch (final UnsupportedOperationException e) {
-        }
+        assertThrows(UnsupportedOperationException.class, () -> new ToStringBuilder(base).append(3L).toString());
 
         assertEquals("{\"a\":3}", new ToStringBuilder(base).append("a", 3L)
                 .toString());
@@ -270,92 +235,48 @@ public class JsonToStringStyleTest {
     public void testObjectArray() {
         Object[] array = new Object[]{null, base, new int[]{3, 6}};
 
-        try {
-            new ToStringBuilder(base).append(array).toString();
-            fail("Should have generated UnsupportedOperationException");
-        } catch (final UnsupportedOperationException e) {
-        }
+        assertThrows(UnsupportedOperationException.class, () -> new ToStringBuilder(base).append(array).toString());
 
-        try {
-            new ToStringBuilder(base).append((Object) array).toString();
-            fail("Should have generated UnsupportedOperationException");
-        } catch (final UnsupportedOperationException e) {
-        }
+        assertThrows(
+                UnsupportedOperationException.class, () -> new ToStringBuilder(base).append((Object) array).toString());
 
-        array = null;
-        try {
-            new ToStringBuilder(base).append(array).toString();
-            fail("Should have generated UnsupportedOperationException");
-        } catch (final UnsupportedOperationException e) {
-        }
+        assertThrows(
+                UnsupportedOperationException.class, () -> new ToStringBuilder(base).append((Object[]) null).toString());
 
-        try {
-            new ToStringBuilder(base).append((Object) array).toString();
-            fail("Should have generated UnsupportedOperationException");
-        } catch (final UnsupportedOperationException e) {
-        }
+        assertThrows(
+                UnsupportedOperationException.class, () -> new ToStringBuilder(base).append((Object) array).toString());
     }
 
     @Test
     public void testLongArray() {
         long[] array = new long[]{1, 2, -3, 4};
 
-        try {
-            new ToStringBuilder(base).append(array).toString();
-            fail("Should have generated UnsupportedOperationException");
-        } catch (final UnsupportedOperationException e) {
-        }
+        assertThrows(UnsupportedOperationException.class, () -> new ToStringBuilder(base).append(array).toString());
 
-        try {
-            new ToStringBuilder(base).append((Object) array).toString();
-            fail("Should have generated UnsupportedOperationException");
-        } catch (final UnsupportedOperationException e) {
-        }
+        assertThrows(
+                UnsupportedOperationException.class, () -> new ToStringBuilder(base).append((Object) array).toString());
 
-        array = null;
+        assertThrows(
+                UnsupportedOperationException.class, () -> new ToStringBuilder(base).append((long[]) null).toString());
 
-        try {
-            new ToStringBuilder(base).append(array).toString();
-            fail("Should have generated UnsupportedOperationException");
-        } catch (final UnsupportedOperationException e) {
-        }
-
-        try {
-            new ToStringBuilder(base).append((Object) array).toString();
-            fail("Should have generated UnsupportedOperationException");
-        } catch (final UnsupportedOperationException e) {
-        }
+        assertThrows(
+                UnsupportedOperationException.class, () -> new ToStringBuilder(base).append((Object) array).toString());
     }
 
     @Test
     public void testLongArrayArray() {
         long[][] array = new long[][]{{1, 2}, null, {5}};
 
-        try {
-            new ToStringBuilder(base).append(array).toString();
-            fail("Should have generated UnsupportedOperationException");
-        } catch (final UnsupportedOperationException e) {
-        }
+        assertThrows(UnsupportedOperationException.class, () -> new ToStringBuilder(base).append(array).toString());
 
-        try {
-            new ToStringBuilder(base).append((Object) array).toString();
-            fail("Should have generated UnsupportedOperationException");
-        } catch (final UnsupportedOperationException e) {
-        }
+        assertThrows(
+                UnsupportedOperationException.class, () -> new ToStringBuilder(base).append((Object) array).toString());
 
-        array = null;
+        assertThrows(
+                UnsupportedOperationException.class, () -> new ToStringBuilder(base).append((long[][]) null).toString());
 
-        try {
-            new ToStringBuilder(base).append(array).toString();
-            fail("Should have generated UnsupportedOperationException");
-        } catch (final UnsupportedOperationException e) {
-        }
-
-        try {
-            new ToStringBuilder(base).append((Object) array).toString();
-            fail("Should have generated UnsupportedOperationException");
-        } catch (final UnsupportedOperationException e) {
-        }
+        assertThrows(
+                UnsupportedOperationException.class, () -> new ToStringBuilder(base).append((Object) array).toString());
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/builder/MultiLineToStringStyleTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/MultiLineToStringStyleTest.java
@@ -35,12 +35,12 @@ public class MultiLineToStringStyleTest {
     private final String baseStr = base.getClass().getName() + "@" + Integer.toHexString(System.identityHashCode(base));
 
     @BeforeEach
-    public void setUp() throws Exception {
+    public void setUp() {
         ToStringBuilder.setDefaultStyle(ToStringStyle.MULTI_LINE_STYLE);
     }
 
     @AfterEach
-    public void tearDown() throws Exception {
+    public void tearDown() {
         ToStringBuilder.setDefaultStyle(ToStringStyle.DEFAULT_STYLE);
     }
 

--- a/src/test/java/org/apache/commons/lang3/builder/MultilineRecursiveToStringStyleTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/MultilineRecursiveToStringStyleTest.java
@@ -203,7 +203,7 @@ public class MultilineRecursiveToStringStyleTest {
 
 
     @Test
-    public void testLANG1319() throws Exception {
+    public void testLANG1319() {
         final String[] stringArray = {"1", "2"};
 
         final String exp = getClassPrefix(stringArray) + "[" + BR

--- a/src/test/java/org/apache/commons/lang3/builder/NoClassNameToStringStyleTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/NoClassNameToStringStyleTest.java
@@ -34,12 +34,12 @@ public class NoClassNameToStringStyleTest {
     private final Integer base = Integer.valueOf(5);
 
     @BeforeEach
-    public void setUp() throws Exception {
+    public void setUp() {
         ToStringBuilder.setDefaultStyle(ToStringStyle.NO_CLASS_NAME_STYLE);
     }
 
     @AfterEach
-    public void tearDown() throws Exception {
+    public void tearDown() {
         ToStringBuilder.setDefaultStyle(ToStringStyle.DEFAULT_STYLE);
     }
 

--- a/src/test/java/org/apache/commons/lang3/builder/NoFieldNamesToStringStyleTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/NoFieldNamesToStringStyleTest.java
@@ -35,12 +35,12 @@ public class NoFieldNamesToStringStyleTest {
     private final String baseStr = base.getClass().getName() + "@" + Integer.toHexString(System.identityHashCode(base));
 
     @BeforeEach
-    public void setUp() throws Exception {
+    public void setUp() {
         ToStringBuilder.setDefaultStyle(ToStringStyle.NO_FIELD_NAMES_STYLE);
     }
 
     @AfterEach
-    public void tearDown() throws Exception {
+    public void tearDown() {
         ToStringBuilder.setDefaultStyle(ToStringStyle.DEFAULT_STYLE);
     }
 

--- a/src/test/java/org/apache/commons/lang3/builder/RecursiveToStringStyleTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/RecursiveToStringStyleTest.java
@@ -34,12 +34,12 @@ public class RecursiveToStringStyleTest {
     private final String baseStr = base.getClass().getName() + "@" + Integer.toHexString(System.identityHashCode(base));
 
     @BeforeEach
-    public void setUp() throws Exception {
+    public void setUp() {
         ToStringBuilder.setDefaultStyle(new RecursiveToStringStyle());
     }
 
     @AfterEach
-    public void tearDown() throws Exception {
+    public void tearDown() {
         ToStringBuilder.setDefaultStyle(ToStringStyle.DEFAULT_STYLE);
     }
 

--- a/src/test/java/org/apache/commons/lang3/builder/ReflectionToStringBuilderMutateInspectConcurrencyTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/ReflectionToStringBuilderMutateInspectConcurrencyTest.java
@@ -91,7 +91,7 @@ public class ReflectionToStringBuilderMutateInspectConcurrencyTest {
 
     @Test
     @Disabled
-    public void testConcurrency() throws Exception {
+    public void testConcurrency() {
         final TestFixture testFixture = new TestFixture();
         final int numMutators = 10;
         final int numIterations = 10;

--- a/src/test/java/org/apache/commons/lang3/builder/ShortPrefixToStringStyleTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/ShortPrefixToStringStyleTest.java
@@ -35,12 +35,12 @@ public class ShortPrefixToStringStyleTest {
     private final String baseStr = "Integer";
 
     @BeforeEach
-    public void setUp() throws Exception {
+    public void setUp() {
         ToStringBuilder.setDefaultStyle(ToStringStyle.SHORT_PREFIX_STYLE);
     }
 
     @AfterEach
-    public void tearDown() throws Exception {
+    public void tearDown() {
         ToStringBuilder.setDefaultStyle(ToStringStyle.DEFAULT_STYLE);
     }
 

--- a/src/test/java/org/apache/commons/lang3/builder/SimpleToStringStyleTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/SimpleToStringStyleTest.java
@@ -34,12 +34,12 @@ public class SimpleToStringStyleTest {
     private final Integer base = Integer.valueOf(5);
 
     @BeforeEach
-    public void setUp() throws Exception {
+    public void setUp() {
         ToStringBuilder.setDefaultStyle(ToStringStyle.SIMPLE_STYLE);
     }
 
     @AfterEach
-    public void tearDown() throws Exception {
+    public void tearDown() {
         ToStringBuilder.setDefaultStyle(ToStringStyle.DEFAULT_STYLE);
     }
 

--- a/src/test/java/org/apache/commons/lang3/builder/StandardToStringStyleTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/StandardToStringStyleTest.java
@@ -50,12 +50,12 @@ public class StandardToStringStyleTest {
     }
 
     @BeforeEach
-    public void setUp() throws Exception {
+    public void setUp() {
         ToStringBuilder.setDefaultStyle(STYLE);
     }
 
     @AfterEach
-    public void tearDown() throws Exception {
+    public void tearDown() {
         ToStringBuilder.setDefaultStyle(ToStringStyle.DEFAULT_STYLE);
     }
 

--- a/src/test/java/org/apache/commons/lang3/builder/ToStringBuilderTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/ToStringBuilderTest.java
@@ -425,7 +425,7 @@ public class ToStringBuilderTest {
     }
 
     @Test
-    public void testReflectionArrayArrayCycle() throws Exception {
+    public void testReflectionArrayArrayCycle() {
         final Object[][] objects = new Object[2][2];
         objects[0][0] = objects;
         objects[0][1] = objects;

--- a/src/test/java/org/apache/commons/lang3/concurrent/AtomicInitializerTest.java
+++ b/src/test/java/org/apache/commons/lang3/concurrent/AtomicInitializerTest.java
@@ -29,7 +29,7 @@ public class AtomicInitializerTest extends AbstractConcurrentInitializerTest {
     protected ConcurrentInitializer<Object> createInitializer() {
         return new AtomicInitializer<Object>() {
             @Override
-            protected Object initialize() throws ConcurrentException {
+            protected Object initialize() {
                 return new Object();
             }
         };

--- a/src/test/java/org/apache/commons/lang3/concurrent/AtomicSafeInitializerTest.java
+++ b/src/test/java/org/apache/commons/lang3/concurrent/AtomicSafeInitializerTest.java
@@ -32,7 +32,7 @@ public class AtomicSafeInitializerTest extends
     private AtomicSafeInitializerTestImpl initializer;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    public void setUp() {
         initializer = new AtomicSafeInitializerTestImpl();
     }
 
@@ -70,7 +70,7 @@ public class AtomicSafeInitializerTest extends
         final AtomicInteger initCounter = new AtomicInteger();
 
         @Override
-        protected Object initialize() throws ConcurrentException {
+        protected Object initialize() {
             initCounter.incrementAndGet();
             return new Object();
         }

--- a/src/test/java/org/apache/commons/lang3/concurrent/BackgroundInitializerTest.java
+++ b/src/test/java/org/apache/commons/lang3/concurrent/BackgroundInitializerTest.java
@@ -162,11 +162,9 @@ public class BackgroundInitializerTest {
 
     /**
      * Tests calling get() before start(). This should cause an exception.
-     *
-     * @throws org.apache.commons.lang3.concurrent.ConcurrentException because the test implementation may throw it
      */
     @Test
-    public void testGetBeforeStart() throws ConcurrentException {
+    public void testGetBeforeStart() {
         final BackgroundInitializerTestImpl init = new BackgroundInitializerTestImpl();
         assertThrows(IllegalStateException.class, init::get);
     }

--- a/src/test/java/org/apache/commons/lang3/concurrent/BasicThreadFactoryTest.java
+++ b/src/test/java/org/apache/commons/lang3/concurrent/BasicThreadFactoryTest.java
@@ -42,7 +42,7 @@ public class BasicThreadFactoryTest {
     private BasicThreadFactory.Builder builder;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    public void setUp() {
         builder = new BasicThreadFactory.Builder();
     }
 

--- a/src/test/java/org/apache/commons/lang3/concurrent/BasicThreadFactoryTest.java
+++ b/src/test/java/org/apache/commons/lang3/concurrent/BasicThreadFactoryTest.java
@@ -175,7 +175,7 @@ public class BasicThreadFactoryTest {
         final BasicThreadFactory factory = builder.wrappedFactory(wrapped).daemon(
                 flag).build();
         assertSame(t, factory.newThread(r), "Wrong thread");
-        assertTrue(flag == t.isDaemon(), "Wrong daemon flag");
+        assertEquals(flag, t.isDaemon(), "Wrong daemon flag");
         EasyMock.verify(wrapped, r);
     }
 

--- a/src/test/java/org/apache/commons/lang3/concurrent/CallableBackgroundInitializerTest.java
+++ b/src/test/java/org/apache/commons/lang3/concurrent/CallableBackgroundInitializerTest.java
@@ -98,7 +98,7 @@ public class CallableBackgroundInitializerTest  {
          * Records this invocation and returns the test result.
          */
         @Override
-        public Integer call() throws Exception {
+        public Integer call() {
             callCount++;
             return RESULT;
         }

--- a/src/test/java/org/apache/commons/lang3/concurrent/CircuitBreakingExceptionTest.java
+++ b/src/test/java/org/apache/commons/lang3/concurrent/CircuitBreakingExceptionTest.java
@@ -59,7 +59,7 @@ public class CircuitBreakingExceptionTest extends AbstractExceptionTest {
     }
 
     @Test
-    public void testWithCauseAndMessage() throws Exception {
+    public void testWithCauseAndMessage() {
         final Exception exception = new CircuitBreakingException(EXCEPTION_MESSAGE, generateCause());
         assertNotNull(exception);
         assertEquals(EXCEPTION_MESSAGE, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
@@ -70,7 +70,7 @@ public class CircuitBreakingExceptionTest extends AbstractExceptionTest {
     }
 
     @Test
-    public void testWithoutCause() throws Exception {
+    public void testWithoutCause() {
         final Exception exception = new CircuitBreakingException(EXCEPTION_MESSAGE);
         assertNotNull(exception);
         assertEquals(EXCEPTION_MESSAGE, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
@@ -80,7 +80,7 @@ public class CircuitBreakingExceptionTest extends AbstractExceptionTest {
     }
 
     @Test
-    public void testWithoutMessage() throws Exception {
+    public void testWithoutMessage() {
         final Exception exception = new CircuitBreakingException(generateCause());
         assertNotNull(exception);
         assertNotNull(exception.getMessage());

--- a/src/test/java/org/apache/commons/lang3/concurrent/ConcurrentUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/concurrent/ConcurrentUtilsTest.java
@@ -183,11 +183,9 @@ public class ConcurrentUtilsTest {
 
     /**
      * Tests handleCause() if the cause is an error.
-     *
-     * @throws org.apache.commons.lang3.concurrent.ConcurrentException so we don't have to catch it
      */
     @Test
-    public void testHandleCauseError() throws ConcurrentException {
+    public void testHandleCauseError() {
         final Error err = new AssertionError("Test");
         Error e = assertThrows(Error.class, () -> ConcurrentUtils.handleCause(new ExecutionException(err)));
         assertEquals(err, e, "Wrong error");
@@ -195,11 +193,9 @@ public class ConcurrentUtilsTest {
 
     /**
      * Tests handleCause() if the cause is an unchecked exception.
-     *
-     * @throws org.apache.commons.lang3.concurrent.ConcurrentException so we don't have to catch it
      */
     @Test
-    public void testHandleCauseUncheckedException() throws ConcurrentException {
+    public void testHandleCauseUncheckedException() {
         final RuntimeException rex = new RuntimeException("Test");
         RuntimeException r =
                 assertThrows(RuntimeException.class, () -> ConcurrentUtils.handleCause(new ExecutionException(rex)));

--- a/src/test/java/org/apache/commons/lang3/concurrent/ConcurrentUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/concurrent/ConcurrentUtilsTest.java
@@ -23,7 +23,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -108,12 +107,9 @@ public class ConcurrentUtilsTest {
     @Test
     public void testExtractCauseError() {
         final Error err = new AssertionError("Test");
-        try {
-            ConcurrentUtils.extractCause(new ExecutionException(err));
-            fail("Error not thrown!");
-        } catch (final Error e) {
-            assertEquals(err, e, "Wrong error");
-        }
+        AssertionError e =
+                assertThrows(AssertionError.class, () -> ConcurrentUtils.extractCause(new ExecutionException(err)));
+        assertEquals(err, e, "Wrong error");
     }
 
     /**
@@ -122,12 +118,8 @@ public class ConcurrentUtilsTest {
     @Test
     public void testExtractCauseUncheckedException() {
         final RuntimeException rex = new RuntimeException("Test");
-        try {
-            ConcurrentUtils.extractCause(new ExecutionException(rex));
-            fail("Runtime exception not thrown!");
-        } catch (final RuntimeException r) {
-            assertEquals(rex, r, "Wrong exception");
-        }
+        RuntimeException r =
+                assertThrows(RuntimeException.class, () -> ConcurrentUtils.extractCause(new ExecutionException(rex)));
     }
 
     /**
@@ -163,12 +155,8 @@ public class ConcurrentUtilsTest {
     @Test
     public void testExtractCauseUncheckedError() {
         final Error err = new AssertionError("Test");
-        try {
-            ConcurrentUtils.extractCauseUnchecked(new ExecutionException(err));
-            fail("Error not thrown!");
-        } catch (final Error e) {
-            assertEquals(err, e, "Wrong error");
-        }
+        Error e = assertThrows(Error.class, () -> ConcurrentUtils.extractCauseUnchecked(new ExecutionException(err)));
+        assertEquals(err, e, "Wrong error");
     }
 
     /**
@@ -177,12 +165,9 @@ public class ConcurrentUtilsTest {
     @Test
     public void testExtractCauseUncheckedUncheckedException() {
         final RuntimeException rex = new RuntimeException("Test");
-        try {
-            ConcurrentUtils.extractCauseUnchecked(new ExecutionException(rex));
-            fail("Runtime exception not thrown!");
-        } catch (final RuntimeException r) {
-            assertEquals(rex, r, "Wrong exception");
-        }
+        RuntimeException r =
+                assertThrows(RuntimeException.class, () -> ConcurrentUtils.extractCauseUnchecked(new ExecutionException(rex)));
+        assertEquals(rex, r, "Wrong exception");
     }
 
     /**
@@ -204,12 +189,8 @@ public class ConcurrentUtilsTest {
     @Test
     public void testHandleCauseError() throws ConcurrentException {
         final Error err = new AssertionError("Test");
-        try {
-            ConcurrentUtils.handleCause(new ExecutionException(err));
-            fail("Error not thrown!");
-        } catch (final Error e) {
-            assertEquals(err, e, "Wrong error");
-        }
+        Error e = assertThrows(Error.class, () -> ConcurrentUtils.handleCause(new ExecutionException(err)));
+        assertEquals(err, e, "Wrong error");
     }
 
     /**
@@ -220,12 +201,9 @@ public class ConcurrentUtilsTest {
     @Test
     public void testHandleCauseUncheckedException() throws ConcurrentException {
         final RuntimeException rex = new RuntimeException("Test");
-        try {
-            ConcurrentUtils.handleCause(new ExecutionException(rex));
-            fail("Runtime exception not thrown!");
-        } catch (final RuntimeException r) {
-            assertEquals(rex, r, "Wrong exception");
-        }
+        RuntimeException r =
+                assertThrows(RuntimeException.class, () -> ConcurrentUtils.handleCause(new ExecutionException(rex)));
+        assertEquals(rex, r, "Wrong exception");
     }
 
     /**
@@ -234,12 +212,9 @@ public class ConcurrentUtilsTest {
     @Test
     public void testHandleCauseChecked() {
         final Exception ex = new Exception("Test");
-        try {
-            ConcurrentUtils.handleCause(new ExecutionException(ex));
-            fail("ConcurrentException not thrown!");
-        } catch (final ConcurrentException cex) {
-            assertEquals(ex, cex.getCause(), "Wrong cause");
-        }
+        ConcurrentException cex =
+                assertThrows(ConcurrentException.class, () -> ConcurrentUtils.handleCause(new ExecutionException(ex)));
+        assertEquals(ex, cex.getCause(), "Wrong cause");
     }
 
     /**
@@ -261,12 +236,8 @@ public class ConcurrentUtilsTest {
     @Test
     public void testHandleCauseUncheckedError() {
         final Error err = new AssertionError("Test");
-        try {
-            ConcurrentUtils.handleCauseUnchecked(new ExecutionException(err));
-            fail("Error not thrown!");
-        } catch (final Error e) {
-            assertEquals(err, e, "Wrong error");
-        }
+        Error e = assertThrows(Error.class, () -> ConcurrentUtils.handleCauseUnchecked(new ExecutionException(err)));
+        assertEquals(err, e, "Wrong error");
     }
 
     /**
@@ -275,12 +246,9 @@ public class ConcurrentUtilsTest {
     @Test
     public void testHandleCauseUncheckedUncheckedException() {
         final RuntimeException rex = new RuntimeException("Test");
-        try {
-            ConcurrentUtils.handleCauseUnchecked(new ExecutionException(rex));
-            fail("Runtime exception not thrown!");
-        } catch (final RuntimeException r) {
-            assertEquals(rex, r, "Wrong exception");
-        }
+        RuntimeException r =
+                assertThrows(RuntimeException.class, () -> ConcurrentUtils.handleCauseUnchecked(new ExecutionException(rex)));
+        assertEquals(rex, r, "Wrong exception");
     }
 
     /**
@@ -289,12 +257,9 @@ public class ConcurrentUtilsTest {
     @Test
     public void testHandleCauseUncheckedChecked() {
         final Exception ex = new Exception("Test");
-        try {
-            ConcurrentUtils.handleCauseUnchecked(new ExecutionException(ex));
-            fail("ConcurrentRuntimeException not thrown!");
-        } catch (final ConcurrentRuntimeException crex) {
-            assertEquals(ex, crex.getCause(), "Wrong cause");
-        }
+        ConcurrentRuntimeException crex =
+                assertThrows(ConcurrentRuntimeException.class, () -> ConcurrentUtils.handleCauseUnchecked(new ExecutionException(ex)));
+        assertEquals(ex, crex.getCause(), "Wrong cause");
     }
 
     /**
@@ -386,12 +351,9 @@ public class ConcurrentUtilsTest {
         final Exception cause = new Exception();
         EasyMock.expect(init.get()).andThrow(new ConcurrentException(cause));
         EasyMock.replay(init);
-        try {
-            ConcurrentUtils.initializeUnchecked(init);
-            fail("Exception not thrown!");
-        } catch (final ConcurrentRuntimeException crex) {
-            assertSame(cause, crex.getCause(), "Wrong cause");
-        }
+        ConcurrentRuntimeException crex =
+                assertThrows(ConcurrentRuntimeException.class, () -> ConcurrentUtils.initializeUnchecked(init));
+        assertSame(cause, crex.getCause(), "Wrong cause");
         EasyMock.verify(init);
     }
 
@@ -567,13 +529,11 @@ public class ConcurrentUtilsTest {
         final Exception ex = new Exception();
         EasyMock.expect(init.get()).andThrow(new ConcurrentException(ex));
         EasyMock.replay(init);
-        try {
-            ConcurrentUtils.createIfAbsentUnchecked(
-                    new ConcurrentHashMap<>(), "test", init);
-            fail("Exception not thrown!");
-        } catch (final ConcurrentRuntimeException crex) {
-            assertEquals(ex, crex.getCause(), "Wrong cause");
-        }
+        ConcurrentRuntimeException crex =
+                assertThrows(
+                        ConcurrentRuntimeException.class,
+                        () -> ConcurrentUtils.createIfAbsentUnchecked(new ConcurrentHashMap<>(), "test", init));
+        assertEquals(ex, crex.getCause(), "Wrong cause");
         EasyMock.verify(init);
     }
 }

--- a/src/test/java/org/apache/commons/lang3/concurrent/ConstantInitializerTest.java
+++ b/src/test/java/org/apache/commons/lang3/concurrent/ConstantInitializerTest.java
@@ -35,7 +35,7 @@ public class ConstantInitializerTest {
     private ConstantInitializer<Integer> init;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    public void setUp() {
         init = new ConstantInitializer<>(VALUE);
     }
 

--- a/src/test/java/org/apache/commons/lang3/concurrent/ConstantInitializerTest.java
+++ b/src/test/java/org/apache/commons/lang3/concurrent/ConstantInitializerTest.java
@@ -46,9 +46,9 @@ public class ConstantInitializerTest {
      * @param expected the expected result
      */
     private void checkEquals(final Object obj, final boolean expected) {
-        assertTrue(expected == init.equals(obj), "Wrong result of equals");
+        assertEquals(expected, init.equals(obj), "Wrong result of equals");
         if (obj != null) {
-            assertTrue(expected == obj.equals(init), "Not symmetric");
+            assertEquals(expected, obj.equals(init), "Not symmetric");
             if (expected) {
                 assertEquals(init.hashCode(), obj.hashCode(), "Different hash codes");
             }

--- a/src/test/java/org/apache/commons/lang3/concurrent/LazyInitializerTest.java
+++ b/src/test/java/org/apache/commons/lang3/concurrent/LazyInitializerTest.java
@@ -26,7 +26,7 @@ public class LazyInitializerTest extends AbstractConcurrentInitializerTest {
     private LazyInitializerTestImpl initializer;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    public void setUp() {
         initializer = new LazyInitializerTestImpl();
     }
 

--- a/src/test/java/org/apache/commons/lang3/concurrent/MemoizerTest.java
+++ b/src/test/java/org/apache/commons/lang3/concurrent/MemoizerTest.java
@@ -24,7 +24,6 @@ import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.fail;
 
 public class MemoizerTest {
 
@@ -54,13 +53,7 @@ public class MemoizerTest {
         expect(computable.compute(input)).andThrow(interruptedException);
         replay(computable);
 
-        try {
-            memoizer.compute(input);
-            fail("Expected Throwable to be thrown!");
-        } catch (final Throwable expected) {
-            // Should always be thrown the first time
-        }
-
+        assertThrows(Throwable.class, () -> memoizer.compute(input));
         assertThrows(IllegalStateException.class, () -> memoizer.compute(input));
     }
 
@@ -72,13 +65,7 @@ public class MemoizerTest {
         expect(computable.compute(input)).andThrow(interruptedException);
         replay(computable);
 
-        try {
-            memoizer.compute(input);
-            fail("Expected Throwable to be thrown!");
-        } catch (final Throwable expected) {
-            // Should always be thrown the first time
-        }
-
+        assertThrows(Throwable.class, () -> memoizer.compute(input));
         assertThrows(IllegalStateException.class, () -> memoizer.compute(input));
     }
 
@@ -91,13 +78,7 @@ public class MemoizerTest {
         expect(computable.compute(input)).andThrow(interruptedException).andReturn(answer);
         replay(computable);
 
-        try {
-            memoizer.compute(input);
-            fail("Expected Throwable to be thrown!");
-        } catch (final Throwable expected) {
-            // Should always be thrown the first time
-        }
-
+        assertThrows(Throwable.class, () -> memoizer.compute(input));
         assertEquals(answer, memoizer.compute(input));
     }
 

--- a/src/test/java/org/apache/commons/lang3/concurrent/MultiBackgroundInitializerTest.java
+++ b/src/test/java/org/apache/commons/lang3/concurrent/MultiBackgroundInitializerTest.java
@@ -21,7 +21,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Iterator;
 import java.util.NoSuchElementException;
@@ -194,13 +193,11 @@ public class MultiBackgroundInitializerTest {
     @Test
     public void testAddInitializerAfterStart() throws ConcurrentException {
         initializer.start();
-        try {
-            initializer.addInitializer(CHILD_INIT,
-                    new ChildBackgroundInitializer());
-            fail("Could add initializer after start()!");
-        } catch (final IllegalStateException istex) {
-            initializer.get();
-        }
+        assertThrows(
+                IllegalStateException.class,
+                () -> initializer.addInitializer(CHILD_INIT, new ChildBackgroundInitializer()),
+                "Could add initializer after start()!");
+        initializer.get();
     }
 
     /**
@@ -276,12 +273,8 @@ public class MultiBackgroundInitializerTest {
         child.ex = new RuntimeException();
         initializer.addInitializer(CHILD_INIT, child);
         initializer.start();
-        try {
-            initializer.get();
-            fail("Runtime exception not thrown!");
-        } catch (final Exception ex) {
-            assertEquals(child.ex, ex, "Wrong exception");
-        }
+        Exception ex = assertThrows(Exception.class, initializer::get);
+        assertEquals(child.ex, ex, "Wrong exception");
     }
 
     /**

--- a/src/test/java/org/apache/commons/lang3/concurrent/MultiBackgroundInitializerTest.java
+++ b/src/test/java/org/apache/commons/lang3/concurrent/MultiBackgroundInitializerTest.java
@@ -42,7 +42,7 @@ public class MultiBackgroundInitializerTest {
     private MultiBackgroundInitializer initializer;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    public void setUp() {
         initializer = new MultiBackgroundInitializer();
     }
 

--- a/src/test/java/org/apache/commons/lang3/concurrent/TimedSemaphoreTest.java
+++ b/src/test/java/org/apache/commons/lang3/concurrent/TimedSemaphoreTest.java
@@ -21,7 +21,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ScheduledExecutorService;
@@ -105,9 +104,7 @@ public class TimedSemaphoreTest {
         int count = 0;
         do {
             Thread.sleep(PERIOD);
-            if (count++ > trials) {
-                fail("endOfPeriod() not called!");
-            }
+            assertFalse(count++ > trials, "endOfPeriod() not called!");
         } while (semaphore.getPeriodEnds() <= 0);
         semaphore.shutdown();
     }

--- a/src/test/java/org/apache/commons/lang3/concurrent/TimedSemaphoreTest.java
+++ b/src/test/java/org/apache/commons/lang3/concurrent/TimedSemaphoreTest.java
@@ -290,11 +290,9 @@ public class TimedSemaphoreTest {
 
     /**
      * Tries to call acquire() after shutdown(). This should cause an exception.
-     *
-     * @throws java.lang.InterruptedException so we don't have to catch it
      */
     @Test
-    public void testPassAfterShutdown() throws InterruptedException {
+    public void testPassAfterShutdown() {
         final TimedSemaphore semaphore = new TimedSemaphore(PERIOD, UNIT, LIMIT);
         semaphore.shutdown();
         assertThrows(IllegalStateException.class, semaphore::acquire);

--- a/src/test/java/org/apache/commons/lang3/event/EventUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/event/EventUtilsTest.java
@@ -179,7 +179,7 @@ public class EventUtilsTest {
         }
 
         @Override
-        public Object invoke(final Object proxy, final Method method, final Object[] args) throws Throwable {
+        public Object invoke(final Object proxy, final Method method, final Object[] args) {
             final Integer count = eventCounts.get(method.getName());
             if (count == null) {
                 eventCounts.put(method.getName(), Integer.valueOf(1));

--- a/src/test/java/org/apache/commons/lang3/exception/AbstractExceptionContextTest.java
+++ b/src/test/java/org/apache/commons/lang3/exception/AbstractExceptionContextTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.BeforeEach;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.Serializable;
@@ -72,8 +73,8 @@ public abstract class AbstractExceptionContextTest<T extends ExceptionContext & 
         assertTrue(message.contains("some value"));
         assertTrue(message.contains("5"));
 
-        assertTrue(exceptionContext.getFirstContextValue("test1") == null);
-        assertTrue(exceptionContext.getFirstContextValue("test2").equals("some value"));
+        assertNull(exceptionContext.getFirstContextValue("test1"));
+        assertEquals("some value", exceptionContext.getFirstContextValue("test2"));
 
         assertEquals(5, exceptionContext.getContextLabels().size());
         assertTrue(exceptionContext.getContextLabels().contains("test1"));
@@ -99,7 +100,7 @@ public abstract class AbstractExceptionContextTest<T extends ExceptionContext & 
         assertTrue(message.contains("test Poorly written obj"));
         assertTrue(message.contains("Crap"));
 
-        assertTrue(exceptionContext.getFirstContextValue("crap") == null);
+        assertNull(exceptionContext.getFirstContextValue("crap"));
         assertTrue(exceptionContext.getFirstContextValue("test Poorly written obj") instanceof ObjectWithFaultyToString);
 
         assertEquals(7, exceptionContext.getContextEntries().size());
@@ -126,13 +127,13 @@ public abstract class AbstractExceptionContextTest<T extends ExceptionContext & 
     public void testGetFirstContextValue() {
         exceptionContext.addContextValue("test2", "different value");
 
-        assertTrue(exceptionContext.getFirstContextValue("test1") == null);
-        assertTrue(exceptionContext.getFirstContextValue("test2").equals("some value"));
-        assertTrue(exceptionContext.getFirstContextValue("crap") == null);
+        assertNull(exceptionContext.getFirstContextValue("test1"));
+        assertEquals("some value", exceptionContext.getFirstContextValue("test2"));
+        assertNull(exceptionContext.getFirstContextValue("crap"));
 
         exceptionContext.setContextValue("test2", "another");
 
-        assertTrue(exceptionContext.getFirstContextValue("test2").equals("another"));
+        assertEquals("another", exceptionContext.getFirstContextValue("test2"));
     }
 
     @Test
@@ -144,7 +145,7 @@ public abstract class AbstractExceptionContextTest<T extends ExceptionContext & 
 
         exceptionContext.setContextValue("test2", "another");
 
-        assertTrue(exceptionContext.getFirstContextValue("test2").equals("another"));
+        assertEquals("another", exceptionContext.getFirstContextValue("test2"));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/exception/CloneFailedExceptionTest.java
+++ b/src/test/java/org/apache/commons/lang3/exception/CloneFailedExceptionTest.java
@@ -50,7 +50,7 @@ public class CloneFailedExceptionTest extends AbstractExceptionTest {
     }
 
     @Test
-    public void testWithCauseAndMessage() throws Exception {
+    public void testWithCauseAndMessage() {
         final Exception exception = new CloneFailedException(EXCEPTION_MESSAGE, generateCause());
         assertNotNull(exception);
         assertEquals(EXCEPTION_MESSAGE, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
@@ -61,7 +61,7 @@ public class CloneFailedExceptionTest extends AbstractExceptionTest {
     }
 
     @Test
-    public void testWithoutCause() throws Exception {
+    public void testWithoutCause() {
         final Exception exception = new CloneFailedException(EXCEPTION_MESSAGE);
         assertNotNull(exception);
         assertEquals(EXCEPTION_MESSAGE, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
@@ -71,7 +71,7 @@ public class CloneFailedExceptionTest extends AbstractExceptionTest {
     }
 
     @Test
-    public void testWithoutMessage() throws Exception {
+    public void testWithoutMessage() {
         final Exception exception = new CloneFailedException(generateCause());
         assertNotNull(exception);
         assertNotNull(exception.getMessage());

--- a/src/test/java/org/apache/commons/lang3/exception/ContextedExceptionTest.java
+++ b/src/test/java/org/apache/commons/lang3/exception/ContextedExceptionTest.java
@@ -17,6 +17,7 @@
 package org.apache.commons.lang3.exception;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -98,7 +99,7 @@ public class ContextedExceptionTest extends AbstractExceptionContextTest<Context
         .addContextValue("test Poorly written obj", new ObjectWithFaultyToString());
 
         final String message = exceptionContext.getMessage();
-        assertTrue(message != null);
+        assertNotNull(message);
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/exception/ContextedRuntimeExceptionTest.java
+++ b/src/test/java/org/apache/commons/lang3/exception/ContextedRuntimeExceptionTest.java
@@ -17,6 +17,7 @@
 package org.apache.commons.lang3.exception;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -100,7 +101,7 @@ public class ContextedRuntimeExceptionTest extends AbstractExceptionContextTest<
         .addContextValue("test Poorly written obj", new ObjectWithFaultyToString());
 
         final String message = exceptionContext.getMessage();
-        assertTrue(message != null);
+        assertNotNull(message);
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/exception/ExceptionUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/exception/ExceptionUtilsTest.java
@@ -22,7 +22,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -379,11 +378,9 @@ public class ExceptionUtilsTest {
         assertEquals(0, out.toString().length());
 
         out = new ByteArrayOutputStream(1024);
-        try {
-            ExceptionUtils.printRootCauseStackTrace(withCause, (PrintStream) null);
-            fail();
-        } catch (final IllegalArgumentException ex) {
-        }
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> ExceptionUtils.printRootCauseStackTrace(withCause, (PrintStream) null));
 
         out = new ByteArrayOutputStream(1024);
         final Throwable cause = createExceptionWithCause();
@@ -405,11 +402,9 @@ public class ExceptionUtilsTest {
         assertEquals(0, writer.getBuffer().length());
 
         writer = new StringWriter(1024);
-        try {
-            ExceptionUtils.printRootCauseStackTrace(withCause, (PrintWriter) null);
-            fail();
-        } catch (final IllegalArgumentException ex) {
-        }
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> ExceptionUtils.printRootCauseStackTrace(withCause, (PrintWriter) null));
 
         writer = new StringWriter(1024);
         final Throwable cause = createExceptionWithCause();
@@ -542,30 +537,17 @@ public class ExceptionUtilsTest {
     @Test
     public void testThrow() {
         final Exception expected = new InterruptedException();
-        try {
-            ExceptionUtils.rethrow(expected);
-            fail("Exception not thrown");
-        } catch (final Exception actual) {
-            assertSame(expected, actual);
-        }
+        Exception actual = assertThrows(Exception.class, () -> ExceptionUtils.rethrow(expected));
+        assertSame(expected, actual);
     }
 
     @Test
     public void testCatchTechniques() {
-        try {
-            throwsCheckedException();
-            fail("Exception not thrown");
-        } catch (final Exception ioe) {
-            assertTrue(ioe instanceof IOException);
-            assertEquals(1, ExceptionUtils.getThrowableCount(ioe));
-        }
+        IOException ioe = assertThrows(IOException.class, ExceptionUtilsTest::throwsCheckedException);
+        assertEquals(1, ExceptionUtils.getThrowableCount(ioe));
 
-        try {
-            redeclareCheckedException();
-            fail("Exception not thrown");
-        } catch (final IOException ioe) {
-            assertEquals(1, ExceptionUtils.getThrowableCount(ioe));
-        }
+        ioe = assertThrows(IOException.class, ExceptionUtilsTest::redeclareCheckedException);
+        assertEquals(1, ExceptionUtils.getThrowableCount(ioe));
     }
 
     private static int redeclareCheckedException() throws IOException {
@@ -586,41 +568,25 @@ public class ExceptionUtilsTest {
 
     @Test
     public void testWrapAndUnwrapError() {
-        try {
-            ExceptionUtils.wrapAndThrow(new OutOfMemoryError());
-            fail("Error not thrown");
-        } catch (final Throwable t) {
-            assertTrue(ExceptionUtils.hasCause(t, Error.class));
-        }
+        Throwable t = assertThrows(Throwable.class, () -> ExceptionUtils.wrapAndThrow(new OutOfMemoryError()));
+        assertTrue(ExceptionUtils.hasCause(t, Error.class));
     }
 
     @Test
     public void testWrapAndUnwrapRuntimeException() {
-        try {
-            ExceptionUtils.wrapAndThrow(new IllegalArgumentException());
-            fail("RuntimeException not thrown");
-        } catch (final Throwable t) {
-            assertTrue(ExceptionUtils.hasCause(t, RuntimeException.class));
-        }
+        Throwable t = assertThrows(Throwable.class, () -> ExceptionUtils.wrapAndThrow(new IllegalArgumentException()));
+        assertTrue(ExceptionUtils.hasCause(t, RuntimeException.class));
     }
 
     @Test
     public void testWrapAndUnwrapCheckedException() {
-        try {
-            ExceptionUtils.wrapAndThrow(new IOException());
-            fail("Checked Exception not thrown");
-        } catch (final Throwable t) {
-            assertTrue(ExceptionUtils.hasCause(t, IOException.class));
-        }
+        Throwable t = assertThrows(Throwable.class, () -> ExceptionUtils.wrapAndThrow(new IOException()));
+        assertTrue(ExceptionUtils.hasCause(t, IOException.class));
     }
 
     @Test
     public void testWrapAndUnwrapThrowable() {
-        try {
-            ExceptionUtils.wrapAndThrow(new TestThrowable());
-            fail("Checked Exception not thrown");
-        } catch (final Throwable t) {
-            assertTrue(ExceptionUtils.hasCause(t, TestThrowable.class));
-        }
+        Throwable t = assertThrows(Throwable.class, () -> ExceptionUtils.wrapAndThrow(new TestThrowable()));
+        assertTrue(ExceptionUtils.hasCause(t, TestThrowable.class));
     }
 }

--- a/src/test/java/org/apache/commons/lang3/exception/ExceptionUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/exception/ExceptionUtilsTest.java
@@ -67,7 +67,7 @@ public class ExceptionUtilsTest {
 
 
     @AfterEach
-    public void tearDown() throws Exception {
+    public void tearDown() {
         withoutCause = null;
         nested = null;
         withCause = null;
@@ -364,14 +364,14 @@ public class ExceptionUtilsTest {
 
     //-----------------------------------------------------------------------
     @Test
-    public void testPrintRootCauseStackTrace_Throwable() throws Exception {
+    public void testPrintRootCauseStackTrace_Throwable() {
         ExceptionUtils.printRootCauseStackTrace(null);
         // could pipe system.err to a known stream, but not much point as
         // internally this method calls stream method anyway
     }
 
     @Test
-    public void testPrintRootCauseStackTrace_ThrowableStream() throws Exception {
+    public void testPrintRootCauseStackTrace_ThrowableStream() {
         ByteArrayOutputStream out = new ByteArrayOutputStream(1024);
         ExceptionUtils.printRootCauseStackTrace(null, (PrintStream) null);
         ExceptionUtils.printRootCauseStackTrace(null, new PrintStream(out));
@@ -395,7 +395,7 @@ public class ExceptionUtilsTest {
     }
 
     @Test
-    public void testPrintRootCauseStackTrace_ThrowableWriter() throws Exception {
+    public void testPrintRootCauseStackTrace_ThrowableWriter() {
         StringWriter writer = new StringWriter(1024);
         ExceptionUtils.printRootCauseStackTrace(null, (PrintWriter) null);
         ExceptionUtils.printRootCauseStackTrace(null, new PrintWriter(writer));
@@ -420,7 +420,7 @@ public class ExceptionUtilsTest {
 
     //-----------------------------------------------------------------------
     @Test
-    public void testGetRootCauseStackTrace_Throwable() throws Exception {
+    public void testGetRootCauseStackTrace_Throwable() {
         assertEquals(0, ExceptionUtils.getRootCauseStackTrace(null).length);
 
         final Throwable cause = createExceptionWithCause();
@@ -446,7 +446,7 @@ public class ExceptionUtilsTest {
     }
 
     @Test
-    public void testRemoveCommonFrames_ListList() throws Exception {
+    public void testRemoveCommonFrames_ListList() {
         assertThrows(IllegalArgumentException.class, () -> ExceptionUtils.removeCommonFrames(null, null));
     }
 
@@ -550,7 +550,7 @@ public class ExceptionUtilsTest {
         assertEquals(1, ExceptionUtils.getThrowableCount(ioe));
     }
 
-    private static int redeclareCheckedException() throws IOException {
+    private static int redeclareCheckedException() {
         return throwsCheckedException();
     }
 

--- a/src/test/java/org/apache/commons/lang3/math/FractionTest.java
+++ b/src/test/java/org/apache/commons/lang3/math/FractionTest.java
@@ -19,7 +19,7 @@
 package org.apache.commons.lang3.math;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -621,7 +621,7 @@ public class FractionTest  {
 
         f = Fraction.getFraction(6, 10);
         assertEquals(f, f.pow(1));
-        assertFalse(f.pow(1).equals(Fraction.getFraction(3,5)));
+        assertNotEquals(f.pow(1), Fraction.getFraction(3, 5));
 
         f = Fraction.getFraction(6, 10);
         f = f.pow(2);
@@ -646,11 +646,11 @@ public class FractionTest  {
         // zero to any positive power is still zero.
         f = Fraction.getFraction(0, 1231);
         f = f.pow(1);
-        assertTrue(0==f.compareTo(Fraction.ZERO));
+        assertEquals(0, f.compareTo(Fraction.ZERO));
         assertEquals(0, f.getNumerator());
         assertEquals(1231, f.getDenominator());
         f = f.pow(2);
-        assertTrue(0==f.compareTo(Fraction.ZERO));
+        assertEquals(0, f.compareTo(Fraction.ZERO));
         assertEquals(0, f.getNumerator());
         assertEquals(1, f.getDenominator());
 
@@ -994,21 +994,21 @@ public class FractionTest  {
         Fraction f2 = null;
 
         f1 = Fraction.getFraction(3, 5);
-        assertFalse(f1.equals(null));
-        assertFalse(f1.equals(new Object()));
-        assertFalse(f1.equals(Integer.valueOf(6)));
+        assertNotEquals(null, f1);
+        assertNotEquals(f1, new Object());
+        assertNotEquals(f1, Integer.valueOf(6));
 
         f1 = Fraction.getFraction(3, 5);
         f2 = Fraction.getFraction(2, 5);
-        assertFalse(f1.equals(f2));
-        assertTrue(f1.equals(f1));
-        assertTrue(f2.equals(f2));
+        assertNotEquals(f1, f2);
+        assertEquals(f1, f1);
+        assertEquals(f2, f2);
 
         f2 = Fraction.getFraction(3, 5);
-        assertTrue(f1.equals(f2));
+        assertEquals(f1, f2);
 
         f2 = Fraction.getFraction(6, 10);
-        assertFalse(f1.equals(f2));
+        assertNotEquals(f1, f2);
     }
 
     @Test
@@ -1016,7 +1016,7 @@ public class FractionTest  {
         final Fraction f1 = Fraction.getFraction(3, 5);
         Fraction f2 = Fraction.getFraction(3, 5);
 
-        assertTrue(f1.hashCode() == f2.hashCode());
+        assertEquals(f1.hashCode(), f2.hashCode());
 
         f2 = Fraction.getFraction(2, 5);
         assertTrue(f1.hashCode() != f2.hashCode());
@@ -1031,30 +1031,30 @@ public class FractionTest  {
         Fraction f2 = null;
 
         f1 = Fraction.getFraction(3, 5);
-        assertTrue(f1.compareTo(f1) == 0);
+        assertEquals(0, f1.compareTo(f1));
 
         final Fraction fr = f1;
         assertThrows(NullPointerException.class, () -> fr.compareTo(null));
 
         f2 = Fraction.getFraction(2, 5);
         assertTrue(f1.compareTo(f2) > 0);
-        assertTrue(f2.compareTo(f2) == 0);
+        assertEquals(0, f2.compareTo(f2));
 
         f2 = Fraction.getFraction(4, 5);
         assertTrue(f1.compareTo(f2) < 0);
-        assertTrue(f2.compareTo(f2) == 0);
+        assertEquals(0, f2.compareTo(f2));
 
         f2 = Fraction.getFraction(3, 5);
-        assertTrue(f1.compareTo(f2) == 0);
-        assertTrue(f2.compareTo(f2) == 0);
+        assertEquals(0, f1.compareTo(f2));
+        assertEquals(0, f2.compareTo(f2));
 
         f2 = Fraction.getFraction(6, 10);
-        assertTrue(f1.compareTo(f2) == 0);
-        assertTrue(f2.compareTo(f2) == 0);
+        assertEquals(0, f1.compareTo(f2));
+        assertEquals(0, f2.compareTo(f2));
 
         f2 = Fraction.getFraction(-1, 1, Integer.MAX_VALUE);
         assertTrue(f1.compareTo(f2) > 0);
-        assertTrue(f2.compareTo(f2) == 0);
+        assertEquals(0, f2.compareTo(f2));
 
     }
 

--- a/src/test/java/org/apache/commons/lang3/math/FractionTest.java
+++ b/src/test/java/org/apache/commons/lang3/math/FractionTest.java
@@ -23,7 +23,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import org.junit.jupiter.api.Test;
 
@@ -119,30 +118,13 @@ public class FractionTest  {
         assertEquals(10, f.getDenominator());
 
         // zero denominator
-        try {
-            f = Fraction.getFraction(1, 0);
-            fail("expecting ArithmeticException");
-        } catch (final ArithmeticException ex) {}
-
-        try {
-            f = Fraction.getFraction(2, 0);
-            fail("expecting ArithmeticException");
-        } catch (final ArithmeticException ex) {}
-
-        try {
-            f = Fraction.getFraction(-3, 0);
-            fail("expecting ArithmeticException");
-        } catch (final ArithmeticException ex) {}
+        assertThrows(ArithmeticException.class, () -> Fraction.getFraction(1, 0));
+        assertThrows(ArithmeticException.class, () -> Fraction.getFraction(2, 0));
+        assertThrows(ArithmeticException.class, () -> Fraction.getFraction(-3, 0));
 
         // very large: can't represent as unsimplified fraction, although
-        try {
-            f = Fraction.getFraction(4, Integer.MIN_VALUE);
-            fail("expecting ArithmeticException");
-        } catch (final ArithmeticException ex) {}
-        try {
-            f = Fraction.getFraction(1, Integer.MIN_VALUE);
-            fail("expecting ArithmeticException");
-        } catch (final ArithmeticException ex) {}
+        assertThrows(ArithmeticException.class, () -> Fraction.getFraction(4, Integer.MIN_VALUE));
+        assertThrows(ArithmeticException.class, () -> Fraction.getFraction(1, Integer.MIN_VALUE));
     }
 
     @Test
@@ -168,86 +150,37 @@ public class FractionTest  {
         assertEquals(2, f.getDenominator());
 
         // negatives
-        try {
-            f = Fraction.getFraction(1, -6, -10);
-            fail("expecting ArithmeticException");
-        } catch (final ArithmeticException ex) {}
-
-        try {
-            f = Fraction.getFraction(1, -6, -10);
-            fail("expecting ArithmeticException");
-        } catch (final ArithmeticException ex) {}
-
-        try {
-            f = Fraction.getFraction(1, -6, -10);
-            fail("expecting ArithmeticException");
-        } catch (final ArithmeticException ex) {}
+        assertThrows(ArithmeticException.class, () -> Fraction.getFraction(1, -6, -10));
+        assertThrows(ArithmeticException.class, () -> Fraction.getFraction(1, -6, -10));
+        assertThrows(ArithmeticException.class, () -> Fraction.getFraction(1, -6, -10));
 
         // negative whole
         f = Fraction.getFraction(-1, 6, 10);
         assertEquals(-16, f.getNumerator());
         assertEquals(10, f.getDenominator());
 
-        try {
-            f = Fraction.getFraction(-1, -6, 10);
-            fail("expecting ArithmeticException");
-        } catch (final ArithmeticException ex) {}
-
-        try {
-            f = Fraction.getFraction(-1, 6, -10);
-            fail("expecting ArithmeticException");
-        } catch (final ArithmeticException ex) {}
-
-        try {
-            f = Fraction.getFraction(-1, -6, -10);
-            fail("expecting ArithmeticException");
-        } catch (final ArithmeticException ex) {}
+        assertThrows(ArithmeticException.class, () -> Fraction.getFraction(-1, -6, 10));
+        assertThrows(ArithmeticException.class, () -> Fraction.getFraction(-1, 6, -10));
+        assertThrows(ArithmeticException.class, () -> Fraction.getFraction(-1, -6, -10));
 
         // zero denominator
-        try {
-            f = Fraction.getFraction(0, 1, 0);
-            fail("expecting ArithmeticException");
-        } catch (final ArithmeticException ex) {}
-
-        try {
-            f = Fraction.getFraction(1, 2, 0);
-            fail("expecting ArithmeticException");
-        } catch (final ArithmeticException ex) {}
-
-        try {
-            f = Fraction.getFraction(-1, -3, 0);
-            fail("expecting ArithmeticException");
-        } catch (final ArithmeticException ex) {}
-
-        try {
-            f = Fraction.getFraction(Integer.MAX_VALUE, 1, 2);
-            fail("expecting ArithmeticException");
-        } catch (final ArithmeticException ex) {}
-
-        try {
-            f = Fraction.getFraction(-Integer.MAX_VALUE, 1, 2);
-            fail("expecting ArithmeticException");
-        } catch (final ArithmeticException ex) {}
+        assertThrows(ArithmeticException.class, () -> Fraction.getFraction(0, 1, 0));
+        assertThrows(ArithmeticException.class, () -> Fraction.getFraction(1, 2, 0));
+        assertThrows(ArithmeticException.class, () -> Fraction.getFraction(-1, -3, 0));
+        assertThrows(ArithmeticException.class, () -> Fraction.getFraction(Integer.MAX_VALUE, 1, 2));
+        assertThrows(ArithmeticException.class, () -> Fraction.getFraction(-Integer.MAX_VALUE, 1, 2));
 
         // very large
         f = Fraction.getFraction(-1, 0, Integer.MAX_VALUE);
         assertEquals(-Integer.MAX_VALUE, f.getNumerator());
         assertEquals(Integer.MAX_VALUE, f.getDenominator());
 
-        try {
-            // negative denominators not allowed in this constructor.
-            f = Fraction.getFraction(0, 4, Integer.MIN_VALUE);
-            fail("expecting ArithmeticException");
-        } catch (final ArithmeticException ex) {}
-        try {
-            f = Fraction.getFraction(1, 1, Integer.MAX_VALUE);
-            fail("expecting ArithmeticException");
-        } catch (final ArithmeticException ex) {}
-        try {
-            f = Fraction.getFraction(-1, 2, Integer.MAX_VALUE);
-            fail("expecting ArithmeticException");
-        } catch (final ArithmeticException ex) {}
+        // negative denominators not allowed in this constructor.
+        assertThrows(ArithmeticException.class, () -> Fraction.getFraction(0, 4, Integer.MIN_VALUE));
+        assertThrows(ArithmeticException.class, () -> Fraction.getFraction(1, 1, Integer.MAX_VALUE));
+        assertThrows(ArithmeticException.class, () -> Fraction.getFraction(-1, 2, Integer.MAX_VALUE));
     }
+
     @Test
     public void testReducedFactory_int_int() {
         Fraction f = null;
@@ -285,20 +218,9 @@ public class FractionTest  {
         assertEquals(5, f.getDenominator());
 
         // zero denominator
-        try {
-            f = Fraction.getReducedFraction(1, 0);
-            fail("expecting ArithmeticException");
-        } catch (final ArithmeticException ex) {}
-
-        try {
-            f = Fraction.getReducedFraction(2, 0);
-            fail("expecting ArithmeticException");
-        } catch (final ArithmeticException ex) {}
-
-        try {
-            f = Fraction.getReducedFraction(-3, 0);
-            fail("expecting ArithmeticException");
-        } catch (final ArithmeticException ex) {}
+        assertThrows(ArithmeticException.class, () -> Fraction.getReducedFraction(1, 0));
+        assertThrows(ArithmeticException.class, () -> Fraction.getReducedFraction(2, 0));
+        assertThrows(ArithmeticException.class, () -> Fraction.getReducedFraction(-3, 0));
 
         // reduced
         f = Fraction.getReducedFraction(0, 2);
@@ -328,10 +250,7 @@ public class FractionTest  {
         assertEquals(-(Integer.MIN_VALUE / 2), f.getDenominator());
 
         // Can't reduce, negation will throw
-        try {
-            f = Fraction.getReducedFraction(-7, Integer.MIN_VALUE);
-            fail("Expecting ArithmeticException");
-        } catch (final ArithmeticException ex) {}
+        assertThrows(ArithmeticException.class, () -> Fraction.getReducedFraction(-7, Integer.MIN_VALUE));
 
         // LANG-662
         f = Fraction.getReducedFraction(Integer.MIN_VALUE, 2);
@@ -341,30 +260,13 @@ public class FractionTest  {
 
     @Test
     public void testFactory_double() {
-        Fraction f = null;
-
-        try {
-            f = Fraction.getFraction(Double.NaN);
-            fail("expecting ArithmeticException");
-        } catch (final ArithmeticException ex) {}
-
-        try {
-            f = Fraction.getFraction(Double.POSITIVE_INFINITY);
-            fail("expecting ArithmeticException");
-        } catch (final ArithmeticException ex) {}
-
-        try {
-            f = Fraction.getFraction(Double.NEGATIVE_INFINITY);
-            fail("expecting ArithmeticException");
-        } catch (final ArithmeticException ex) {}
-
-        try {
-            f = Fraction.getFraction((double) Integer.MAX_VALUE + 1);
-            fail("expecting ArithmeticException");
-        } catch (final ArithmeticException ex) {}
+        assertThrows(ArithmeticException.class, () -> Fraction.getFraction(Double.NaN));
+        assertThrows(ArithmeticException.class, () -> Fraction.getFraction(Double.POSITIVE_INFINITY));
+        assertThrows(ArithmeticException.class, () -> Fraction.getFraction(Double.NEGATIVE_INFINITY));
+        assertThrows(ArithmeticException.class, () -> Fraction.getFraction((double) Integer.MAX_VALUE + 1));
 
         // zero
-        f = Fraction.getFraction(0.0d);
+        Fraction f = Fraction.getFraction(0.0d);
         assertEquals(0, f.getNumerator());
         assertEquals(1, f.getDenominator());
 
@@ -402,12 +304,8 @@ public class FractionTest  {
         Fraction f2 = null;
         for (int i = 1; i <= 100; i++) {  // denominator
             for (int j = 1; j <= i; j++) {  // numerator
-                try {
-                    f = Fraction.getFraction((double) j / (double) i);
-                } catch (final ArithmeticException ex) {
-                    System.err.println(j + " " + i);
-                    throw ex;
-                }
+                f = Fraction.getFraction((double) j / (double) i);
+
                 f2 = Fraction.getReducedFraction(j, i);
                 assertEquals(f2.getNumerator(), f.getNumerator());
                 assertEquals(f2.getDenominator(), f.getDenominator());
@@ -416,12 +314,7 @@ public class FractionTest  {
         // save time by skipping some tests!  (
         for (int i = 1001; i <= 10000; i+=SKIP) {  // denominator
             for (int j = 1; j <= i; j++) {  // numerator
-                try {
-                    f = Fraction.getFraction((double) j / (double) i);
-                } catch (final ArithmeticException ex) {
-                    System.err.println(j + " " + i);
-                    throw ex;
-                }
+                f = Fraction.getFraction((double) j / (double) i);
                 f2 = Fraction.getReducedFraction(j, i);
                 assertEquals(f2.getNumerator(), f.getNumerator());
                 assertEquals(f2.getDenominator(), f.getDenominator());
@@ -455,20 +348,9 @@ public class FractionTest  {
         assertEquals(2, f.getNumerator());
         assertEquals(3, f.getDenominator());
 
-        try {
-            f = Fraction.getFraction("2.3R");
-            fail("Expecting NumberFormatException");
-        } catch (final NumberFormatException ex) {}
-
-        try {
-            f = Fraction.getFraction("2147483648"); // too big
-            fail("Expecting NumberFormatException");
-        } catch (final NumberFormatException ex) {}
-
-        try {
-            f = Fraction.getFraction(".");
-            fail("Expecting NumberFormatException");
-        } catch (final NumberFormatException ex) {}
+        assertThrows(NumberFormatException.class, () -> Fraction.getFraction("2.3R"));
+        assertThrows(NumberFormatException.class, () -> Fraction.getFraction("2147483648")); // too big
+        assertThrows(NumberFormatException.class, () -> Fraction.getFraction("."));
     }
 
     @Test
@@ -499,35 +381,12 @@ public class FractionTest  {
         assertEquals(-6, f.getNumerator());
         assertEquals(4, f.getDenominator());
 
-        try {
-            f = Fraction.getFraction("2 3");
-            fail("expecting NumberFormatException");
-        } catch (final NumberFormatException ex) {}
-
-        try {
-            f = Fraction.getFraction("a 3");
-            fail("expecting NumberFormatException");
-        } catch (final NumberFormatException ex) {}
-
-        try {
-            f = Fraction.getFraction("2 b/4");
-            fail("expecting NumberFormatException");
-        } catch (final NumberFormatException ex) {}
-
-        try {
-            f = Fraction.getFraction("2 ");
-            fail("expecting NumberFormatException");
-        } catch (final NumberFormatException ex) {}
-
-        try {
-            f = Fraction.getFraction(" 3");
-            fail("expecting NumberFormatException");
-        } catch (final NumberFormatException ex) {}
-
-        try {
-            f = Fraction.getFraction(" ");
-            fail("expecting NumberFormatException");
-        } catch (final NumberFormatException ex) {}
+        assertThrows(NumberFormatException.class, () -> Fraction.getFraction("2 3"));
+        assertThrows(NumberFormatException.class, () -> Fraction.getFraction("a 3"));
+        assertThrows(NumberFormatException.class, () -> Fraction.getFraction("2 b/4"));
+        assertThrows(NumberFormatException.class, () -> Fraction.getFraction("2 "));
+        assertThrows(NumberFormatException.class, () -> Fraction.getFraction(" 3"));
+        assertThrows(NumberFormatException.class, () -> Fraction.getFraction(" "));
     }
 
     @Test
@@ -558,25 +417,10 @@ public class FractionTest  {
         assertEquals(2, f.getNumerator());
         assertEquals(4, f.getDenominator());
 
-        try {
-            f = Fraction.getFraction("2/d");
-            fail("expecting NumberFormatException");
-        } catch (final NumberFormatException ex) {}
-
-        try {
-            f = Fraction.getFraction("2e/3");
-            fail("expecting NumberFormatException");
-        } catch (final NumberFormatException ex) {}
-
-        try {
-            f = Fraction.getFraction("2/");
-            fail("expecting NumberFormatException");
-        } catch (final NumberFormatException ex) {}
-
-        try {
-            f = Fraction.getFraction("/");
-            fail("expecting NumberFormatException");
-        } catch (final NumberFormatException ex) {}
+        assertThrows(NumberFormatException.class, () -> Fraction.getFraction("2/d"));
+        assertThrows(NumberFormatException.class, () -> Fraction.getFraction("2e/3"));
+        assertThrows(NumberFormatException.class, () -> Fraction.getFraction("2/"));
+        assertThrows(NumberFormatException.class, () -> Fraction.getFraction("/"));
     }
 
     @Test
@@ -681,18 +525,8 @@ public class FractionTest  {
         assertEquals(-47, f.getNumerator());
         assertEquals(15, f.getDenominator());
 
-        f = Fraction.getFraction(0, 3);
-        try {
-            f = f.invert();
-            fail("expecting ArithmeticException");
-        } catch (final ArithmeticException ex) {}
-
-        // large values
-        f = Fraction.getFraction(Integer.MIN_VALUE, 1);
-        try {
-            f = f.invert();
-            fail("expecting ArithmeticException");
-        } catch (final ArithmeticException ex) {}
+        assertThrows(ArithmeticException.class, () -> Fraction.getFraction(0, 3).invert());
+        assertThrows(ArithmeticException.class, () -> Fraction.getFraction(Integer.MIN_VALUE, 1).invert());
 
         f = Fraction.getFraction(Integer.MAX_VALUE, 1);
         f = f.invert();
@@ -720,11 +554,7 @@ public class FractionTest  {
         assertEquals(Integer.MIN_VALUE+2, f.getNumerator());
         assertEquals(Integer.MAX_VALUE, f.getDenominator());
 
-        f = Fraction.getFraction(Integer.MIN_VALUE, 1);
-        try {
-            f = f.negate();
-            fail("expecting ArithmeticException");
-        } catch (final ArithmeticException ex) {}
+        assertThrows(ArithmeticException.class, () -> Fraction.getFraction(Integer.MIN_VALUE, 1).negate());
     }
 
     @Test
@@ -751,11 +581,7 @@ public class FractionTest  {
         assertEquals(Integer.MAX_VALUE, f.getNumerator());
         assertEquals(1, f.getDenominator());
 
-        f = Fraction.getFraction(Integer.MIN_VALUE, 1);
-        try {
-            f = f.abs();
-            fail("expecting ArithmeticException");
-        } catch (final ArithmeticException ex) {}
+        assertThrows(ArithmeticException.class, () -> Fraction.getFraction(Integer.MIN_VALUE, 1).abs());
     }
 
     @Test
@@ -829,14 +655,9 @@ public class FractionTest  {
         assertEquals(1, f.getDenominator());
 
         // zero to negative powers should throw an exception
-        try {
-            f = f.pow(-1);
-            fail("expecting ArithmeticException");
-        } catch (final ArithmeticException ex) {}
-        try {
-            f = f.pow(Integer.MIN_VALUE);
-            fail("expecting ArithmeticException");
-        } catch (final ArithmeticException ex) {}
+        final Fraction fr = f;
+        assertThrows(ArithmeticException.class, () -> fr.pow(-1));
+        assertThrows(ArithmeticException.class, () -> fr.pow(Integer.MIN_VALUE));
 
         // one to any power is still one.
         f = Fraction.getFraction(1, 1);
@@ -851,24 +672,12 @@ public class FractionTest  {
         f = f.pow(Integer.MIN_VALUE);
         assertEquals(f, Fraction.ONE);
 
-        f = Fraction.getFraction(Integer.MAX_VALUE, 1);
-        try {
-            f = f.pow(2);
-            fail("expecting ArithmeticException");
-        } catch (final ArithmeticException ex) {}
+        assertThrows(ArithmeticException.class, () -> Fraction.getFraction(Integer.MAX_VALUE, 1).pow(2));
 
         // Numerator growing too negative during the pow operation.
-        f = Fraction.getFraction(Integer.MIN_VALUE, 1);
-        try {
-            f = f.pow(3);
-            fail("expecting ArithmeticException");
-        } catch (final ArithmeticException ex) {}
+        assertThrows(ArithmeticException.class, () -> Fraction.getFraction(Integer.MIN_VALUE, 1).pow(3));
 
-        f = Fraction.getFraction(65536, 1);
-        try {
-            f = f.pow(2);
-            fail("expecting ArithmeticException");
-        } catch (final ArithmeticException ex) {}
+        assertThrows(ArithmeticException.class, () -> Fraction.getFraction(65536, 1).pow(2));
     }
 
     @Test
@@ -928,14 +737,11 @@ public class FractionTest  {
 
         f1 = Fraction.getFraction(-1, 13*13*2*2);
         f2 = Fraction.getFraction(-2, 13*17*2);
-        f = f1.add(f2);
-        assertEquals(13*13*17*2*2, f.getDenominator());
-        assertEquals(-17 - 2*13*2, f.getNumerator());
+        final Fraction fr = f1.add(f2);
+        assertEquals(13*13*17*2*2, fr.getDenominator());
+        assertEquals(-17 - 2*13*2, fr.getNumerator());
 
-        try {
-            f.add(null);
-            fail("expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException ex) {}
+        assertThrows(IllegalArgumentException.class, () -> fr.add(null));
 
         // if this fraction is added naively, it will overflow.
         // check that it doesn't.
@@ -957,37 +763,23 @@ public class FractionTest  {
         assertEquals(Integer.MAX_VALUE, f.getNumerator());
         assertEquals(1, f.getDenominator());
 
-        try {
-            f = f.add(Fraction.ONE); // should overflow
-            fail("expecting ArithmeticException but got: " + f.toString());
-        } catch (final ArithmeticException ex) {}
+        final Fraction overflower = f;
+        assertThrows(ArithmeticException.class, () -> overflower.add(Fraction.ONE)); // should overflow
 
         // denominator should not be a multiple of 2 or 3 to trigger overflow
-        f1 = Fraction.getFraction(Integer.MIN_VALUE, 5);
-        f2 = Fraction.getFraction(-1,5);
-        try {
-            f = f1.add(f2); // should overflow
-            fail("expecting ArithmeticException but got: " + f.toString());
-        } catch (final ArithmeticException ex) {}
+        assertThrows(
+                ArithmeticException.class,
+                () -> Fraction.getFraction(Integer.MIN_VALUE, 5).add(Fraction.getFraction(-1,5)));
 
-        try {
-            f= Fraction.getFraction(-Integer.MAX_VALUE, 1);
-            f = f.add(f);
-            fail("expecting ArithmeticException");
-        } catch (final ArithmeticException ex) {}
+        final Fraction maxValue = Fraction.getFraction(-Integer.MAX_VALUE, 1);
+        assertThrows(ArithmeticException.class, () -> maxValue.add(maxValue));
 
-        try {
-            f= Fraction.getFraction(-Integer.MAX_VALUE, 1);
-            f = f.add(f);
-            fail("expecting ArithmeticException");
-        } catch (final ArithmeticException ex) {}
+        final Fraction negativeMaxValue = Fraction.getFraction(-Integer.MAX_VALUE, 1);
+        assertThrows(ArithmeticException.class, () -> negativeMaxValue.add(negativeMaxValue));
 
-        f1 = Fraction.getFraction(3,327680);
-        f2 = Fraction.getFraction(2,59049);
-        try {
-            f = f1.add(f2); // should overflow
-            fail("expecting ArithmeticException but got: " + f.toString());
-        } catch (final ArithmeticException ex) {}
+        final Fraction f3 = Fraction.getFraction(3,327680);
+        final Fraction f4 = Fraction.getFraction(2,59049);
+        assertThrows(ArithmeticException.class, () -> f3.add(f4)); // should overflow
     }
 
     @Test
@@ -1043,10 +835,8 @@ public class FractionTest  {
         f = f2.subtract(f1);
         assertSame(f2, f);
 
-        try {
-            f.subtract(null);
-            fail("expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException ex) {}
+        final Fraction fr = f;
+        assertThrows(IllegalArgumentException.class, () -> fr.subtract(null));
 
         // if this fraction is subtracted naively, it will overflow.
         // check that it doesn't.
@@ -1068,39 +858,28 @@ public class FractionTest  {
         assertEquals(Integer.MAX_VALUE-1, f.getNumerator());
         assertEquals(1, f.getDenominator());
 
-        try {
-            f1 = Fraction.getFraction(1, Integer.MAX_VALUE);
-            f2 = Fraction.getFraction(1, Integer.MAX_VALUE - 1);
+        // Should overflow
+        assertThrows(
+                ArithmeticException.class,
+                () -> Fraction.getFraction(1, Integer.MAX_VALUE).subtract(Fraction.getFraction(1, Integer.MAX_VALUE - 1)));
             f = f1.subtract(f2);
-            fail("expecting ArithmeticException");  //should overflow
-        } catch (final ArithmeticException ex) {}
 
         // denominator should not be a multiple of 2 or 3 to trigger overflow
-        f1 = Fraction.getFraction(Integer.MIN_VALUE, 5);
-        f2 = Fraction.getFraction(1,5);
-        try {
-            f = f1.subtract(f2); // should overflow
-            fail("expecting ArithmeticException but got: " + f.toString());
-        } catch (final ArithmeticException ex) {}
+        assertThrows(
+                ArithmeticException.class,
+                () -> Fraction.getFraction(Integer.MIN_VALUE, 5).subtract(Fraction.getFraction(1,5)));
 
-        try {
-            f= Fraction.getFraction(Integer.MIN_VALUE, 1);
-            f = f.subtract(Fraction.ONE);
-            fail("expecting ArithmeticException");
-        } catch (final ArithmeticException ex) {}
+        assertThrows(
+                ArithmeticException.class, () -> Fraction.getFraction(Integer.MIN_VALUE, 1).subtract(Fraction.ONE));
 
-        try {
-            f= Fraction.getFraction(Integer.MAX_VALUE, 1);
-            f = f.subtract(Fraction.ONE.negate());
-            fail("expecting ArithmeticException");
-        } catch (final ArithmeticException ex) {}
+        assertThrows(
+                ArithmeticException.class,
+                () -> Fraction.getFraction(Integer.MAX_VALUE, 1).subtract(Fraction.ONE.negate()));
 
-        f1 = Fraction.getFraction(3,327680);
-        f2 = Fraction.getFraction(2,59049);
-        try {
-            f = f1.subtract(f2); // should overflow
-            fail("expecting ArithmeticException but got: " + f.toString());
-        } catch (final ArithmeticException ex) {}
+        // Should overflow
+        assertThrows(
+                ArithmeticException.class,
+                () -> Fraction.getFraction(3,327680).subtract(Fraction.getFraction(2,59049)));
     }
 
     @Test
@@ -1154,22 +933,14 @@ public class FractionTest  {
         assertEquals(Integer.MIN_VALUE, f.getNumerator());
         assertEquals(1, f.getDenominator());
 
-        try {
-            f.multiplyBy(null);
-            fail("expecting IllegalArgumentException");
-        } catch (final IllegalArgumentException ex) {}
+        final Fraction fr = f;
+        assertThrows(IllegalArgumentException.class, () -> fr.multiplyBy(null));
 
-        try {
-            f1 = Fraction.getFraction(1, Integer.MAX_VALUE);
-            f = f1.multiplyBy(f1);  // should overflow
-            fail("expecting ArithmeticException");
-        } catch (final ArithmeticException ex) {}
+        final Fraction fr1 = Fraction.getFraction(1, Integer.MAX_VALUE);
+        assertThrows(ArithmeticException.class, () -> fr1.multiplyBy(fr1));
 
-        try {
-            f1 = Fraction.getFraction(1, -Integer.MAX_VALUE);
-            f = f1.multiplyBy(f1);  // should overflow
-            fail("expecting ArithmeticException");
-        } catch (final ArithmeticException ex) {}
+        final Fraction fr2 = Fraction.getFraction(1, -Integer.MAX_VALUE);
+        assertThrows(ArithmeticException.class, () -> fr2.multiplyBy(fr2));
     }
 
     @Test
@@ -1184,12 +955,7 @@ public class FractionTest  {
         assertEquals(3, f.getNumerator());
         assertEquals(2, f.getDenominator());
 
-        f1 = Fraction.getFraction(3, 5);
-        f2 = Fraction.ZERO;
-        try {
-            f = f1.divideBy(f2);
-            fail("expecting ArithmeticException");
-        } catch (final ArithmeticException ex) {}
+        assertThrows(ArithmeticException.class, () -> Fraction.getFraction(3, 5).divideBy(Fraction.ZERO));
 
         f1 = Fraction.getFraction(0, 5);
         f2 = Fraction.getFraction(2, 7);
@@ -1209,25 +975,17 @@ public class FractionTest  {
 
         f1 = Fraction.getFraction(Integer.MIN_VALUE, Integer.MAX_VALUE);
         f2 = Fraction.getFraction(1, Integer.MAX_VALUE);
-        f = f1.divideBy(f2);
-        assertEquals(Integer.MIN_VALUE, f.getNumerator());
-        assertEquals(1, f.getDenominator());
+        final Fraction fr = f1.divideBy(f2);
+        assertEquals(Integer.MIN_VALUE, fr.getNumerator());
+        assertEquals(1, fr.getDenominator());
 
-        try {
-            f.divideBy(null);
-            fail("IllegalArgumentException");
-        } catch (final IllegalArgumentException ex) {}
+        assertThrows(IllegalArgumentException.class, () -> fr.divideBy(null));
 
-        try {
-            f1 = Fraction.getFraction(1, Integer.MAX_VALUE);
-            f = f1.divideBy(f1.invert());  // should overflow
-            fail("expecting ArithmeticException");
-        } catch (final ArithmeticException ex) {}
-        try {
-            f1 = Fraction.getFraction(1, -Integer.MAX_VALUE);
-            f = f1.divideBy(f1.invert());  // should overflow
-            fail("expecting ArithmeticException");
-        } catch (final ArithmeticException ex) {}
+        final Fraction smallest = Fraction.getFraction(1, Integer.MAX_VALUE);
+        assertThrows(ArithmeticException.class, () -> smallest.divideBy(smallest.invert())); // Should overflow
+
+        final Fraction negative = Fraction.getFraction(1, -Integer.MAX_VALUE);
+        assertThrows(ArithmeticException.class, () -> negative.divideBy(negative.invert())); // Should overflow
     }
 
     @Test
@@ -1275,10 +1033,8 @@ public class FractionTest  {
         f1 = Fraction.getFraction(3, 5);
         assertTrue(f1.compareTo(f1) == 0);
 
-        try {
-            f1.compareTo(null);
-            fail("expecting NullPointerException");
-        } catch (final NullPointerException ex) {}
+        final Fraction fr = f1;
+        assertThrows(NullPointerException.class, () -> fr.compareTo(null));
 
         f2 = Fraction.getFraction(2, 5);
         assertTrue(f1.compareTo(f2) > 0);

--- a/src/test/java/org/apache/commons/lang3/math/IEEE754rUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/math/IEEE754rUtilsTest.java
@@ -17,8 +17,8 @@
 package org.apache.commons.lang3.math;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import org.junit.jupiter.api.Test;
 
@@ -55,46 +55,45 @@ public class IEEE754rUtilsTest  {
 
     @Test
     public void testEnforceExceptions() {
-        try {
-            IEEE754rUtils.min( (float[]) null);
-            fail("IllegalArgumentException expected for null input");
-        } catch(final IllegalArgumentException iae) { /* expected */ }
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> IEEE754rUtils.min( (float[]) null),
+                "IllegalArgumentException expected for null input");
 
-        try {
-            IEEE754rUtils.min();
-            fail("IllegalArgumentException expected for empty input");
-        } catch(final IllegalArgumentException iae) { /* expected */ }
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> IEEE754rUtils.min(),
+                "IllegalArgumentException expected for empty input");
 
-        try {
-            IEEE754rUtils.max( (float[]) null);
-            fail("IllegalArgumentException expected for null input");
-        } catch(final IllegalArgumentException iae) { /* expected */ }
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> IEEE754rUtils.max( (float[]) null),
+                "IllegalArgumentException expected for null input");
 
-        try {
-            IEEE754rUtils.max();
-            fail("IllegalArgumentException expected for empty input");
-        } catch(final IllegalArgumentException iae) { /* expected */ }
+        assertThrows(
+                IllegalArgumentException.class,
+                IEEE754rUtils::max,
+                "IllegalArgumentException expected for empty input");
 
-        try {
-            IEEE754rUtils.min( (double[]) null);
-            fail("IllegalArgumentException expected for null input");
-        } catch(final IllegalArgumentException iae) { /* expected */ }
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> IEEE754rUtils.min( (double[]) null),
+                "IllegalArgumentException expected for null input");
 
-        try {
-            IEEE754rUtils.min(new double[0]);
-            fail("IllegalArgumentException expected for empty input");
-        } catch(final IllegalArgumentException iae) { /* expected */ }
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> IEEE754rUtils.min(new double[0]),
+                "IllegalArgumentException expected for empty input");
 
-        try {
-            IEEE754rUtils.max( (double[]) null);
-            fail("IllegalArgumentException expected for null input");
-        } catch(final IllegalArgumentException iae) { /* expected */ }
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> IEEE754rUtils.max( (double[]) null),
+                "IllegalArgumentException expected for null input");
 
-        try {
-            IEEE754rUtils.max(new double[0]);
-            fail("IllegalArgumentException expected for empty input");
-        } catch(final IllegalArgumentException iae) { /* expected */ }
-
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> IEEE754rUtils.max(new double[0]),
+                "IllegalArgumentException expected for empty input");
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java
@@ -616,12 +616,9 @@ public class NumberUtilsTest {
     }
 
     protected void testCreateFloatFailure(final String str) {
-        try {
-            final Float value = NumberUtils.createFloat(str);
-            fail("createFloat(\"" + str + "\") should have failed: " + value);
-        } catch (final NumberFormatException ex) {
-            // empty
-        }
+        assertThrows(
+                NumberFormatException.class,
+                () -> NumberUtils.createFloat(str), "createFloat(\"" + str + "\") should have failed.");
     }
 
     @Test
@@ -636,12 +633,10 @@ public class NumberUtilsTest {
     }
 
     protected void testCreateDoubleFailure(final String str) {
-        try {
-            final Double value = NumberUtils.createDouble(str);
-            fail("createDouble(\"" + str + "\") should have failed: " + value);
-        } catch (final NumberFormatException ex) {
-            // empty
-        }
+        assertThrows(
+                NumberFormatException.class,
+                () -> NumberUtils.createDouble(str),
+                "createDouble(\"" + str + "\") should have failed.");
     }
 
     @Test
@@ -656,12 +651,10 @@ public class NumberUtilsTest {
     }
 
     protected void testCreateIntegerFailure(final String str) {
-        try {
-            final Integer value = NumberUtils.createInteger(str);
-            fail("createInteger(\"" + str + "\") should have failed: " + value);
-        } catch (final NumberFormatException ex) {
-            // empty
-        }
+        assertThrows(
+                NumberFormatException.class,
+                () -> NumberUtils.createInteger(str),
+                "createInteger(\"" + str + "\") should have failed.");
     }
 
     @Test
@@ -676,12 +669,10 @@ public class NumberUtilsTest {
     }
 
     protected void testCreateLongFailure(final String str) {
-        try {
-            final Long value = NumberUtils.createLong(str);
-            fail("createLong(\"" + str + "\") should have failed: " + value);
-        } catch (final NumberFormatException ex) {
-            // empty
-        }
+        assertThrows(
+                NumberFormatException.class,
+                () -> NumberUtils.createLong(str),
+                "createLong(\"" + str + "\") should have failed.");
     }
 
     @Test
@@ -709,12 +700,10 @@ public class NumberUtilsTest {
     }
 
     protected void testCreateBigIntegerFailure(final String str) {
-        try {
-            final BigInteger value = NumberUtils.createBigInteger(str);
-            fail("createBigInteger(\"" + str + "\") should have failed: " + value);
-        } catch (final NumberFormatException ex) {
-            // empty
-        }
+        assertThrows(
+                NumberFormatException.class,
+                () -> NumberUtils.createBigInteger(str),
+                "createBigInteger(\"" + str + "\") should have failed.");
     }
 
     @Test
@@ -735,12 +724,10 @@ public class NumberUtilsTest {
     }
 
     protected void testCreateBigDecimalFailure(final String str) {
-        try {
-            final BigDecimal value = NumberUtils.createBigDecimal(str);
-            fail("createBigDecimal(\"" + str + "\") should have failed: " + value);
-        } catch (final NumberFormatException ex) {
-            // empty
-        }
+        assertThrows(
+                NumberFormatException.class,
+                () -> NumberUtils.createBigDecimal(str),
+                "createBigDecimal(\"" + str + "\") should have failed.");
     }
 
     // min/max tests
@@ -954,15 +941,13 @@ public class NumberUtilsTest {
     @Test
     public void testMaxDouble() {
         final double[] d = null;
-        try {
-            NumberUtils.max(d);
-            fail("No exception was thrown for null input.");
-        } catch (final IllegalArgumentException ex) {}
+        assertThrows(
+                IllegalArgumentException.class, () -> NumberUtils.max(d), "No exception was thrown for null input.");
 
-        try {
-            NumberUtils.max(new double[0]);
-            fail("No exception was thrown for empty input.");
-        } catch (final IllegalArgumentException ex) {}
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> NumberUtils.max(new double[0]),
+                "No exception was thrown for empty input.");
 
         // TODO: JUnit Jupiter 5.3.1 doesn't support delta=0.
         // This should be replaced when it is supported in JUnit Jupiter 5.4.

--- a/src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java
@@ -21,7 +21,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
@@ -1395,10 +1394,9 @@ public class NumberUtilsTest {
     private void compareIsCreatableWithCreateNumber(final String val, final boolean expected) {
         final boolean isValid = NumberUtils.isCreatable(val);
         final boolean canCreate = checkCreateNumber(val);
-        if (isValid == expected && canCreate == expected) {
-            return;
-        }
-        fail("Expecting "+ expected + " for isCreatable/createNumber using \"" + val + "\" but got " + isValid + " and " + canCreate);
+        assertTrue(
+                isValid == expected && canCreate == expected,
+                "Expecting " + expected + " for isCreatable/createNumber using \"" + val + "\" but got " + isValid + " and " + canCreate);
     }
 
     /**
@@ -1501,10 +1499,9 @@ public class NumberUtilsTest {
     private void compareIsNumberWithCreateNumber(final String val, final boolean expected) {
         final boolean isValid = NumberUtils.isCreatable(val);
         final boolean canCreate = checkCreateNumber(val);
-        if (isValid == expected && canCreate == expected) {
-            return;
-        }
-        fail("Expecting "+ expected + " for isCreatable/createNumber using \"" + val + "\" but got " + isValid + " and " + canCreate);
+        assertTrue(
+                isValid == expected && canCreate == expected,
+                "Expecting "+ expected + " for isCreatable/createNumber using \"" + val + "\" but got " + isValid + " and " + canCreate);
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java
@@ -19,6 +19,7 @@ package org.apache.commons.lang3.math;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -53,10 +54,10 @@ public class NumberUtilsTest {
      */
     @Test
     public void testToIntString() {
-        assertTrue(NumberUtils.toInt("12345") == 12345, "toInt(String) 1 failed");
-        assertTrue(NumberUtils.toInt("abc") == 0, "toInt(String) 2 failed");
-        assertTrue(NumberUtils.toInt("") == 0, "toInt(empty) failed");
-        assertTrue(NumberUtils.toInt(null) == 0, "toInt(null) failed");
+        assertEquals(12345, NumberUtils.toInt("12345"), "toInt(String) 1 failed");
+        assertEquals(0, NumberUtils.toInt("abc"), "toInt(String) 2 failed");
+        assertEquals(0, NumberUtils.toInt(""), "toInt(empty) failed");
+        assertEquals(0, NumberUtils.toInt(null), "toInt(null) failed");
     }
 
     /**
@@ -64,8 +65,8 @@ public class NumberUtilsTest {
      */
     @Test
     public void testToIntStringI() {
-        assertTrue(NumberUtils.toInt("12345", 5) == 12345, "toInt(String,int) 1 failed");
-        assertTrue(NumberUtils.toInt("1234.5", 5) == 5, "toInt(String,int) 2 failed");
+        assertEquals(12345, NumberUtils.toInt("12345", 5), "toInt(String,int) 1 failed");
+        assertEquals(5, NumberUtils.toInt("1234.5", 5), "toInt(String,int) 2 failed");
     }
 
     /**
@@ -73,14 +74,14 @@ public class NumberUtilsTest {
      */
     @Test
     public void testToLongString() {
-        assertTrue(NumberUtils.toLong("12345") == 12345L, "toLong(String) 1 failed");
-        assertTrue(NumberUtils.toLong("abc") == 0L, "toLong(String) 2 failed");
-        assertTrue(NumberUtils.toLong("1L") == 0L, "toLong(String) 3 failed");
-        assertTrue(NumberUtils.toLong("1l") == 0L, "toLong(String) 4 failed");
-        assertTrue(NumberUtils.toLong(Long.MAX_VALUE+"") == Long.MAX_VALUE, "toLong(Long.MAX_VALUE) failed");
-        assertTrue(NumberUtils.toLong(Long.MIN_VALUE+"") == Long.MIN_VALUE, "toLong(Long.MIN_VALUE) failed");
-        assertTrue(NumberUtils.toLong("") == 0L, "toLong(empty) failed");
-        assertTrue(NumberUtils.toLong(null) == 0L, "toLong(null) failed");
+        assertEquals(12345L, NumberUtils.toLong("12345"), "toLong(String) 1 failed");
+        assertEquals(0L, NumberUtils.toLong("abc"), "toLong(String) 2 failed");
+        assertEquals(0L, NumberUtils.toLong("1L"), "toLong(String) 3 failed");
+        assertEquals(0L, NumberUtils.toLong("1l"), "toLong(String) 4 failed");
+        assertEquals(NumberUtils.toLong(Long.MAX_VALUE + ""), Long.MAX_VALUE, "toLong(Long.MAX_VALUE) failed");
+        assertEquals(NumberUtils.toLong(Long.MIN_VALUE + ""), Long.MIN_VALUE, "toLong(Long.MIN_VALUE) failed");
+        assertEquals(0L, NumberUtils.toLong(""), "toLong(empty) failed");
+        assertEquals(0L, NumberUtils.toLong(null), "toLong(null) failed");
     }
 
     /**
@@ -88,8 +89,8 @@ public class NumberUtilsTest {
      */
     @Test
     public void testToLongStringL() {
-        assertTrue(NumberUtils.toLong("12345", 5L) == 12345L, "toLong(String,long) 1 failed");
-        assertTrue(NumberUtils.toLong("1234.5", 5L) == 5L, "toLong(String,long) 2 failed");
+        assertEquals(12345L, NumberUtils.toLong("12345", 5L), "toLong(String,long) 1 failed");
+        assertEquals(5L, NumberUtils.toLong("1234.5", 5L), "toLong(String,long) 2 failed");
     }
 
     /**
@@ -204,10 +205,10 @@ public class NumberUtilsTest {
      */
     @Test
     public void testToByteString() {
-        assertTrue(NumberUtils.toByte("123") == 123, "toByte(String) 1 failed");
-        assertTrue(NumberUtils.toByte("abc") == 0, "toByte(String) 2 failed");
-        assertTrue(NumberUtils.toByte("") == 0, "toByte(empty) failed");
-        assertTrue(NumberUtils.toByte(null) == 0, "toByte(null) failed");
+        assertEquals(123, NumberUtils.toByte("123"), "toByte(String) 1 failed");
+        assertEquals(0, NumberUtils.toByte("abc"), "toByte(String) 2 failed");
+        assertEquals(0, NumberUtils.toByte(""), "toByte(empty) failed");
+        assertEquals(0, NumberUtils.toByte(null), "toByte(null) failed");
     }
 
     /**
@@ -215,8 +216,8 @@ public class NumberUtilsTest {
      */
     @Test
     public void testToByteStringI() {
-        assertTrue(NumberUtils.toByte("123", (byte) 5) == 123, "toByte(String,byte) 1 failed");
-        assertTrue(NumberUtils.toByte("12.3", (byte) 5) == 5, "toByte(String,byte) 2 failed");
+        assertEquals(123, NumberUtils.toByte("123", (byte) 5), "toByte(String,byte) 1 failed");
+        assertEquals(5, NumberUtils.toByte("12.3", (byte) 5), "toByte(String,byte) 2 failed");
     }
 
     /**
@@ -224,10 +225,10 @@ public class NumberUtilsTest {
      */
     @Test
     public void testToShortString() {
-        assertTrue(NumberUtils.toShort("12345") == 12345, "toShort(String) 1 failed");
-        assertTrue(NumberUtils.toShort("abc") == 0, "toShort(String) 2 failed");
-        assertTrue(NumberUtils.toShort("") == 0, "toShort(empty) failed");
-        assertTrue(NumberUtils.toShort(null) == 0, "toShort(null) failed");
+        assertEquals(12345, NumberUtils.toShort("12345"), "toShort(String) 1 failed");
+        assertEquals(0, NumberUtils.toShort("abc"), "toShort(String) 2 failed");
+        assertEquals(0, NumberUtils.toShort(""), "toShort(empty) failed");
+        assertEquals(0, NumberUtils.toShort(null), "toShort(null) failed");
     }
 
     /**
@@ -235,8 +236,8 @@ public class NumberUtilsTest {
      */
     @Test
     public void testToShortStringI() {
-        assertTrue(NumberUtils.toShort("12345", (short) 5) == 12345, "toShort(String,short) 1 failed");
-        assertTrue(NumberUtils.toShort("1234.5", (short) 5) == 5, "toShort(String,short) 2 failed");
+        assertEquals(12345, NumberUtils.toShort("12345", (short) 5), "toShort(String,short) 1 failed");
+        assertEquals(5, NumberUtils.toShort("1234.5", (short) 5), "toShort(String,short) 2 failed");
     }
 
     /**
@@ -244,19 +245,13 @@ public class NumberUtilsTest {
      */
     @Test
     public void testToScaledBigDecimalBigDecimal() {
-        assertTrue(NumberUtils.toScaledBigDecimal(BigDecimal.valueOf(123.456)).equals(BigDecimal.valueOf(123.46)),
-                "toScaledBigDecimal(BigDecimal) 1 failed");
+        assertEquals(NumberUtils.toScaledBigDecimal(BigDecimal.valueOf(123.456)), BigDecimal.valueOf(123.46), "toScaledBigDecimal(BigDecimal) 1 failed");
         // Test RoudingMode.HALF_EVEN default rounding.
-        assertTrue(NumberUtils.toScaledBigDecimal(BigDecimal.valueOf(23.515)).equals(BigDecimal.valueOf(23.52)),
-                "toScaledBigDecimal(BigDecimal) 2 failed");
-        assertTrue(NumberUtils.toScaledBigDecimal(BigDecimal.valueOf(23.525)).equals(BigDecimal.valueOf(23.52)),
-                "toScaledBigDecimal(BigDecimal) 3 failed");
-        assertTrue(NumberUtils.toScaledBigDecimal(BigDecimal.valueOf(23.525))
-                        .multiply(BigDecimal.valueOf(100)).toString()
-                        .equals("2352.00"),
-                "toScaledBigDecimal(BigDecimal) 4 failed");
-        assertTrue(NumberUtils.toScaledBigDecimal((BigDecimal) null).equals(BigDecimal.ZERO),
-                "toScaledBigDecimal(BigDecimal) 5 failed");
+        assertEquals(NumberUtils.toScaledBigDecimal(BigDecimal.valueOf(23.515)), BigDecimal.valueOf(23.52), "toScaledBigDecimal(BigDecimal) 2 failed");
+        assertEquals(NumberUtils.toScaledBigDecimal(BigDecimal.valueOf(23.525)), BigDecimal.valueOf(23.52), "toScaledBigDecimal(BigDecimal) 3 failed");
+        assertEquals("2352.00", NumberUtils.toScaledBigDecimal(BigDecimal.valueOf(23.525))
+                .multiply(BigDecimal.valueOf(100)).toString(), "toScaledBigDecimal(BigDecimal) 4 failed");
+        assertEquals(NumberUtils.toScaledBigDecimal((BigDecimal) null), BigDecimal.ZERO, "toScaledBigDecimal(BigDecimal) 5 failed");
     }
 
     /**
@@ -264,19 +259,13 @@ public class NumberUtilsTest {
      */
     @Test
     public void testToScaledBigDecimalBigDecimalIRM() {
-        assertTrue(NumberUtils.toScaledBigDecimal(BigDecimal.valueOf(123.456), 1, RoundingMode.CEILING).equals(BigDecimal.valueOf(123.5)),
-                "toScaledBigDecimal(BigDecimal, int, RoudingMode) 1 failed");
-        assertTrue(NumberUtils.toScaledBigDecimal(BigDecimal.valueOf(23.5159), 3, RoundingMode.FLOOR).equals(BigDecimal.valueOf(23.515)),
-                "toScaledBigDecimal(BigDecimal, int, RoudingMode) 2 failed");
-        assertTrue(NumberUtils.toScaledBigDecimal(BigDecimal.valueOf(23.525), 2, RoundingMode.HALF_UP).equals(BigDecimal.valueOf(23.53)),
-                "toScaledBigDecimal(BigDecimal, int, RoudingMode) 3 failed");
-        assertTrue(NumberUtils.toScaledBigDecimal(BigDecimal.valueOf(23.521), 4, RoundingMode.HALF_EVEN)
-                        .multiply(BigDecimal.valueOf(1000))
-                        .toString()
-                        .equals("23521.0000"),
-                "toScaledBigDecimal(BigDecimal, int, RoudingMode) 4 failed");
-        assertTrue(NumberUtils.toScaledBigDecimal((BigDecimal) null, 2, RoundingMode.HALF_UP).equals(BigDecimal.ZERO),
-                "toScaledBigDecimal(BigDecimal, int, RoudingMode) 5 failed");
+        assertEquals(NumberUtils.toScaledBigDecimal(BigDecimal.valueOf(123.456), 1, RoundingMode.CEILING), BigDecimal.valueOf(123.5), "toScaledBigDecimal(BigDecimal, int, RoudingMode) 1 failed");
+        assertEquals(NumberUtils.toScaledBigDecimal(BigDecimal.valueOf(23.5159), 3, RoundingMode.FLOOR), BigDecimal.valueOf(23.515), "toScaledBigDecimal(BigDecimal, int, RoudingMode) 2 failed");
+        assertEquals(NumberUtils.toScaledBigDecimal(BigDecimal.valueOf(23.525), 2, RoundingMode.HALF_UP), BigDecimal.valueOf(23.53), "toScaledBigDecimal(BigDecimal, int, RoudingMode) 3 failed");
+        assertEquals("23521.0000", NumberUtils.toScaledBigDecimal(BigDecimal.valueOf(23.521), 4, RoundingMode.HALF_EVEN)
+                .multiply(BigDecimal.valueOf(1000))
+                .toString(), "toScaledBigDecimal(BigDecimal, int, RoudingMode) 4 failed");
+        assertEquals(NumberUtils.toScaledBigDecimal((BigDecimal) null, 2, RoundingMode.HALF_UP), BigDecimal.ZERO, "toScaledBigDecimal(BigDecimal, int, RoudingMode) 5 failed");
     }
 
     /**
@@ -284,21 +273,15 @@ public class NumberUtilsTest {
      */
     @Test
     public void testToScaledBigDecimalFloat() {
-        assertTrue(NumberUtils.toScaledBigDecimal(Float.valueOf(123.456f)).equals(BigDecimal.valueOf(123.46)),
-                "toScaledBigDecimal(Float) 1 failed");
+        assertEquals(NumberUtils.toScaledBigDecimal(Float.valueOf(123.456f)), BigDecimal.valueOf(123.46), "toScaledBigDecimal(Float) 1 failed");
         // Test RoudingMode.HALF_EVEN default rounding.
-        assertTrue(NumberUtils.toScaledBigDecimal(Float.valueOf(23.515f)).equals(BigDecimal.valueOf(23.51)),
-                "toScaledBigDecimal(Float) 2 failed");
+        assertEquals(NumberUtils.toScaledBigDecimal(Float.valueOf(23.515f)), BigDecimal.valueOf(23.51), "toScaledBigDecimal(Float) 2 failed");
         // Note. NumberUtils.toScaledBigDecimal(Float.valueOf(23.515f)).equals(BigDecimal.valueOf(23.51))
         // because of roundoff error. It is ok.
-        assertTrue(NumberUtils.toScaledBigDecimal(Float.valueOf(23.525f)).equals(BigDecimal.valueOf(23.52)),
-                "toScaledBigDecimal(Float) 3 failed");
-        assertTrue(NumberUtils.toScaledBigDecimal(Float.valueOf(23.525f))
-                        .multiply(BigDecimal.valueOf(100)).toString()
-                        .equals("2352.00"),
-                "toScaledBigDecimal(Float) 4 failed");
-        assertTrue(NumberUtils.toScaledBigDecimal((Float) null).equals(BigDecimal.ZERO),
-                "toScaledBigDecimal(Float) 5 failed");
+        assertEquals(NumberUtils.toScaledBigDecimal(Float.valueOf(23.525f)), BigDecimal.valueOf(23.52), "toScaledBigDecimal(Float) 3 failed");
+        assertEquals("2352.00", NumberUtils.toScaledBigDecimal(Float.valueOf(23.525f))
+                .multiply(BigDecimal.valueOf(100)).toString(), "toScaledBigDecimal(Float) 4 failed");
+        assertEquals(NumberUtils.toScaledBigDecimal((Float) null), BigDecimal.ZERO, "toScaledBigDecimal(Float) 5 failed");
     }
 
     /**
@@ -306,20 +289,14 @@ public class NumberUtilsTest {
      */
     @Test
     public void testToScaledBigDecimalFloatIRM() {
-        assertTrue(NumberUtils.toScaledBigDecimal(Float.valueOf(123.456f), 1, RoundingMode.CEILING).equals(BigDecimal.valueOf(123.5)),
-                "toScaledBigDecimal(Float, int, RoudingMode) 1 failed");
-        assertTrue(NumberUtils.toScaledBigDecimal(Float.valueOf(23.5159f), 3, RoundingMode.FLOOR).equals(BigDecimal.valueOf(23.515)),
-                "toScaledBigDecimal(Float, int, RoudingMode) 2 failed");
+        assertEquals(NumberUtils.toScaledBigDecimal(Float.valueOf(123.456f), 1, RoundingMode.CEILING), BigDecimal.valueOf(123.5), "toScaledBigDecimal(Float, int, RoudingMode) 1 failed");
+        assertEquals(NumberUtils.toScaledBigDecimal(Float.valueOf(23.5159f), 3, RoundingMode.FLOOR), BigDecimal.valueOf(23.515), "toScaledBigDecimal(Float, int, RoudingMode) 2 failed");
         // The following happens due to roundoff error. We're ok with this.
-        assertTrue(NumberUtils.toScaledBigDecimal(Float.valueOf(23.525f), 2, RoundingMode.HALF_UP).equals(BigDecimal.valueOf(23.52)),
-                "toScaledBigDecimal(Float, int, RoudingMode) 3 failed");
-        assertTrue(NumberUtils.toScaledBigDecimal(Float.valueOf(23.521f), 4, RoundingMode.HALF_EVEN)
-                        .multiply(BigDecimal.valueOf(1000))
-                        .toString()
-                        .equals("23521.0000"),
-                "toScaledBigDecimal(Float, int, RoudingMode) 4 failed");
-        assertTrue(NumberUtils.toScaledBigDecimal((Float) null, 2, RoundingMode.HALF_UP).equals(BigDecimal.ZERO),
-                "toScaledBigDecimal(Float, int, RoudingMode) 5 failed");
+        assertEquals(NumberUtils.toScaledBigDecimal(Float.valueOf(23.525f), 2, RoundingMode.HALF_UP), BigDecimal.valueOf(23.52), "toScaledBigDecimal(Float, int, RoudingMode) 3 failed");
+        assertEquals("23521.0000", NumberUtils.toScaledBigDecimal(Float.valueOf(23.521f), 4, RoundingMode.HALF_EVEN)
+                .multiply(BigDecimal.valueOf(1000))
+                .toString(), "toScaledBigDecimal(Float, int, RoudingMode) 4 failed");
+        assertEquals(NumberUtils.toScaledBigDecimal((Float) null, 2, RoundingMode.HALF_UP), BigDecimal.ZERO, "toScaledBigDecimal(Float, int, RoudingMode) 5 failed");
     }
 
     /**
@@ -327,19 +304,13 @@ public class NumberUtilsTest {
      */
     @Test
     public void testToScaledBigDecimalDouble() {
-        assertTrue(NumberUtils.toScaledBigDecimal(Double.valueOf(123.456d)).equals(BigDecimal.valueOf(123.46)),
-                "toScaledBigDecimal(Double) 1 failed");
+        assertEquals(NumberUtils.toScaledBigDecimal(Double.valueOf(123.456d)), BigDecimal.valueOf(123.46), "toScaledBigDecimal(Double) 1 failed");
         // Test RoudingMode.HALF_EVEN default rounding.
-        assertTrue(NumberUtils.toScaledBigDecimal(Double.valueOf(23.515d)).equals(BigDecimal.valueOf(23.52)),
-                "toScaledBigDecimal(Double) 2 failed");
-        assertTrue(NumberUtils.toScaledBigDecimal(Double.valueOf(23.525d)).equals(BigDecimal.valueOf(23.52)),
-                "toScaledBigDecimal(Double) 3 failed");
-        assertTrue(NumberUtils.toScaledBigDecimal(Double.valueOf(23.525d))
-                        .multiply(BigDecimal.valueOf(100)).toString()
-                        .equals("2352.00"),
-                "toScaledBigDecimal(Double) 4 failed");
-        assertTrue(NumberUtils.toScaledBigDecimal((Double) null).equals(BigDecimal.ZERO),
-                "toScaledBigDecimal(Double) 5 failed");
+        assertEquals(NumberUtils.toScaledBigDecimal(Double.valueOf(23.515d)), BigDecimal.valueOf(23.52), "toScaledBigDecimal(Double) 2 failed");
+        assertEquals(NumberUtils.toScaledBigDecimal(Double.valueOf(23.525d)), BigDecimal.valueOf(23.52), "toScaledBigDecimal(Double) 3 failed");
+        assertEquals("2352.00", NumberUtils.toScaledBigDecimal(Double.valueOf(23.525d))
+                .multiply(BigDecimal.valueOf(100)).toString(), "toScaledBigDecimal(Double) 4 failed");
+        assertEquals(NumberUtils.toScaledBigDecimal((Double) null), BigDecimal.ZERO, "toScaledBigDecimal(Double) 5 failed");
     }
 
     /**
@@ -347,19 +318,13 @@ public class NumberUtilsTest {
      */
     @Test
     public void testToScaledBigDecimalDoubleIRM() {
-        assertTrue(NumberUtils.toScaledBigDecimal(Double.valueOf(123.456d), 1, RoundingMode.CEILING).equals(BigDecimal.valueOf(123.5)),
-                "toScaledBigDecimal(Double, int, RoudingMode) 1 failed");
-        assertTrue(NumberUtils.toScaledBigDecimal(Double.valueOf(23.5159d), 3, RoundingMode.FLOOR).equals(BigDecimal.valueOf(23.515)),
-                "toScaledBigDecimal(Double, int, RoudingMode) 2 failed");
-        assertTrue(NumberUtils.toScaledBigDecimal(Double.valueOf(23.525d), 2, RoundingMode.HALF_UP).equals(BigDecimal.valueOf(23.53)),
-                "toScaledBigDecimal(Double, int, RoudingMode) 3 failed");
-        assertTrue(NumberUtils.toScaledBigDecimal(Double.valueOf(23.521d), 4, RoundingMode.HALF_EVEN)
-                        .multiply(BigDecimal.valueOf(1000))
-                        .toString()
-                        .equals("23521.0000"),
-                "toScaledBigDecimal(Double, int, RoudingMode) 4 failed");
-        assertTrue(NumberUtils.toScaledBigDecimal((Double) null, 2, RoundingMode.HALF_UP).equals(BigDecimal.ZERO),
-                "toScaledBigDecimal(Double, int, RoudingMode) 5 failed");
+        assertEquals(NumberUtils.toScaledBigDecimal(Double.valueOf(123.456d), 1, RoundingMode.CEILING), BigDecimal.valueOf(123.5), "toScaledBigDecimal(Double, int, RoudingMode) 1 failed");
+        assertEquals(NumberUtils.toScaledBigDecimal(Double.valueOf(23.5159d), 3, RoundingMode.FLOOR), BigDecimal.valueOf(23.515), "toScaledBigDecimal(Double, int, RoudingMode) 2 failed");
+        assertEquals(NumberUtils.toScaledBigDecimal(Double.valueOf(23.525d), 2, RoundingMode.HALF_UP), BigDecimal.valueOf(23.53), "toScaledBigDecimal(Double, int, RoudingMode) 3 failed");
+        assertEquals("23521.0000", NumberUtils.toScaledBigDecimal(Double.valueOf(23.521d), 4, RoundingMode.HALF_EVEN)
+                .multiply(BigDecimal.valueOf(1000))
+                .toString(), "toScaledBigDecimal(Double, int, RoudingMode) 4 failed");
+        assertEquals(NumberUtils.toScaledBigDecimal((Double) null, 2, RoundingMode.HALF_UP), BigDecimal.ZERO, "toScaledBigDecimal(Double, int, RoudingMode) 5 failed");
     }
 
     /**
@@ -367,19 +332,13 @@ public class NumberUtilsTest {
      */
     @Test
     public void testToScaledBigDecimalString() {
-        assertTrue(NumberUtils.toScaledBigDecimal("123.456").equals(BigDecimal.valueOf(123.46)),
-                "toScaledBigDecimal(String) 1 failed");
+        assertEquals(NumberUtils.toScaledBigDecimal("123.456"), BigDecimal.valueOf(123.46), "toScaledBigDecimal(String) 1 failed");
         // Test RoudingMode.HALF_EVEN default rounding.
-        assertTrue(NumberUtils.toScaledBigDecimal("23.515").equals(BigDecimal.valueOf(23.52)),
-                "toScaledBigDecimal(String) 2 failed");
-        assertTrue(NumberUtils.toScaledBigDecimal("23.525").equals(BigDecimal.valueOf(23.52)),
-                "toScaledBigDecimal(String) 3 failed");
-        assertTrue(NumberUtils.toScaledBigDecimal("23.525")
-                        .multiply(BigDecimal.valueOf(100)).toString()
-                        .equals("2352.00"),
-                "toScaledBigDecimal(String) 4 failed");
-        assertTrue(NumberUtils.toScaledBigDecimal((String) null).equals(BigDecimal.ZERO),
-                "toScaledBigDecimal(String) 5 failed");
+        assertEquals(NumberUtils.toScaledBigDecimal("23.515"), BigDecimal.valueOf(23.52), "toScaledBigDecimal(String) 2 failed");
+        assertEquals(NumberUtils.toScaledBigDecimal("23.525"), BigDecimal.valueOf(23.52), "toScaledBigDecimal(String) 3 failed");
+        assertEquals("2352.00", NumberUtils.toScaledBigDecimal("23.525")
+                .multiply(BigDecimal.valueOf(100)).toString(), "toScaledBigDecimal(String) 4 failed");
+        assertEquals(NumberUtils.toScaledBigDecimal((String) null), BigDecimal.ZERO, "toScaledBigDecimal(String) 5 failed");
     }
 
     /**
@@ -387,19 +346,13 @@ public class NumberUtilsTest {
      */
     @Test
     public void testToScaledBigDecimalStringIRM() {
-        assertTrue(NumberUtils.toScaledBigDecimal("123.456", 1, RoundingMode.CEILING).equals(BigDecimal.valueOf(123.5)),
-                "toScaledBigDecimal(String, int, RoudingMode) 1 failed");
-        assertTrue(NumberUtils.toScaledBigDecimal("23.5159", 3, RoundingMode.FLOOR).equals(BigDecimal.valueOf(23.515)),
-                "toScaledBigDecimal(String, int, RoudingMode) 2 failed");
-        assertTrue(NumberUtils.toScaledBigDecimal("23.525", 2, RoundingMode.HALF_UP).equals(BigDecimal.valueOf(23.53)),
-                "toScaledBigDecimal(String, int, RoudingMode) 3 failed");
-        assertTrue(NumberUtils.toScaledBigDecimal("23.521", 4, RoundingMode.HALF_EVEN)
-                        .multiply(BigDecimal.valueOf(1000))
-                        .toString()
-                        .equals("23521.0000"),
-                "toScaledBigDecimal(String, int, RoudingMode) 4 failed");
-        assertTrue(NumberUtils.toScaledBigDecimal((String) null, 2, RoundingMode.HALF_UP).equals(BigDecimal.ZERO),
-                "toScaledBigDecimal(String, int, RoudingMode) 5 failed");
+        assertEquals(NumberUtils.toScaledBigDecimal("123.456", 1, RoundingMode.CEILING), BigDecimal.valueOf(123.5), "toScaledBigDecimal(String, int, RoudingMode) 1 failed");
+        assertEquals(NumberUtils.toScaledBigDecimal("23.5159", 3, RoundingMode.FLOOR), BigDecimal.valueOf(23.515), "toScaledBigDecimal(String, int, RoudingMode) 2 failed");
+        assertEquals(NumberUtils.toScaledBigDecimal("23.525", 2, RoundingMode.HALF_UP), BigDecimal.valueOf(23.53), "toScaledBigDecimal(String, int, RoudingMode) 3 failed");
+        assertEquals("23521.0000", NumberUtils.toScaledBigDecimal("23.521", 4, RoundingMode.HALF_EVEN)
+                .multiply(BigDecimal.valueOf(1000))
+                .toString(), "toScaledBigDecimal(String, int, RoudingMode) 4 failed");
+        assertEquals(NumberUtils.toScaledBigDecimal((String) null, 2, RoundingMode.HALF_UP), BigDecimal.ZERO, "toScaledBigDecimal(String, int, RoudingMode) 5 failed");
     }
 
     @Test
@@ -417,15 +370,15 @@ public class NumberUtilsTest {
         assertEquals(Long.valueOf(12345), NumberUtils.createNumber("12345l"), "createNumber(String) 6 failed");
         assertEquals(Float.valueOf("-1234.5"), NumberUtils.createNumber("-1234.5"), "createNumber(String) 7 failed");
         assertEquals(Integer.valueOf("-12345"), NumberUtils.createNumber("-12345"), "createNumber(String) 8 failed");
-        assertTrue(0xFADE == NumberUtils.createNumber("0xFADE").intValue(), "createNumber(String) 9a failed");
-        assertTrue(0xFADE == NumberUtils.createNumber("0Xfade").intValue(), "createNumber(String) 9b failed");
-        assertTrue(-0xFADE == NumberUtils.createNumber("-0xFADE").intValue(), "createNumber(String) 10a failed");
-        assertTrue(-0xFADE == NumberUtils.createNumber("-0Xfade").intValue(), "createNumber(String) 10b failed");
+        assertEquals(0xFADE, NumberUtils.createNumber("0xFADE").intValue(), "createNumber(String) 9a failed");
+        assertEquals(0xFADE, NumberUtils.createNumber("0Xfade").intValue(), "createNumber(String) 9b failed");
+        assertEquals(-0xFADE, NumberUtils.createNumber("-0xFADE").intValue(), "createNumber(String) 10a failed");
+        assertEquals(-0xFADE, NumberUtils.createNumber("-0Xfade").intValue(), "createNumber(String) 10b failed");
         assertEquals(Double.valueOf("1.1E200"), NumberUtils.createNumber("1.1E200"), "createNumber(String) 11 failed");
         assertEquals(Float.valueOf("1.1E20"), NumberUtils.createNumber("1.1E20"), "createNumber(String) 12 failed");
         assertEquals(Double.valueOf("-1.1E200"), NumberUtils.createNumber("-1.1E200"), "createNumber(String) 13 failed");
         assertEquals(Double.valueOf("1.1E-200"), NumberUtils.createNumber("1.1E-200"), "createNumber(String) 14 failed");
-        assertEquals(null, NumberUtils.createNumber(null), "createNumber(null) failed");
+        assertNull(NumberUtils.createNumber(null), "createNumber(null) failed");
         assertEquals(new BigInteger("12345678901234567890"), NumberUtils.createNumber("12345678901234567890L"), "createNumber(String) failed");
 
         assertEquals(new BigDecimal("1.1E-700"), NumberUtils.createNumber("1.1E-700F"), "createNumber(String) 15 failed");
@@ -606,7 +559,7 @@ public class NumberUtilsTest {
     @Test
     public void testCreateFloat() {
         assertEquals(Float.valueOf("1234.5"), NumberUtils.createFloat("1234.5"), "createFloat(String) failed");
-        assertEquals(null, NumberUtils.createFloat(null), "createFloat(null) failed");
+        assertNull(NumberUtils.createFloat(null), "createFloat(null) failed");
         this.testCreateFloatFailure("");
         this.testCreateFloatFailure(" ");
         this.testCreateFloatFailure("\b\t\n\f\r");
@@ -623,7 +576,7 @@ public class NumberUtilsTest {
     @Test
     public void testCreateDouble() {
         assertEquals(Double.valueOf("1234.5"), NumberUtils.createDouble("1234.5"), "createDouble(String) failed");
-        assertEquals(null, NumberUtils.createDouble(null), "createDouble(null) failed");
+        assertNull(NumberUtils.createDouble(null), "createDouble(null) failed");
         this.testCreateDoubleFailure("");
         this.testCreateDoubleFailure(" ");
         this.testCreateDoubleFailure("\b\t\n\f\r");
@@ -641,7 +594,7 @@ public class NumberUtilsTest {
     @Test
     public void testCreateInteger() {
         assertEquals(Integer.valueOf("12345"), NumberUtils.createInteger("12345"), "createInteger(String) failed");
-        assertEquals(null, NumberUtils.createInteger(null), "createInteger(null) failed");
+        assertNull(NumberUtils.createInteger(null), "createInteger(null) failed");
         this.testCreateIntegerFailure("");
         this.testCreateIntegerFailure(" ");
         this.testCreateIntegerFailure("\b\t\n\f\r");
@@ -659,7 +612,7 @@ public class NumberUtilsTest {
     @Test
     public void testCreateLong() {
         assertEquals(Long.valueOf("12345"), NumberUtils.createLong("12345"), "createLong(String) failed");
-        assertEquals(null, NumberUtils.createLong(null), "createLong(null) failed");
+        assertNull(NumberUtils.createLong(null), "createLong(null) failed");
         this.testCreateLongFailure("");
         this.testCreateLongFailure(" ");
         this.testCreateLongFailure("\b\t\n\f\r");
@@ -677,7 +630,7 @@ public class NumberUtilsTest {
     @Test
     public void testCreateBigInteger() {
         assertEquals(new BigInteger("12345"), NumberUtils.createBigInteger("12345"), "createBigInteger(String) failed");
-        assertEquals(null, NumberUtils.createBigInteger(null), "createBigInteger(null) failed");
+        assertNull(NumberUtils.createBigInteger(null), "createBigInteger(null) failed");
         this.testCreateBigIntegerFailure("");
         this.testCreateBigIntegerFailure(" ");
         this.testCreateBigIntegerFailure("\b\t\n\f\r");
@@ -708,7 +661,7 @@ public class NumberUtilsTest {
     @Test
     public void testCreateBigDecimal() {
         assertEquals(new BigDecimal("1234.5"), NumberUtils.createBigDecimal("1234.5"), "createBigDecimal(String) failed");
-        assertEquals(null, NumberUtils.createBigDecimal(null), "createBigDecimal(null) failed");
+        assertNull(NumberUtils.createBigDecimal(null), "createBigDecimal(null) failed");
         this.testCreateBigDecimalFailure("");
         this.testCreateBigDecimalFailure(" ");
         this.testCreateBigDecimalFailure("\b\t\n\f\r");
@@ -1111,188 +1064,188 @@ public class NumberUtilsTest {
     // Testing JDK against old Lang functionality
     @Test
     public void testCompareDouble() {
-        assertTrue(Double.compare(Double.NaN, Double.NaN) == 0);
-        assertTrue(Double.compare(Double.NaN, Double.POSITIVE_INFINITY) == +1);
-        assertTrue(Double.compare(Double.NaN, Double.MAX_VALUE) == +1);
-        assertTrue(Double.compare(Double.NaN, 1.2d) == +1);
-        assertTrue(Double.compare(Double.NaN, 0.0d) == +1);
-        assertTrue(Double.compare(Double.NaN, -0.0d) == +1);
-        assertTrue(Double.compare(Double.NaN, -1.2d) == +1);
-        assertTrue(Double.compare(Double.NaN, -Double.MAX_VALUE) == +1);
-        assertTrue(Double.compare(Double.NaN, Double.NEGATIVE_INFINITY) == +1);
+        assertEquals(0, Double.compare(Double.NaN, Double.NaN));
+        assertEquals(Double.compare(Double.NaN, Double.POSITIVE_INFINITY), +1);
+        assertEquals(Double.compare(Double.NaN, Double.MAX_VALUE), +1);
+        assertEquals(Double.compare(Double.NaN, 1.2d), +1);
+        assertEquals(Double.compare(Double.NaN, 0.0d), +1);
+        assertEquals(Double.compare(Double.NaN, -0.0d), +1);
+        assertEquals(Double.compare(Double.NaN, -1.2d), +1);
+        assertEquals(Double.compare(Double.NaN, -Double.MAX_VALUE), +1);
+        assertEquals(Double.compare(Double.NaN, Double.NEGATIVE_INFINITY), +1);
 
-        assertTrue(Double.compare(Double.POSITIVE_INFINITY, Double.NaN) == -1);
-        assertTrue(Double.compare(Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY) == 0);
-        assertTrue(Double.compare(Double.POSITIVE_INFINITY, Double.MAX_VALUE) == +1);
-        assertTrue(Double.compare(Double.POSITIVE_INFINITY, 1.2d) == +1);
-        assertTrue(Double.compare(Double.POSITIVE_INFINITY, 0.0d) == +1);
-        assertTrue(Double.compare(Double.POSITIVE_INFINITY, -0.0d) == +1);
-        assertTrue(Double.compare(Double.POSITIVE_INFINITY, -1.2d) == +1);
-        assertTrue(Double.compare(Double.POSITIVE_INFINITY, -Double.MAX_VALUE) == +1);
-        assertTrue(Double.compare(Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY) == +1);
+        assertEquals(Double.compare(Double.POSITIVE_INFINITY, Double.NaN), -1);
+        assertEquals(0, Double.compare(Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY));
+        assertEquals(Double.compare(Double.POSITIVE_INFINITY, Double.MAX_VALUE), +1);
+        assertEquals(Double.compare(Double.POSITIVE_INFINITY, 1.2d), +1);
+        assertEquals(Double.compare(Double.POSITIVE_INFINITY, 0.0d), +1);
+        assertEquals(Double.compare(Double.POSITIVE_INFINITY, -0.0d), +1);
+        assertEquals(Double.compare(Double.POSITIVE_INFINITY, -1.2d), +1);
+        assertEquals(Double.compare(Double.POSITIVE_INFINITY, -Double.MAX_VALUE), +1);
+        assertEquals(Double.compare(Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY), +1);
 
-        assertTrue(Double.compare(Double.MAX_VALUE, Double.NaN) == -1);
-        assertTrue(Double.compare(Double.MAX_VALUE, Double.POSITIVE_INFINITY) == -1);
-        assertTrue(Double.compare(Double.MAX_VALUE, Double.MAX_VALUE) == 0);
-        assertTrue(Double.compare(Double.MAX_VALUE, 1.2d) == +1);
-        assertTrue(Double.compare(Double.MAX_VALUE, 0.0d) == +1);
-        assertTrue(Double.compare(Double.MAX_VALUE, -0.0d) == +1);
-        assertTrue(Double.compare(Double.MAX_VALUE, -1.2d) == +1);
-        assertTrue(Double.compare(Double.MAX_VALUE, -Double.MAX_VALUE) == +1);
-        assertTrue(Double.compare(Double.MAX_VALUE, Double.NEGATIVE_INFINITY) == +1);
+        assertEquals(Double.compare(Double.MAX_VALUE, Double.NaN), -1);
+        assertEquals(Double.compare(Double.MAX_VALUE, Double.POSITIVE_INFINITY), -1);
+        assertEquals(0, Double.compare(Double.MAX_VALUE, Double.MAX_VALUE));
+        assertEquals(Double.compare(Double.MAX_VALUE, 1.2d), +1);
+        assertEquals(Double.compare(Double.MAX_VALUE, 0.0d), +1);
+        assertEquals(Double.compare(Double.MAX_VALUE, -0.0d), +1);
+        assertEquals(Double.compare(Double.MAX_VALUE, -1.2d), +1);
+        assertEquals(Double.compare(Double.MAX_VALUE, -Double.MAX_VALUE), +1);
+        assertEquals(Double.compare(Double.MAX_VALUE, Double.NEGATIVE_INFINITY), +1);
 
-        assertTrue(Double.compare(1.2d, Double.NaN) == -1);
-        assertTrue(Double.compare(1.2d, Double.POSITIVE_INFINITY) == -1);
-        assertTrue(Double.compare(1.2d, Double.MAX_VALUE) == -1);
-        assertTrue(Double.compare(1.2d, 1.2d) == 0);
-        assertTrue(Double.compare(1.2d, 0.0d) == +1);
-        assertTrue(Double.compare(1.2d, -0.0d) == +1);
-        assertTrue(Double.compare(1.2d, -1.2d) == +1);
-        assertTrue(Double.compare(1.2d, -Double.MAX_VALUE) == +1);
-        assertTrue(Double.compare(1.2d, Double.NEGATIVE_INFINITY) == +1);
+        assertEquals(Double.compare(1.2d, Double.NaN), -1);
+        assertEquals(Double.compare(1.2d, Double.POSITIVE_INFINITY), -1);
+        assertEquals(Double.compare(1.2d, Double.MAX_VALUE), -1);
+        assertEquals(0, Double.compare(1.2d, 1.2d));
+        assertEquals(Double.compare(1.2d, 0.0d), +1);
+        assertEquals(Double.compare(1.2d, -0.0d), +1);
+        assertEquals(Double.compare(1.2d, -1.2d), +1);
+        assertEquals(Double.compare(1.2d, -Double.MAX_VALUE), +1);
+        assertEquals(Double.compare(1.2d, Double.NEGATIVE_INFINITY), +1);
 
-        assertTrue(Double.compare(0.0d, Double.NaN) == -1);
-        assertTrue(Double.compare(0.0d, Double.POSITIVE_INFINITY) == -1);
-        assertTrue(Double.compare(0.0d, Double.MAX_VALUE) == -1);
-        assertTrue(Double.compare(0.0d, 1.2d) == -1);
-        assertTrue(Double.compare(0.0d, 0.0d) == 0);
-        assertTrue(Double.compare(0.0d, -0.0d) == +1);
-        assertTrue(Double.compare(0.0d, -1.2d) == +1);
-        assertTrue(Double.compare(0.0d, -Double.MAX_VALUE) == +1);
-        assertTrue(Double.compare(0.0d, Double.NEGATIVE_INFINITY) == +1);
+        assertEquals(Double.compare(0.0d, Double.NaN), -1);
+        assertEquals(Double.compare(0.0d, Double.POSITIVE_INFINITY), -1);
+        assertEquals(Double.compare(0.0d, Double.MAX_VALUE), -1);
+        assertEquals(Double.compare(0.0d, 1.2d), -1);
+        assertEquals(0, Double.compare(0.0d, 0.0d));
+        assertEquals(Double.compare(0.0d, -0.0d), +1);
+        assertEquals(Double.compare(0.0d, -1.2d), +1);
+        assertEquals(Double.compare(0.0d, -Double.MAX_VALUE), +1);
+        assertEquals(Double.compare(0.0d, Double.NEGATIVE_INFINITY), +1);
 
-        assertTrue(Double.compare(-0.0d, Double.NaN) == -1);
-        assertTrue(Double.compare(-0.0d, Double.POSITIVE_INFINITY) == -1);
-        assertTrue(Double.compare(-0.0d, Double.MAX_VALUE) == -1);
-        assertTrue(Double.compare(-0.0d, 1.2d) == -1);
-        assertTrue(Double.compare(-0.0d, 0.0d) == -1);
-        assertTrue(Double.compare(-0.0d, -0.0d) == 0);
-        assertTrue(Double.compare(-0.0d, -1.2d) == +1);
-        assertTrue(Double.compare(-0.0d, -Double.MAX_VALUE) == +1);
-        assertTrue(Double.compare(-0.0d, Double.NEGATIVE_INFINITY) == +1);
+        assertEquals(Double.compare(-0.0d, Double.NaN), -1);
+        assertEquals(Double.compare(-0.0d, Double.POSITIVE_INFINITY), -1);
+        assertEquals(Double.compare(-0.0d, Double.MAX_VALUE), -1);
+        assertEquals(Double.compare(-0.0d, 1.2d), -1);
+        assertEquals(Double.compare(-0.0d, 0.0d), -1);
+        assertEquals(0, Double.compare(-0.0d, -0.0d));
+        assertEquals(Double.compare(-0.0d, -1.2d), +1);
+        assertEquals(Double.compare(-0.0d, -Double.MAX_VALUE), +1);
+        assertEquals(Double.compare(-0.0d, Double.NEGATIVE_INFINITY), +1);
 
-        assertTrue(Double.compare(-1.2d, Double.NaN) == -1);
-        assertTrue(Double.compare(-1.2d, Double.POSITIVE_INFINITY) == -1);
-        assertTrue(Double.compare(-1.2d, Double.MAX_VALUE) == -1);
-        assertTrue(Double.compare(-1.2d, 1.2d) == -1);
-        assertTrue(Double.compare(-1.2d, 0.0d) == -1);
-        assertTrue(Double.compare(-1.2d, -0.0d) == -1);
-        assertTrue(Double.compare(-1.2d, -1.2d) == 0);
-        assertTrue(Double.compare(-1.2d, -Double.MAX_VALUE) == +1);
-        assertTrue(Double.compare(-1.2d, Double.NEGATIVE_INFINITY) == +1);
+        assertEquals(Double.compare(-1.2d, Double.NaN), -1);
+        assertEquals(Double.compare(-1.2d, Double.POSITIVE_INFINITY), -1);
+        assertEquals(Double.compare(-1.2d, Double.MAX_VALUE), -1);
+        assertEquals(Double.compare(-1.2d, 1.2d), -1);
+        assertEquals(Double.compare(-1.2d, 0.0d), -1);
+        assertEquals(Double.compare(-1.2d, -0.0d), -1);
+        assertEquals(0, Double.compare(-1.2d, -1.2d));
+        assertEquals(Double.compare(-1.2d, -Double.MAX_VALUE), +1);
+        assertEquals(Double.compare(-1.2d, Double.NEGATIVE_INFINITY), +1);
 
-        assertTrue(Double.compare(-Double.MAX_VALUE, Double.NaN) == -1);
-        assertTrue(Double.compare(-Double.MAX_VALUE, Double.POSITIVE_INFINITY) == -1);
-        assertTrue(Double.compare(-Double.MAX_VALUE, Double.MAX_VALUE) == -1);
-        assertTrue(Double.compare(-Double.MAX_VALUE, 1.2d) == -1);
-        assertTrue(Double.compare(-Double.MAX_VALUE, 0.0d) == -1);
-        assertTrue(Double.compare(-Double.MAX_VALUE, -0.0d) == -1);
-        assertTrue(Double.compare(-Double.MAX_VALUE, -1.2d) == -1);
-        assertTrue(Double.compare(-Double.MAX_VALUE, -Double.MAX_VALUE) == 0);
-        assertTrue(Double.compare(-Double.MAX_VALUE, Double.NEGATIVE_INFINITY) == +1);
+        assertEquals(Double.compare(-Double.MAX_VALUE, Double.NaN), -1);
+        assertEquals(Double.compare(-Double.MAX_VALUE, Double.POSITIVE_INFINITY), -1);
+        assertEquals(Double.compare(-Double.MAX_VALUE, Double.MAX_VALUE), -1);
+        assertEquals(Double.compare(-Double.MAX_VALUE, 1.2d), -1);
+        assertEquals(Double.compare(-Double.MAX_VALUE, 0.0d), -1);
+        assertEquals(Double.compare(-Double.MAX_VALUE, -0.0d), -1);
+        assertEquals(Double.compare(-Double.MAX_VALUE, -1.2d), -1);
+        assertEquals(0, Double.compare(-Double.MAX_VALUE, -Double.MAX_VALUE));
+        assertEquals(Double.compare(-Double.MAX_VALUE, Double.NEGATIVE_INFINITY), +1);
 
-        assertTrue(Double.compare(Double.NEGATIVE_INFINITY, Double.NaN) == -1);
-        assertTrue(Double.compare(Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY) == -1);
-        assertTrue(Double.compare(Double.NEGATIVE_INFINITY, Double.MAX_VALUE) == -1);
-        assertTrue(Double.compare(Double.NEGATIVE_INFINITY, 1.2d) == -1);
-        assertTrue(Double.compare(Double.NEGATIVE_INFINITY, 0.0d) == -1);
-        assertTrue(Double.compare(Double.NEGATIVE_INFINITY, -0.0d) == -1);
-        assertTrue(Double.compare(Double.NEGATIVE_INFINITY, -1.2d) == -1);
-        assertTrue(Double.compare(Double.NEGATIVE_INFINITY, -Double.MAX_VALUE) == -1);
-        assertTrue(Double.compare(Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY) == 0);
+        assertEquals(Double.compare(Double.NEGATIVE_INFINITY, Double.NaN), -1);
+        assertEquals(Double.compare(Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY), -1);
+        assertEquals(Double.compare(Double.NEGATIVE_INFINITY, Double.MAX_VALUE), -1);
+        assertEquals(Double.compare(Double.NEGATIVE_INFINITY, 1.2d), -1);
+        assertEquals(Double.compare(Double.NEGATIVE_INFINITY, 0.0d), -1);
+        assertEquals(Double.compare(Double.NEGATIVE_INFINITY, -0.0d), -1);
+        assertEquals(Double.compare(Double.NEGATIVE_INFINITY, -1.2d), -1);
+        assertEquals(Double.compare(Double.NEGATIVE_INFINITY, -Double.MAX_VALUE), -1);
+        assertEquals(0, Double.compare(Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY));
     }
 
     @Test
     public void testCompareFloat() {
-        assertTrue(Float.compare(Float.NaN, Float.NaN) == 0);
-        assertTrue(Float.compare(Float.NaN, Float.POSITIVE_INFINITY) == +1);
-        assertTrue(Float.compare(Float.NaN, Float.MAX_VALUE) == +1);
-        assertTrue(Float.compare(Float.NaN, 1.2f) == +1);
-        assertTrue(Float.compare(Float.NaN, 0.0f) == +1);
-        assertTrue(Float.compare(Float.NaN, -0.0f) == +1);
-        assertTrue(Float.compare(Float.NaN, -1.2f) == +1);
-        assertTrue(Float.compare(Float.NaN, -Float.MAX_VALUE) == +1);
-        assertTrue(Float.compare(Float.NaN, Float.NEGATIVE_INFINITY) == +1);
+        assertEquals(0, Float.compare(Float.NaN, Float.NaN));
+        assertEquals(Float.compare(Float.NaN, Float.POSITIVE_INFINITY), +1);
+        assertEquals(Float.compare(Float.NaN, Float.MAX_VALUE), +1);
+        assertEquals(Float.compare(Float.NaN, 1.2f), +1);
+        assertEquals(Float.compare(Float.NaN, 0.0f), +1);
+        assertEquals(Float.compare(Float.NaN, -0.0f), +1);
+        assertEquals(Float.compare(Float.NaN, -1.2f), +1);
+        assertEquals(Float.compare(Float.NaN, -Float.MAX_VALUE), +1);
+        assertEquals(Float.compare(Float.NaN, Float.NEGATIVE_INFINITY), +1);
 
-        assertTrue(Float.compare(Float.POSITIVE_INFINITY, Float.NaN) == -1);
-        assertTrue(Float.compare(Float.POSITIVE_INFINITY, Float.POSITIVE_INFINITY) == 0);
-        assertTrue(Float.compare(Float.POSITIVE_INFINITY, Float.MAX_VALUE) == +1);
-        assertTrue(Float.compare(Float.POSITIVE_INFINITY, 1.2f) == +1);
-        assertTrue(Float.compare(Float.POSITIVE_INFINITY, 0.0f) == +1);
-        assertTrue(Float.compare(Float.POSITIVE_INFINITY, -0.0f) == +1);
-        assertTrue(Float.compare(Float.POSITIVE_INFINITY, -1.2f) == +1);
-        assertTrue(Float.compare(Float.POSITIVE_INFINITY, -Float.MAX_VALUE) == +1);
-        assertTrue(Float.compare(Float.POSITIVE_INFINITY, Float.NEGATIVE_INFINITY) == +1);
+        assertEquals(Float.compare(Float.POSITIVE_INFINITY, Float.NaN), -1);
+        assertEquals(0, Float.compare(Float.POSITIVE_INFINITY, Float.POSITIVE_INFINITY));
+        assertEquals(Float.compare(Float.POSITIVE_INFINITY, Float.MAX_VALUE), +1);
+        assertEquals(Float.compare(Float.POSITIVE_INFINITY, 1.2f), +1);
+        assertEquals(Float.compare(Float.POSITIVE_INFINITY, 0.0f), +1);
+        assertEquals(Float.compare(Float.POSITIVE_INFINITY, -0.0f), +1);
+        assertEquals(Float.compare(Float.POSITIVE_INFINITY, -1.2f), +1);
+        assertEquals(Float.compare(Float.POSITIVE_INFINITY, -Float.MAX_VALUE), +1);
+        assertEquals(Float.compare(Float.POSITIVE_INFINITY, Float.NEGATIVE_INFINITY), +1);
 
-        assertTrue(Float.compare(Float.MAX_VALUE, Float.NaN) == -1);
-        assertTrue(Float.compare(Float.MAX_VALUE, Float.POSITIVE_INFINITY) == -1);
-        assertTrue(Float.compare(Float.MAX_VALUE, Float.MAX_VALUE) == 0);
-        assertTrue(Float.compare(Float.MAX_VALUE, 1.2f) == +1);
-        assertTrue(Float.compare(Float.MAX_VALUE, 0.0f) == +1);
-        assertTrue(Float.compare(Float.MAX_VALUE, -0.0f) == +1);
-        assertTrue(Float.compare(Float.MAX_VALUE, -1.2f) == +1);
-        assertTrue(Float.compare(Float.MAX_VALUE, -Float.MAX_VALUE) == +1);
-        assertTrue(Float.compare(Float.MAX_VALUE, Float.NEGATIVE_INFINITY) == +1);
+        assertEquals(Float.compare(Float.MAX_VALUE, Float.NaN), -1);
+        assertEquals(Float.compare(Float.MAX_VALUE, Float.POSITIVE_INFINITY), -1);
+        assertEquals(0, Float.compare(Float.MAX_VALUE, Float.MAX_VALUE));
+        assertEquals(Float.compare(Float.MAX_VALUE, 1.2f), +1);
+        assertEquals(Float.compare(Float.MAX_VALUE, 0.0f), +1);
+        assertEquals(Float.compare(Float.MAX_VALUE, -0.0f), +1);
+        assertEquals(Float.compare(Float.MAX_VALUE, -1.2f), +1);
+        assertEquals(Float.compare(Float.MAX_VALUE, -Float.MAX_VALUE), +1);
+        assertEquals(Float.compare(Float.MAX_VALUE, Float.NEGATIVE_INFINITY), +1);
 
-        assertTrue(Float.compare(1.2f, Float.NaN) == -1);
-        assertTrue(Float.compare(1.2f, Float.POSITIVE_INFINITY) == -1);
-        assertTrue(Float.compare(1.2f, Float.MAX_VALUE) == -1);
-        assertTrue(Float.compare(1.2f, 1.2f) == 0);
-        assertTrue(Float.compare(1.2f, 0.0f) == +1);
-        assertTrue(Float.compare(1.2f, -0.0f) == +1);
-        assertTrue(Float.compare(1.2f, -1.2f) == +1);
-        assertTrue(Float.compare(1.2f, -Float.MAX_VALUE) == +1);
-        assertTrue(Float.compare(1.2f, Float.NEGATIVE_INFINITY) == +1);
+        assertEquals(Float.compare(1.2f, Float.NaN), -1);
+        assertEquals(Float.compare(1.2f, Float.POSITIVE_INFINITY), -1);
+        assertEquals(Float.compare(1.2f, Float.MAX_VALUE), -1);
+        assertEquals(0, Float.compare(1.2f, 1.2f));
+        assertEquals(Float.compare(1.2f, 0.0f), +1);
+        assertEquals(Float.compare(1.2f, -0.0f), +1);
+        assertEquals(Float.compare(1.2f, -1.2f), +1);
+        assertEquals(Float.compare(1.2f, -Float.MAX_VALUE), +1);
+        assertEquals(Float.compare(1.2f, Float.NEGATIVE_INFINITY), +1);
 
-        assertTrue(Float.compare(0.0f, Float.NaN) == -1);
-        assertTrue(Float.compare(0.0f, Float.POSITIVE_INFINITY) == -1);
-        assertTrue(Float.compare(0.0f, Float.MAX_VALUE) == -1);
-        assertTrue(Float.compare(0.0f, 1.2f) == -1);
-        assertTrue(Float.compare(0.0f, 0.0f) == 0);
-        assertTrue(Float.compare(0.0f, -0.0f) == +1);
-        assertTrue(Float.compare(0.0f, -1.2f) == +1);
-        assertTrue(Float.compare(0.0f, -Float.MAX_VALUE) == +1);
-        assertTrue(Float.compare(0.0f, Float.NEGATIVE_INFINITY) == +1);
+        assertEquals(Float.compare(0.0f, Float.NaN), -1);
+        assertEquals(Float.compare(0.0f, Float.POSITIVE_INFINITY), -1);
+        assertEquals(Float.compare(0.0f, Float.MAX_VALUE), -1);
+        assertEquals(Float.compare(0.0f, 1.2f), -1);
+        assertEquals(0, Float.compare(0.0f, 0.0f));
+        assertEquals(Float.compare(0.0f, -0.0f), +1);
+        assertEquals(Float.compare(0.0f, -1.2f), +1);
+        assertEquals(Float.compare(0.0f, -Float.MAX_VALUE), +1);
+        assertEquals(Float.compare(0.0f, Float.NEGATIVE_INFINITY), +1);
 
-        assertTrue(Float.compare(-0.0f, Float.NaN) == -1);
-        assertTrue(Float.compare(-0.0f, Float.POSITIVE_INFINITY) == -1);
-        assertTrue(Float.compare(-0.0f, Float.MAX_VALUE) == -1);
-        assertTrue(Float.compare(-0.0f, 1.2f) == -1);
-        assertTrue(Float.compare(-0.0f, 0.0f) == -1);
-        assertTrue(Float.compare(-0.0f, -0.0f) == 0);
-        assertTrue(Float.compare(-0.0f, -1.2f) == +1);
-        assertTrue(Float.compare(-0.0f, -Float.MAX_VALUE) == +1);
-        assertTrue(Float.compare(-0.0f, Float.NEGATIVE_INFINITY) == +1);
+        assertEquals(Float.compare(-0.0f, Float.NaN), -1);
+        assertEquals(Float.compare(-0.0f, Float.POSITIVE_INFINITY), -1);
+        assertEquals(Float.compare(-0.0f, Float.MAX_VALUE), -1);
+        assertEquals(Float.compare(-0.0f, 1.2f), -1);
+        assertEquals(Float.compare(-0.0f, 0.0f), -1);
+        assertEquals(0, Float.compare(-0.0f, -0.0f));
+        assertEquals(Float.compare(-0.0f, -1.2f), +1);
+        assertEquals(Float.compare(-0.0f, -Float.MAX_VALUE), +1);
+        assertEquals(Float.compare(-0.0f, Float.NEGATIVE_INFINITY), +1);
 
-        assertTrue(Float.compare(-1.2f, Float.NaN) == -1);
-        assertTrue(Float.compare(-1.2f, Float.POSITIVE_INFINITY) == -1);
-        assertTrue(Float.compare(-1.2f, Float.MAX_VALUE) == -1);
-        assertTrue(Float.compare(-1.2f, 1.2f) == -1);
-        assertTrue(Float.compare(-1.2f, 0.0f) == -1);
-        assertTrue(Float.compare(-1.2f, -0.0f) == -1);
-        assertTrue(Float.compare(-1.2f, -1.2f) == 0);
-        assertTrue(Float.compare(-1.2f, -Float.MAX_VALUE) == +1);
-        assertTrue(Float.compare(-1.2f, Float.NEGATIVE_INFINITY) == +1);
+        assertEquals(Float.compare(-1.2f, Float.NaN), -1);
+        assertEquals(Float.compare(-1.2f, Float.POSITIVE_INFINITY), -1);
+        assertEquals(Float.compare(-1.2f, Float.MAX_VALUE), -1);
+        assertEquals(Float.compare(-1.2f, 1.2f), -1);
+        assertEquals(Float.compare(-1.2f, 0.0f), -1);
+        assertEquals(Float.compare(-1.2f, -0.0f), -1);
+        assertEquals(0, Float.compare(-1.2f, -1.2f));
+        assertEquals(Float.compare(-1.2f, -Float.MAX_VALUE), +1);
+        assertEquals(Float.compare(-1.2f, Float.NEGATIVE_INFINITY), +1);
 
-        assertTrue(Float.compare(-Float.MAX_VALUE, Float.NaN) == -1);
-        assertTrue(Float.compare(-Float.MAX_VALUE, Float.POSITIVE_INFINITY) == -1);
-        assertTrue(Float.compare(-Float.MAX_VALUE, Float.MAX_VALUE) == -1);
-        assertTrue(Float.compare(-Float.MAX_VALUE, 1.2f) == -1);
-        assertTrue(Float.compare(-Float.MAX_VALUE, 0.0f) == -1);
-        assertTrue(Float.compare(-Float.MAX_VALUE, -0.0f) == -1);
-        assertTrue(Float.compare(-Float.MAX_VALUE, -1.2f) == -1);
-        assertTrue(Float.compare(-Float.MAX_VALUE, -Float.MAX_VALUE) == 0);
-        assertTrue(Float.compare(-Float.MAX_VALUE, Float.NEGATIVE_INFINITY) == +1);
+        assertEquals(Float.compare(-Float.MAX_VALUE, Float.NaN), -1);
+        assertEquals(Float.compare(-Float.MAX_VALUE, Float.POSITIVE_INFINITY), -1);
+        assertEquals(Float.compare(-Float.MAX_VALUE, Float.MAX_VALUE), -1);
+        assertEquals(Float.compare(-Float.MAX_VALUE, 1.2f), -1);
+        assertEquals(Float.compare(-Float.MAX_VALUE, 0.0f), -1);
+        assertEquals(Float.compare(-Float.MAX_VALUE, -0.0f), -1);
+        assertEquals(Float.compare(-Float.MAX_VALUE, -1.2f), -1);
+        assertEquals(0, Float.compare(-Float.MAX_VALUE, -Float.MAX_VALUE));
+        assertEquals(Float.compare(-Float.MAX_VALUE, Float.NEGATIVE_INFINITY), +1);
 
-        assertTrue(Float.compare(Float.NEGATIVE_INFINITY, Float.NaN) == -1);
-        assertTrue(Float.compare(Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY) == -1);
-        assertTrue(Float.compare(Float.NEGATIVE_INFINITY, Float.MAX_VALUE) == -1);
-        assertTrue(Float.compare(Float.NEGATIVE_INFINITY, 1.2f) == -1);
-        assertTrue(Float.compare(Float.NEGATIVE_INFINITY, 0.0f) == -1);
-        assertTrue(Float.compare(Float.NEGATIVE_INFINITY, -0.0f) == -1);
-        assertTrue(Float.compare(Float.NEGATIVE_INFINITY, -1.2f) == -1);
-        assertTrue(Float.compare(Float.NEGATIVE_INFINITY, -Float.MAX_VALUE) == -1);
-        assertTrue(Float.compare(Float.NEGATIVE_INFINITY, Float.NEGATIVE_INFINITY) == 0);
+        assertEquals(Float.compare(Float.NEGATIVE_INFINITY, Float.NaN), -1);
+        assertEquals(Float.compare(Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY), -1);
+        assertEquals(Float.compare(Float.NEGATIVE_INFINITY, Float.MAX_VALUE), -1);
+        assertEquals(Float.compare(Float.NEGATIVE_INFINITY, 1.2f), -1);
+        assertEquals(Float.compare(Float.NEGATIVE_INFINITY, 0.0f), -1);
+        assertEquals(Float.compare(Float.NEGATIVE_INFINITY, -0.0f), -1);
+        assertEquals(Float.compare(Float.NEGATIVE_INFINITY, -1.2f), -1);
+        assertEquals(Float.compare(Float.NEGATIVE_INFINITY, -Float.MAX_VALUE), -1);
+        assertEquals(0, Float.compare(Float.NEGATIVE_INFINITY, Float.NEGATIVE_INFINITY));
     }
 
     @Test
@@ -1558,23 +1511,23 @@ public class NumberUtilsTest {
         assertTrue(NumberUtils.FLOAT_ONE instanceof Float);
         assertTrue(NumberUtils.FLOAT_MINUS_ONE instanceof Float);
 
-        assertTrue(NumberUtils.LONG_ZERO.longValue() == 0);
-        assertTrue(NumberUtils.LONG_ONE.longValue() == 1);
-        assertTrue(NumberUtils.LONG_MINUS_ONE.longValue() == -1);
-        assertTrue(NumberUtils.INTEGER_ZERO.intValue() == 0);
-        assertTrue(NumberUtils.INTEGER_ONE.intValue() == 1);
-        assertTrue(NumberUtils.INTEGER_MINUS_ONE.intValue() == -1);
-        assertTrue(NumberUtils.SHORT_ZERO.shortValue() == 0);
-        assertTrue(NumberUtils.SHORT_ONE.shortValue() == 1);
-        assertTrue(NumberUtils.SHORT_MINUS_ONE.shortValue() == -1);
-        assertTrue(NumberUtils.BYTE_ZERO.byteValue() == 0);
-        assertTrue(NumberUtils.BYTE_ONE.byteValue() == 1);
-        assertTrue(NumberUtils.BYTE_MINUS_ONE.byteValue() == -1);
-        assertTrue(NumberUtils.DOUBLE_ZERO.doubleValue() == 0.0d);
-        assertTrue(NumberUtils.DOUBLE_ONE.doubleValue() == 1.0d);
+        assertEquals(0, NumberUtils.LONG_ZERO.longValue());
+        assertEquals(1, NumberUtils.LONG_ONE.longValue());
+        assertEquals(NumberUtils.LONG_MINUS_ONE.longValue(), -1);
+        assertEquals(0, NumberUtils.INTEGER_ZERO.intValue());
+        assertEquals(1, NumberUtils.INTEGER_ONE.intValue());
+        assertEquals(NumberUtils.INTEGER_MINUS_ONE.intValue(), -1);
+        assertEquals(0, NumberUtils.SHORT_ZERO.shortValue());
+        assertEquals(1, NumberUtils.SHORT_ONE.shortValue());
+        assertEquals(NumberUtils.SHORT_MINUS_ONE.shortValue(), -1);
+        assertEquals(0, NumberUtils.BYTE_ZERO.byteValue());
+        assertEquals(1, NumberUtils.BYTE_ONE.byteValue());
+        assertEquals(NumberUtils.BYTE_MINUS_ONE.byteValue(), -1);
+        assertTrue(0.0d == NumberUtils.DOUBLE_ZERO.doubleValue());
+        assertTrue(1.0d == NumberUtils.DOUBLE_ONE.doubleValue());
         assertTrue(NumberUtils.DOUBLE_MINUS_ONE.doubleValue() == -1.0d);
-        assertTrue(NumberUtils.FLOAT_ZERO.floatValue() == 0.0f);
-        assertTrue(NumberUtils.FLOAT_ONE.floatValue() == 1.0f);
+        assertTrue(0.0f == NumberUtils.FLOAT_ZERO.floatValue());
+        assertTrue(1.0f == NumberUtils.FLOAT_ONE.floatValue());
         assertTrue(NumberUtils.FLOAT_MINUS_ONE.floatValue() == -1.0f);
     }
 
@@ -1610,28 +1563,28 @@ public class NumberUtilsTest {
     @Test
     public void compareInt() {
         assertTrue(NumberUtils.compare(-3, 0) < 0);
-        assertTrue(NumberUtils.compare(113, 113)==0);
+        assertEquals(0, NumberUtils.compare(113, 113));
         assertTrue(NumberUtils.compare(213, 32) > 0);
     }
 
     @Test
     public void compareLong() {
         assertTrue(NumberUtils.compare(-3L, 0L) < 0);
-        assertTrue(NumberUtils.compare(113L, 113L)==0);
+        assertEquals(0, NumberUtils.compare(113L, 113L));
         assertTrue(NumberUtils.compare(213L, 32L) > 0);
     }
 
     @Test
     public void compareShort() {
         assertTrue(NumberUtils.compare((short)-3, (short)0) < 0);
-        assertTrue(NumberUtils.compare((short)113, (short)113)==0);
+        assertEquals(0, NumberUtils.compare((short) 113, (short) 113));
         assertTrue(NumberUtils.compare((short)213, (short)32) > 0);
     }
 
     @Test
     public void compareByte() {
         assertTrue(NumberUtils.compare((byte)-3, (byte)0) < 0);
-        assertTrue(NumberUtils.compare((byte)113, (byte)113)==0);
+        assertEquals(0, NumberUtils.compare((byte) 113, (byte) 113));
         assertTrue(NumberUtils.compare((byte)123, (byte)32) > 0);
     }
 }

--- a/src/test/java/org/apache/commons/lang3/mutable/MutableBooleanTest.java
+++ b/src/test/java/org/apache/commons/lang3/mutable/MutableBooleanTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -73,16 +74,16 @@ public class MutableBooleanTest {
         final MutableBoolean mutBoolB = new MutableBoolean(false);
         final MutableBoolean mutBoolC = new MutableBoolean(true);
 
-        assertTrue(mutBoolA.equals(mutBoolA));
-        assertTrue(mutBoolA.equals(mutBoolB));
-        assertTrue(mutBoolB.equals(mutBoolA));
-        assertTrue(mutBoolB.equals(mutBoolB));
-        assertFalse(mutBoolA.equals(mutBoolC));
-        assertFalse(mutBoolB.equals(mutBoolC));
-        assertTrue(mutBoolC.equals(mutBoolC));
-        assertFalse(mutBoolA.equals(null));
-        assertFalse(mutBoolA.equals(Boolean.FALSE));
-        assertFalse(mutBoolA.equals("false"));
+        assertEquals(mutBoolA, mutBoolA);
+        assertEquals(mutBoolA, mutBoolB);
+        assertEquals(mutBoolB, mutBoolA);
+        assertEquals(mutBoolB, mutBoolB);
+        assertNotEquals(mutBoolA, mutBoolC);
+        assertNotEquals(mutBoolB, mutBoolC);
+        assertEquals(mutBoolC, mutBoolC);
+        assertNotEquals(null, mutBoolA);
+        assertNotEquals(mutBoolA, Boolean.FALSE);
+        assertNotEquals("false", mutBoolA);
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/mutable/MutableByteTest.java
+++ b/src/test/java/org/apache/commons/lang3/mutable/MutableByteTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -80,16 +81,16 @@ public class MutableByteTest {
         final MutableByte mutNumB = new MutableByte((byte) 0);
         final MutableByte mutNumC = new MutableByte((byte) 1);
 
-        assertTrue(mutNumA.equals(mutNumA));
-        assertTrue(mutNumA.equals(mutNumB));
-        assertTrue(mutNumB.equals(mutNumA));
-        assertTrue(mutNumB.equals(mutNumB));
-        assertFalse(mutNumA.equals(mutNumC));
-        assertFalse(mutNumB.equals(mutNumC));
-        assertTrue(mutNumC.equals(mutNumC));
-        assertFalse(mutNumA.equals(null));
-        assertFalse(mutNumA.equals(Byte.valueOf((byte) 0)));
-        assertFalse(mutNumA.equals("0"));
+        assertEquals(mutNumA, mutNumA);
+        assertEquals(mutNumA, mutNumB);
+        assertEquals(mutNumB, mutNumA);
+        assertEquals(mutNumB, mutNumB);
+        assertNotEquals(mutNumA, mutNumC);
+        assertNotEquals(mutNumB, mutNumC);
+        assertEquals(mutNumC, mutNumC);
+        assertNotEquals(null, mutNumA);
+        assertNotEquals(mutNumA, Byte.valueOf((byte) 0));
+        assertNotEquals("0", mutNumA);
     }
 
     @Test
@@ -98,10 +99,10 @@ public class MutableByteTest {
         final MutableByte mutNumB = new MutableByte((byte) 0);
         final MutableByte mutNumC = new MutableByte((byte) 1);
 
-        assertTrue(mutNumA.hashCode() == mutNumA.hashCode());
-        assertTrue(mutNumA.hashCode() == mutNumB.hashCode());
+        assertEquals(mutNumA.hashCode(), mutNumA.hashCode());
+        assertEquals(mutNumA.hashCode(), mutNumB.hashCode());
         assertFalse(mutNumA.hashCode() == mutNumC.hashCode());
-        assertTrue(mutNumA.hashCode() == Byte.valueOf((byte) 0).hashCode());
+        assertEquals(mutNumA.hashCode(), Byte.valueOf((byte) 0).hashCode());
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/mutable/MutableDoubleTest.java
+++ b/src/test/java/org/apache/commons/lang3/mutable/MutableDoubleTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -92,16 +93,16 @@ public class MutableDoubleTest {
         final MutableDouble mutNumB = new MutableDouble(0d);
         final MutableDouble mutNumC = new MutableDouble(1d);
 
-        assertTrue(mutNumA.equals(mutNumA));
-        assertTrue(mutNumA.equals(mutNumB));
-        assertTrue(mutNumB.equals(mutNumA));
-        assertTrue(mutNumB.equals(mutNumB));
-        assertFalse(mutNumA.equals(mutNumC));
-        assertFalse(mutNumB.equals(mutNumC));
-        assertTrue(mutNumC.equals(mutNumC));
-        assertFalse(mutNumA.equals(null));
-        assertFalse(mutNumA.equals(Double.valueOf(0d)));
-        assertFalse(mutNumA.equals("0"));
+        assertEquals(mutNumA, mutNumA);
+        assertEquals(mutNumA, mutNumB);
+        assertEquals(mutNumB, mutNumA);
+        assertEquals(mutNumB, mutNumB);
+        assertNotEquals(mutNumA, mutNumC);
+        assertNotEquals(mutNumB, mutNumC);
+        assertEquals(mutNumC, mutNumC);
+        assertNotEquals(null, mutNumA);
+        assertNotEquals(mutNumA, Double.valueOf(0d));
+        assertNotEquals("0", mutNumA);
     }
 
     @Test
@@ -110,10 +111,10 @@ public class MutableDoubleTest {
         final MutableDouble mutNumB = new MutableDouble(0d);
         final MutableDouble mutNumC = new MutableDouble(1d);
 
-        assertTrue(mutNumA.hashCode() == mutNumA.hashCode());
-        assertTrue(mutNumA.hashCode() == mutNumB.hashCode());
+        assertEquals(mutNumA.hashCode(), mutNumA.hashCode());
+        assertEquals(mutNumA.hashCode(), mutNumB.hashCode());
         assertFalse(mutNumA.hashCode() == mutNumC.hashCode());
-        assertTrue(mutNumA.hashCode() == Double.valueOf(0d).hashCode());
+        assertEquals(mutNumA.hashCode(), Double.valueOf(0d).hashCode());
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/mutable/MutableFloatTest.java
+++ b/src/test/java/org/apache/commons/lang3/mutable/MutableFloatTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -92,16 +93,16 @@ public class MutableFloatTest {
         final MutableFloat mutNumB = new MutableFloat(0f);
         final MutableFloat mutNumC = new MutableFloat(1f);
 
-        assertTrue(mutNumA.equals(mutNumA));
-        assertTrue(mutNumA.equals(mutNumB));
-        assertTrue(mutNumB.equals(mutNumA));
-        assertTrue(mutNumB.equals(mutNumB));
-        assertFalse(mutNumA.equals(mutNumC));
-        assertFalse(mutNumB.equals(mutNumC));
-        assertTrue(mutNumC.equals(mutNumC));
-        assertFalse(mutNumA.equals(null));
-        assertFalse(mutNumA.equals(Float.valueOf(0f)));
-        assertFalse(mutNumA.equals("0"));
+        assertEquals(mutNumA, mutNumA);
+        assertEquals(mutNumA, mutNumB);
+        assertEquals(mutNumB, mutNumA);
+        assertEquals(mutNumB, mutNumB);
+        assertNotEquals(mutNumA, mutNumC);
+        assertNotEquals(mutNumB, mutNumC);
+        assertEquals(mutNumC, mutNumC);
+        assertNotEquals(null, mutNumA);
+        assertNotEquals(mutNumA, Float.valueOf(0f));
+        assertNotEquals("0", mutNumA);
     }
 
     @Test
@@ -110,10 +111,10 @@ public class MutableFloatTest {
         final MutableFloat mutNumB = new MutableFloat(0f);
         final MutableFloat mutNumC = new MutableFloat(1f);
 
-        assertTrue(mutNumA.hashCode() == mutNumA.hashCode());
-        assertTrue(mutNumA.hashCode() == mutNumB.hashCode());
+        assertEquals(mutNumA.hashCode(), mutNumA.hashCode());
+        assertEquals(mutNumA.hashCode(), mutNumB.hashCode());
         assertFalse(mutNumA.hashCode() == mutNumC.hashCode());
-        assertTrue(mutNumA.hashCode() == Float.valueOf(0f).hashCode());
+        assertEquals(mutNumA.hashCode(), Float.valueOf(0f).hashCode());
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/mutable/MutableIntTest.java
+++ b/src/test/java/org/apache/commons/lang3/mutable/MutableIntTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -87,16 +88,16 @@ public class MutableIntTest {
      * @param numC must not equal numA; must not equal numC.
      */
     void testEquals(final Number numA, final Number numB, final Number numC) {
-        assertTrue(numA.equals(numA));
-        assertTrue(numA.equals(numB));
-        assertTrue(numB.equals(numA));
-        assertTrue(numB.equals(numB));
-        assertFalse(numA.equals(numC));
-        assertFalse(numB.equals(numC));
-        assertTrue(numC.equals(numC));
-        assertFalse(numA.equals(null));
-        assertFalse(numA.equals(Integer.valueOf(0)));
-        assertFalse(numA.equals("0"));
+        assertEquals(numA, numA);
+        assertEquals(numA, numB);
+        assertEquals(numB, numA);
+        assertEquals(numB, numB);
+        assertNotEquals(numA, numC);
+        assertNotEquals(numB, numC);
+        assertEquals(numC, numC);
+        assertNotEquals(null, numA);
+        assertNotEquals(numA, Integer.valueOf(0));
+        assertNotEquals("0", numA);
     }
 
     @Test
@@ -105,10 +106,10 @@ public class MutableIntTest {
         final MutableInt mutNumB = new MutableInt(0);
         final MutableInt mutNumC = new MutableInt(1);
 
-        assertTrue(mutNumA.hashCode() == mutNumA.hashCode());
-        assertTrue(mutNumA.hashCode() == mutNumB.hashCode());
+        assertEquals(mutNumA.hashCode(), mutNumA.hashCode());
+        assertEquals(mutNumA.hashCode(), mutNumB.hashCode());
         assertFalse(mutNumA.hashCode() == mutNumC.hashCode());
-        assertTrue(mutNumA.hashCode() == Integer.valueOf(0).hashCode());
+        assertEquals(mutNumA.hashCode(), Integer.valueOf(0).hashCode());
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/mutable/MutableLongTest.java
+++ b/src/test/java/org/apache/commons/lang3/mutable/MutableLongTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -80,16 +81,16 @@ public class MutableLongTest {
         final MutableLong mutNumB = new MutableLong(0);
         final MutableLong mutNumC = new MutableLong(1);
 
-        assertTrue(mutNumA.equals(mutNumA));
-        assertTrue(mutNumA.equals(mutNumB));
-        assertTrue(mutNumB.equals(mutNumA));
-        assertTrue(mutNumB.equals(mutNumB));
-        assertFalse(mutNumA.equals(mutNumC));
-        assertFalse(mutNumB.equals(mutNumC));
-        assertTrue(mutNumC.equals(mutNumC));
-        assertFalse(mutNumA.equals(null));
-        assertFalse(mutNumA.equals(Long.valueOf(0)));
-        assertFalse(mutNumA.equals("0"));
+        assertEquals(mutNumA, mutNumA);
+        assertEquals(mutNumA, mutNumB);
+        assertEquals(mutNumB, mutNumA);
+        assertEquals(mutNumB, mutNumB);
+        assertNotEquals(mutNumA, mutNumC);
+        assertNotEquals(mutNumB, mutNumC);
+        assertEquals(mutNumC, mutNumC);
+        assertNotEquals(null, mutNumA);
+        assertNotEquals(mutNumA, Long.valueOf(0));
+        assertNotEquals("0", mutNumA);
     }
 
     @Test
@@ -98,10 +99,10 @@ public class MutableLongTest {
         final MutableLong mutNumB = new MutableLong(0);
         final MutableLong mutNumC = new MutableLong(1);
 
-        assertTrue(mutNumA.hashCode() == mutNumA.hashCode());
-        assertTrue(mutNumA.hashCode() == mutNumB.hashCode());
+        assertEquals(mutNumA.hashCode(), mutNumA.hashCode());
+        assertEquals(mutNumA.hashCode(), mutNumB.hashCode());
         assertFalse(mutNumA.hashCode() == mutNumC.hashCode());
-        assertTrue(mutNumA.hashCode() == Long.valueOf(0).hashCode());
+        assertEquals(mutNumA.hashCode(), Long.valueOf(0).hashCode());
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/mutable/MutableShortTest.java
+++ b/src/test/java/org/apache/commons/lang3/mutable/MutableShortTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -71,16 +72,16 @@ public class MutableShortTest {
         final MutableShort mutNumB = new MutableShort((short) 0);
         final MutableShort mutNumC = new MutableShort((short) 1);
 
-        assertTrue(mutNumA.equals(mutNumA));
-        assertTrue(mutNumA.equals(mutNumB));
-        assertTrue(mutNumB.equals(mutNumA));
-        assertTrue(mutNumB.equals(mutNumB));
-        assertFalse(mutNumA.equals(mutNumC));
-        assertFalse(mutNumB.equals(mutNumC));
-        assertTrue(mutNumC.equals(mutNumC));
-        assertFalse(mutNumA.equals(null));
-        assertFalse(mutNumA.equals(Short.valueOf((short) 0)));
-        assertFalse(mutNumA.equals("0"));
+        assertEquals(mutNumA, mutNumA);
+        assertEquals(mutNumA, mutNumB);
+        assertEquals(mutNumB, mutNumA);
+        assertEquals(mutNumB, mutNumB);
+        assertNotEquals(mutNumA, mutNumC);
+        assertNotEquals(mutNumB, mutNumC);
+        assertEquals(mutNumC, mutNumC);
+        assertNotEquals(null, mutNumA);
+        assertNotEquals(mutNumA, Short.valueOf((short) 0));
+        assertNotEquals("0", mutNumA);
     }
 
     @Test
@@ -89,10 +90,10 @@ public class MutableShortTest {
         final MutableShort mutNumB = new MutableShort((short) 0);
         final MutableShort mutNumC = new MutableShort((short) 1);
 
-        assertTrue(mutNumA.hashCode() == mutNumA.hashCode());
-        assertTrue(mutNumA.hashCode() == mutNumB.hashCode());
+        assertEquals(mutNumA.hashCode(), mutNumA.hashCode());
+        assertEquals(mutNumA.hashCode(), mutNumB.hashCode());
         assertFalse(mutNumA.hashCode() == mutNumC.hashCode());
-        assertTrue(mutNumA.hashCode() == Short.valueOf((short) 0).hashCode());
+        assertEquals(mutNumA.hashCode(), Short.valueOf((short) 0).hashCode());
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/mutable/MutableShortTest.java
+++ b/src/test/java/org/apache/commons/lang3/mutable/MutableShortTest.java
@@ -20,8 +20,8 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * JUnit tests.
@@ -42,10 +42,7 @@ public class MutableShortTest {
 
         assertEquals((short) 2, new MutableShort("2").shortValue());
 
-        try {
-            new MutableShort((Number)null);
-            fail();
-        } catch (final NullPointerException ex) {}
+        assertThrows(NullPointerException.class, () -> new MutableShort((Number)null));
     }
 
     @Test
@@ -65,10 +62,7 @@ public class MutableShortTest {
         mutNum.setValue(new MutableShort((short) 3));
         assertEquals((short) 3, mutNum.shortValue());
         assertEquals(Short.valueOf((short) 3), mutNum.getValue());
-        try {
-            mutNum.setValue(null);
-            fail();
-        } catch (final NullPointerException ex) {}
+        assertThrows(NullPointerException.class, () -> mutNum.setValue(null));
     }
 
     @Test
@@ -108,10 +102,7 @@ public class MutableShortTest {
         assertEquals((short) 0, mutNum.compareTo(new MutableShort((short) 0)));
         assertEquals((short) +1, mutNum.compareTo(new MutableShort((short) -1)));
         assertEquals((short) -1, mutNum.compareTo(new MutableShort((short) 1)));
-        try {
-            mutNum.compareTo(null);
-            fail();
-        } catch (final NullPointerException ex) {}
+        assertThrows(NullPointerException.class, () -> mutNum.compareTo(null));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/reflect/ConstructorUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/reflect/ConstructorUtilsTest.java
@@ -20,8 +20,8 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.lang.reflect.Constructor;
 import java.util.Arrays;
@@ -186,24 +186,15 @@ public class ConstructorUtilsTest {
                 TestBean.class, new Object[] { NumberUtils.DOUBLE_ONE },
                 new Class[] { Double.TYPE }).toString());
 
-        try {
-            ConstructorUtils.invokeExactConstructor(TestBean.class,
-                    NumberUtils.BYTE_ONE);
-            fail("should throw NoSuchMethodException");
-        } catch (final NoSuchMethodException e) {
-        }
-        try {
-            ConstructorUtils.invokeExactConstructor(TestBean.class,
-                    NumberUtils.LONG_ONE);
-            fail("should throw NoSuchMethodException");
-        } catch (final NoSuchMethodException e) {
-        }
-        try {
-            ConstructorUtils.invokeExactConstructor(TestBean.class,
-                    Boolean.TRUE);
-            fail("should throw NoSuchMethodException");
-        } catch (final NoSuchMethodException e) {
-        }
+        assertThrows(
+                NoSuchMethodException.class,
+                () -> ConstructorUtils.invokeExactConstructor(TestBean.class,NumberUtils.BYTE_ONE));
+        assertThrows(
+                NoSuchMethodException.class,
+                () -> ConstructorUtils.invokeExactConstructor(TestBean.class, NumberUtils.LONG_ONE));
+        assertThrows(
+                NoSuchMethodException.class,
+                () -> ConstructorUtils.invokeExactConstructor(TestBean.class, Boolean.TRUE));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/reflect/ConstructorUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/reflect/ConstructorUtilsTest.java
@@ -130,7 +130,7 @@ public class ConstructorUtilsTest {
 
 
     @BeforeEach
-    public void setUp() throws Exception {
+    public void setUp() {
         classCache.clear();
     }
 
@@ -207,7 +207,7 @@ public class ConstructorUtilsTest {
     }
 
     @Test
-    public void testGetAccessibleConstructorFromDescription() throws Exception {
+    public void testGetAccessibleConstructorFromDescription() {
         assertNotNull(ConstructorUtils.getAccessibleConstructor(Object.class,
                 ArrayUtils.EMPTY_CLASS_ARRAY));
         assertNull(ConstructorUtils.getAccessibleConstructor(
@@ -215,7 +215,7 @@ public class ConstructorUtilsTest {
     }
 
     @Test
-    public void testGetMatchingAccessibleMethod() throws Exception {
+    public void testGetMatchingAccessibleMethod() {
         expectMatchingAccessibleConstructorParameterTypes(TestBean.class,
                 ArrayUtils.EMPTY_CLASS_ARRAY, ArrayUtils.EMPTY_CLASS_ARRAY);
         expectMatchingAccessibleConstructorParameterTypes(TestBean.class, null,

--- a/src/test/java/org/apache/commons/lang3/reflect/FieldUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/reflect/FieldUtilsTest.java
@@ -43,7 +43,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
@@ -373,47 +372,35 @@ public class FieldUtilsTest {
         assertEquals(Foo.VALUE, FieldUtils.readStaticField(PrivatelyShadowedChild.class, "VALUE"));
         assertEquals(Foo.VALUE, FieldUtils.readStaticField(PublicChild.class, "VALUE"));
 
-        try {
-            FieldUtils.readStaticField(null, "none");
-            fail("null class should cause an IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // expected
-        }
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FieldUtils.readStaticField(null, "none"),
+                "null class should cause an IllegalArgumentException");
 
-        try {
-            FieldUtils.readStaticField(Foo.class, null);
-            fail("null field name should cause an IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // expected
-        }
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FieldUtils.readStaticField(Foo.class, null),
+                "null field name should cause an IllegalArgumentException");
 
-        try {
-            FieldUtils.readStaticField(Foo.class, "");
-            fail("empty field name should cause an IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // expected
-        }
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FieldUtils.readStaticField(Foo.class, ""),
+                "empty field name should cause an IllegalArgumentException");
 
-        try {
-            FieldUtils.readStaticField(Foo.class, " ");
-            fail("blank field name should cause an IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // expected
-        }
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FieldUtils.readStaticField(Foo.class, " "),
+                "blank field name should cause an IllegalArgumentException");
 
-        try {
-            FieldUtils.readStaticField(Foo.class, "does_not_exist");
-            fail("a field that doesn't exist should cause an IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // expected
-        }
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FieldUtils.readStaticField(Foo.class, "does_not_exist"),
+                "a field that doesn't exist should cause an IllegalArgumentException");
 
-        try {
-            FieldUtils.readStaticField(PublicChild.class, "s");
-            fail("non-static field should cause an IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // expected
-        }
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FieldUtils.readStaticField(PublicChild.class, "s"),
+                "non-static field should cause an IllegalArgumentException");
     }
 
     @Test
@@ -423,88 +410,60 @@ public class FieldUtilsTest {
         assertEquals(Foo.VALUE, FieldUtils.readStaticField(PrivatelyShadowedChild.class, "VALUE", true));
         assertEquals("child", FieldUtils.readStaticField(PublicChild.class, "VALUE", true));
 
-        try {
-            FieldUtils.readStaticField(null, "none", true);
-            fail("null class should cause an IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // expected
-        }
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FieldUtils.readStaticField(null, "none", true),
+                "null class should cause an IllegalArgumentException");
 
-        try {
-            FieldUtils.readStaticField(Foo.class, null, true);
-            fail("null field name should cause an IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // expected
-        }
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FieldUtils.readStaticField(Foo.class, null, true),
+                "null field name should cause an IllegalArgumentException");
 
-        try {
-            FieldUtils.readStaticField(Foo.class, "", true);
-            fail("empty field name should cause an IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // expected
-        }
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FieldUtils.readStaticField(Foo.class, "", true),
+                "empty field name should cause an IllegalArgumentException");
 
-        try {
-            FieldUtils.readStaticField(Foo.class, " ", true);
-            fail("blank field name should cause an IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // expected
-        }
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FieldUtils.readStaticField(Foo.class, " ", true),
+                "blank field name should cause an IllegalArgumentException");
 
-        try {
-            FieldUtils.readStaticField(Foo.class, "does_not_exist", true);
-            fail("a field that doesn't exist should cause an IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // expected
-        }
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FieldUtils.readStaticField(Foo.class, "does_not_exist", true),
+                "a field that doesn't exist should cause an IllegalArgumentException");
 
-        try {
-            FieldUtils.readStaticField(PublicChild.class, "s", false);
-            fail("non-static field should cause an IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // expected
-        }
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FieldUtils.readStaticField(PublicChild.class, "s", false),
+                "non-static field should cause an IllegalArgumentException");
     }
 
     @Test
     public void testReadDeclaredNamedStaticField() throws Exception {
         assertEquals(Foo.VALUE, FieldUtils.readDeclaredStaticField(Foo.class, "VALUE"));
-        try {
-            FieldUtils.readDeclaredStaticField(PublicChild.class, "VALUE");
-            fail("expected IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // pass
-        }
-        try {
-            FieldUtils.readDeclaredStaticField(PubliclyShadowedChild.class, "VALUE");
-            fail("expected IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // pass
-        }
-        try {
-            FieldUtils.readDeclaredStaticField(PrivatelyShadowedChild.class, "VALUE");
-            fail("expected IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // pass
-        }
+        assertThrows(
+                IllegalArgumentException.class, () -> FieldUtils.readDeclaredStaticField(PublicChild.class, "VALUE"));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FieldUtils.readDeclaredStaticField(PubliclyShadowedChild.class, "VALUE"));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FieldUtils.readDeclaredStaticField(PrivatelyShadowedChild.class, "VALUE"));
     }
 
     @Test
     public void testReadDeclaredNamedStaticFieldForceAccess() throws Exception {
         assertEquals(Foo.VALUE, FieldUtils.readDeclaredStaticField(Foo.class, "VALUE", true));
         assertEquals("child", FieldUtils.readDeclaredStaticField(PublicChild.class, "VALUE", true));
-        try {
-            FieldUtils.readDeclaredStaticField(PubliclyShadowedChild.class, "VALUE", true);
-            fail("expected IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // pass
-        }
-        try {
-            FieldUtils.readDeclaredStaticField(PrivatelyShadowedChild.class, "VALUE", true);
-            fail("expected IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // pass
-        }
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FieldUtils.readDeclaredStaticField(PubliclyShadowedChild.class, "VALUE", true));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FieldUtils.readDeclaredStaticField(PrivatelyShadowedChild.class, "VALUE", true));
     }
 
     @Test
@@ -526,12 +485,10 @@ public class FieldUtilsTest {
         assertEquals(D0, FieldUtils.readField(parentD, publiclyShadowedChild));
         assertEquals(D0, FieldUtils.readField(parentD, privatelyShadowedChild));
 
-        try {
-            FieldUtils.readField(null, publicChild);
-            fail("a null field should cause an IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // expected
-        }
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FieldUtils.readField(null, publicChild),
+                "a null field should cause an IllegalArgumentException");
     }
 
     @Test
@@ -557,12 +514,10 @@ public class FieldUtilsTest {
         assertEquals(D0, FieldUtils.readField(parentD, publiclyShadowedChild, true));
         assertEquals(D0, FieldUtils.readField(parentD, privatelyShadowedChild, true));
 
-        try {
-            FieldUtils.readField(null, publicChild, true);
-            fail("a null field should cause an IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // expected
-        }
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FieldUtils.readField(null, publicChild, true),
+                "a null field should cause an IllegalArgumentException");
     }
 
     @Test
@@ -571,73 +526,36 @@ public class FieldUtilsTest {
         assertEquals("ss", FieldUtils.readField(publiclyShadowedChild, "s"));
         assertEquals("s", FieldUtils.readField(privatelyShadowedChild, "s"));
 
-        try {
-            FieldUtils.readField(publicChild, null);
-            fail("a null field name should cause an IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // expected
-        }
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FieldUtils.readField(publicChild, null),
+                "a null field name should cause an IllegalArgumentException");
 
-        try {
-            FieldUtils.readField(publicChild, "");
-            fail("an empty field name should cause an IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // expected
-        }
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FieldUtils.readField(publicChild, ""),
+                "an empty field name should cause an IllegalArgumentException");
 
-        try {
-            FieldUtils.readField(publicChild, " ");
-            fail("a blank field name should cause an IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // expected
-        }
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FieldUtils.readField(publicChild, " "),
+                "a blank field name should cause an IllegalArgumentException");
 
-        try {
-            FieldUtils.readField((Object) null, "none");
-            fail("a null target should cause an IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // expected
-        }
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FieldUtils.readField((Object) null, "none"),
+                "a null target should cause an IllegalArgumentException");
 
-        try {
-            FieldUtils.readField(publicChild, "b");
-            fail("expected IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // pass
-        }
+        assertThrows(IllegalArgumentException.class, () -> FieldUtils.readField(publicChild, "b"));
+
         assertEquals(Boolean.TRUE, FieldUtils.readField(publiclyShadowedChild, "b"));
-        try {
-            FieldUtils.readField(privatelyShadowedChild, "b");
-            fail("expected IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // pass
-        }
-        try {
-            FieldUtils.readField(publicChild, "i");
-            fail("expected IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // pass
-        }
+        assertThrows( IllegalArgumentException.class, () -> FieldUtils.readField(privatelyShadowedChild, "b"));
+        assertThrows(IllegalArgumentException.class, () -> FieldUtils.readField(publicChild, "i"));
         assertEquals(I1, FieldUtils.readField(publiclyShadowedChild, "i"));
-        try {
-            FieldUtils.readField(privatelyShadowedChild, "i");
-            fail("expected IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // pass
-        }
-        try {
-            FieldUtils.readField(publicChild, "d");
-            fail("expected IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // pass
-        }
+        assertThrows(IllegalArgumentException.class, () -> FieldUtils.readField(privatelyShadowedChild, "i"));
+        assertThrows(IllegalArgumentException.class, () -> FieldUtils.readField(publicChild, "d"));
         assertEquals(D1, FieldUtils.readField(publiclyShadowedChild, "d"));
-        try {
-            FieldUtils.readField(privatelyShadowedChild, "d");
-            fail("expected IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // pass
-        }
+        assertThrows(IllegalArgumentException.class, () -> FieldUtils.readField(privatelyShadowedChild, "d"));
     }
 
     @Test
@@ -655,179 +573,95 @@ public class FieldUtilsTest {
         assertEquals(D1, FieldUtils.readField(publiclyShadowedChild, "d", true));
         assertEquals(D1, FieldUtils.readField(privatelyShadowedChild, "d", true));
 
-        try {
-            FieldUtils.readField(publicChild, null, true);
-            fail("a null field name should cause an IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // expected
-        }
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FieldUtils.readField(publicChild, null, true),
+                "a null field name should cause an IllegalArgumentException");
 
-        try {
-            FieldUtils.readField(publicChild, "", true);
-            fail("an empty field name should cause an IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // expected
-        }
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FieldUtils.readField(publicChild, "", true),
+                "an empty field name should cause an IllegalArgumentException");
 
-        try {
-            FieldUtils.readField(publicChild, " ", true);
-            fail("a blank field name should cause an IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // expected
-        }
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FieldUtils.readField(publicChild, " ", true),
+                "a blank field name should cause an IllegalArgumentException");
 
-        try {
-            FieldUtils.readField((Object) null, "none", true);
-            fail("a null target should cause an IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // expected
-        }
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FieldUtils.readField((Object) null, "none", true),
+                "a null target should cause an IllegalArgumentException");
     }
 
     @Test
     public void testReadDeclaredNamedField() throws Exception {
-        try {
-            FieldUtils.readDeclaredField(publicChild, null);
-            fail("a null field name should cause an IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // expected
-        }
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FieldUtils.readDeclaredField(publicChild, null),
+                "a null field name should cause an IllegalArgumentException");
 
-        try {
-            FieldUtils.readDeclaredField(publicChild, "");
-            fail("an empty field name should cause an IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // expected
-        }
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FieldUtils.readDeclaredField(publicChild, ""),
+                "an empty field name should cause an IllegalArgumentException");
 
-        try {
-            FieldUtils.readDeclaredField(publicChild, " ");
-            fail("a blank field name should cause an IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // expected
-        }
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FieldUtils.readDeclaredField(publicChild, " "),
+                "a blank field name should cause an IllegalArgumentException");
 
-        try {
-            FieldUtils.readDeclaredField(null, "none");
-            fail("a null target should cause an IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // expected
-        }
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FieldUtils.readDeclaredField(null, "none"),
+                "a null target should cause an IllegalArgumentException");
 
-        try {
-            FieldUtils.readDeclaredField(publicChild, "s");
-            fail("expected IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // pass
-        }
+        assertThrows(IllegalArgumentException.class, () -> FieldUtils.readDeclaredField(publicChild, "s"));
         assertEquals("ss", FieldUtils.readDeclaredField(publiclyShadowedChild, "s"));
-        try {
-            FieldUtils.readDeclaredField(privatelyShadowedChild, "s");
-            fail("expected IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // pass
-        }
-        try {
-            FieldUtils.readDeclaredField(publicChild, "b");
-            fail("expected IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // pass
-        }
+        assertThrows(IllegalArgumentException.class, () -> FieldUtils.readDeclaredField(privatelyShadowedChild, "s"));
+        assertThrows(IllegalArgumentException.class, () -> FieldUtils.readDeclaredField(publicChild, "b"));
         assertEquals(Boolean.TRUE, FieldUtils.readDeclaredField(publiclyShadowedChild, "b"));
-        try {
-            FieldUtils.readDeclaredField(privatelyShadowedChild, "b");
-            fail("expected IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // pass
-        }
-        try {
-            FieldUtils.readDeclaredField(publicChild, "i");
-            fail("expected IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // pass
-        }
+        assertThrows(IllegalArgumentException.class, () -> FieldUtils.readDeclaredField(privatelyShadowedChild, "b"));
+        assertThrows(IllegalArgumentException.class, () -> FieldUtils.readDeclaredField(publicChild, "i"));
         assertEquals(I1, FieldUtils.readDeclaredField(publiclyShadowedChild, "i"));
-        try {
-            FieldUtils.readDeclaredField(privatelyShadowedChild, "i");
-            fail("expected IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // pass
-        }
-        try {
-            FieldUtils.readDeclaredField(publicChild, "d");
-            fail("expected IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // pass
-        }
+        assertThrows(IllegalArgumentException.class, () -> FieldUtils.readDeclaredField(privatelyShadowedChild, "i"));
+        assertThrows(IllegalArgumentException.class, () -> FieldUtils.readDeclaredField(publicChild, "d"));
         assertEquals(D1, FieldUtils.readDeclaredField(publiclyShadowedChild, "d"));
-        try {
-            FieldUtils.readDeclaredField(privatelyShadowedChild, "d");
-            fail("expected IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // pass
-        }
+        assertThrows(IllegalArgumentException.class, () -> FieldUtils.readDeclaredField(privatelyShadowedChild, "d"));
     }
 
     @Test
     public void testReadDeclaredNamedFieldForceAccess() throws Exception {
-        try {
-            FieldUtils.readDeclaredField(publicChild, null, true);
-            fail("a null field name should cause an IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // expected
-        }
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FieldUtils.readDeclaredField(publicChild, null, true),
+                "a null field name should cause an IllegalArgumentException");
 
-        try {
-            FieldUtils.readDeclaredField(publicChild, "", true);
-            fail("an empty field name should cause an IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // expected
-        }
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FieldUtils.readDeclaredField(publicChild, "", true),
+                "an empty field name should cause an IllegalArgumentException");
 
-        try {
-            FieldUtils.readDeclaredField(publicChild, " ", true);
-            fail("a blank field name should cause an IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // expected
-        }
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FieldUtils.readDeclaredField(publicChild, " ", true),
+                "a blank field name should cause an IllegalArgumentException");
 
-        try {
-            FieldUtils.readDeclaredField(null, "none", true);
-            fail("a null target should cause an IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // expected
-        }
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FieldUtils.readDeclaredField(null, "none", true),
+                "a null target should cause an IllegalArgumentException");
 
-        try {
-            FieldUtils.readDeclaredField(publicChild, "s", true);
-            fail("expected IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // pass
-        }
+        assertThrows(IllegalArgumentException.class, () -> FieldUtils.readDeclaredField(publicChild, "s", true));
         assertEquals("ss", FieldUtils.readDeclaredField(publiclyShadowedChild, "s", true));
         assertEquals("ss", FieldUtils.readDeclaredField(privatelyShadowedChild, "s", true));
-        try {
-            FieldUtils.readDeclaredField(publicChild, "b", true);
-            fail("expected IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // pass
-        }
+        assertThrows(IllegalArgumentException.class, () -> FieldUtils.readDeclaredField(publicChild, "b", true));
         assertEquals(Boolean.TRUE, FieldUtils.readDeclaredField(publiclyShadowedChild, "b", true));
         assertEquals(Boolean.TRUE, FieldUtils.readDeclaredField(privatelyShadowedChild, "b", true));
-        try {
-            FieldUtils.readDeclaredField(publicChild, "i", true);
-            fail("expected IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // pass
-        }
+        assertThrows(IllegalArgumentException.class, () -> FieldUtils.readDeclaredField(publicChild, "i", true));
         assertEquals(I1, FieldUtils.readDeclaredField(publiclyShadowedChild, "i", true));
         assertEquals(I1, FieldUtils.readDeclaredField(privatelyShadowedChild, "i", true));
-        try {
-            FieldUtils.readDeclaredField(publicChild, "d", true);
-            fail("expected IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // pass
-        }
+        assertThrows(IllegalArgumentException.class, () -> FieldUtils.readDeclaredField(publicChild, "d", true));
         assertEquals(D1, FieldUtils.readDeclaredField(publiclyShadowedChild, "d", true));
         assertEquals(D1, FieldUtils.readDeclaredField(privatelyShadowedChild, "d", true));
     }
@@ -837,55 +671,27 @@ public class FieldUtilsTest {
         Field field = StaticContainer.class.getDeclaredField("mutablePublic");
         FieldUtils.writeStaticField(field, "new");
         assertEquals("new", StaticContainer.mutablePublic);
-        field = StaticContainer.class.getDeclaredField("mutableProtected");
-        try {
-            FieldUtils.writeStaticField(field, "new");
-            fail("Expected IllegalAccessException");
-        } catch (final IllegalAccessException e) {
-            // pass
-        }
-        field = StaticContainer.class.getDeclaredField("mutablePackage");
-        try {
-            FieldUtils.writeStaticField(field, "new");
-            fail("Expected IllegalAccessException");
-        } catch (final IllegalAccessException e) {
-            // pass
-        }
-        field = StaticContainer.class.getDeclaredField("mutablePrivate");
-        try {
-            FieldUtils.writeStaticField(field, "new");
-            fail("Expected IllegalAccessException");
-        } catch (final IllegalAccessException e) {
-            // pass
-        }
-        field = StaticContainer.class.getDeclaredField("IMMUTABLE_PUBLIC");
-        try {
-            FieldUtils.writeStaticField(field, "new");
-            fail("Expected IllegalAccessException");
-        } catch (final IllegalAccessException e) {
-            // pass
-        }
-        field = StaticContainer.class.getDeclaredField("IMMUTABLE_PROTECTED");
-        try {
-            FieldUtils.writeStaticField(field, "new");
-            fail("Expected IllegalAccessException");
-        } catch (final IllegalAccessException e) {
-            // pass
-        }
-        field = StaticContainer.class.getDeclaredField("IMMUTABLE_PACKAGE");
-        try {
-            FieldUtils.writeStaticField(field, "new");
-            fail("Expected IllegalAccessException");
-        } catch (final IllegalAccessException e) {
-            // pass
-        }
-        field = StaticContainer.class.getDeclaredField("IMMUTABLE_PRIVATE");
-        try {
-            FieldUtils.writeStaticField(field, "new");
-            fail("Expected IllegalAccessException");
-        } catch (final IllegalAccessException e) {
-            // pass
-        }
+        assertThrows(
+                IllegalAccessException.class,
+                () -> FieldUtils.writeStaticField(StaticContainer.class.getDeclaredField("mutableProtected"), "new"));
+        assertThrows(
+                IllegalAccessException.class,
+                () -> FieldUtils.writeStaticField(StaticContainer.class.getDeclaredField("mutablePackage"), "new"));
+        assertThrows(
+                IllegalAccessException.class,
+                () -> FieldUtils.writeStaticField(StaticContainer.class.getDeclaredField("mutablePrivate"), "new"));
+        assertThrows(
+                IllegalAccessException.class,
+                () -> FieldUtils.writeStaticField(StaticContainer.class.getDeclaredField("IMMUTABLE_PUBLIC"), "new"));
+        assertThrows(
+                IllegalAccessException.class,
+                () -> FieldUtils.writeStaticField(StaticContainer.class.getDeclaredField("IMMUTABLE_PROTECTED"), "new"));
+        assertThrows(
+                IllegalAccessException.class,
+                () -> FieldUtils.writeStaticField(StaticContainer.class.getDeclaredField("IMMUTABLE_PACKAGE"), "new"));
+        assertThrows(
+                IllegalAccessException.class,
+                () -> FieldUtils.writeStaticField(StaticContainer.class.getDeclaredField("IMMUTABLE_PRIVATE"), "new"));
     }
 
     @Test
@@ -902,82 +708,45 @@ public class FieldUtilsTest {
         field = StaticContainer.class.getDeclaredField("mutablePrivate");
         FieldUtils.writeStaticField(field, "new", true);
         assertEquals("new", StaticContainer.getMutablePrivate());
-        field = StaticContainer.class.getDeclaredField("IMMUTABLE_PUBLIC");
-        try {
-            FieldUtils.writeStaticField(field, "new", true);
-            fail("Expected IllegalAccessException");
-        } catch (final IllegalAccessException e) {
-            // pass
-        }
-        field = StaticContainer.class.getDeclaredField("IMMUTABLE_PROTECTED");
-        try {
-            FieldUtils.writeStaticField(field, "new", true);
-            fail("Expected IllegalAccessException");
-        } catch (final IllegalAccessException e) {
-            // pass
-        }
-        field = StaticContainer.class.getDeclaredField("IMMUTABLE_PACKAGE");
-        try {
-            FieldUtils.writeStaticField(field, "new", true);
-            fail("Expected IllegalAccessException");
-        } catch (final IllegalAccessException e) {
-            // pass
-        }
-        field = StaticContainer.class.getDeclaredField("IMMUTABLE_PRIVATE");
-        try {
-            FieldUtils.writeStaticField(field, "new", true);
-            fail("Expected IllegalAccessException");
-        } catch (final IllegalAccessException e) {
-            // pass
-        }
+        assertThrows(
+                IllegalAccessException.class,
+                () -> FieldUtils.writeStaticField(StaticContainer.class.getDeclaredField("IMMUTABLE_PUBLIC"), "new", true));
+        assertThrows(
+                IllegalAccessException.class,
+                () -> FieldUtils.writeStaticField(StaticContainer.class.getDeclaredField("IMMUTABLE_PROTECTED"), "new", true));
+        assertThrows(
+                IllegalAccessException.class,
+                () -> FieldUtils.writeStaticField(StaticContainer.class.getDeclaredField("IMMUTABLE_PACKAGE"), "new", true));
+        assertThrows(
+                IllegalAccessException.class,
+                () -> FieldUtils.writeStaticField(StaticContainer.class.getDeclaredField("IMMUTABLE_PRIVATE"), "new", true));
     }
 
     @Test
     public void testWriteNamedStaticField() throws Exception {
         FieldUtils.writeStaticField(StaticContainerChild.class, "mutablePublic", "new");
         assertEquals("new", StaticContainer.mutablePublic);
-        try {
-            FieldUtils.writeStaticField(StaticContainerChild.class, "mutableProtected", "new");
-            fail("Expected IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // pass
-        }
-        try {
-            FieldUtils.writeStaticField(StaticContainerChild.class, "mutablePackage", "new");
-            fail("Expected IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // pass
-        }
-        try {
-            FieldUtils.writeStaticField(StaticContainerChild.class, "mutablePrivate", "new");
-            fail("Expected IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // pass
-        }
-        try {
-            FieldUtils.writeStaticField(StaticContainerChild.class, "IMMUTABLE_PUBLIC", "new");
-            fail("Expected IllegalAccessException");
-        } catch (final IllegalAccessException e) {
-            // pass
-        }
-        try {
-            FieldUtils.writeStaticField(StaticContainerChild.class, "IMMUTABLE_PROTECTED", "new");
-            fail("Expected IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // pass
-        }
-        try {
-            FieldUtils.writeStaticField(StaticContainerChild.class, "IMMUTABLE_PACKAGE", "new");
-            fail("Expected IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // pass
-        }
-        try {
-            FieldUtils.writeStaticField(StaticContainerChild.class, "IMMUTABLE_PRIVATE", "new");
-            fail("Expected IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // pass
-        }
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FieldUtils.writeStaticField(StaticContainerChild.class, "mutableProtected", "new"));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FieldUtils.writeStaticField(StaticContainerChild.class, "mutablePackage", "new"));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FieldUtils.writeStaticField(StaticContainerChild.class, "mutablePrivate", "new"));
+        assertThrows(
+                IllegalAccessException.class,
+                () -> FieldUtils.writeStaticField(StaticContainerChild.class, "IMMUTABLE_PUBLIC", "new"));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FieldUtils.writeStaticField(StaticContainerChild.class, "IMMUTABLE_PROTECTED", "new"));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FieldUtils.writeStaticField(StaticContainerChild.class, "IMMUTABLE_PACKAGE", "new"));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FieldUtils.writeStaticField(StaticContainerChild.class, "IMMUTABLE_PRIVATE", "new"));
     }
 
     @Test
@@ -990,78 +759,45 @@ public class FieldUtilsTest {
         assertEquals("new", StaticContainer.getMutablePackage());
         FieldUtils.writeStaticField(StaticContainerChild.class, "mutablePrivate", "new", true);
         assertEquals("new", StaticContainer.getMutablePrivate());
-        try {
-            FieldUtils.writeStaticField(StaticContainerChild.class, "IMMUTABLE_PUBLIC", "new", true);
-            fail("Expected IllegalAccessException");
-        } catch (final IllegalAccessException e) {
-            // pass
-        }
-        try {
-            FieldUtils.writeStaticField(StaticContainerChild.class, "IMMUTABLE_PROTECTED", "new", true);
-            fail("Expected IllegalAccessException");
-        } catch (final IllegalAccessException e) {
-            // pass
-        }
-        try {
-            FieldUtils.writeStaticField(StaticContainerChild.class, "IMMUTABLE_PACKAGE", "new", true);
-            fail("Expected IllegalAccessException");
-        } catch (final IllegalAccessException e) {
-            // pass
-        }
-        try {
-            FieldUtils.writeStaticField(StaticContainerChild.class, "IMMUTABLE_PRIVATE", "new", true);
-            fail("Expected IllegalAccessException");
-        } catch (final IllegalAccessException e) {
-            // pass
-        }
+        assertThrows(
+                IllegalAccessException.class,
+                () -> FieldUtils.writeStaticField(StaticContainerChild.class, "IMMUTABLE_PUBLIC", "new", true));
+        assertThrows(
+                IllegalAccessException.class,
+                () -> FieldUtils.writeStaticField(StaticContainerChild.class, "IMMUTABLE_PROTECTED", "new", true));
+        assertThrows(
+                IllegalAccessException.class,
+                () -> FieldUtils.writeStaticField(StaticContainerChild.class, "IMMUTABLE_PACKAGE", "new", true));
+        assertThrows(
+                IllegalAccessException.class,
+                () -> FieldUtils.writeStaticField(StaticContainerChild.class, "IMMUTABLE_PRIVATE", "new", true));
     }
 
     @Test
     public void testWriteDeclaredNamedStaticField() throws Exception {
         FieldUtils.writeStaticField(StaticContainer.class, "mutablePublic", "new");
         assertEquals("new", StaticContainer.mutablePublic);
-        try {
-            FieldUtils.writeDeclaredStaticField(StaticContainer.class, "mutableProtected", "new");
-            fail("Expected IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // pass
-        }
-        try {
-            FieldUtils.writeDeclaredStaticField(StaticContainer.class, "mutablePackage", "new");
-            fail("Expected IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // pass
-        }
-        try {
-            FieldUtils.writeDeclaredStaticField(StaticContainer.class, "mutablePrivate", "new");
-            fail("Expected IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // pass
-        }
-        try {
-            FieldUtils.writeDeclaredStaticField(StaticContainer.class, "IMMUTABLE_PUBLIC", "new");
-            fail("Expected IllegalAccessException");
-        } catch (final IllegalAccessException e) {
-            // pass
-        }
-        try {
-            FieldUtils.writeDeclaredStaticField(StaticContainer.class, "IMMUTABLE_PROTECTED", "new");
-            fail("Expected IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // pass
-        }
-        try {
-            FieldUtils.writeDeclaredStaticField(StaticContainer.class, "IMMUTABLE_PACKAGE", "new");
-            fail("Expected IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // pass
-        }
-        try {
-            FieldUtils.writeDeclaredStaticField(StaticContainer.class, "IMMUTABLE_PRIVATE", "new");
-            fail("Expected IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // pass
-        }
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FieldUtils.writeDeclaredStaticField(StaticContainer.class, "mutableProtected", "new"));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FieldUtils.writeDeclaredStaticField(StaticContainer.class, "mutablePackage", "new"));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FieldUtils.writeDeclaredStaticField(StaticContainer.class, "mutablePrivate", "new"));
+        assertThrows(
+                IllegalAccessException.class,
+                () -> FieldUtils.writeDeclaredStaticField(StaticContainer.class, "IMMUTABLE_PUBLIC", "new"));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FieldUtils.writeDeclaredStaticField(StaticContainer.class, "IMMUTABLE_PROTECTED", "new"));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FieldUtils.writeDeclaredStaticField(StaticContainer.class, "IMMUTABLE_PACKAGE", "new"));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FieldUtils.writeDeclaredStaticField(StaticContainer.class, "IMMUTABLE_PRIVATE", "new"));
     }
 
     @Test
@@ -1074,30 +810,18 @@ public class FieldUtilsTest {
         assertEquals("new", StaticContainer.getMutablePackage());
         FieldUtils.writeDeclaredStaticField(StaticContainer.class, "mutablePrivate", "new", true);
         assertEquals("new", StaticContainer.getMutablePrivate());
-        try {
-            FieldUtils.writeDeclaredStaticField(StaticContainer.class, "IMMUTABLE_PUBLIC", "new", true);
-            fail("Expected IllegalAccessException");
-        } catch (final IllegalAccessException e) {
-            // pass
-        }
-        try {
-            FieldUtils.writeDeclaredStaticField(StaticContainer.class, "IMMUTABLE_PROTECTED", "new", true);
-            fail("Expected IllegalAccessException");
-        } catch (final IllegalAccessException e) {
-            // pass
-        }
-        try {
-            FieldUtils.writeDeclaredStaticField(StaticContainer.class, "IMMUTABLE_PACKAGE", "new", true);
-            fail("Expected IllegalAccessException");
-        } catch (final IllegalAccessException e) {
-            // pass
-        }
-        try {
-            FieldUtils.writeDeclaredStaticField(StaticContainer.class, "IMMUTABLE_PRIVATE", "new", true);
-            fail("Expected IllegalAccessException");
-        } catch (final IllegalAccessException e) {
-            // pass
-        }
+        assertThrows(
+                IllegalAccessException.class,
+                () -> FieldUtils.writeDeclaredStaticField(StaticContainer.class, "IMMUTABLE_PUBLIC", "new", true));
+        assertThrows(
+                IllegalAccessException.class,
+                () -> FieldUtils.writeDeclaredStaticField(StaticContainer.class, "IMMUTABLE_PROTECTED", "new", true));
+        assertThrows(
+                IllegalAccessException.class,
+                () -> FieldUtils.writeDeclaredStaticField(StaticContainer.class, "IMMUTABLE_PACKAGE", "new", true));
+        assertThrows(
+                IllegalAccessException.class,
+                () -> FieldUtils.writeDeclaredStaticField(StaticContainer.class, "IMMUTABLE_PRIVATE", "new", true));
     }
 
     @Test
@@ -1105,27 +829,15 @@ public class FieldUtilsTest {
         Field field = parentClass.getDeclaredField("s");
         FieldUtils.writeField(field, publicChild, "S");
         assertEquals("S", field.get(publicChild));
-        field = parentClass.getDeclaredField("b");
-        try {
-            FieldUtils.writeField(field, publicChild, Boolean.TRUE);
-            fail("Expected IllegalAccessException");
-        } catch (final IllegalAccessException e) {
-            // pass
-        }
-        field = parentClass.getDeclaredField("i");
-        try {
-            FieldUtils.writeField(field, publicChild, Integer.valueOf(Integer.MAX_VALUE));
-            fail("Expected IllegalAccessException");
-        } catch (final IllegalAccessException e) {
-            // pass
-        }
-        field = parentClass.getDeclaredField("d");
-        try {
-            FieldUtils.writeField(field, publicChild, Double.valueOf(Double.MAX_VALUE));
-            fail("Expected IllegalAccessException");
-        } catch (final IllegalAccessException e) {
-            // pass
-        }
+        assertThrows(
+                IllegalAccessException.class,
+                () -> FieldUtils.writeField(parentClass.getDeclaredField("b"), publicChild, Boolean.TRUE));
+        assertThrows(
+                IllegalAccessException.class,
+                () -> FieldUtils.writeField(parentClass.getDeclaredField("i"), publicChild, Integer.valueOf(Integer.MAX_VALUE)));
+        assertThrows(
+                IllegalAccessException.class,
+                () -> FieldUtils.writeField(parentClass.getDeclaredField("d"), publicChild, Double.valueOf(Double.MAX_VALUE)));
     }
 
     @Test
@@ -1148,24 +860,10 @@ public class FieldUtilsTest {
     public void testWriteNamedField() throws Exception {
         FieldUtils.writeField(publicChild, "s", "S");
         assertEquals("S", FieldUtils.readField(publicChild, "s"));
-        try {
-            FieldUtils.writeField(publicChild, "b", Boolean.TRUE);
-            fail("Expected IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // pass
-        }
-        try {
-            FieldUtils.writeField(publicChild, "i", Integer.valueOf(1));
-            fail("Expected IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // pass
-        }
-        try {
-            FieldUtils.writeField(publicChild, "d", Double.valueOf(1.0));
-            fail("Expected IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // pass
-        }
+        assertThrows(IllegalArgumentException.class, () -> FieldUtils.writeField(publicChild, "b", Boolean.TRUE));
+        assertThrows(IllegalArgumentException.class, () -> FieldUtils.writeField(publicChild, "i", Integer.valueOf(1)));
+        assertThrows(
+                IllegalArgumentException.class, () -> FieldUtils.writeField(publicChild, "d", Double.valueOf(1.0)));
 
         FieldUtils.writeField(publiclyShadowedChild, "s", "S");
         assertEquals("S", FieldUtils.readField(publiclyShadowedChild, "s"));
@@ -1178,24 +876,15 @@ public class FieldUtilsTest {
 
         FieldUtils.writeField(privatelyShadowedChild, "s", "S");
         assertEquals("S", FieldUtils.readField(privatelyShadowedChild, "s"));
-        try {
-            FieldUtils.writeField(privatelyShadowedChild, "b", Boolean.TRUE);
-            fail("Expected IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // pass
-        }
-        try {
-            FieldUtils.writeField(privatelyShadowedChild, "i", Integer.valueOf(1));
-            fail("Expected IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // pass
-        }
-        try {
-            FieldUtils.writeField(privatelyShadowedChild, "d", Double.valueOf(1.0));
-            fail("Expected IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // pass
-        }
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FieldUtils.writeField(privatelyShadowedChild, "b", Boolean.TRUE));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FieldUtils.writeField(privatelyShadowedChild, "i", Integer.valueOf(1)));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FieldUtils.writeField(privatelyShadowedChild, "d", Double.valueOf(1.0)));
     }
 
     @Test
@@ -1230,30 +919,15 @@ public class FieldUtilsTest {
 
     @Test
     public void testWriteDeclaredNamedField() throws Exception {
-        try {
-            FieldUtils.writeDeclaredField(publicChild, "s", "S");
-            fail("Expected IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // pass
-        }
-        try {
-            FieldUtils.writeDeclaredField(publicChild, "b", Boolean.TRUE);
-            fail("Expected IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // pass
-        }
-        try {
-            FieldUtils.writeDeclaredField(publicChild, "i", Integer.valueOf(1));
-            fail("Expected IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // pass
-        }
-        try {
-            FieldUtils.writeDeclaredField(publicChild, "d", Double.valueOf(1.0));
-            fail("Expected IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // pass
-        }
+        assertThrows(IllegalArgumentException.class, () -> FieldUtils.writeDeclaredField(publicChild, "s", "S"));
+        assertThrows(
+                IllegalArgumentException.class, () -> FieldUtils.writeDeclaredField(publicChild, "b", Boolean.TRUE));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FieldUtils.writeDeclaredField(publicChild, "i", Integer.valueOf(1)));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FieldUtils.writeDeclaredField(publicChild, "d", Double.valueOf(1.0)));
 
         FieldUtils.writeDeclaredField(publiclyShadowedChild, "s", "S");
         assertEquals("S", FieldUtils.readDeclaredField(publiclyShadowedChild, "s"));
@@ -1264,58 +938,31 @@ public class FieldUtilsTest {
         FieldUtils.writeDeclaredField(publiclyShadowedChild, "d", Double.valueOf(0.0));
         assertEquals(Double.valueOf(0.0), FieldUtils.readDeclaredField(publiclyShadowedChild, "d"));
 
-        try {
-            FieldUtils.writeDeclaredField(privatelyShadowedChild, "s", "S");
-            fail("Expected IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // pass
-        }
-        try {
-            FieldUtils.writeDeclaredField(privatelyShadowedChild, "b", Boolean.TRUE);
-            fail("Expected IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // pass
-        }
-        try {
-            FieldUtils.writeDeclaredField(privatelyShadowedChild, "i", Integer.valueOf(1));
-            fail("Expected IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // pass
-        }
-        try {
-            FieldUtils.writeDeclaredField(privatelyShadowedChild, "d", Double.valueOf(1.0));
-            fail("Expected IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // pass
-        }
+        assertThrows(
+                IllegalArgumentException.class, () -> FieldUtils.writeDeclaredField(privatelyShadowedChild, "s", "S"));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FieldUtils.writeDeclaredField(privatelyShadowedChild, "b", Boolean.TRUE));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FieldUtils.writeDeclaredField(privatelyShadowedChild, "i", Integer.valueOf(1)));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FieldUtils.writeDeclaredField(privatelyShadowedChild, "d", Double.valueOf(1.0)));
     }
 
     @Test
     public void testWriteDeclaredNamedFieldForceAccess() throws Exception {
-        try {
-            FieldUtils.writeDeclaredField(publicChild, "s", "S", true);
-            fail("Expected IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // pass
-        }
-        try {
-            FieldUtils.writeDeclaredField(publicChild, "b", Boolean.TRUE, true);
-            fail("Expected IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // pass
-        }
-        try {
-            FieldUtils.writeDeclaredField(publicChild, "i", Integer.valueOf(1), true);
-            fail("Expected IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // pass
-        }
-        try {
-            FieldUtils.writeDeclaredField(publicChild, "d", Double.valueOf(1.0), true);
-            fail("Expected IllegalArgumentException");
-        } catch (final IllegalArgumentException e) {
-            // pass
-        }
+        assertThrows(IllegalArgumentException.class, () -> FieldUtils.writeDeclaredField(publicChild, "s", "S", true));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FieldUtils.writeDeclaredField(publicChild, "b", Boolean.TRUE, true));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FieldUtils.writeDeclaredField(publicChild, "i", Integer.valueOf(1), true));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FieldUtils.writeDeclaredField(publicChild, "d", Double.valueOf(1.0), true));
 
         FieldUtils.writeDeclaredField(publiclyShadowedChild, "s", "S", true);
         assertEquals("S", FieldUtils.readDeclaredField(publiclyShadowedChild, "s", true));

--- a/src/test/java/org/apache/commons/lang3/reflect/FieldUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/reflect/FieldUtilsTest.java
@@ -335,7 +335,7 @@ public class FieldUtilsTest {
     }
 
     @Test
-    public void testReadStaticFieldIllegalArgumentException1() throws Exception {
+    public void testReadStaticFieldIllegalArgumentException1() {
         assertThrows(IllegalArgumentException.class, () -> FieldUtils.readStaticField(null));
     }
 
@@ -354,12 +354,12 @@ public class FieldUtilsTest {
     }
 
     @Test
-    public void testReadStaticFieldForceAccessIllegalArgumentException1() throws Exception {
+    public void testReadStaticFieldForceAccessIllegalArgumentException1() {
         assertThrows(IllegalArgumentException.class, () -> FieldUtils.readStaticField(null, true));
     }
 
     @Test
-    public void testReadStaticFieldForceAccessIllegalArgumentException2() throws Exception {
+    public void testReadStaticFieldForceAccessIllegalArgumentException2() {
         final Field nonStaticField = FieldUtils.getField(PublicChild.class, "s", true);
         assumeTrue(nonStaticField != null);
         assertThrows(IllegalArgumentException.class, () -> FieldUtils.readStaticField(nonStaticField));

--- a/src/test/java/org/apache/commons/lang3/reflect/MethodUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/reflect/MethodUtilsTest.java
@@ -28,7 +28,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
@@ -435,12 +434,7 @@ public class MethodUtilsTest {
         assertEquals("foo(long...)", MethodUtils.invokeMethod(testBean, "foo",
                 1L, 2L));
 
-        try {
-            MethodUtils.invokeMethod(testBean, "foo",
-                    1, 2);
-            fail("should throw NoSuchMethodException");
-        } catch (final NoSuchMethodException expected) {
-        }
+        assertThrows(NoSuchMethodException.class, () -> MethodUtils.invokeMethod(testBean, "foo", 1, 2));
 
         TestBean.verify(new ImmutablePair<>("String...", new String[]{"x", "y"}),
                 MethodUtils.invokeMethod(testBean, "varOverloadEcho", "x", "y"));
@@ -471,23 +465,14 @@ public class MethodUtilsTest {
                 "foo", new Object[]{NumberUtils.DOUBLE_ONE},
                 new Class[]{Double.TYPE}));
 
-        try {
-            MethodUtils
-                    .invokeExactMethod(testBean, "foo", NumberUtils.BYTE_ONE);
-            fail("should throw NoSuchMethodException");
-        } catch (final NoSuchMethodException e) {
-        }
-        try {
-            MethodUtils
-                    .invokeExactMethod(testBean, "foo", NumberUtils.LONG_ONE);
-            fail("should throw NoSuchMethodException");
-        } catch (final NoSuchMethodException e) {
-        }
-        try {
-            MethodUtils.invokeExactMethod(testBean, "foo", Boolean.TRUE);
-            fail("should throw NoSuchMethodException");
-        } catch (final NoSuchMethodException e) {
-        }
+        assertThrows(
+                NoSuchMethodException.class,
+                () -> MethodUtils.invokeExactMethod(testBean, "foo", NumberUtils.BYTE_ONE));
+
+        assertThrows(
+                NoSuchMethodException.class,
+                () -> MethodUtils.invokeExactMethod(testBean, "foo", NumberUtils.LONG_ONE));
+        assertThrows(NoSuchMethodException.class, () -> MethodUtils.invokeExactMethod(testBean, "foo", Boolean.TRUE));
     }
 
     @Test
@@ -526,11 +511,8 @@ public class MethodUtilsTest {
         TestBean.verify(new ImmutablePair<>("Number...", new Number[]{17, 23, 42}),
                 MethodUtils.invokeStaticMethod(TestBean.class, "varOverloadEchoStatic", 17, 23, 42));
 
-        try {
-            MethodUtils.invokeStaticMethod(TestBean.class, "does_not_exist");
-            fail("should throw NoSuchMethodException");
-        } catch (final NoSuchMethodException e) {
-        }
+        assertThrows(
+                NoSuchMethodException.class, () -> MethodUtils.invokeStaticMethod(TestBean.class, "does_not_exist"));
     }
 
     @Test
@@ -551,24 +533,15 @@ public class MethodUtilsTest {
                 TestBean.class, "bar", new Object[]{NumberUtils.DOUBLE_ONE},
                 new Class[]{Double.TYPE}));
 
-        try {
-            MethodUtils.invokeExactStaticMethod(TestBean.class, "bar",
-                    NumberUtils.BYTE_ONE);
-            fail("should throw NoSuchMethodException");
-        } catch (final NoSuchMethodException e) {
-        }
-        try {
-            MethodUtils.invokeExactStaticMethod(TestBean.class, "bar",
-                    NumberUtils.LONG_ONE);
-            fail("should throw NoSuchMethodException");
-        } catch (final NoSuchMethodException e) {
-        }
-        try {
-            MethodUtils.invokeExactStaticMethod(TestBean.class, "bar",
-                    Boolean.TRUE);
-            fail("should throw NoSuchMethodException");
-        } catch (final NoSuchMethodException e) {
-        }
+        assertThrows(
+                NoSuchMethodException.class,
+                () -> MethodUtils.invokeExactStaticMethod(TestBean.class, "bar", NumberUtils.BYTE_ONE));
+        assertThrows(
+                NoSuchMethodException.class,
+                () -> MethodUtils.invokeExactStaticMethod(TestBean.class, "bar", NumberUtils.LONG_ONE));
+        assertThrows(
+                NoSuchMethodException.class,
+                () -> MethodUtils.invokeExactStaticMethod(TestBean.class, "bar", Boolean.TRUE));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/reflect/MethodUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/reflect/MethodUtilsTest.java
@@ -317,7 +317,7 @@ public class MethodUtilsTest {
     private final Map<Class<?>, Class<?>[]> classCache = new HashMap<>();
 
     @BeforeEach
-    public void setUp() throws Exception {
+    public void setUp() {
         testBean = new TestBean();
         classCache.clear();
     }
@@ -328,7 +328,7 @@ public class MethodUtilsTest {
     }
 
     @Test
-    public void verifyJavaVarargsOverloadingResolution() throws Exception {
+    public void verifyJavaVarargsOverloadingResolution() {
         // This code is not a test of MethodUtils.
         // Rather it makes explicit the behavior of the Java specification for
         // various cases of overload resolution.
@@ -564,8 +564,7 @@ public class MethodUtilsTest {
     }
 
     @Test
-    public void testGetAccessibleInterfaceMethodFromDescription()
-            throws Exception {
+    public void testGetAccessibleInterfaceMethodFromDescription() {
         final Class<?>[][] p = {ArrayUtils.EMPTY_CLASS_ARRAY, null};
         for (final Class<?>[] element : p) {
             final Method accessibleMethod = MethodUtils.getAccessibleMethod(
@@ -582,7 +581,7 @@ public class MethodUtilsTest {
     }
 
     @Test
-    public void testGetAccessiblePublicMethodFromDescription() throws Exception {
+    public void testGetAccessiblePublicMethodFromDescription() {
         assertSame(MutableObject.class, MethodUtils.getAccessibleMethod(
                 MutableObject.class, "getValue", ArrayUtils.EMPTY_CLASS_ARRAY)
                 .getDeclaringClass());
@@ -596,7 +595,7 @@ public class MethodUtilsTest {
     }
 
     @Test
-    public void testGetMatchingAccessibleMethod() throws Exception {
+    public void testGetMatchingAccessibleMethod() {
         expectMatchingAccessibleMethodParameterTypes(TestBean.class, "foo",
                 ArrayUtils.EMPTY_CLASS_ARRAY, ArrayUtils.EMPTY_CLASS_ARRAY);
         expectMatchingAccessibleMethodParameterTypes(TestBean.class, "foo",
@@ -710,7 +709,7 @@ public class MethodUtilsTest {
     }
 
     @Test
-    public void testGetMethodsWithAnnotationSearchSupersAndIgnoreAccess() throws NoSuchMethodException {
+    public void testGetMethodsWithAnnotationSearchSupersAndIgnoreAccess() {
         assertArrayEquals(new Method[0], MethodUtils.getMethodsWithAnnotation(Object.class, Annotated.class,
                 true, true));
 
@@ -730,7 +729,7 @@ public class MethodUtilsTest {
     }
 
     @Test
-    public void testGetMethodsWithAnnotationNotSearchSupersButIgnoreAccess() throws NoSuchMethodException {
+    public void testGetMethodsWithAnnotationNotSearchSupersButIgnoreAccess() {
         assertArrayEquals(new Method[0], MethodUtils.getMethodsWithAnnotation(Object.class, Annotated.class,
                 false, true));
 
@@ -744,7 +743,7 @@ public class MethodUtilsTest {
     }
 
     @Test
-    public void testGetMethodsWithAnnotationSearchSupersButNotIgnoreAccess() throws NoSuchMethodException {
+    public void testGetMethodsWithAnnotationSearchSupersButNotIgnoreAccess() {
         assertArrayEquals(new Method[0], MethodUtils.getMethodsWithAnnotation(Object.class, Annotated.class,
                 true, false));
 
@@ -760,7 +759,7 @@ public class MethodUtilsTest {
     }
 
     @Test
-    public void testGetMethodsWithAnnotationNotSearchSupersAndNotIgnoreAccess() throws NoSuchMethodException {
+    public void testGetMethodsWithAnnotationNotSearchSupersAndNotIgnoreAccess() {
         assertArrayEquals(new Method[0], MethodUtils.getMethodsWithAnnotation(Object.class, Annotated.class,
                 false, false));
 

--- a/src/test/java/org/apache/commons/lang3/reflect/TypeUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/reflect/TypeUtilsTest.java
@@ -532,7 +532,7 @@ public class TypeUtilsTest<B> {
     }
 
     @Test
-    public void testTypesSatisfyVariables() throws SecurityException, NoSuchFieldException,
+    public void testTypesSatisfyVariables() throws SecurityException,
             NoSuchMethodException {
         final Map<TypeVariable<?>, Type> typeVarAssigns = new HashMap<>();
         final Integer max = TypeUtilsTest.<Integer> stub();
@@ -548,7 +548,7 @@ public class TypeUtilsTest<B> {
 
     @Test
     public void testDetermineTypeVariableAssignments() throws SecurityException,
-            NoSuchFieldException, NoSuchMethodException {
+            NoSuchFieldException {
         final ParameterizedType iterableType = (ParameterizedType) getClass().getField("iterable")
                 .getGenericType();
         final Map<TypeVariable<?>, Type> typeVarAssigns = TypeUtils.determineTypeArguments(TreeSet.class,
@@ -634,7 +634,7 @@ public class TypeUtilsTest<B> {
     }
 
     @Test
-    public void testGetPrimitiveArrayComponentType() throws Exception {
+    public void testGetPrimitiveArrayComponentType() {
         assertEquals(boolean.class, TypeUtils.getArrayComponentType(boolean[].class));
         assertEquals(byte.class, TypeUtils.getArrayComponentType(byte[].class));
         assertEquals(short.class, TypeUtils.getArrayComponentType(short[].class));
@@ -679,7 +679,7 @@ public class TypeUtilsTest<B> {
     }
 
     @Test
-    public void testLang820() throws Exception {
+    public void testLang820() {
         final Type[] typeArray = {String.class, String.class};
         final Type[] expectedArray = {String.class};
         assertArrayEquals(expectedArray, TypeUtils.normalizeUpperBounds(typeArray));

--- a/src/test/java/org/apache/commons/lang3/text/ExtendedMessageFormatTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/ExtendedMessageFormatTest.java
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.BeforeEach;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.text.DateFormat;
 import java.text.FieldPosition;
@@ -301,33 +301,33 @@ public class ExtendedMessageFormatTest {
         ExtendedMessageFormat other = null;
 
         // Same object
-        assertTrue(emf.equals(emf), "same, equals()");
-        assertTrue(emf.hashCode() == emf.hashCode(), "same, hashcode()");
+        assertEquals(emf, emf, "same, equals()");
+        assertEquals(emf.hashCode(), emf.hashCode(), "same, hashcode()");
 
         // Equal Object
         other = new ExtendedMessageFormat(pattern, Locale.US, fmtRegistry);
-        assertTrue(emf.equals(other), "equal, equals()");
-        assertTrue(emf.hashCode() == other.hashCode(), "equal, hashcode()");
+        assertEquals(emf, other, "equal, equals()");
+        assertEquals(emf.hashCode(), other.hashCode(), "equal, hashcode()");
 
         // Different Class
         other = new OtherExtendedMessageFormat(pattern, Locale.US, fmtRegistry);
-        assertFalse(emf.equals(other), "class, equals()");
-        assertTrue(emf.hashCode() == other.hashCode(), "class, hashcode()"); // same hashcode
+        assertNotEquals(emf, other, "class, equals()");
+        assertEquals(emf.hashCode(), other.hashCode(), "class, hashcode()"); // same hashcode
 
         // Different pattern
         other = new ExtendedMessageFormat("X" + pattern, Locale.US, fmtRegistry);
-        assertFalse(emf.equals(other), "pattern, equals()");
+        assertNotEquals(emf, other, "pattern, equals()");
         assertFalse(emf.hashCode() == other.hashCode(), "pattern, hashcode()");
 
         // Different registry
         other = new ExtendedMessageFormat(pattern, Locale.US, otherRegitry);
-        assertFalse(emf.equals(other), "registry, equals()");
+        assertNotEquals(emf, other, "registry, equals()");
         assertFalse(emf.hashCode() == other.hashCode(), "registry, hashcode()");
 
         // Different Locale
         other = new ExtendedMessageFormat(pattern, Locale.FRANCE, fmtRegistry);
-        assertFalse(emf.equals(other), "locale, equals()");
-        assertTrue(emf.hashCode() == other.hashCode(), "locale, hashcode()"); // same hashcode
+        assertNotEquals(emf, other, "locale, equals()");
+        assertEquals(emf.hashCode(), other.hashCode(), "locale, hashcode()"); // same hashcode
     }
 
     /**

--- a/src/test/java/org/apache/commons/lang3/text/ExtendedMessageFormatTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/ExtendedMessageFormatTest.java
@@ -48,7 +48,7 @@ public class ExtendedMessageFormatTest {
     private final Map<String, FormatFactory> registry = new HashMap<>();
 
     @BeforeEach
-    public void setUp() throws Exception {
+    public void setUp() {
         registry.put("lower", new LowerCaseFormatFactory());
         registry.put("upper", new UpperCaseFormatFactory());
     }

--- a/src/test/java/org/apache/commons/lang3/text/StrBuilderAppendInsertTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/StrBuilderAppendInsertTest.java
@@ -20,7 +20,7 @@ package org.apache.commons.lang3.text;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.text.DecimalFormatSymbols;
 import java.util.Arrays;
@@ -165,47 +165,36 @@ public class StrBuilderAppendInsertTest {
         sb.append("foo", 0, 3);
         assertEquals("foo", sb.toString());
 
-        try {
-            sb.append("bar", -1, 1);
-            fail("append(char[], -1,) expected IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        final StrBuilder sb1 = sb;
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb1.append("bar", -1, 1),
+                "append(char[], -1,) expected IndexOutOfBoundsException");
 
-        try {
-            sb.append("bar", 3, 1);
-            fail("append(char[], 3,) expected IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb1.append("bar", 3, 1),
+                "append(char[], 3,) expected IndexOutOfBoundsException");
 
-        try {
-            sb.append("bar", 1, -1);
-            fail("append(char[],, -1) expected IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb1.append("bar", 1, -1),
+                "append(char[],, -1) expected IndexOutOfBoundsException");
 
-        try {
-            sb.append("bar", 1, 3);
-            fail("append(char[], 1, 3) expected IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb1.append("bar", 1, 3),
+                "append(char[], 1, 3) expected IndexOutOfBoundsException");
 
-        try {
-            sb.append("bar", -1, 3);
-            fail("append(char[], -1, 3) expected IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb1.append("bar", -1, 3),
+                "append(char[], -1, 3) expected IndexOutOfBoundsException");
 
-        try {
-            sb.append("bar", 4, 0);
-            fail("append(char[], 4, 0) expected IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb1.append("bar", 4, 0),
+                "append(char[], 4, 0) expected IndexOutOfBoundsException");
 
         sb.append("bar", 3, 0);
         assertEquals("foo", sb.toString());
@@ -228,47 +217,36 @@ public class StrBuilderAppendInsertTest {
         sb.append(new StringBuilder("foo"), 0, 3);
         assertEquals("foo", sb.toString());
 
-        try {
-            sb.append(new StringBuilder("bar"), -1, 1);
-            fail("append(StringBuilder, -1,) expected IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        final StrBuilder sb1 = sb;
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb1.append(new StringBuilder("bar"), -1, 1),
+                "append(StringBuilder, -1,) expected IndexOutOfBoundsException");
 
-        try {
-            sb.append(new StringBuilder("bar"), 3, 1);
-            fail("append(StringBuilder, 3,) expected IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb1.append(new StringBuilder("bar"), 3, 1),
+                "append(StringBuilder, 3,) expected IndexOutOfBoundsException");
 
-        try {
-            sb.append(new StringBuilder("bar"), 1, -1);
-            fail("append(StringBuilder,, -1) expected IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb1.append(new StringBuilder("bar"), 1, -1),
+                "append(StringBuilder,, -1) expected IndexOutOfBoundsException");
 
-        try {
-            sb.append(new StringBuilder("bar"), 1, 3);
-            fail("append(StringBuilder, 1, 3) expected IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb1.append(new StringBuilder("bar"), 1, 3),
+                "append(StringBuilder, 1, 3) expected IndexOutOfBoundsException");
 
-        try {
-            sb.append(new StringBuilder("bar"), -1, 3);
-            fail("append(StringBuilder, -1, 3) expected IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb1.append(new StringBuilder("bar"), -1, 3),
+                "append(StringBuilder, -1, 3) expected IndexOutOfBoundsException");
 
-        try {
-            sb.append(new StringBuilder("bar"), 4, 0);
-            fail("append(StringBuilder, 4, 0) expected IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb1.append(new StringBuilder("bar"), 4, 0),
+                "append(StringBuilder, 4, 0) expected IndexOutOfBoundsException");
 
         sb.append(new StringBuilder("bar"), 3, 0);
         assertEquals("foo", sb.toString());
@@ -309,47 +287,36 @@ public class StrBuilderAppendInsertTest {
         sb.append(new StringBuffer("foo"), 0, 3);
         assertEquals("foo", sb.toString());
 
-        try {
-            sb.append(new StringBuffer("bar"), -1, 1);
-            fail("append(char[], -1,) expected IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        final StrBuilder sb1 = sb;
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb1.append(new StringBuffer("bar"), -1, 1),
+                "append(char[], -1,) expected IndexOutOfBoundsException");
 
-        try {
-            sb.append(new StringBuffer("bar"), 3, 1);
-            fail("append(char[], 3,) expected IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb1.append(new StringBuffer("bar"), 3, 1),
+                "append(char[], 3,) expected IndexOutOfBoundsException");
 
-        try {
-            sb.append(new StringBuffer("bar"), 1, -1);
-            fail("append(char[],, -1) expected IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb1.append(new StringBuffer("bar"), 1, -1),
+                "append(char[],, -1) expected IndexOutOfBoundsException");
 
-        try {
-            sb.append(new StringBuffer("bar"), 1, 3);
-            fail("append(char[], 1, 3) expected IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb1.append(new StringBuffer("bar"), 1, 3),
+                "append(char[], 1, 3) expected IndexOutOfBoundsException");
 
-        try {
-            sb.append(new StringBuffer("bar"), -1, 3);
-            fail("append(char[], -1, 3) expected IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb1.append(new StringBuffer("bar"), -1, 3),
+                "append(char[], -1, 3) expected IndexOutOfBoundsException");
 
-        try {
-            sb.append(new StringBuffer("bar"), 4, 0);
-            fail("append(char[], 4, 0) expected IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb1.append(new StringBuffer("bar"), 4, 0),
+                "append(char[], 4, 0) expected IndexOutOfBoundsException");
 
         sb.append(new StringBuffer("bar"), 3, 0);
         assertEquals("foo", sb.toString());
@@ -387,47 +354,36 @@ public class StrBuilderAppendInsertTest {
         sb.append(new StrBuilder("foo"), 0, 3);
         assertEquals("foo", sb.toString());
 
-        try {
-            sb.append(new StrBuilder("bar"), -1, 1);
-            fail("append(char[], -1,) expected IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        final StrBuilder sb1 = sb;
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb1.append(new StrBuilder("bar"), -1, 1),
+                "append(char[], -1,) expected IndexOutOfBoundsException");
 
-        try {
-            sb.append(new StrBuilder("bar"), 3, 1);
-            fail("append(char[], 3,) expected IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb1.append(new StrBuilder("bar"), 3, 1),
+                "append(char[], 3,) expected IndexOutOfBoundsException");
 
-        try {
-            sb.append(new StrBuilder("bar"), 1, -1);
-            fail("append(char[],, -1) expected IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb1.append(new StrBuilder("bar"), 1, -1),
+                "append(char[],, -1) expected IndexOutOfBoundsException");
 
-        try {
-            sb.append(new StrBuilder("bar"), 1, 3);
-            fail("append(char[], 1, 3) expected IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb1.append(new StrBuilder("bar"), 1, 3),
+                "append(char[], 1, 3) expected IndexOutOfBoundsException");
 
-        try {
-            sb.append(new StrBuilder("bar"), -1, 3);
-            fail("append(char[], -1, 3) expected IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb1.append(new StrBuilder("bar"), -1, 3),
+                "append(char[], -1, 3) expected IndexOutOfBoundsException");
 
-        try {
-            sb.append(new StrBuilder("bar"), 4, 0);
-            fail("append(char[], 4, 0) expected IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb1.append(new StrBuilder("bar"), 4, 0),
+                "append(char[], 4, 0) expected IndexOutOfBoundsException");
 
         sb.append(new StrBuilder("bar"), 3, 0);
         assertEquals("foo", sb.toString());
@@ -462,47 +418,36 @@ public class StrBuilderAppendInsertTest {
         sb.append(new char[]{'f', 'o', 'o'}, 0, 3);
         assertEquals("foo", sb.toString());
 
-        try {
-            sb.append(new char[]{'b', 'a', 'r'}, -1, 1);
-            fail("append(char[], -1,) expected IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        final StrBuilder sb1 = sb;
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb1.append(new char[]{'b', 'a', 'r'}, -1, 1),
+                "append(char[], -1,) expected IndexOutOfBoundsException");
 
-        try {
-            sb.append(new char[]{'b', 'a', 'r'}, 3, 1);
-            fail("append(char[], 3,) expected IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb1.append(new char[]{'b', 'a', 'r'}, 3, 1),
+                "append(char[], 3,) expected IndexOutOfBoundsException");
 
-        try {
-            sb.append(new char[]{'b', 'a', 'r'}, 1, -1);
-            fail("append(char[],, -1) expected IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb1.append(new char[]{'b', 'a', 'r'}, 1, -1),
+                "append(char[],, -1) expected IndexOutOfBoundsException");
 
-        try {
-            sb.append(new char[]{'b', 'a', 'r'}, 1, 3);
-            fail("append(char[], 1, 3) expected IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb1.append(new char[]{'b', 'a', 'r'}, 1, 3),
+                "append(char[], 1, 3) expected IndexOutOfBoundsException");
 
-        try {
-            sb.append(new char[]{'b', 'a', 'r'}, -1, 3);
-            fail("append(char[], -1, 3) expected IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb1.append(new char[]{'b', 'a', 'r'}, -1, 3),
+                "append(char[], -1, 3) expected IndexOutOfBoundsException");
 
-        try {
-            sb.append(new char[]{'b', 'a', 'r'}, 4, 0);
-            fail("append(char[], 4, 0) expected IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb1.append(new char[]{'b', 'a', 'r'}, 4, 0),
+                "append(char[], 4, 0) expected IndexOutOfBoundsException");
 
         sb.append(new char[]{'b', 'a', 'r'}, 3, 0);
         assertEquals("foo", sb.toString());
@@ -1288,19 +1233,15 @@ public class StrBuilderAppendInsertTest {
         sb.append("barbaz");
         assertEquals("barbaz", sb.toString());
 
-        try {
-            sb.insert(-1, FOO);
-            fail("insert(-1, Object) expected StringIndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb.insert(-1, FOO),
+                "insert(-1, Object) expected StringIndexOutOfBoundsException");
 
-        try {
-            sb.insert(7, FOO);
-            fail("insert(7, Object) expected StringIndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb.insert(7, FOO),
+                "insert(7, Object) expected StringIndexOutOfBoundsException");
 
         sb.insert(0, (Object) null);
         assertEquals("barbaz", sb.toString());
@@ -1312,19 +1253,15 @@ public class StrBuilderAppendInsertTest {
         sb.append("barbaz");
         assertEquals("barbaz", sb.toString());
 
-        try {
-            sb.insert(-1, "foo");
-            fail("insert(-1, String) expected StringIndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb.insert(-1, "foo"),
+                "insert(-1, String) expected StringIndexOutOfBoundsException");
 
-        try {
-            sb.insert(7, "foo");
-            fail("insert(7, String) expected StringIndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb.insert(7, "foo"),
+                "insert(7, String) expected StringIndexOutOfBoundsException");
 
         sb.insert(0, (String) null);
         assertEquals("barbaz", sb.toString());
@@ -1336,19 +1273,15 @@ public class StrBuilderAppendInsertTest {
         sb.append("barbaz");
         assertEquals("barbaz", sb.toString());
 
-        try {
-            sb.insert(-1, new char[]{'f', 'o', 'o'});
-            fail("insert(-1, char[]) expected StringIndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb.insert(-1, new char[]{'f', 'o', 'o'}),
+                "insert(-1, char[]) expected StringIndexOutOfBoundsException");
 
-        try {
-            sb.insert(7, new char[]{'f', 'o', 'o'});
-            fail("insert(7, char[]) expected StringIndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb.insert(7, new char[]{'f', 'o', 'o'}),
+                "insert(7, char[]) expected StringIndexOutOfBoundsException");
 
         sb.insert(0, (char[]) null);
         assertEquals("barbaz", sb.toString());
@@ -1363,19 +1296,15 @@ public class StrBuilderAppendInsertTest {
         sb.append("barbaz");
         assertEquals("barbaz", sb.toString());
 
-        try {
-            sb.insert(-1, new char[]{'a', 'b', 'c', 'f', 'o', 'o', 'd', 'e', 'f'}, 3, 3);
-            fail("insert(-1, char[], 3, 3) expected StringIndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb.insert(-1, new char[]{'a', 'b', 'c', 'f', 'o', 'o', 'd', 'e', 'f'}, 3, 3),
+                "insert(-1, char[], 3, 3) expected StringIndexOutOfBoundsException");
 
-        try {
-            sb.insert(7, new char[]{'a', 'b', 'c', 'f', 'o', 'o', 'd', 'e', 'f'}, 3, 3);
-            fail("insert(7, char[], 3, 3) expected StringIndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb.insert(7, new char[]{'a', 'b', 'c', 'f', 'o', 'o', 'd', 'e', 'f'}, 3, 3),
+                "insert(7, char[], 3, 3) expected StringIndexOutOfBoundsException");
 
         sb.insert(0, null, 0, 0);
         assertEquals("barbaz", sb.toString());
@@ -1383,33 +1312,25 @@ public class StrBuilderAppendInsertTest {
         sb.insert(0, new char[0], 0, 0);
         assertEquals("barbaz", sb.toString());
 
-        try {
-            sb.insert(0, new char[]{'a', 'b', 'c', 'f', 'o', 'o', 'd', 'e', 'f'}, -1, 3);
-            fail("insert(0, char[], -1, 3) expected StringIndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb.insert(0, new char[]{'a', 'b', 'c', 'f', 'o', 'o', 'd', 'e', 'f'}, -1, 3),
+                "insert(0, char[], -1, 3) expected StringIndexOutOfBoundsException");
 
-        try {
-            sb.insert(0, new char[]{'a', 'b', 'c', 'f', 'o', 'o', 'd', 'e', 'f'}, 10, 3);
-            fail("insert(0, char[], 10, 3) expected StringIndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb.insert(0, new char[]{'a', 'b', 'c', 'f', 'o', 'o', 'd', 'e', 'f'}, 10, 3),
+                "insert(0, char[], 10, 3) expected StringIndexOutOfBoundsException");
 
-        try {
-            sb.insert(0, new char[]{'a', 'b', 'c', 'f', 'o', 'o', 'd', 'e', 'f'}, 0, -1);
-            fail("insert(0, char[], 0, -1) expected StringIndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb.insert(0, new char[]{'a', 'b', 'c', 'f', 'o', 'o', 'd', 'e', 'f'}, 0, -1),
+                "insert(0, char[], 0, -1) expected StringIndexOutOfBoundsException");
 
-        try {
-            sb.insert(0, new char[]{'a', 'b', 'c', 'f', 'o', 'o', 'd', 'e', 'f'}, 0, 10);
-            fail("insert(0, char[], 0, 10) expected StringIndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb.insert(0, new char[]{'a', 'b', 'c', 'f', 'o', 'o', 'd', 'e', 'f'}, 0, 10),
+                "insert(0, char[], 0, 10) expected StringIndexOutOfBoundsException");
 
         sb.insert(0, new char[]{'a', 'b', 'c', 'f', 'o', 'o', 'd', 'e', 'f'}, 0, 0);
         assertEquals("barbaz", sb.toString());
@@ -1421,19 +1342,15 @@ public class StrBuilderAppendInsertTest {
         sb.append("barbaz");
         assertEquals("barbaz", sb.toString());
 
-        try {
-            sb.insert(-1, true);
-            fail("insert(-1, boolean) expected StringIndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb.insert(-1, true),
+                "insert(-1, boolean) expected StringIndexOutOfBoundsException");
 
-        try {
-            sb.insert(7, true);
-            fail("insert(7, boolean) expected StringIndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb.insert(7, true),
+                "insert(7, boolean) expected StringIndexOutOfBoundsException");
 
         sb.insert(0, true);
         assertEquals("truebarbaz", sb.toString());
@@ -1445,19 +1362,15 @@ public class StrBuilderAppendInsertTest {
         sb.append("barbaz");
         assertEquals("barbaz", sb.toString());
 
-        try {
-            sb.insert(-1, '!');
-            fail("insert(-1, char) expected StringIndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb.insert(-1, '!'),
+                "insert(-1, char) expected StringIndexOutOfBoundsException");
 
-        try {
-            sb.insert(7, '!');
-            fail("insert(7, char) expected StringIndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb.insert(7, '!'),
+                "insert(7, char) expected StringIndexOutOfBoundsException");
 
         sb.insert(0, '!');
         assertEquals("!barbaz", sb.toString());
@@ -1466,19 +1379,15 @@ public class StrBuilderAppendInsertTest {
         sb.append("barbaz");
         assertEquals("barbaz", sb.toString());
 
-        try {
-            sb.insert(-1, 0);
-            fail("insert(-1, int) expected StringIndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb.insert(-1, 0),
+                "insert(-1, int) expected StringIndexOutOfBoundsException");
 
-        try {
-            sb.insert(7, 0);
-            fail("insert(7, int) expected StringIndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb.insert(7, 0),
+                "insert(7, int) expected StringIndexOutOfBoundsException");
 
         sb.insert(0, '0');
         assertEquals("0barbaz", sb.toString());
@@ -1487,19 +1396,15 @@ public class StrBuilderAppendInsertTest {
         sb.append("barbaz");
         assertEquals("barbaz", sb.toString());
 
-        try {
-            sb.insert(-1, 1L);
-            fail("insert(-1, long) expected StringIndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb.insert(-1, 1L),
+                "insert(-1, long) expected StringIndexOutOfBoundsException");
 
-        try {
-            sb.insert(7, 1L);
-            fail("insert(7, long) expected StringIndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb.insert(7, 1L),
+                "insert(7, long) expected StringIndexOutOfBoundsException");
 
         sb.insert(0, 1L);
         assertEquals("1barbaz", sb.toString());
@@ -1508,19 +1413,15 @@ public class StrBuilderAppendInsertTest {
         sb.append("barbaz");
         assertEquals("barbaz", sb.toString());
 
-        try {
-            sb.insert(-1, 2.3F);
-            fail("insert(-1, float) expected StringIndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb.insert(-1, 2.3F),
+                "insert(-1, float) expected StringIndexOutOfBoundsException");
 
-        try {
-            sb.insert(7, 2.3F);
-            fail("insert(7, float) expected StringIndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb.insert(7, 2.3F),
+                "insert(7, float) expected StringIndexOutOfBoundsException");
 
         sb.insert(0, 2.3F);
         assertEquals("2.3barbaz", sb.toString());
@@ -1529,19 +1430,15 @@ public class StrBuilderAppendInsertTest {
         sb.append("barbaz");
         assertEquals("barbaz", sb.toString());
 
-        try {
-            sb.insert(-1, 4.5D);
-            fail("insert(-1, double) expected StringIndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb.insert(-1, 4.5D),
+                "insert(-1, double) expected StringIndexOutOfBoundsException");
 
-        try {
-            sb.insert(7, 4.5D);
-            fail("insert(7, double) expected StringIndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb.insert(7, 4.5D),
+                "insert(7, double) expected StringIndexOutOfBoundsException");
 
         sb.insert(0, 4.5D);
         assertEquals("4.5barbaz", sb.toString());
@@ -1555,19 +1452,15 @@ public class StrBuilderAppendInsertTest {
         sb.append("barbaz");
         assertEquals("barbaz", sb.toString());
 
-        try {
-            sb.insert(-1, FOO);
-            fail("insert(-1, Object) expected StringIndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb.insert(-1, FOO),
+                "insert(-1, Object) expected StringIndexOutOfBoundsException");
 
-        try {
-            sb.insert(7, FOO);
-            fail("insert(7, Object) expected StringIndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb.insert(7, FOO),
+                "insert(7, Object) expected StringIndexOutOfBoundsException");
 
         sb.insert(0, (Object) null);
         assertEquals("nullbarbaz", sb.toString());
@@ -1579,19 +1472,15 @@ public class StrBuilderAppendInsertTest {
         sb.append("barbaz");
         assertEquals("barbaz", sb.toString());
 
-        try {
-            sb.insert(-1, "foo");
-            fail("insert(-1, String) expected StringIndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb.insert(-1, "foo"),
+                "insert(-1, String) expected StringIndexOutOfBoundsException");
 
-        try {
-            sb.insert(7, "foo");
-            fail("insert(7, String) expected StringIndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb.insert(7, "foo"),
+                "insert(7, String) expected StringIndexOutOfBoundsException");
 
         sb.insert(0, (String) null);
         assertEquals("nullbarbaz", sb.toString());

--- a/src/test/java/org/apache/commons/lang3/text/StrBuilderTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/StrBuilderTest.java
@@ -25,8 +25,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.io.Reader;
@@ -267,12 +267,10 @@ public class StrBuilderTest {
         assertEquals(33, sb.size());
         assertTrue(sb.isEmpty() == false);
 
-        try {
-            sb.setLength(-1);
-            fail("setLength(-1) expected StringIndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb.setLength(-1),
+                "setLength(-1) expected StringIndexOutOfBoundsException");
 
         sb.setLength(33);
         assertEquals(33, sb.capacity());
@@ -322,12 +320,10 @@ public class StrBuilderTest {
         sb.setLength(3);  // lengthen
         assertEquals("He\0", sb.toString());
 
-        try {
-            sb.setLength(-1);
-            fail("setLength(-1) expected StringIndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb.setLength(-1),
+                "setLength(-1) expected StringIndexOutOfBoundsException");
     }
 
     //-----------------------------------------------------------------------
@@ -400,62 +396,40 @@ public class StrBuilderTest {
     @Test
     public void testCharAt() {
         final StrBuilder sb = new StrBuilder();
-        try {
-            sb.charAt(0);
-            fail("charAt(0) expected IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
-        try {
-            sb.charAt(-1);
-            fail("charAt(-1) expected IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(
+                IndexOutOfBoundsException.class, () -> sb.charAt(0), "charAt(0) expected IndexOutOfBoundsException");
+        assertThrows(
+                IndexOutOfBoundsException.class, () -> sb.charAt(-1), "charAt(-1) expected IndexOutOfBoundsException");
         sb.append("foo");
         assertEquals('f', sb.charAt(0));
         assertEquals('o', sb.charAt(1));
         assertEquals('o', sb.charAt(2));
-        try {
-            sb.charAt(-1);
-            fail("charAt(-1) expected IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
-        try {
-            sb.charAt(3);
-            fail("charAt(3) expected IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(
+                IndexOutOfBoundsException.class, () -> sb.charAt(-1), "charAt(-1) expected IndexOutOfBoundsException");
+        assertThrows(
+                IndexOutOfBoundsException.class, () -> sb.charAt(3), "charAt(3) expected IndexOutOfBoundsException");
     }
 
     //-----------------------------------------------------------------------
     @Test
     public void testSetCharAt() {
         final StrBuilder sb = new StrBuilder();
-        try {
-            sb.setCharAt(0, 'f');
-            fail("setCharAt(0,) expected IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
-        try {
-            sb.setCharAt(-1, 'f');
-            fail("setCharAt(-1,) expected IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb.setCharAt(0, 'f'),
+                "setCharAt(0,) expected IndexOutOfBoundsException");
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb.setCharAt(-1, 'f'),
+                "setCharAt(-1,) expected IndexOutOfBoundsException");
         sb.append("foo");
         sb.setCharAt(0, 'b');
         sb.setCharAt(1, 'a');
         sb.setCharAt(2, 'r');
-        try {
-            sb.setCharAt(3, '!');
-            fail("setCharAt(3,) expected IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb.setCharAt(3, '!'),
+                "setCharAt(3,) expected IndexOutOfBoundsException");
         assertEquals("bar", sb.toString());
     }
 
@@ -466,10 +440,7 @@ public class StrBuilderTest {
         sb.deleteCharAt(0);
         assertEquals("bc", sb.toString());
 
-        try {
-            sb.deleteCharAt(1000);
-            fail("Expected IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {}
+        assertThrows(IndexOutOfBoundsException.class, () -> sb.deleteCharAt(1000));
     }
 
     //-----------------------------------------------------------------------
@@ -509,17 +480,11 @@ public class StrBuilderTest {
         a = sb.toCharArray(0, 1);
         assertNotNull(a, "toCharArray(int,int) result is null");
 
-        try {
-            sb.toCharArray(-1, 5);
-            fail("no string index out of bound on -1");
-        } catch (final IndexOutOfBoundsException e) {
-        }
+        assertThrows(
+                IndexOutOfBoundsException.class, () -> sb.toCharArray(-1, 5), "no string index out of bound on -1");
 
-        try {
-            sb.toCharArray(6, 5);
-            fail("no string index out of bound on -1");
-        } catch (final IndexOutOfBoundsException e) {
-        }
+        assertThrows(
+                IndexOutOfBoundsException.class, () -> sb.toCharArray(6, 5), "no string index out of bound on -1");
     }
 
     @Test
@@ -559,33 +524,14 @@ public class StrBuilderTest {
         sb.getChars(0,5,a,0);
         assertTrue(Arrays.equals(new char[] {'j','u','n','i','t'},a));
 
-        a = new char[5];
-        sb.getChars(0,2,a,3);
-        assertTrue(Arrays.equals(new char[] {0,0,0,'j','u'},a));
+        final char[] b = new char[5];
+        sb.getChars(0,2,b,3);
+        assertTrue(Arrays.equals(new char[] {0,0,0,'j','u'},b));
 
-        try {
-            sb.getChars(-1,0,a,0);
-            fail("no exception");
-        } catch (final IndexOutOfBoundsException e) {
-        }
-
-        try {
-            sb.getChars(0,-1,a,0);
-            fail("no exception");
-        } catch (final IndexOutOfBoundsException e) {
-        }
-
-        try {
-            sb.getChars(0,20,a,0);
-            fail("no exception");
-        } catch (final IndexOutOfBoundsException e) {
-        }
-
-        try {
-            sb.getChars(4,2,a,0);
-            fail("no exception");
-        } catch (final IndexOutOfBoundsException e) {
-        }
+        assertThrows(IndexOutOfBoundsException.class, () -> sb.getChars(-1,0,b,0));
+        assertThrows(IndexOutOfBoundsException.class, () -> sb.getChars(0,-1,b,0));
+        assertThrows(IndexOutOfBoundsException.class, () -> sb.getChars(0,20,b,0));
+        assertThrows(IndexOutOfBoundsException.class, () -> sb.getChars(4,2,b,0));
     }
 
     //-----------------------------------------------------------------------
@@ -601,20 +547,9 @@ public class StrBuilderTest {
         sb.delete(0, 1000);
         assertEquals("", sb.toString());
 
-        try {
-            sb.delete(1, 2);
-            fail("Expected IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {}
-        try {
-            sb.delete(-1, 1);
-            fail("Expected IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {}
-
-        sb = new StrBuilder("anything");
-        try {
-            sb.delete(2, 1);
-            fail("Expected IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {}
+        assertThrows(IndexOutOfBoundsException.class, () -> sb.delete(1, 2));
+        assertThrows(IndexOutOfBoundsException.class, () -> sb.delete(-1, 1));
+        assertThrows(IndexOutOfBoundsException.class, () -> new StrBuilder("anything").delete(2, 1));
     }
 
     //-----------------------------------------------------------------------
@@ -757,23 +692,14 @@ public class StrBuilderTest {
         sb.replace(0, 1000, "text");
         assertEquals("text", sb.toString());
 
-        sb = new StrBuilder("atext");
-        sb.replace(1, 1, "ny");
-        assertEquals("anytext", sb.toString());
-        try {
-            sb.replace(2, 1, "anything");
-            fail("Expected IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {}
+        StrBuilder sb1 = new StrBuilder("atext");
+        sb1.replace(1, 1, "ny");
+        assertEquals("anytext", sb1.toString());
+        assertThrows(IndexOutOfBoundsException.class, () -> sb1.replace(2, 1, "anything"));
 
-        sb = new StrBuilder();
-        try {
-            sb.replace(1, 2, "anything");
-            fail("Expected IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {}
-        try {
-            sb.replace(-1, 1, "anything");
-            fail("Expected IndexOutOfBoundsException");
-        } catch (final IndexOutOfBoundsException e) {}
+        StrBuilder sb2 = new StrBuilder();
+        assertThrows(IndexOutOfBoundsException.class, () -> sb2.replace(1, 2, "anything"));
+        assertThrows(IndexOutOfBoundsException.class, () -> sb2.replace(-1, 1, "anything"));
     }
 
     //-----------------------------------------------------------------------
@@ -1033,19 +959,17 @@ public class StrBuilderTest {
         sb.replace(StrMatcher.stringMatcher("aa"), "-", 10, sb.length(), -1);
         assertEquals("aaxaaaayaa", sb.toString());
 
-        sb = new StrBuilder("aaxaaaayaa");
-        try {
-            sb.replace(StrMatcher.stringMatcher("aa"), "-", 11, sb.length(), -1);
-            fail();
-        } catch (final IndexOutOfBoundsException ex) {}
-        assertEquals("aaxaaaayaa", sb.toString());
+        StrBuilder sb1 = new StrBuilder("aaxaaaayaa");
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb1.replace(StrMatcher.stringMatcher("aa"), "-", 11, sb1.length(), -1));
+        assertEquals("aaxaaaayaa", sb1.toString());
 
-        sb = new StrBuilder("aaxaaaayaa");
-        try {
-            sb.replace(StrMatcher.stringMatcher("aa"), "-", -1, sb.length(), -1);
-            fail();
-        } catch (final IndexOutOfBoundsException ex) {}
-        assertEquals("aaxaaaayaa", sb.toString());
+        StrBuilder sb2 = new StrBuilder("aaxaaaayaa");
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb2.replace(StrMatcher.stringMatcher("aa"), "-", -1, sb2.length(), -1));
+        assertEquals("aaxaaaayaa", sb2.toString());
     }
 
     @Test
@@ -1094,12 +1018,11 @@ public class StrBuilderTest {
         sb.replace(StrMatcher.stringMatcher("aa"), "-", 0, 1000, -1);
         assertEquals("-x--y-", sb.toString());
 
-        sb = new StrBuilder("aaxaaaayaa");
-        try {
-            sb.replace(StrMatcher.stringMatcher("aa"), "-", 2, 1, -1);
-            fail();
-        } catch (final IndexOutOfBoundsException ex) {}
-        assertEquals("aaxaaaayaa", sb.toString());
+        StrBuilder sb1 = new StrBuilder("aaxaaaayaa");
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> sb1.replace(StrMatcher.stringMatcher("aa"), "-", 2, 1, -1));
+        assertEquals("aaxaaaayaa", sb1.toString());
     }
 
     @Test
@@ -1202,28 +1125,16 @@ public class StrBuilderTest {
     public void testSubSequenceIntInt() {
        final StrBuilder sb = new StrBuilder ("hello goodbye");
        // Start index is negative
-       try {
-            sb.subSequence(-1, 5);
-            fail();
-        } catch (final IndexOutOfBoundsException e) {}
+        assertThrows(IndexOutOfBoundsException.class, () -> sb.subSequence(-1, 5));
 
         // End index is negative
-       try {
-            sb.subSequence(2, -1);
-            fail();
-        } catch (final IndexOutOfBoundsException e) {}
+        assertThrows(IndexOutOfBoundsException.class, () -> sb.subSequence(2, -1));
 
         // End index greater than length()
-        try {
-            sb.subSequence(2, sb.length() + 1);
-            fail();
-        } catch (final IndexOutOfBoundsException e) {}
+        assertThrows(IndexOutOfBoundsException.class, () -> sb.subSequence(2, sb.length() + 1));
 
         // Start index greater then end index
-        try {
-            sb.subSequence(3, 2);
-            fail();
-        } catch (final IndexOutOfBoundsException e) {}
+        assertThrows(IndexOutOfBoundsException.class, () -> sb.subSequence(3, 2));
 
         // Normal cases
         assertEquals ("hello", sb.subSequence(0, 5));
@@ -1239,16 +1150,9 @@ public class StrBuilderTest {
         assertEquals ("hello goodbye".substring(6), sb.substring(6));
         assertEquals ("hello goodbye", sb.substring(0));
         assertEquals ("hello goodbye".substring(0), sb.substring(0));
-        try {
-            sb.substring(-1);
-            fail ();
-        } catch (final IndexOutOfBoundsException e) {}
+        assertThrows(IndexOutOfBoundsException.class, () -> sb.substring(-1));
 
-        try {
-            sb.substring(15);
-            fail ();
-        } catch (final IndexOutOfBoundsException e) {}
-
+        assertThrows(IndexOutOfBoundsException.class, () -> sb.substring(15));
     }
 
     @Test
@@ -1262,15 +1166,8 @@ public class StrBuilderTest {
 
         assertEquals ("goodbye", sb.substring(6, 20));
 
-        try {
-            sb.substring(-1, 5);
-            fail();
-        } catch (final IndexOutOfBoundsException e) {}
-
-        try {
-            sb.substring(15, 20);
-            fail();
-        } catch (final IndexOutOfBoundsException e) {}
+        assertThrows(IndexOutOfBoundsException.class, () -> sb.substring(-1, 5));
+        assertThrows(IndexOutOfBoundsException.class, () -> sb.substring(15, 20));
     }
 
     // -----------------------------------------------------------------------
@@ -1736,40 +1633,25 @@ public class StrBuilderTest {
         reader.close();
         assertTrue(reader.ready());
 
-        reader = sb.asReader();
-        array = new char[3];
-        try {
-            reader.read(array, -1, 0);
-            fail();
-        } catch (final IndexOutOfBoundsException ex) {}
-        try {
-            reader.read(array, 0, -1);
-            fail();
-        } catch (final IndexOutOfBoundsException ex) {}
-        try {
-            reader.read(array, 100, 1);
-            fail();
-        } catch (final IndexOutOfBoundsException ex) {}
-        try {
-            reader.read(array, 0, 100);
-            fail();
-        } catch (final IndexOutOfBoundsException ex) {}
-        try {
-            reader.read(array, Integer.MAX_VALUE, Integer.MAX_VALUE);
-            fail();
-        } catch (final IndexOutOfBoundsException ex) {}
+        final Reader r = sb.asReader();
+        final char[] arr = new char[3];
+        assertThrows(IndexOutOfBoundsException.class, () -> r.read(arr, -1, 0));
+        assertThrows(IndexOutOfBoundsException.class, () -> r.read(arr, 0, -1));
+        assertThrows(IndexOutOfBoundsException.class, () -> r.read(arr, 100, 1));
+        assertThrows(IndexOutOfBoundsException.class, () -> r.read(arr, 0, 100));
+        assertThrows(IndexOutOfBoundsException.class, () -> r.read(arr, Integer.MAX_VALUE, Integer.MAX_VALUE));
 
-        assertEquals(0, reader.read(array, 0, 0));
-        assertEquals(0, array[0]);
-        assertEquals(0, array[1]);
-        assertEquals(0, array[2]);
+        assertEquals(0, r.read(arr, 0, 0));
+        assertEquals(0, arr[0]);
+        assertEquals(0, arr[1]);
+        assertEquals(0, arr[2]);
 
-        reader.skip(9);
-        assertEquals(-1, reader.read(array, 0, 1));
+        r.skip(9);
+        assertEquals(-1, r.read(arr, 0, 1));
 
-        reader.reset();
+        r.reset();
         array = new char[30];
-        assertEquals(9, reader.read(array, 0, 30));
+        assertEquals(9, r.read(array, 0, 30));
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/apache/commons/lang3/text/StrBuilderTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/StrBuilderTest.java
@@ -1560,7 +1560,7 @@ public class StrBuilderTest {
 
     //-----------------------------------------------------------------------
     @Test
-    public void testAsTokenizer() throws Exception {
+    public void testAsTokenizer() {
         // from Javadoc
         final StrBuilder b = new StrBuilder();
         b.append("a b ");
@@ -1740,7 +1740,7 @@ public class StrBuilderTest {
     }
 
     @Test
-    public void test_LANG_1131_EqualsWithNullStrBuilder() throws Exception {
+    public void test_LANG_1131_EqualsWithNullStrBuilder() {
         final StrBuilder sb = new StrBuilder();
         final StrBuilder other = null;
         assertFalse(sb.equals(other));

--- a/src/test/java/org/apache/commons/lang3/text/StrBuilderTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/StrBuilderTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -241,7 +242,7 @@ public class StrBuilderTest {
         assertTrue(sb.capacity() >= 32);
         assertEquals(3, sb.length());
         assertEquals(3, sb.size());
-        assertTrue(sb.isEmpty() == false);
+        assertFalse(sb.isEmpty());
 
         sb.clear();
         assertTrue(sb.capacity() >= 32);
@@ -253,19 +254,19 @@ public class StrBuilderTest {
         assertTrue(sb.capacity() > 32);
         assertEquals(33, sb.length());
         assertEquals(33, sb.size());
-        assertTrue(sb.isEmpty() == false);
+        assertFalse(sb.isEmpty());
 
         sb.ensureCapacity(16);
         assertTrue(sb.capacity() > 16);
         assertEquals(33, sb.length());
         assertEquals(33, sb.size());
-        assertTrue(sb.isEmpty() == false);
+        assertFalse(sb.isEmpty());
 
         sb.minimizeCapacity();
         assertEquals(33, sb.capacity());
         assertEquals(33, sb.length());
         assertEquals(33, sb.size());
-        assertTrue(sb.isEmpty() == false);
+        assertFalse(sb.isEmpty());
 
         assertThrows(
                 IndexOutOfBoundsException.class,
@@ -276,21 +277,21 @@ public class StrBuilderTest {
         assertEquals(33, sb.capacity());
         assertEquals(33, sb.length());
         assertEquals(33, sb.size());
-        assertTrue(sb.isEmpty() == false);
+        assertFalse(sb.isEmpty());
 
         sb.setLength(16);
         assertTrue(sb.capacity() >= 16);
         assertEquals(16, sb.length());
         assertEquals(16, sb.size());
         assertEquals("1234567890123456", sb.toString());
-        assertTrue(sb.isEmpty() == false);
+        assertFalse(sb.isEmpty());
 
         sb.setLength(32);
         assertTrue(sb.capacity() >= 32);
         assertEquals(32, sb.length());
         assertEquals(32, sb.size());
         assertEquals("1234567890123456\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0", sb.toString());
-        assertTrue(sb.isEmpty() == false);
+        assertFalse(sb.isEmpty());
 
         sb.setLength(0);
         assertTrue(sb.capacity() >= 32);
@@ -1721,22 +1722,22 @@ public class StrBuilderTest {
         assertTrue(sb1.equals(sb2));
         assertTrue(sb1.equals(sb1));
         assertTrue(sb2.equals(sb2));
-        assertTrue(sb1.equals((Object) sb2));
+        assertEquals(sb1, (Object) sb2);
 
         sb1.append("abc");
         assertFalse(sb1.equals(sb2));
-        assertFalse(sb1.equals((Object) sb2));
+        assertNotEquals(sb1, (Object) sb2);
 
         sb2.append("ABC");
         assertFalse(sb1.equals(sb2));
-        assertFalse(sb1.equals((Object) sb2));
+        assertNotEquals(sb1, (Object) sb2);
 
         sb2.clear().append("abc");
         assertTrue(sb1.equals(sb2));
-        assertTrue(sb1.equals((Object) sb2));
+        assertEquals(sb1, (Object) sb2);
 
-        assertFalse(sb1.equals(Integer.valueOf(1)));
-        assertFalse(sb1.equals("abc"));
+        assertNotEquals(sb1, Integer.valueOf(1));
+        assertNotEquals("abc", sb1);
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/text/StrLookupTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/StrLookupTest.java
@@ -19,7 +19,7 @@ package org.apache.commons.lang3.text;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -46,12 +46,7 @@ public class StrLookupTest  {
         assertEquals(System.getProperty("os.name"), StrLookup.systemPropertiesLookup().lookup("os.name"));
         assertNull(StrLookup.systemPropertiesLookup().lookup(""));
         assertNull(StrLookup.systemPropertiesLookup().lookup("other"));
-        try {
-            StrLookup.systemPropertiesLookup().lookup(null);
-            fail();
-        } catch (final NullPointerException ex) {
-            // expected
-        }
+        assertThrows(NullPointerException.class, () -> StrLookup.systemPropertiesLookup().lookup(null));
     }
 
     /**

--- a/src/test/java/org/apache/commons/lang3/text/StrSubstitutorTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/StrSubstitutorTest.java
@@ -21,8 +21,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -246,22 +246,18 @@ public class StrSubstitutorTest {
         map.put("critterColor", "brown");
         map.put("critterType", "${animal}");
         StrSubstitutor sub = new StrSubstitutor(map);
-        try {
-            sub.replace("The ${animal} jumps over the ${target}.");
-            fail("Cyclic replacement was not detected!");
-        } catch (final IllegalStateException ex) {
-            // expected
-        }
+        assertThrows(
+                IllegalStateException.class,
+                () -> sub.replace("The ${animal} jumps over the ${target}."),
+                "Cyclic replacement was not detected!");
 
         // also check even when default value is set.
         map.put("critterType", "${animal:-fox}");
-        sub = new StrSubstitutor(map);
-        try {
-            sub.replace("The ${animal} jumps over the ${target}.");
-            fail("Cyclic replacement was not detected!");
-        } catch (final IllegalStateException ex) {
-            // expected
-        }
+        StrSubstitutor sub2 = new StrSubstitutor(map);
+        assertThrows(
+                IllegalStateException.class,
+                () -> sub2.replace("The ${animal} jumps over the ${target}."),
+                "Cyclic replacement was not detected!");
     }
 
     /**
@@ -477,23 +473,13 @@ public class StrSubstitutorTest {
 
         sub.setVariablePrefix("<<");
         assertTrue(sub.getVariablePrefixMatcher() instanceof StrMatcher.StringMatcher);
-        try {
-            sub.setVariablePrefix(null);
-            fail();
-        } catch (final IllegalArgumentException ex) {
-            // expected
-        }
+        assertThrows(IllegalArgumentException.class, () -> sub.setVariablePrefix(null));
         assertTrue(sub.getVariablePrefixMatcher() instanceof StrMatcher.StringMatcher);
 
         final StrMatcher matcher = StrMatcher.commaMatcher();
         sub.setVariablePrefixMatcher(matcher);
         assertSame(matcher, sub.getVariablePrefixMatcher());
-        try {
-            sub.setVariablePrefixMatcher(null);
-            fail();
-        } catch (final IllegalArgumentException ex) {
-            // expected
-        }
+        assertThrows(IllegalArgumentException.class, () -> sub.setVariablePrefixMatcher(null));
         assertSame(matcher, sub.getVariablePrefixMatcher());
     }
 
@@ -509,23 +495,13 @@ public class StrSubstitutorTest {
 
         sub.setVariableSuffix("<<");
         assertTrue(sub.getVariableSuffixMatcher() instanceof StrMatcher.StringMatcher);
-        try {
-            sub.setVariableSuffix(null);
-            fail();
-        } catch (final IllegalArgumentException ex) {
-            // expected
-        }
+        assertThrows(IllegalArgumentException.class, () -> sub.setVariableSuffix(null));
         assertTrue(sub.getVariableSuffixMatcher() instanceof StrMatcher.StringMatcher);
 
         final StrMatcher matcher = StrMatcher.commaMatcher();
         sub.setVariableSuffixMatcher(matcher);
         assertSame(matcher, sub.getVariableSuffixMatcher());
-        try {
-            sub.setVariableSuffixMatcher(null);
-            fail();
-        } catch (final IllegalArgumentException ex) {
-            // expected
-        }
+        assertThrows(IllegalArgumentException.class, () -> sub.setVariableSuffixMatcher(null));
         assertSame(matcher, sub.getVariableSuffixMatcher());
     }
 

--- a/src/test/java/org/apache/commons/lang3/text/StrSubstitutorTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/StrSubstitutorTest.java
@@ -42,14 +42,14 @@ public class StrSubstitutorTest {
     private Map<String, String> values;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    public void setUp() {
         values = new HashMap<>();
         values.put("animal", "quick brown fox");
         values.put("target", "lazy dog");
     }
 
     @AfterEach
-    public void tearDown() throws Exception {
+    public void tearDown() {
         values = null;
     }
 

--- a/src/test/java/org/apache/commons/lang3/text/StrTokenizerTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/StrTokenizerTest.java
@@ -22,8 +22,8 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -541,10 +541,7 @@ public class StrTokenizerTest {
         assertFalse(tokenizer.hasPrevious());
         assertNull(tokenizer.nextToken());
         assertEquals(0, tokenizer.size());
-        try {
-            tokenizer.next();
-            fail();
-        } catch (final NoSuchElementException ex) {}
+        assertThrows(NoSuchElementException.class, tokenizer::next);
     }
 
     @Test
@@ -805,25 +802,13 @@ public class StrTokenizerTest {
     public void testIteration() {
         final StrTokenizer tkn = new StrTokenizer("a b c");
         assertFalse(tkn.hasPrevious());
-        try {
-            tkn.previous();
-            fail();
-        } catch (final NoSuchElementException ex) {}
+        assertThrows(NoSuchElementException.class, tkn::previous);
         assertTrue(tkn.hasNext());
 
         assertEquals("a", tkn.next());
-        try {
-            tkn.remove();
-            fail();
-        } catch (final UnsupportedOperationException ex) {}
-        try {
-            tkn.set("x");
-            fail();
-        } catch (final UnsupportedOperationException ex) {}
-        try {
-            tkn.add("y");
-            fail();
-        } catch (final UnsupportedOperationException ex) {}
+        assertThrows(UnsupportedOperationException.class, tkn::remove);
+        assertThrows(UnsupportedOperationException.class, () -> tkn.set("x"));
+        assertThrows(UnsupportedOperationException.class, () -> tkn.add("y"));
         assertTrue(tkn.hasPrevious());
         assertTrue(tkn.hasNext());
 
@@ -835,10 +820,7 @@ public class StrTokenizerTest {
         assertTrue(tkn.hasPrevious());
         assertFalse(tkn.hasNext());
 
-        try {
-            tkn.next();
-            fail();
-        } catch (final NoSuchElementException ex) {}
+        assertThrows(NoSuchElementException.class, tkn::next);
         assertTrue(tkn.hasPrevious());
         assertFalse(tkn.hasNext());
     }

--- a/src/test/java/org/apache/commons/lang3/text/StrTokenizerTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/StrTokenizerTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -43,8 +44,8 @@ public class StrTokenizerTest {
     private static final String TSV_SIMPLE_FIXTURE = "A\tb\tc";
 
     private void checkClone(final StrTokenizer tokenizer) {
-        assertFalse(StrTokenizer.getCSVInstance() == tokenizer);
-        assertFalse(StrTokenizer.getTSVInstance() == tokenizer);
+        assertNotSame(StrTokenizer.getCSVInstance(), tokenizer);
+        assertNotSame(StrTokenizer.getTSVInstance(), tokenizer);
     }
 
     // -----------------------------------------------------------------------
@@ -182,11 +183,9 @@ public class StrTokenizerTest {
 
         assertEquals(expected.length, tokens.length, ArrayUtils.toString(tokens));
 
-        assertTrue(nextCount == expected.length,
-                "could not cycle through entire token list" + " using the 'hasNext' and 'next' methods");
+        assertEquals(nextCount, expected.length, "could not cycle through entire token list" + " using the 'hasNext' and 'next' methods");
 
-        assertTrue(prevCount == expected.length,
-                "could not cycle through entire token list" + " using the 'hasPrevious' and 'previous' methods");
+        assertEquals(prevCount, expected.length, "could not cycle through entire token list" + " using the 'hasPrevious' and 'previous' methods");
 
     }
 

--- a/src/test/java/org/apache/commons/lang3/text/WordUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/WordUtilsTest.java
@@ -420,7 +420,7 @@ public class WordUtilsTest {
     }
 
     @Test
-    public void testLANG1292() throws Exception {
+    public void testLANG1292() {
         // Prior to fix, this was throwing StringIndexOutOfBoundsException
         WordUtils.wrap("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa "
                 + "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa "
@@ -428,7 +428,7 @@ public class WordUtilsTest {
     }
 
     @Test
-    public void testLANG1397() throws Exception {
+    public void testLANG1397() {
         // Prior to fix, this was throwing StringIndexOutOfBoundsException
         WordUtils.wrap("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa "
             + "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa "

--- a/src/test/java/org/apache/commons/lang3/text/translate/NumericEntityUnescaperTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/translate/NumericEntityUnescaperTest.java
@@ -18,7 +18,7 @@
 package org.apache.commons.lang3.text.translate;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
@@ -67,15 +67,10 @@ public class NumericEntityUnescaperTest  {
         assertEquals(expected, result, "Failed to ignore unfinished entities (i.e. missing semi-colon)");
 
         // fail it
-        neu = new NumericEntityUnescaper(NumericEntityUnescaper.OPTION.errorIfNoSemiColon);
-        input = "Test &#x30 not test";
-
-        try {
-            result = neu.translate(input);
-            fail("IllegalArgumentException expected");
-        } catch(final IllegalArgumentException iae) {
-            // expected
-        }
+        final NumericEntityUnescaper failingNeu =
+                new NumericEntityUnescaper(NumericEntityUnescaper.OPTION.errorIfNoSemiColon);
+        final String failingInput = "Test &#x30 not test";
+        assertThrows(IllegalArgumentException.class, () -> failingNeu.translate(failingInput));
     }
 
 }

--- a/src/test/java/org/apache/commons/lang3/text/translate/UnicodeUnescaperTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/translate/UnicodeUnescaperTest.java
@@ -18,7 +18,7 @@
 package org.apache.commons.lang3.text.translate;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
@@ -51,11 +51,9 @@ public class UnicodeUnescaperTest {
         final UnicodeUnescaper uu = new UnicodeUnescaper();
 
         final String input = "\\0047\\u006";
-        try {
-            uu.translate(input);
-            fail("A lack of digits in a Unicode escape sequence failed to throw an exception");
-        } catch(final IllegalArgumentException iae) {
-            // expected
-        }
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> uu.translate(input),
+                "A lack of digits in a Unicode escape sequence failed to throw an exception");
     }
 }

--- a/src/test/java/org/apache/commons/lang3/time/DateFormatUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/DateFormatUtilsTest.java
@@ -139,7 +139,7 @@ public class DateFormatUtilsTest {
     }
 
     @Test
-    public void testDateTimeISO() throws Exception {
+    public void testDateTimeISO() {
         testGmtMinus3("2002-02-23T09:11:12", DateFormatUtils.ISO_DATETIME_FORMAT.getPattern());
         testGmtMinus3("2002-02-23T09:11:12-03:00", DateFormatUtils.ISO_DATETIME_TIME_ZONE_FORMAT.getPattern());
         testUTC("2002-02-23T09:11:12Z", DateFormatUtils.ISO_DATETIME_TIME_ZONE_FORMAT.getPattern());
@@ -204,7 +204,7 @@ public class DateFormatUtilsTest {
      * This method test that the bug is fixed.
      */
     @Test
-    public void testLang916() throws Exception {
+    public void testLang916() {
 
         final Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("Europe/Paris"));
         cal.clear();

--- a/src/test/java/org/apache/commons/lang3/time/DateUtilsFragmentTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/DateUtilsFragmentTest.java
@@ -20,7 +20,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.util.Calendar;
 import java.util.Date;
 
@@ -47,114 +48,66 @@ public class DateUtilsFragmentTest {
 
     @Test
     public void testNullDate() {
-        try {
-            DateUtils.getFragmentInMilliseconds((Date) null, Calendar.MILLISECOND);
-            fail();
-        } catch(final IllegalArgumentException iae) {}
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> DateUtils.getFragmentInMilliseconds((Date) null, Calendar.MILLISECOND));
 
-        try {
-            DateUtils.getFragmentInSeconds((Date) null, Calendar.MILLISECOND);
-            fail();
-        } catch(final IllegalArgumentException iae) {}
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> DateUtils.getFragmentInSeconds((Date) null, Calendar.MILLISECOND));
 
-        try {
-            DateUtils.getFragmentInMinutes((Date) null, Calendar.MILLISECOND);
-            fail();
-        } catch(final IllegalArgumentException iae) {}
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> DateUtils.getFragmentInMinutes((Date) null, Calendar.MILLISECOND));
 
-        try {
-            DateUtils.getFragmentInHours((Date) null, Calendar.MILLISECOND);
-            fail();
-        } catch(final IllegalArgumentException iae) {}
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> DateUtils.getFragmentInHours((Date) null, Calendar.MILLISECOND));
 
-        try {
-            DateUtils.getFragmentInDays((Date) null, Calendar.MILLISECOND);
-            fail();
-        } catch(final IllegalArgumentException iae) {}
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> DateUtils.getFragmentInDays((Date) null, Calendar.MILLISECOND));
     }
 
     @Test
     public void testNullCalendar() {
-        try {
-            DateUtils.getFragmentInMilliseconds((Calendar) null, Calendar.MILLISECOND);
-            fail();
-        } catch(final IllegalArgumentException iae) {}
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> DateUtils.getFragmentInMilliseconds((Calendar) null, Calendar.MILLISECOND));
 
-        try {
-            DateUtils.getFragmentInSeconds((Calendar) null, Calendar.MILLISECOND);
-            fail();
-        } catch(final IllegalArgumentException iae) {}
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> DateUtils.getFragmentInSeconds((Calendar) null, Calendar.MILLISECOND));
 
-        try {
-            DateUtils.getFragmentInMinutes((Calendar) null, Calendar.MILLISECOND);
-            fail();
-        } catch(final IllegalArgumentException iae) {}
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> DateUtils.getFragmentInMinutes((Calendar) null, Calendar.MILLISECOND));
 
-        try {
-            DateUtils.getFragmentInHours((Calendar) null, Calendar.MILLISECOND);
-            fail();
-        } catch(final IllegalArgumentException iae) {}
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> DateUtils.getFragmentInHours((Calendar) null, Calendar.MILLISECOND));
 
-        try {
-            DateUtils.getFragmentInDays((Calendar) null, Calendar.MILLISECOND);
-            fail();
-        } catch(final IllegalArgumentException iae) {}
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> DateUtils.getFragmentInDays((Calendar) null, Calendar.MILLISECOND));
     }
 
     @Test
     public void testInvalidFragmentWithDate() {
-        try {
-            DateUtils.getFragmentInMilliseconds(aDate, 0);
-            fail();
-        } catch(final IllegalArgumentException iae) {}
-
-        try {
-            DateUtils.getFragmentInSeconds(aDate, 0);
-            fail();
-        } catch(final IllegalArgumentException iae) {}
-
-        try {
-            DateUtils.getFragmentInMinutes(aDate, 0);
-            fail();
-        } catch(final IllegalArgumentException iae) {}
-
-        try {
-            DateUtils.getFragmentInHours(aDate, 0);
-            fail();
-        } catch(final IllegalArgumentException iae) {}
-
-        try {
-            DateUtils.getFragmentInDays(aDate, 0);
-            fail();
-        } catch(final IllegalArgumentException iae) {}
+        assertThrows(IllegalArgumentException.class, () -> DateUtils.getFragmentInMilliseconds(aDate, 0));
+        assertThrows(IllegalArgumentException.class, () -> DateUtils.getFragmentInSeconds(aDate, 0));
+        assertThrows(IllegalArgumentException.class, () -> DateUtils.getFragmentInMinutes(aDate, 0));
+        assertThrows(IllegalArgumentException.class, () -> DateUtils.getFragmentInHours(aDate, 0));
+        assertThrows(IllegalArgumentException.class, () -> DateUtils.getFragmentInDays(aDate, 0));
     }
 
     @Test
     public void testInvalidFragmentWithCalendar() {
-        try {
-            DateUtils.getFragmentInMilliseconds(aCalendar, 0);
-            fail();
-        } catch(final IllegalArgumentException iae) {}
-
-        try {
-            DateUtils.getFragmentInSeconds(aCalendar, 0);
-            fail();
-        } catch(final IllegalArgumentException iae) {}
-
-        try {
-            DateUtils.getFragmentInMinutes(aCalendar, 0);
-            fail();
-        } catch(final IllegalArgumentException iae) {}
-
-        try {
-            DateUtils.getFragmentInHours(aCalendar, 0);
-            fail();
-        } catch(final IllegalArgumentException iae) {}
-
-        try {
-            DateUtils.getFragmentInDays(aCalendar, 0);
-            fail();
-        } catch(final IllegalArgumentException iae) {}
+        assertThrows(IllegalArgumentException.class, () -> DateUtils.getFragmentInMilliseconds(aCalendar, 0));
+        assertThrows(IllegalArgumentException.class, () -> DateUtils.getFragmentInSeconds(aCalendar, 0));
+        assertThrows(IllegalArgumentException.class, () -> DateUtils.getFragmentInMinutes(aCalendar, 0));
+        assertThrows(IllegalArgumentException.class, () -> DateUtils.getFragmentInHours(aCalendar, 0));
+        assertThrows(IllegalArgumentException.class, () -> DateUtils.getFragmentInDays(aCalendar, 0));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/time/DateUtilsFragmentTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/DateUtilsFragmentTest.java
@@ -518,13 +518,13 @@ testResult);
     }
 
     @Test
-    public void testDaysOfMonthWithCalendar() throws Exception {
+    public void testDaysOfMonthWithCalendar() {
         final long testResult = DateUtils.getFragmentInDays(aCalendar, Calendar.MONTH);
         assertEquals(days, testResult);
     }
 
     @Test
-    public void testDaysOfMonthWithDate() throws Exception {
+    public void testDaysOfMonthWithDate() {
         final long testResult = DateUtils.getFragmentInDays(aDate, Calendar.MONTH);
         final Calendar cal = Calendar.getInstance();
         cal.setTime(aDate);
@@ -532,13 +532,13 @@ testResult);
     }
 
     @Test
-    public void testDaysOfYearWithCalendar() throws Exception {
+    public void testDaysOfYearWithCalendar() {
         final long testResult = DateUtils.getFragmentInDays(aCalendar, Calendar.YEAR);
         assertEquals(aCalendar.get(Calendar.DAY_OF_YEAR), testResult);
     }
 
     @Test
-    public void testDaysOfYearWithDate() throws Exception {
+    public void testDaysOfYearWithDate() {
         final long testResult = DateUtils.getFragmentInDays(aDate, Calendar.YEAR);
         final Calendar cal = Calendar.getInstance();
         cal.setTime(aDate);

--- a/src/test/java/org/apache/commons/lang3/time/DateUtilsRoundingTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/DateUtilsRoundingTest.java
@@ -596,7 +596,7 @@ public class DateUtilsRoundingTest {
      * @since 3.0
      */
     @Test
-    public void testTruncateMilliSecond() throws Exception {
+    public void testTruncateMilliSecond() {
         final int calendarField = Calendar.MILLISECOND;
         baseTruncateTest(targetMilliSecondDate, targetMilliSecondDate, calendarField);
     }

--- a/src/test/java/org/apache/commons/lang3/time/DateUtilsRoundingTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/DateUtilsRoundingTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
@@ -667,7 +667,7 @@ public class DateUtilsRoundingTest {
         //Date-comparison
         assertEquals(truncatedDate, DateUtils.truncate(truncatedDate, calendarField), "Truncating "+ fdf.format(truncatedDate) +" as Date with CalendarField-value "+ calendarField +" must return itself");
         assertEquals(truncatedDate, DateUtils.truncate(lastTruncateDate, calendarField));
-        assertFalse(truncatedDate.equals(DateUtils.truncate(nextTruncateDate, calendarField)), fdf.format(lastTruncateDate) +" is not an extreme when truncating as Date with CalendarField-value "+ calendarField);
+        assertNotEquals(truncatedDate, DateUtils.truncate(nextTruncateDate, calendarField), fdf.format(lastTruncateDate) + " is not an extreme when truncating as Date with CalendarField-value " + calendarField);
 
         //Calendar-initiations
         Calendar truncatedCalendar, lastTruncateCalendar, nextTruncateCalendar;
@@ -681,15 +681,15 @@ public class DateUtilsRoundingTest {
         //Calendar-comparison
         assertEquals(truncatedCalendar, DateUtils.truncate(truncatedCalendar, calendarField), "Truncating "+ fdf.format(truncatedCalendar) +" as Calendar with CalendarField-value "+ calendarField +" must return itself");
         assertEquals(truncatedCalendar, DateUtils.truncate(lastTruncateCalendar, calendarField));
-        assertFalse(truncatedCalendar.equals(DateUtils.truncate(nextTruncateCalendar, calendarField)), fdf.format(lastTruncateCalendar) +" is not an extreme when truncating as Calendar with CalendarField-value "+ calendarField);
+        assertNotEquals(truncatedCalendar, DateUtils.truncate(nextTruncateCalendar, calendarField), fdf.format(lastTruncateCalendar) + " is not an extreme when truncating as Calendar with CalendarField-value " + calendarField);
 
         //Object-comparison
         assertEquals(truncatedDate, DateUtils.truncate((Object) truncatedDate, calendarField), "Truncating "+ fdf.format(truncatedDate) +" as Date cast to Object with CalendarField-value "+ calendarField +" must return itself as Date");
         assertEquals(truncatedDate, DateUtils.truncate((Object) lastTruncateDate, calendarField));
-        assertFalse(truncatedDate.equals(DateUtils.truncate((Object) nextTruncateDate, calendarField)), fdf.format(lastTruncateDate) +" is not an extreme when truncating as Date cast to Object with CalendarField-value "+ calendarField);
+        assertNotEquals(truncatedDate, DateUtils.truncate((Object) nextTruncateDate, calendarField), fdf.format(lastTruncateDate) + " is not an extreme when truncating as Date cast to Object with CalendarField-value " + calendarField);
         assertEquals(truncatedDate, DateUtils.truncate((Object) truncatedCalendar, calendarField), "Truncating "+ fdf.format(truncatedCalendar) +" as Calendar cast to Object with CalendarField-value "+ calendarField +" must return itself as Date");
         assertEquals(truncatedDate, DateUtils.truncate((Object) lastTruncateCalendar, calendarField));
-        assertFalse(truncatedDate.equals(DateUtils.truncate((Object) nextTruncateCalendar, calendarField)), fdf.format(lastTruncateCalendar) +" is not an extreme when truncating as Calendar cast to Object with CalendarField-value "+ calendarField);
+        assertNotEquals(truncatedDate, DateUtils.truncate((Object) nextTruncateCalendar, calendarField), fdf.format(lastTruncateCalendar) + " is not an extreme when truncating as Calendar cast to Object with CalendarField-value " + calendarField);
     }
 
     /**
@@ -717,14 +717,14 @@ public class DateUtilsRoundingTest {
 
         final Date toPrevRoundDate = DateUtils.addMilliseconds(minDate, -1);
         final Date toNextRoundDate = DateUtils.addMilliseconds(maxDate, 1);
-        assertFalse(januaryOneDate.equals(DateUtils.round(toPrevRoundDate, calendarField)), fdf.format(minDate) +" is not an lower-extreme when rounding as Date with CalendarField-value "+ calendarField);
-        assertFalse(januaryOneDate.equals(DateUtils.round(toNextRoundDate, calendarField)), fdf.format(maxDate) +" is not an upper-extreme when rounding as Date with CalendarField-value "+ calendarField);
+        assertNotEquals(januaryOneDate, DateUtils.round(toPrevRoundDate, calendarField), fdf.format(minDate) + " is not an lower-extreme when rounding as Date with CalendarField-value " + calendarField);
+        assertNotEquals(januaryOneDate, DateUtils.round(toNextRoundDate, calendarField), fdf.format(maxDate) + " is not an upper-extreme when rounding as Date with CalendarField-value " + calendarField);
 
         final Calendar toPrevRoundCalendar = Calendar.getInstance();
         toPrevRoundCalendar.setTime(toPrevRoundDate);
         final Calendar toNextRoundCalendar = Calendar.getInstance();
         toNextRoundCalendar.setTime(toNextRoundDate);
-        assertFalse(januaryOneDate.equals(DateUtils.round(toPrevRoundDate, calendarField)), fdf.format(minCalendar) +" is not an lower-extreme when rounding as Date with CalendarField-value "+ calendarField);
-        assertFalse(januaryOneDate.equals(DateUtils.round(toNextRoundDate, calendarField)), fdf.format(maxCalendar) +" is not an upper-extreme when rounding as Date with CalendarField-value "+ calendarField);
+        assertNotEquals(januaryOneDate, DateUtils.round(toPrevRoundDate, calendarField), fdf.format(minCalendar) + " is not an lower-extreme when rounding as Date with CalendarField-value " + calendarField);
+        assertNotEquals(januaryOneDate, DateUtils.round(toNextRoundDate, calendarField), fdf.format(maxCalendar) + " is not an upper-extreme when rounding as Date with CalendarField-value " + calendarField);
     }
 }

--- a/src/test/java/org/apache/commons/lang3/time/DateUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/DateUtilsTest.java
@@ -22,7 +22,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
@@ -366,10 +365,7 @@ public class DateUtilsTest {
         final Date date = DateUtils.parseDate(dateStr, parsers);
         assertEquals(cal.getTime(), date);
 
-        try {
-            DateUtils.parseDateStrictly(dateStr, parsers);
-            fail();
-        } catch (final ParseException ex) {}
+        assertThrows(ParseException.class, () -> DateUtils.parseDateStrictly(dateStr, parsers));
     }
 
     //-----------------------------------------------------------------------
@@ -556,12 +552,10 @@ public class DateUtilsTest {
         assertDate(BASE_DATE, 2000, 6, 5, 4, 3, 2, 1);
         assertDate(result, 2000, 1, 5, 4, 3, 2, 1);
 
-        try {
-            DateUtils.setMonths(BASE_DATE, 12);
-            fail("DateUtils.setMonths did not throw an expected IllegalArgumentException.");
-        } catch (final IllegalArgumentException e) {
-
-        }
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> DateUtils.setMonths(BASE_DATE, 12),
+                "DateUtils.setMonths did not throw an expected IllegalArgumentException.");
     }
 
     // -----------------------------------------------------------------------
@@ -577,12 +571,10 @@ public class DateUtilsTest {
         assertDate(BASE_DATE, 2000, 6, 5, 4, 3, 2, 1);
         assertDate(result, 2000, 6, 29, 4, 3, 2, 1);
 
-        try {
-            DateUtils.setDays(BASE_DATE, 32);
-            fail("DateUtils.setDays did not throw an expected IllegalArgumentException.");
-        } catch (final IllegalArgumentException e) {
-
-        }
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> DateUtils.setDays(BASE_DATE, 32),
+                "DateUtils.setDays did not throw an expected IllegalArgumentException.");
     }
 
     // -----------------------------------------------------------------------
@@ -598,12 +590,10 @@ public class DateUtilsTest {
         assertDate(BASE_DATE, 2000, 6, 5, 4, 3, 2, 1);
         assertDate(result, 2000, 6, 5, 23, 3, 2, 1);
 
-        try {
-            DateUtils.setHours(BASE_DATE, 24);
-            fail("DateUtils.setHours did not throw an expected IllegalArgumentException.");
-        } catch (final IllegalArgumentException e) {
-
-        }
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> DateUtils.setHours(BASE_DATE, 24),
+                "DateUtils.setHours did not throw an expected IllegalArgumentException.");
     }
 
     // -----------------------------------------------------------------------
@@ -619,12 +609,10 @@ public class DateUtilsTest {
         assertDate(BASE_DATE, 2000, 6, 5, 4, 3, 2, 1);
         assertDate(result, 2000, 6, 5, 4, 59, 2, 1);
 
-        try {
-            DateUtils.setMinutes(BASE_DATE, 60);
-            fail("DateUtils.setMinutes did not throw an expected IllegalArgumentException.");
-        } catch (final IllegalArgumentException e) {
-
-        }
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> DateUtils.setMinutes(BASE_DATE, 60),
+                "DateUtils.setMinutes did not throw an expected IllegalArgumentException.");
     }
 
     // -----------------------------------------------------------------------
@@ -640,12 +628,10 @@ public class DateUtilsTest {
         assertDate(BASE_DATE, 2000, 6, 5, 4, 3, 2, 1);
         assertDate(result, 2000, 6, 5, 4, 3, 59, 1);
 
-        try {
-            DateUtils.setSeconds(BASE_DATE, 60);
-            fail("DateUtils.setSeconds did not throw an expected IllegalArgumentException.");
-        } catch (final IllegalArgumentException e) {
-
-        }
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> DateUtils.setSeconds(BASE_DATE, 60),
+                "DateUtils.setSeconds did not throw an expected IllegalArgumentException.");
     }
 
     // -----------------------------------------------------------------------
@@ -661,12 +647,10 @@ public class DateUtilsTest {
         assertDate(BASE_DATE, 2000, 6, 5, 4, 3, 2, 1);
         assertDate(result, 2000, 6, 5, 4, 3, 2, 999);
 
-        try {
-            DateUtils.setMilliseconds(BASE_DATE, 1000);
-            fail("DateUtils.setMilliseconds did not throw an expected IllegalArgumentException.");
-        } catch (final IllegalArgumentException e) {
-
-        }
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> DateUtils.setMilliseconds(BASE_DATE, 1000),
+                "DateUtils.setMilliseconds did not throw an expected IllegalArgumentException.");
     }
 
     //-----------------------------------------------------------------------
@@ -686,12 +670,7 @@ public class DateUtilsTest {
     @Test
     public void testToCalendar() {
         assertEquals(date1, DateUtils.toCalendar(date1).getTime(), "Failed to convert to a Calendar and back");
-        try {
-            DateUtils.toCalendar(null);
-            fail("Expected NullPointerException to be thrown");
-        } catch(final NullPointerException npe) {
-            // expected
-        }
+        assertThrows(NullPointerException.class, () -> DateUtils.toCalendar(null));
     }
 
     //-----------------------------------------------------------------------
@@ -851,26 +830,11 @@ public class DateUtilsTest {
                 DateUtils.round((Object) dateAmPm4, Calendar.AM_PM),
                 "round ampm-4 failed");
 
-        try {
-            DateUtils.round((Date) null, Calendar.SECOND);
-            fail();
-        } catch (final IllegalArgumentException ex) {}
-        try {
-            DateUtils.round((Calendar) null, Calendar.SECOND);
-            fail();
-        } catch (final IllegalArgumentException ex) {}
-        try {
-            DateUtils.round((Object) null, Calendar.SECOND);
-            fail();
-        } catch (final IllegalArgumentException ex) {}
-        try {
-            DateUtils.round("", Calendar.SECOND);
-            fail();
-        } catch (final ClassCastException ex) {}
-        try {
-            DateUtils.round(date1, -9999);
-            fail();
-        } catch(final IllegalArgumentException ex) {}
+        assertThrows(IllegalArgumentException.class, () -> DateUtils.round((Date) null, Calendar.SECOND));
+        assertThrows(IllegalArgumentException.class, () -> DateUtils.round((Calendar) null, Calendar.SECOND));
+        assertThrows(IllegalArgumentException.class, () -> DateUtils.round((Object) null, Calendar.SECOND));
+        assertThrows(ClassCastException.class, () -> DateUtils.round("", Calendar.SECOND));
+        assertThrows(IllegalArgumentException.class, () -> DateUtils.round(date1, -9999));
 
         assertEquals(dateTimeParser.parse("February 3, 2002 00:00:00.000"),
                 DateUtils.round((Object) calAmPm1, Calendar.AM_PM),
@@ -1147,22 +1111,10 @@ public class DateUtilsTest {
                 DateUtils.truncate((Object) calAmPm4, Calendar.AM_PM),
                 "truncate ampm-4 failed");
 
-        try {
-            DateUtils.truncate((Date) null, Calendar.SECOND);
-            fail();
-        } catch (final IllegalArgumentException ex) {}
-        try {
-            DateUtils.truncate((Calendar) null, Calendar.SECOND);
-            fail();
-        } catch (final IllegalArgumentException ex) {}
-        try {
-            DateUtils.truncate((Object) null, Calendar.SECOND);
-            fail();
-        } catch (final IllegalArgumentException ex) {}
-        try {
-            DateUtils.truncate("", Calendar.SECOND);
-            fail();
-        } catch (final ClassCastException ex) {}
+        assertThrows(IllegalArgumentException.class, () -> DateUtils.truncate((Date) null, Calendar.SECOND));
+        assertThrows(IllegalArgumentException.class, () -> DateUtils.truncate((Calendar) null, Calendar.SECOND));
+        assertThrows(IllegalArgumentException.class, () -> DateUtils.truncate((Object) null, Calendar.SECOND));
+        assertThrows(ClassCastException.class, () -> DateUtils.truncate("", Calendar.SECOND));
 
         // Fix for http://issues.apache.org/bugzilla/show_bug.cgi?id=25560
         // Test truncate across beginning of daylight saving time
@@ -1191,15 +1143,9 @@ public class DateUtilsTest {
         final Date endOfTime = new Date(Long.MAX_VALUE); // fyi: Sun Aug 17 07:12:55 CET 292278994 -- 807 millis
         final GregorianCalendar endCal = new GregorianCalendar();
         endCal.setTime(endOfTime);
-        try {
-            DateUtils.truncate(endCal, Calendar.DATE);
-            fail();
-        } catch (final ArithmeticException ex) {}
+        assertThrows(ArithmeticException.class, () -> DateUtils.truncate(endCal, Calendar.DATE));
         endCal.set(Calendar.YEAR, 280000001);
-        try {
-            DateUtils.truncate(endCal, Calendar.DATE);
-            fail();
-        } catch (final ArithmeticException ex) {}
+        assertThrows(ArithmeticException.class, () -> DateUtils.truncate(endCal, Calendar.DATE));
         endCal.set(Calendar.YEAR, 280000000);
         final Calendar cal = DateUtils.truncate(endCal, Calendar.DATE);
         assertEquals(0, cal.get(Calendar.HOUR));
@@ -1445,27 +1391,11 @@ public class DateUtilsTest {
                 DateUtils.ceiling((Object) calAmPm4, Calendar.AM_PM),
                 "ceiling ampm-4 failed");
 
-        try {
-            DateUtils.ceiling((Date) null, Calendar.SECOND);
-            fail();
-        } catch (final IllegalArgumentException ex) {}
-        try {
-            DateUtils.ceiling((Calendar) null, Calendar.SECOND);
-            fail();
-        } catch (final IllegalArgumentException ex) {}
-        try {
-            DateUtils.ceiling((Object) null, Calendar.SECOND);
-            fail();
-        } catch (final IllegalArgumentException ex) {}
-        try {
-            DateUtils.ceiling("", Calendar.SECOND);
-            fail();
-        } catch (final ClassCastException ex) {}
-        try {
-            DateUtils.ceiling(date1, -9999);
-            fail();
-        } catch(final IllegalArgumentException ex) {}
-
+        assertThrows(IllegalArgumentException.class, () -> DateUtils.ceiling((Date) null, Calendar.SECOND));
+        assertThrows(IllegalArgumentException.class, () -> DateUtils.ceiling((Calendar) null, Calendar.SECOND));
+        assertThrows(IllegalArgumentException.class, () -> DateUtils.ceiling((Object) null, Calendar.SECOND));
+        assertThrows(ClassCastException.class, () -> DateUtils.ceiling("", Calendar.SECOND));
+        assertThrows(IllegalArgumentException.class, () -> DateUtils.ceiling(date1, -9999));
 
         // Fix for http://issues.apache.org/bugzilla/show_bug.cgi?id=25560
         // Test ceiling across the beginning of daylight saving time
@@ -1532,15 +1462,9 @@ public class DateUtilsTest {
         final Date endOfTime = new Date(Long.MAX_VALUE); // fyi: Sun Aug 17 07:12:55 CET 292278994 -- 807 millis
         final GregorianCalendar endCal = new GregorianCalendar();
         endCal.setTime(endOfTime);
-        try {
-            DateUtils.ceiling(endCal, Calendar.DATE);
-            fail();
-        } catch (final ArithmeticException ex) {}
+        assertThrows(ArithmeticException.class, () -> DateUtils.ceiling(endCal, Calendar.DATE));
         endCal.set(Calendar.YEAR, 280000001);
-        try {
-            DateUtils.ceiling(endCal, Calendar.DATE);
-            fail();
-        } catch (final ArithmeticException ex) {}
+        assertThrows(ArithmeticException.class, () -> DateUtils.ceiling(endCal, Calendar.DATE));
         endCal.set(Calendar.YEAR, 280000000);
         final Calendar cal = DateUtils.ceiling(endCal, Calendar.DATE);
         assertEquals(0, cal.get(Calendar.HOUR));
@@ -1553,25 +1477,14 @@ public class DateUtilsTest {
      */
     @Test
     public void testIteratorEx() throws Exception {
-        try {
-            DateUtils.iterator(Calendar.getInstance(), -9999);
-        } catch (final IllegalArgumentException ex) {}
-        try {
-            DateUtils.iterator((Date) null, DateUtils.RANGE_WEEK_CENTER);
-            fail();
-        } catch (final IllegalArgumentException ex) {}
-        try {
-            DateUtils.iterator((Calendar) null, DateUtils.RANGE_WEEK_CENTER);
-            fail();
-        } catch (final IllegalArgumentException ex) {}
-        try {
-            DateUtils.iterator((Object) null, DateUtils.RANGE_WEEK_CENTER);
-            fail();
-        } catch (final IllegalArgumentException ex) {}
-        try {
-            DateUtils.iterator("", DateUtils.RANGE_WEEK_CENTER);
-            fail();
-        } catch (final ClassCastException ex) {}
+        assertThrows(IllegalArgumentException.class, () -> DateUtils.iterator(Calendar.getInstance(), -9999));
+        assertThrows
+                (IllegalArgumentException.class, () -> DateUtils.iterator((Date) null, DateUtils.RANGE_WEEK_CENTER));
+        assertThrows
+                (IllegalArgumentException.class, () -> DateUtils.iterator((Calendar) null, DateUtils.RANGE_WEEK_CENTER));
+        assertThrows
+                (IllegalArgumentException.class, () -> DateUtils.iterator((Object) null, DateUtils.RANGE_WEEK_CENTER));
+        assertThrows(ClassCastException.class, () -> DateUtils.iterator("", DateUtils.RANGE_WEEK_CENTER));
     }
 
     /**
@@ -1607,17 +1520,12 @@ public class DateUtilsTest {
 
             it = DateUtils.iterator((Object) now, DateUtils.RANGE_WEEK_CENTER);
             assertWeekIterator(it, centered);
-            it = DateUtils.iterator((Object) now.getTime(), DateUtils.RANGE_WEEK_CENTER);
-            assertWeekIterator(it, centered);
-            try {
-                it.next();
-                fail();
-            } catch (final NoSuchElementException ex) {}
-            it = DateUtils.iterator(now, DateUtils.RANGE_WEEK_CENTER);
-            it.next();
-            try {
-                it.remove();
-            } catch( final UnsupportedOperationException ex) {}
+            Iterator<?> it2 = DateUtils.iterator((Object) now.getTime(), DateUtils.RANGE_WEEK_CENTER);
+            assertWeekIterator(it2, centered);
+            assertThrows(NoSuchElementException.class, it2::next);
+            Iterator<?> it3 = DateUtils.iterator(now, DateUtils.RANGE_WEEK_CENTER);
+            it3.next();
+            assertThrows(UnsupportedOperationException.class, it3::remove);
 
             now.add(Calendar.DATE,1);
         }

--- a/src/test/java/org/apache/commons/lang3/time/DateUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/DateUtilsTest.java
@@ -654,7 +654,7 @@ public class DateUtilsTest {
     }
 
     //-----------------------------------------------------------------------
-    private void assertDate(final Date date, final int year, final int month, final int day, final int hour, final int min, final int sec, final int mil) throws Exception {
+    private void assertDate(final Date date, final int year, final int month, final int day, final int hour, final int min, final int sec, final int mil) {
         final GregorianCalendar cal = new GregorianCalendar();
         cal.setTime(date);
         assertEquals(year, cal.get(Calendar.YEAR));
@@ -1154,12 +1154,10 @@ public class DateUtilsTest {
     /**
      * Tests for LANG-59
      *
-     * @throws java.lang.Exception so we don't have to catch it
-     *
      * see http://issues.apache.org/jira/browse/LANG-59
      */
     @Test
-    public void testTruncateLang59() throws Exception {
+    public void testTruncateLang59() {
         try {
             // Set TimeZone to Mountain Time
             final TimeZone denverZone = TimeZone.getTimeZone("America/Denver");
@@ -1472,11 +1470,9 @@ public class DateUtilsTest {
 
     /**
      * Tests the iterator exceptions
-     *
-     * @throws java.lang.Exception so we don't have to catch it
      */
     @Test
-    public void testIteratorEx() throws Exception {
+    public void testIteratorEx() {
         assertThrows(IllegalArgumentException.class, () -> DateUtils.iterator(Calendar.getInstance(), -9999));
         assertThrows
                 (IllegalArgumentException.class, () -> DateUtils.iterator((Date) null, DateUtils.RANGE_WEEK_CENTER));
@@ -1489,11 +1485,9 @@ public class DateUtilsTest {
 
     /**
      * Tests the calendar iterator for week ranges
-     *
-     * @throws java.lang.Exception so we don't have to catch it
      */
     @Test
-    public void testWeekIterator() throws Exception {
+    public void testWeekIterator() {
         final Calendar now = Calendar.getInstance();
         for (int i = 0; i< 7; i++) {
             final Calendar today = DateUtils.truncate(now, Calendar.DATE);

--- a/src/test/java/org/apache/commons/lang3/time/DurationFormatUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/DurationFormatUtilsTest.java
@@ -20,6 +20,7 @@ package org.apache.commons.lang3.time;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -397,13 +398,11 @@ public class DurationFormatUtilsTest {
 
         // test failures in equals
         final DurationFormatUtils.Token token = new DurationFormatUtils.Token(DurationFormatUtils.y, 4);
-        assertFalse(token.equals(new Object()), "Token equal to non-Token class. ");
-        assertFalse(token.equals(new DurationFormatUtils.Token(new Object())),
-                "Token equal to Token with wrong value class. ");
-        assertFalse(token.equals(new DurationFormatUtils.Token(DurationFormatUtils.y, 1)),
-                "Token equal to Token with different count. ");
+        assertNotEquals(token, new Object(), "Token equal to non-Token class. ");
+        assertNotEquals(token, new DurationFormatUtils.Token(new Object()), "Token equal to Token with wrong value class. ");
+        assertNotEquals(token, new DurationFormatUtils.Token(DurationFormatUtils.y, 1), "Token equal to Token with different count. ");
         final DurationFormatUtils.Token numToken = new DurationFormatUtils.Token(Integer.valueOf(1), 4);
-        assertTrue(numToken.equals(numToken), "Token with Number value not equal to itself. ");
+        assertEquals(numToken, numToken, "Token with Number value not equal to itself. ");
     }
 
 

--- a/src/test/java/org/apache/commons/lang3/time/FastDateFormatTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/FastDateFormatTest.java
@@ -17,10 +17,9 @@
 package org.apache.commons.lang3.time;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.text.FieldPosition;
@@ -64,7 +63,7 @@ public class FastDateFormatTest {
         final FastDateFormat format2 = FastDateFormat.getInstance("MM-DD-yyyy");
         final FastDateFormat format3 = FastDateFormat.getInstance("MM-DD-yyyy");
 
-        assertTrue(format1 != format2); // -- junit 3.8 version -- assertFalse(format1 == format2);
+        assertNotSame(format1, format2);
         assertSame(format2, format3);
         assertEquals("MM/DD/yyyy", format1.getPattern());
         assertEquals(TimeZone.getDefault(), format1.getTimeZone());
@@ -173,12 +172,12 @@ public class FastDateFormatTest {
         final FastDateFormat longShort = FastDateFormat.getDateTimeInstance(FastDateFormat.LONG, FastDateFormat.SHORT, Locale.US);
         final FastDateFormat longLong = FastDateFormat.getDateTimeInstance(FastDateFormat.LONG, FastDateFormat.LONG, Locale.US);
 
-        assertFalse(shortShort.equals(shortLong));
-        assertFalse(shortShort.equals(longShort));
-        assertFalse(shortShort.equals(longLong));
-        assertFalse(shortLong.equals(longShort));
-        assertFalse(shortLong.equals(longLong));
-        assertFalse(longShort.equals(longLong));
+        assertNotEquals(shortShort, shortLong);
+        assertNotEquals(shortShort, longShort);
+        assertNotEquals(shortShort, longLong);
+        assertNotEquals(shortLong, longShort);
+        assertNotEquals(shortLong, longLong);
+        assertNotEquals(longShort, longLong);
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/time/FastDateFormatTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/FastDateFormatTest.java
@@ -318,7 +318,7 @@ public class FastDateFormatTest {
     }
 
     @Test
-    public void testLANG_1267() throws Exception {
+    public void testLANG_1267() {
         FastDateFormat.getInstance("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
     }
 }

--- a/src/test/java/org/apache/commons/lang3/time/FastDateParserSDFTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/FastDateParserSDFTest.java
@@ -17,9 +17,9 @@
 package org.apache.commons.lang3.time;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.text.ParseException;
 import java.text.ParsePosition;
@@ -163,15 +163,11 @@ public class FastDateParserSDFTest {
         Class<?> fdfE = null;
         try {
             actualTime = fdf.parse(formattedDate);
-            if (!valid) {
-                // failure in test
-                fail("Expected FDP parse to fail, but got " + actualTime);
-            }
+            // failure in test
+            assertTrue(valid, "Expected FDP parse to fail, but got " + actualTime);
         } catch (final ParseException e) {
-            if (valid) {
-                // failure in test
-                fail("Expected FDP parse to succeed, but got " + e);
-            }
+            // failure in test
+            assertFalse(valid, "Expected FDP parse to succeed, but got " + e);
             fdfE = e.getClass();
         }
         if (valid) {

--- a/src/test/java/org/apache/commons/lang3/time/FastDateParserTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/FastDateParserTest.java
@@ -18,6 +18,7 @@ package org.apache.commons.lang3.time;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -462,7 +463,7 @@ public class FastDateParserTest {
             }
         }
         // SDF and FDF should produce equivalent results
-        assertTrue((f==null)==(s==null), "Should both or neither throw Exceptions");
+        assertEquals((f == null), (s == null), "Should both or neither throw Exceptions");
         assertEquals(dsdf, dfdp, "Parsed dates should be equal");
     }
 
@@ -554,7 +555,7 @@ public class FastDateParserTest {
         assertEquals(parser1, parser2);
         assertEquals(parser1.hashCode(), parser2.hashCode());
 
-        assertFalse(parser1.equals(new Object()));
+        assertNotEquals(parser1, new Object());
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/time/FastDateParserTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/FastDateParserTest.java
@@ -20,7 +20,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.Serializable;
 import java.text.ParseException;
@@ -444,9 +443,7 @@ public class FastDateParserTest {
             final SimpleDateFormat sdf = new SimpleDateFormat(format, Locale.US);
             sdf.setTimeZone(NEW_YORK);
             dsdf = sdf.parse(date);
-            if (shouldFail) {
-                fail("Expected SDF failure, but got " + dsdf + " for ["+format+","+date+"]");
-            }
+            assertFalse(shouldFail, "Expected SDF failure, but got " + dsdf + " for ["+format+","+date+"]");
         } catch (final Exception e) {
             s = e;
             if (!shouldFail) {
@@ -457,9 +454,7 @@ public class FastDateParserTest {
         try {
             final DateParser fdp = getInstance(format, NEW_YORK, Locale.US);
             dfdp = fdp.parse(date);
-            if (shouldFail) {
-                fail("Expected FDF failure, but got " + dfdp + " for ["+format+","+date+"]");
-            }
+            assertFalse(shouldFail, "Expected FDF failure, but got " + dfdp + " for ["+format+","+date+"]");
         } catch (final Exception e) {
             f = e;
             if (!shouldFail) {

--- a/src/test/java/org/apache/commons/lang3/time/FastDateParserTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/FastDateParserTest.java
@@ -335,34 +335,27 @@ public class FastDateParserTest {
             final SimpleDateFormat sdf = new SimpleDateFormat(format, locale);
             final DateParser fdf = getInstance(format, locale);
 
-            try {
-                checkParse(locale, cal, sdf, fdf);
-            } catch(final ParseException ex) {
-                fail("Locale "+locale+ " failed with "+format+" era "+(eraBC?"BC":"AD")+"\n" + trimMessage(ex.toString()));
-            }
+            // If parsing fails, a ParseException will be thrown and the test will fail
+            checkParse(locale, cal, sdf, fdf);
         }
     }
 
     @Test
-    public void testJpLocales() {
+    public void testJpLocales() throws ParseException {
 
         final Calendar cal= Calendar.getInstance(GMT);
         cal.clear();
         cal.set(2003, Calendar.FEBRUARY, 10);
         cal.set(Calendar.ERA, GregorianCalendar.BC);
 
-        final Locale locale = LocaleUtils.toLocale("zh"); {
-            // ja_JP_JP cannot handle dates before 1868 properly
+        final Locale locale = LocaleUtils.toLocale("zh");
+        // ja_JP_JP cannot handle dates before 1868 properly
 
-            final SimpleDateFormat sdf = new SimpleDateFormat(LONG_FORMAT, locale);
-            final DateParser fdf = getInstance(LONG_FORMAT, locale);
+        final SimpleDateFormat sdf = new SimpleDateFormat(LONG_FORMAT, locale);
+        final DateParser fdf = getInstance(LONG_FORMAT, locale);
 
-            try {
-                checkParse(locale, cal, sdf, fdf);
-            } catch(final ParseException ex) {
-                fail("Locale "+locale+ " failed with "+LONG_FORMAT+"\n" + trimMessage(ex.toString()));
-            }
-        }
+        // If parsing fails, a ParseException will be thrown and the test will fail
+        checkParse(locale, cal, sdf, fdf);
     }
 
     private String trimMessage(final String msg) {
@@ -668,12 +661,7 @@ public class FastDateParserTest {
         final TimeZone kst = TimeZone.getTimeZone("KST");
         final DateParser fdp = getInstance("yyyyMMdd", kst, Locale.KOREA);
 
-        try {
-            fdp.parse("2015");
-            fail("expected parse exception");
-        } catch (final ParseException pe) {
-            // expected parse exception
-        }
+        assertThrows(ParseException.class, () -> fdp.parse("2015"));
 
         // Wed Apr 29 00:00:00 KST 2015
         Date actual = fdp.parse("20150429");

--- a/src/test/java/org/apache/commons/lang3/time/FastDateParser_TimeZoneStrategyTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/FastDateParser_TimeZoneStrategyTest.java
@@ -27,13 +27,12 @@ import java.util.Locale;
 import java.util.TimeZone;
 
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.fail;
 
 class FastDateParser_TimeZoneStrategyTest {
 
     @ParameterizedTest
     @MethodSource("java.util.Locale#getAvailableLocales")
-    void testTimeZoneStrategyPattern(final Locale locale) {
+    void testTimeZoneStrategyPattern(final Locale locale) throws ParseException {
         final FastDateParser parser = new FastDateParser("z", TimeZone.getDefault(), locale);
         final String[][] zones = DateFormatSymbols.getInstance(locale).getZoneStrings();
         for (final String[] zone : zones) {
@@ -42,17 +41,8 @@ class FastDateParser_TimeZoneStrategyTest {
                 if (tzDisplay == null) {
                     break;
                 }
-                try {
-                    parser.parse(tzDisplay);
-                } catch (final Exception ex) {
-                    fail("'" + tzDisplay + "'"
-                            + " Locale: '" + locale.getDisplayName() + "'"
-                            + " TimeZone: " + zone[0]
-                            + " offset: " + t
-                            + " defaultLocale: " + Locale.getDefault()
-                            + " defaultTimeZone: " + TimeZone.getDefault().getDisplayName()
-                    );
-                }
+                // An exception will be thrown and the test will fail if parsing isn't successful
+                parser.parse(tzDisplay);
             }
         }
     }

--- a/src/test/java/org/apache/commons/lang3/time/FastDatePrinterTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/FastDatePrinterTest.java
@@ -17,7 +17,7 @@
 package org.apache.commons.lang3.time;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -232,7 +232,7 @@ public class FastDatePrinterTest {
         assertEquals(printer1, printer2);
         assertEquals(printer1.hashCode(), printer2.hashCode());
 
-        assertFalse(printer1.equals(new Object()));
+        assertNotEquals(printer1, new Object());
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/time/FastDatePrinterTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/FastDatePrinterTest.java
@@ -23,7 +23,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.Serializable;
 import java.text.FieldPosition;
-import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
@@ -262,7 +261,7 @@ public class FastDatePrinterTest {
 
     @DefaultTimeZone("UTC")
     @Test
-    public void testTimeZoneAsZ() throws Exception {
+    public void testTimeZoneAsZ() {
         final Calendar c = Calendar.getInstance(FastTimeZone.getGmtTimeZone());
         final FastDateFormat noColonFormat = FastDateFormat.getInstance("Z");
         assertEquals("+0000", noColonFormat.format(c));
@@ -309,7 +308,7 @@ public class FastDatePrinterTest {
     }
 
     @Test
-    public void test1806() throws ParseException {
+    public void test1806() {
         for (final Expected1806 trial : Expected1806.values()) {
             final Calendar cal = initializeCalendar(trial.zone);
 
@@ -325,7 +324,7 @@ public class FastDatePrinterTest {
     }
 
     @Test
-    public void testLang1103() throws ParseException {
+    public void testLang1103() {
         final Calendar cal = Calendar.getInstance(SWEDEN);
         cal.set(Calendar.DAY_OF_MONTH, 2);
 
@@ -343,7 +342,7 @@ public class FastDatePrinterTest {
      * This method test that the bug is fixed.
      */
     @Test
-    public void testLang916() throws Exception {
+    public void testLang916() {
 
         final Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("Europe/Paris"));
         cal.clear();

--- a/src/test/java/org/apache/commons/lang3/time/StopWatchTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/StopWatchTest.java
@@ -175,13 +175,6 @@ public class StopWatchTest {
         }
 
         try {
-            watch.stop();
-            fail("Calling stop on an unstarted StopWatch should throw an exception. ");
-        } catch (final IllegalStateException ise) {
-            // expected
-        }
-
-        try {
             watch.suspend();
             fail("Calling suspend on an unstarted StopWatch should throw an exception. ");
         } catch (final IllegalStateException ise) {

--- a/src/test/java/org/apache/commons/lang3/time/StopWatchTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/StopWatchTest.java
@@ -18,8 +18,8 @@ package org.apache.commons.lang3.time;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.concurrent.TimeUnit;
 
@@ -167,105 +167,79 @@ public class StopWatchTest {
     @Test
     public void testBadStates() {
         final StopWatch watch = new StopWatch();
-        try {
-            watch.stop();
-            fail("Calling stop on an unstarted StopWatch should throw an exception. ");
-        } catch (final IllegalStateException ise) {
-            // expected
-        }
+        assertThrows(
+                IllegalStateException.class,
+                watch::stop,
+                "Calling stop on an unstarted StopWatch should throw an exception. ");
 
-        try {
-            watch.suspend();
-            fail("Calling suspend on an unstarted StopWatch should throw an exception. ");
-        } catch (final IllegalStateException ise) {
-            // expected
-        }
+        assertThrows(
+                IllegalStateException.class,
+                watch::suspend,
+                "Calling suspend on an unstarted StopWatch should throw an exception. ");
 
-        try {
-            watch.split();
-            fail("Calling split on a non-running StopWatch should throw an exception. ");
-        } catch (final IllegalStateException ise) {
-            // expected
-        }
+        assertThrows(
+                IllegalStateException.class,
+                watch::split,
+                "Calling split on a non-running StopWatch should throw an exception. ");
 
-        try {
-            watch.unsplit();
-            fail("Calling unsplit on an unsplit StopWatch should throw an exception. ");
-        } catch (final IllegalStateException ise) {
-            // expected
-        }
+        assertThrows(
+                IllegalStateException.class,
+                watch::unsplit,
+                "Calling unsplit on an unsplit StopWatch should throw an exception. ");
 
-        try {
-            watch.resume();
-            fail("Calling resume on an unsuspended StopWatch should throw an exception. ");
-        } catch (final IllegalStateException ise) {
-            // expected
-        }
+        assertThrows(
+                IllegalStateException.class,
+                watch::resume,
+                "Calling resume on an unsuspended StopWatch should throw an exception. ");
 
         watch.start();
 
-        try {
-            watch.start();
-            fail("Calling start on a started StopWatch should throw an exception. ");
-        } catch (final IllegalStateException ise) {
-            // expected
-        }
+        assertThrows(
+                IllegalStateException.class,
+                watch::start,
+                "Calling start on a started StopWatch should throw an exception. ");
 
-        try {
-            watch.unsplit();
-            fail("Calling unsplit on an unsplit StopWatch should throw an exception. ");
-        } catch (final IllegalStateException ise) {
-            // expected
-        }
+        assertThrows(
+                IllegalStateException.class,
+                watch::unsplit,
+                "Calling unsplit on an unsplit StopWatch should throw an exception. ");
 
-        try {
-            watch.getSplitTime();
-            fail("Calling getSplitTime on an unsplit StopWatch should throw an exception. ");
-        } catch (final IllegalStateException ise) {
-            // expected
-        }
+        assertThrows(
+                IllegalStateException.class,
+                watch::getSplitTime,
+                "Calling getSplitTime on an unsplit StopWatch should throw an exception. ");
 
-        try {
-            watch.resume();
-            fail("Calling resume on an unsuspended StopWatch should throw an exception. ");
-        } catch (final IllegalStateException ise) {
-            // expected
-        }
+        assertThrows(
+                IllegalStateException.class,
+                watch::resume,
+                "Calling resume on an unsuspended StopWatch should throw an exception. ");
 
         watch.stop();
 
-        try {
-            watch.start();
-            fail("Calling start on a stopped StopWatch should throw an exception as it needs to be reset. ");
-        } catch (final IllegalStateException ise) {
-            // expected
-        }
+        assertThrows(
+                IllegalStateException.class,
+                watch::start,
+                "Calling start on a stopped StopWatch should throw an exception as it needs to be reset. ");
     }
 
     @Test
     public void testGetStartTime() {
         final long beforeStopWatch = System.currentTimeMillis();
         final StopWatch watch = new StopWatch();
-        try {
-            watch.getStartTime();
-            fail("Calling getStartTime on an unstarted StopWatch should throw an exception");
-        } catch (final IllegalStateException expected) {
-            // expected
-        }
+        assertThrows(
+                IllegalStateException.class,
+                watch::getStartTime,
+                "Calling getStartTime on an unstarted StopWatch should throw an exception");
         watch.start();
-        try {
-            watch.getStartTime();
-            assertTrue(watch.getStartTime() >= beforeStopWatch);
-        } catch (final IllegalStateException ex) {
-            fail("Start time should be available: " + ex.getMessage());
-        }
+
+        watch.getStartTime();
+        assertTrue(watch.getStartTime() >= beforeStopWatch);
+
         watch.reset();
-        try {
-            watch.getStartTime();
-            fail("Calling getStartTime on a reset, but unstarted StopWatch should throw an exception");
-        } catch (final IllegalStateException expected) {
-            // expected
-        }
+        assertThrows(
+                IllegalStateException.class,
+                watch::getStartTime,
+                "Calling getStartTime on a reset, but unstarted StopWatch should throw an exception");
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/time/StopWatchTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/StopWatchTest.java
@@ -160,7 +160,7 @@ public class StopWatchTest {
         }
         watch.stop();
         final long totalTime = watch.getTime();
-        assertTrue(suspendTime == totalTime);
+        assertEquals(suspendTime, totalTime);
     }
 
     // test bad states

--- a/src/test/java/org/apache/commons/lang3/tuple/ImmutablePairTest.java
+++ b/src/test/java/org/apache/commons/lang3/tuple/ImmutablePairTest.java
@@ -36,7 +36,7 @@ import org.junit.jupiter.api.Test;
 public class ImmutablePairTest {
 
     @Test
-    public void testBasic() throws Exception {
+    public void testBasic() {
         final ImmutablePair<Integer, String> pair = new ImmutablePair<>(0, "foo");
         assertEquals(0, pair.left.intValue());
         assertEquals(0, pair.getLeft().intValue());
@@ -50,7 +50,7 @@ public class ImmutablePairTest {
     }
 
     @Test
-    public void testPairOf() throws Exception {
+    public void testPairOf() {
         final ImmutablePair<Integer, String> pair = ImmutablePair.of(0, "foo");
         assertEquals(0, pair.left.intValue());
         assertEquals(0, pair.getLeft().intValue());
@@ -64,7 +64,7 @@ public class ImmutablePairTest {
     }
 
     @Test
-    public void testEquals() throws Exception {
+    public void testEquals() {
         assertEquals(ImmutablePair.of(null, "foo"), ImmutablePair.of(null, "foo"));
         assertFalse(ImmutablePair.of("foo", 0).equals(ImmutablePair.of("foo", null)));
         assertFalse(ImmutablePair.of("foo", "bar").equals(ImmutablePair.of("xyz", "bar")));
@@ -75,7 +75,7 @@ public class ImmutablePairTest {
     }
 
     @Test
-    public void testHashCode() throws Exception {
+    public void testHashCode() {
         assertEquals(ImmutablePair.of(null, "foo").hashCode(), ImmutablePair.of(null, "foo").hashCode());
     }
 
@@ -118,7 +118,7 @@ public class ImmutablePairTest {
     }
 
     @Test
-    public void testToString() throws Exception {
+    public void testToString() {
         assertEquals("(null,null)", ImmutablePair.of(null, null).toString());
         assertEquals("(null,two)", ImmutablePair.of(null, "two").toString());
         assertEquals("(one,null)", ImmutablePair.of("one", null).toString());

--- a/src/test/java/org/apache/commons/lang3/tuple/ImmutablePairTest.java
+++ b/src/test/java/org/apache/commons/lang3/tuple/ImmutablePairTest.java
@@ -17,11 +17,10 @@
 package org.apache.commons.lang3.tuple;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -66,12 +65,12 @@ public class ImmutablePairTest {
     @Test
     public void testEquals() {
         assertEquals(ImmutablePair.of(null, "foo"), ImmutablePair.of(null, "foo"));
-        assertFalse(ImmutablePair.of("foo", 0).equals(ImmutablePair.of("foo", null)));
-        assertFalse(ImmutablePair.of("foo", "bar").equals(ImmutablePair.of("xyz", "bar")));
+        assertNotEquals(ImmutablePair.of("foo", 0), ImmutablePair.of("foo", null));
+        assertNotEquals(ImmutablePair.of("foo", "bar"), ImmutablePair.of("xyz", "bar"));
 
         final ImmutablePair<String, String> p = ImmutablePair.of("foo", "bar");
-        assertTrue(p.equals(p));
-        assertFalse(p.equals(new Object()));
+        assertEquals(p, p);
+        assertNotEquals(p, new Object());
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/tuple/ImmutableTripleTest.java
+++ b/src/test/java/org/apache/commons/lang3/tuple/ImmutableTripleTest.java
@@ -36,7 +36,7 @@ import org.junit.jupiter.api.Test;
 public class ImmutableTripleTest {
 
     @Test
-    public void testBasic() throws Exception {
+    public void testBasic() {
         final ImmutableTriple<Integer, String, Boolean> triple = new ImmutableTriple<>(0, "foo", Boolean.TRUE);
         assertEquals(0, triple.left.intValue());
         assertEquals(0, triple.getLeft().intValue());
@@ -54,7 +54,7 @@ public class ImmutableTripleTest {
     }
 
     @Test
-    public void testTripleOf() throws Exception {
+    public void testTripleOf() {
         final ImmutableTriple<Integer, String, Boolean> triple = ImmutableTriple.of(0, "foo", Boolean.FALSE);
         assertEquals(0, triple.left.intValue());
         assertEquals(0, triple.getLeft().intValue());
@@ -72,7 +72,7 @@ public class ImmutableTripleTest {
     }
 
     @Test
-    public void testEquals() throws Exception {
+    public void testEquals() {
         assertEquals(ImmutableTriple.of(null, "foo", 42), ImmutableTriple.of(null, "foo", 42));
         assertFalse(ImmutableTriple.of("foo", 0, Boolean.TRUE).equals(ImmutableTriple.of("foo", null, null)));
         assertFalse(ImmutableTriple.of("foo", "bar", "baz").equals(ImmutableTriple.of("xyz", "bar", "blo")));
@@ -83,7 +83,7 @@ public class ImmutableTripleTest {
     }
 
     @Test
-    public void testHashCode() throws Exception {
+    public void testHashCode() {
         assertEquals(ImmutableTriple.of(null, "foo", Boolean.TRUE).hashCode(), ImmutableTriple.of(null, "foo", Boolean.TRUE).hashCode());
     }
 
@@ -121,7 +121,7 @@ public class ImmutableTripleTest {
     }
 
     @Test
-    public void testToString() throws Exception {
+    public void testToString() {
         assertEquals("(null,null,null)", ImmutableTriple.of(null, null, null).toString());
         assertEquals("(null,two,null)", ImmutableTriple.of(null, "two", null).toString());
         assertEquals("(one,null,null)", ImmutableTriple.of("one", null, null).toString());

--- a/src/test/java/org/apache/commons/lang3/tuple/ImmutableTripleTest.java
+++ b/src/test/java/org/apache/commons/lang3/tuple/ImmutableTripleTest.java
@@ -17,11 +17,10 @@
 package org.apache.commons.lang3.tuple;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -74,12 +73,12 @@ public class ImmutableTripleTest {
     @Test
     public void testEquals() {
         assertEquals(ImmutableTriple.of(null, "foo", 42), ImmutableTriple.of(null, "foo", 42));
-        assertFalse(ImmutableTriple.of("foo", 0, Boolean.TRUE).equals(ImmutableTriple.of("foo", null, null)));
-        assertFalse(ImmutableTriple.of("foo", "bar", "baz").equals(ImmutableTriple.of("xyz", "bar", "blo")));
+        assertNotEquals(ImmutableTriple.of("foo", 0, Boolean.TRUE), ImmutableTriple.of("foo", null, null));
+        assertNotEquals(ImmutableTriple.of("foo", "bar", "baz"), ImmutableTriple.of("xyz", "bar", "blo"));
 
         final ImmutableTriple<String, String, String> p = ImmutableTriple.of("foo", "bar", "baz");
-        assertTrue(p.equals(p));
-        assertFalse(p.equals(new Object()));
+        assertEquals(p, p);
+        assertNotEquals(p, new Object());
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/tuple/MutablePairTest.java
+++ b/src/test/java/org/apache/commons/lang3/tuple/MutablePairTest.java
@@ -17,9 +17,8 @@
 package org.apache.commons.lang3.tuple;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -72,12 +71,12 @@ public class MutablePairTest {
     @Test
     public void testEquals() {
         assertEquals(MutablePair.of(null, "foo"), MutablePair.of(null, "foo"));
-        assertFalse(MutablePair.of("foo", 0).equals(MutablePair.of("foo", null)));
-        assertFalse(MutablePair.of("foo", "bar").equals(MutablePair.of("xyz", "bar")));
+        assertNotEquals(MutablePair.of("foo", 0), MutablePair.of("foo", null));
+        assertNotEquals(MutablePair.of("foo", "bar"), MutablePair.of("xyz", "bar"));
 
         final MutablePair<String, String> p = MutablePair.of("foo", "bar");
-        assertTrue(p.equals(p));
-        assertFalse(p.equals(new Object()));
+        assertEquals(p, p);
+        assertNotEquals(p, new Object());
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/tuple/MutablePairTest.java
+++ b/src/test/java/org/apache/commons/lang3/tuple/MutablePairTest.java
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.Test;
 public class MutablePairTest {
 
     @Test
-    public void testBasic() throws Exception {
+    public void testBasic() {
         final MutablePair<Integer, String> pair = new MutablePair<>(0, "foo");
         assertEquals(0, pair.getLeft().intValue());
         assertEquals("foo", pair.getRight());
@@ -44,14 +44,14 @@ public class MutablePairTest {
     }
 
     @Test
-    public void testDefault() throws Exception {
+    public void testDefault() {
         final MutablePair<Integer, String> pair = new MutablePair<>();
         assertNull(pair.getLeft());
         assertNull(pair.getRight());
     }
 
     @Test
-    public void testMutate() throws Exception {
+    public void testMutate() {
         final MutablePair<Integer, String> pair = new MutablePair<>(0, "foo");
         pair.setLeft(42);
         pair.setRight("bar");
@@ -60,7 +60,7 @@ public class MutablePairTest {
     }
 
     @Test
-    public void testPairOf() throws Exception {
+    public void testPairOf() {
         final MutablePair<Integer, String> pair = MutablePair.of(0, "foo");
         assertEquals(0, pair.getLeft().intValue());
         assertEquals("foo", pair.getRight());
@@ -70,7 +70,7 @@ public class MutablePairTest {
     }
 
     @Test
-    public void testEquals() throws Exception {
+    public void testEquals() {
         assertEquals(MutablePair.of(null, "foo"), MutablePair.of(null, "foo"));
         assertFalse(MutablePair.of("foo", 0).equals(MutablePair.of("foo", null)));
         assertFalse(MutablePair.of("foo", "bar").equals(MutablePair.of("xyz", "bar")));
@@ -81,12 +81,12 @@ public class MutablePairTest {
     }
 
     @Test
-    public void testHashCode() throws Exception {
+    public void testHashCode() {
         assertEquals(MutablePair.of(null, "foo").hashCode(), MutablePair.of(null, "foo").hashCode());
     }
 
     @Test
-    public void testToString() throws Exception {
+    public void testToString() {
         assertEquals("(null,null)", MutablePair.of(null, null).toString());
         assertEquals("(null,two)", MutablePair.of(null, "two").toString());
         assertEquals("(one,null)", MutablePair.of("one", null).toString());

--- a/src/test/java/org/apache/commons/lang3/tuple/MutableTripleTest.java
+++ b/src/test/java/org/apache/commons/lang3/tuple/MutableTripleTest.java
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.Test;
 public class MutableTripleTest {
 
     @Test
-    public void testBasic() throws Exception {
+    public void testBasic() {
         final MutableTriple<Integer, String, Boolean> triple = new MutableTriple<>(0, "foo", Boolean.FALSE);
         assertEquals(0, triple.getLeft().intValue());
         assertEquals("foo", triple.getMiddle());
@@ -46,7 +46,7 @@ public class MutableTripleTest {
     }
 
     @Test
-    public void testDefault() throws Exception {
+    public void testDefault() {
         final MutableTriple<Integer, String, Boolean> triple = new MutableTriple<>();
         assertNull(triple.getLeft());
         assertNull(triple.getMiddle());
@@ -54,7 +54,7 @@ public class MutableTripleTest {
     }
 
     @Test
-    public void testMutate() throws Exception {
+    public void testMutate() {
         final MutableTriple<Integer, String, Boolean> triple = new MutableTriple<>(0, "foo", Boolean.TRUE);
         triple.setLeft(42);
         triple.setMiddle("bar");
@@ -65,7 +65,7 @@ public class MutableTripleTest {
     }
 
     @Test
-    public void testTripleOf() throws Exception {
+    public void testTripleOf() {
         final MutableTriple<Integer, String, Boolean> triple = MutableTriple.of(0, "foo", Boolean.TRUE);
         assertEquals(0, triple.getLeft().intValue());
         assertEquals("foo", triple.getMiddle());
@@ -77,7 +77,7 @@ public class MutableTripleTest {
     }
 
     @Test
-    public void testEquals() throws Exception {
+    public void testEquals() {
         assertEquals(MutableTriple.of(null, "foo", "baz"), MutableTriple.of(null, "foo", "baz"));
         assertFalse(MutableTriple.of("foo", 0, Boolean.TRUE).equals(MutableTriple.of("foo", null, Boolean.TRUE)));
         assertFalse(MutableTriple.of("foo", "bar", "baz").equals(MutableTriple.of("xyz", "bar", "baz")));
@@ -89,12 +89,12 @@ public class MutableTripleTest {
     }
 
     @Test
-    public void testHashCode() throws Exception {
+    public void testHashCode() {
         assertEquals(MutableTriple.of(null, "foo", "baz").hashCode(), MutableTriple.of(null, "foo", "baz").hashCode());
     }
 
     @Test
-    public void testToString() throws Exception {
+    public void testToString() {
         assertEquals("(null,null,null)", MutableTriple.of(null, null, null).toString());
         assertEquals("(null,two,null)", MutableTriple.of(null, "two", null).toString());
         assertEquals("(one,null,null)", MutableTriple.of("one", null, null).toString());

--- a/src/test/java/org/apache/commons/lang3/tuple/MutableTripleTest.java
+++ b/src/test/java/org/apache/commons/lang3/tuple/MutableTripleTest.java
@@ -17,9 +17,8 @@
 package org.apache.commons.lang3.tuple;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -79,13 +78,13 @@ public class MutableTripleTest {
     @Test
     public void testEquals() {
         assertEquals(MutableTriple.of(null, "foo", "baz"), MutableTriple.of(null, "foo", "baz"));
-        assertFalse(MutableTriple.of("foo", 0, Boolean.TRUE).equals(MutableTriple.of("foo", null, Boolean.TRUE)));
-        assertFalse(MutableTriple.of("foo", "bar", "baz").equals(MutableTriple.of("xyz", "bar", "baz")));
-        assertFalse(MutableTriple.of("foo", "bar", "baz").equals(MutableTriple.of("foo", "bar", "blo")));
+        assertNotEquals(MutableTriple.of("foo", 0, Boolean.TRUE), MutableTriple.of("foo", null, Boolean.TRUE));
+        assertNotEquals(MutableTriple.of("foo", "bar", "baz"), MutableTriple.of("xyz", "bar", "baz"));
+        assertNotEquals(MutableTriple.of("foo", "bar", "baz"), MutableTriple.of("foo", "bar", "blo"));
 
         final MutableTriple<String, String, String> p = MutableTriple.of("foo", "bar", "baz");
-        assertTrue(p.equals(p));
-        assertFalse(p.equals(new Object()));
+        assertEquals(p, p);
+        assertNotEquals(p, new Object());
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/tuple/PairTest.java
+++ b/src/test/java/org/apache/commons/lang3/tuple/PairTest.java
@@ -18,6 +18,7 @@ package org.apache.commons.lang3.tuple;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -56,7 +57,7 @@ public class PairTest {
         assertTrue(set.contains(pair2));
 
         pair2.setValue("bar");
-        assertFalse(pair.equals(pair2));
+        assertNotEquals(pair, pair2);
         assertFalse(pair.hashCode() == pair2.hashCode());
     }
 
@@ -74,9 +75,9 @@ public class PairTest {
     public void testComparable1() {
         final Pair<String, String> pair1 = Pair.of("A", "D");
         final Pair<String, String> pair2 = Pair.of("B", "C");
-        assertTrue(pair1.compareTo(pair1) == 0);
+        assertEquals(0, pair1.compareTo(pair1));
         assertTrue(pair1.compareTo(pair2) < 0);
-        assertTrue(pair2.compareTo(pair2) == 0);
+        assertEquals(0, pair2.compareTo(pair2));
         assertTrue(pair2.compareTo(pair1) > 0);
     }
 
@@ -84,9 +85,9 @@ public class PairTest {
     public void testComparable2() {
         final Pair<String, String> pair1 = Pair.of("A", "C");
         final Pair<String, String> pair2 = Pair.of("A", "D");
-        assertTrue(pair1.compareTo(pair1) == 0);
+        assertEquals(0, pair1.compareTo(pair1));
         assertTrue(pair1.compareTo(pair2) < 0);
-        assertTrue(pair2.compareTo(pair2) == 0);
+        assertEquals(0, pair2.compareTo(pair2));
         assertTrue(pair2.compareTo(pair1) > 0);
     }
 

--- a/src/test/java/org/apache/commons/lang3/tuple/PairTest.java
+++ b/src/test/java/org/apache/commons/lang3/tuple/PairTest.java
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.Test;
 public class PairTest {
 
     @Test
-    public void testPairOf() throws Exception {
+    public void testPairOf() {
         final Pair<Integer, String> pair = Pair.of(0, "foo");
         assertTrue(pair instanceof ImmutablePair<?, ?>);
         assertEquals(0, ((ImmutablePair<Integer, String>) pair).left.intValue());
@@ -46,7 +46,7 @@ public class PairTest {
     }
 
     @Test
-    public void testCompatibilityBetweenPairs() throws Exception {
+    public void testCompatibilityBetweenPairs() {
         final Pair<Integer, String> pair = ImmutablePair.of(0, "foo");
         final Pair<Integer, String> pair2 = MutablePair.of(0, "foo");
         assertEquals(pair, pair2);
@@ -61,7 +61,7 @@ public class PairTest {
     }
 
     @Test
-    public void testMapEntry() throws Exception {
+    public void testMapEntry() {
         final Pair<Integer, String> pair = ImmutablePair.of(0, "foo");
         final HashMap<Integer, String> map = new HashMap<>();
         map.put(0, "foo");
@@ -71,7 +71,7 @@ public class PairTest {
     }
 
     @Test
-    public void testComparable1() throws Exception {
+    public void testComparable1() {
         final Pair<String, String> pair1 = Pair.of("A", "D");
         final Pair<String, String> pair2 = Pair.of("B", "C");
         assertTrue(pair1.compareTo(pair1) == 0);
@@ -81,7 +81,7 @@ public class PairTest {
     }
 
     @Test
-    public void testComparable2() throws Exception {
+    public void testComparable2() {
         final Pair<String, String> pair1 = Pair.of("A", "C");
         final Pair<String, String> pair2 = Pair.of("A", "D");
         assertTrue(pair1.compareTo(pair1) == 0);
@@ -91,13 +91,13 @@ public class PairTest {
     }
 
     @Test
-    public void testToString() throws Exception {
+    public void testToString() {
         final Pair<String, String> pair = Pair.of("Key", "Value");
         assertEquals("(Key,Value)", pair.toString());
     }
 
     @Test
-    public void testToStringCustom() throws Exception {
+    public void testToStringCustom() {
         final Calendar date = Calendar.getInstance();
         date.set(2011, Calendar.APRIL, 25);
         final Pair<String, Calendar> pair = Pair.of("DOB", date);
@@ -105,13 +105,13 @@ public class PairTest {
     }
 
     @Test
-    public void testFormattable_simple() throws Exception {
+    public void testFormattable_simple() {
         final Pair<String, String> pair = Pair.of("Key", "Value");
         assertEquals("(Key,Value)", String.format("%1$s", pair));
     }
 
     @Test
-    public void testFormattable_padded() throws Exception {
+    public void testFormattable_padded() {
         final Pair<String, String> pair = Pair.of("Key", "Value");
         assertEquals("         (Key,Value)", String.format("%1$20s", pair));
     }

--- a/src/test/java/org/apache/commons/lang3/tuple/TripleTest.java
+++ b/src/test/java/org/apache/commons/lang3/tuple/TripleTest.java
@@ -59,9 +59,9 @@ public class TripleTest {
     public void testComparable1() {
         final Triple<String, String, String> triple1 = Triple.of("A", "D", "A");
         final Triple<String, String, String> triple2 = Triple.of("B", "C", "A");
-        assertTrue(triple1.compareTo(triple1) == 0);
+        assertEquals(0, triple1.compareTo(triple1));
         assertTrue(triple1.compareTo(triple2) < 0);
-        assertTrue(triple2.compareTo(triple2) == 0);
+        assertEquals(0, triple2.compareTo(triple2));
         assertTrue(triple2.compareTo(triple1) > 0);
     }
 
@@ -69,9 +69,9 @@ public class TripleTest {
     public void testComparable2() {
         final Triple<String, String, String> triple1 = Triple.of("A", "C", "B");
         final Triple<String, String, String> triple2 = Triple.of("A", "D", "B");
-        assertTrue(triple1.compareTo(triple1) == 0);
+        assertEquals(0, triple1.compareTo(triple1));
         assertTrue(triple1.compareTo(triple2) < 0);
-        assertTrue(triple2.compareTo(triple2) == 0);
+        assertEquals(0, triple2.compareTo(triple2));
         assertTrue(triple2.compareTo(triple1) > 0);
     }
 
@@ -79,9 +79,9 @@ public class TripleTest {
     public void testComparable3() {
         final Triple<String, String, String> triple1 = Triple.of("A", "A", "D");
         final Triple<String, String, String> triple2 = Triple.of("A", "B", "C");
-        assertTrue(triple1.compareTo(triple1) == 0);
+        assertEquals(0, triple1.compareTo(triple1));
         assertTrue(triple1.compareTo(triple2) < 0);
-        assertTrue(triple2.compareTo(triple2) == 0);
+        assertEquals(0, triple2.compareTo(triple2));
         assertTrue(triple2.compareTo(triple1) > 0);
     }
 
@@ -89,9 +89,9 @@ public class TripleTest {
     public void testComparable4() {
         final Triple<String, String, String> triple1 = Triple.of("B", "A", "C");
         final Triple<String, String, String> triple2 = Triple.of("B", "A", "D");
-        assertTrue(triple1.compareTo(triple1) == 0);
+        assertEquals(0, triple1.compareTo(triple1));
         assertTrue(triple1.compareTo(triple2) < 0);
-        assertTrue(triple2.compareTo(triple2) == 0);
+        assertEquals(0, triple2.compareTo(triple2));
         assertTrue(triple2.compareTo(triple1) > 0);
     }
 

--- a/src/test/java/org/apache/commons/lang3/tuple/TripleTest.java
+++ b/src/test/java/org/apache/commons/lang3/tuple/TripleTest.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.Test;
 public class TripleTest {
 
     @Test
-    public void testTripleOf() throws Exception {
+    public void testTripleOf() {
         final Triple<Integer, String, Boolean> triple = Triple.of(0, "foo", Boolean.TRUE);
         assertTrue(triple instanceof ImmutableTriple<?, ?, ?>);
         assertEquals(0, ((ImmutableTriple<Integer, String, Boolean>) triple).left.intValue());
@@ -45,7 +45,7 @@ public class TripleTest {
     }
 
     @Test
-    public void testCompatibilityBetweenTriples() throws Exception {
+    public void testCompatibilityBetweenTriples() {
         final Triple<Integer, String, Boolean> triple = ImmutableTriple.of(0, "foo", Boolean.TRUE);
         final Triple<Integer, String, Boolean> triple2 = MutableTriple.of(0, "foo", Boolean.TRUE);
         assertEquals(triple, triple2);
@@ -56,7 +56,7 @@ public class TripleTest {
     }
 
     @Test
-    public void testComparable1() throws Exception {
+    public void testComparable1() {
         final Triple<String, String, String> triple1 = Triple.of("A", "D", "A");
         final Triple<String, String, String> triple2 = Triple.of("B", "C", "A");
         assertTrue(triple1.compareTo(triple1) == 0);
@@ -66,7 +66,7 @@ public class TripleTest {
     }
 
     @Test
-    public void testComparable2() throws Exception {
+    public void testComparable2() {
         final Triple<String, String, String> triple1 = Triple.of("A", "C", "B");
         final Triple<String, String, String> triple2 = Triple.of("A", "D", "B");
         assertTrue(triple1.compareTo(triple1) == 0);
@@ -76,7 +76,7 @@ public class TripleTest {
     }
 
     @Test
-    public void testComparable3() throws Exception {
+    public void testComparable3() {
         final Triple<String, String, String> triple1 = Triple.of("A", "A", "D");
         final Triple<String, String, String> triple2 = Triple.of("A", "B", "C");
         assertTrue(triple1.compareTo(triple1) == 0);
@@ -86,7 +86,7 @@ public class TripleTest {
     }
 
     @Test
-    public void testComparable4() throws Exception {
+    public void testComparable4() {
         final Triple<String, String, String> triple1 = Triple.of("B", "A", "C");
         final Triple<String, String, String> triple2 = Triple.of("B", "A", "D");
         assertTrue(triple1.compareTo(triple1) == 0);
@@ -96,13 +96,13 @@ public class TripleTest {
     }
 
     @Test
-    public void testToString() throws Exception {
+    public void testToString() {
         final Triple<String, String, String> triple = Triple.of("Key", "Something", "Value");
         assertEquals("(Key,Something,Value)", triple.toString());
     }
 
     @Test
-    public void testToStringCustom() throws Exception {
+    public void testToStringCustom() {
         final Calendar date = Calendar.getInstance();
         date.set(2011, Calendar.APRIL, 25);
         final Triple<String, String, Calendar> triple = Triple.of("DOB", "string", date);
@@ -110,13 +110,13 @@ public class TripleTest {
     }
 
     @Test
-    public void testFormattable_simple() throws Exception {
+    public void testFormattable_simple() {
         final Triple<String, String, String> triple = Triple.of("Key", "Something", "Value");
         assertEquals("(Key,Something,Value)", String.format("%1$s", triple));
     }
 
     @Test
-    public void testFormattable_padded() throws Exception {
+    public void testFormattable_padded() {
         final Triple<String, String, String> triple = Triple.of("Key", "Something", "Value");
         assertEquals("         (Key,Something,Value)", String.format("%1$30s", triple));
     }


### PR DESCRIPTION
Following up after the migration of the test suite to JUnit Jupiter, some test code could be cleaned up to make it clearer and easier to maintain.
This PR contains several patches around that area:

General fixes:
- In order to test an expected exception, `assertThrows` was used instead of a cumbersome `if`-`fail`-`catch` construct.
- In order to fail a test on an unexpected exception, the exception is thrown outside the method, instead of the cumbersome construct of catching it and calling `fail`
- Redundant `throws` clauses were removed
- `assertEquals`, `assertNotEquals`, `assertSame`, `assertNotSame`, `assertNull` and `assertNotNull` were used instead of reimplementing them with conditions in `if` statements or `assertTrue`s.

Specific improvements:
- `ConverstionTest#assertBinaryEquals` was removed in favor of the built-in `Assertions#assertArraysEquals(boolean[], boolean[])`.
- `LocaleUtilsTest#parseAllLocales` was rewritten as a parameterized test instead of implementing it manually with a loop.