### PR TITLE
add tests for use ImmutableTriple as key in java.util.HashMap and java.util.TreeMap

### DIFF
--- a/src/test/java/org/apache/commons/lang3/tuple/ImmutablePairTest.java
+++ b/src/test/java/org/apache/commons/lang3/tuple/ImmutablePairTest.java
@@ -26,6 +26,11 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map.Entry;
+import java.util.TreeMap;
 
 import org.junit.jupiter.api.Test;
 
@@ -135,5 +140,42 @@ public class ImmutablePairTest {
                 new ByteArrayInputStream(baos.toByteArray())).readObject();
         assertEquals(origPair, deserializedPair);
         assertEquals(origPair.hashCode(), deserializedPair.hashCode());
+    }
+    
+    @Test
+    public void testUseAsKeyOfHashMap() {
+    	
+    	HashMap<ImmutablePair<Object, Object>, String> map = new HashMap<>();
+    	
+    	Object o1 = new Object();
+    	Object o2 = new Object();
+    	
+    	ImmutablePair<Object, Object> key1 = ImmutablePair.of(o1, o2);
+    	String value1 = "a1";
+    	map.put(key1, value1);
+    	
+    	assertEquals(value1, map.get(key1));
+    	assertEquals(value1, map.get(ImmutablePair.of(o1, o2)));
+    }
+    
+    @Test
+    public void testUseAsKeyOfTreeMap() {
+    	
+    	TreeMap<ImmutablePair<Integer, Integer>, String> map = new TreeMap<>();
+    	map.put(ImmutablePair.of(1, 2), "12");
+    	map.put(ImmutablePair.of(1, 1), "11");
+    	map.put(ImmutablePair.of(0, 1), "01");
+    	    	
+    	ArrayList<ImmutablePair<Integer, Integer>> expected = new ArrayList<>();
+    	expected.add(ImmutablePair.of(0, 1));
+    	expected.add(ImmutablePair.of(1, 1));
+    	expected.add(ImmutablePair.of(1, 2));
+    	
+    	Iterator<Entry<ImmutablePair<Integer, Integer>, String>> it = map.entrySet().iterator();
+    	for(ImmutablePair<Integer, Integer> item : expected) {
+    		Entry<ImmutablePair<Integer, Integer>, String> entry = it.next();
+        	assertEquals(item, entry.getKey());
+        	assertEquals(item.getLeft() + "" + item.getRight(), entry.getValue());	
+    	}
     }
 }

--- a/src/test/java/org/apache/commons/lang3/tuple/ImmutablePairTest.java
+++ b/src/test/java/org/apache/commons/lang3/tuple/ImmutablePairTest.java
@@ -144,38 +144,31 @@ public class ImmutablePairTest {
     
     @Test
     public void testUseAsKeyOfHashMap() {
-    	
-    	HashMap<ImmutablePair<Object, Object>, String> map = new HashMap<>();
-    	
-    	Object o1 = new Object();
-    	Object o2 = new Object();
-    	
-    	ImmutablePair<Object, Object> key1 = ImmutablePair.of(o1, o2);
-    	String value1 = "a1";
-    	map.put(key1, value1);
-    	
-    	assertEquals(value1, map.get(key1));
-    	assertEquals(value1, map.get(ImmutablePair.of(o1, o2)));
+        HashMap<ImmutablePair<Object, Object>, String> map = new HashMap<>();
+        Object o1 = new Object();
+        Object o2 = new Object();
+        ImmutablePair<Object, Object> key1 = ImmutablePair.of(o1, o2);
+        String value1 = "a1";
+        map.put(key1, value1);
+        assertEquals(value1, map.get(key1));
+        assertEquals(value1, map.get(ImmutablePair.of(o1, o2)));
     }
     
     @Test
     public void testUseAsKeyOfTreeMap() {
-    	
-    	TreeMap<ImmutablePair<Integer, Integer>, String> map = new TreeMap<>();
-    	map.put(ImmutablePair.of(1, 2), "12");
-    	map.put(ImmutablePair.of(1, 1), "11");
-    	map.put(ImmutablePair.of(0, 1), "01");
-    	    	
-    	ArrayList<ImmutablePair<Integer, Integer>> expected = new ArrayList<>();
-    	expected.add(ImmutablePair.of(0, 1));
-    	expected.add(ImmutablePair.of(1, 1));
-    	expected.add(ImmutablePair.of(1, 2));
-    	
-    	Iterator<Entry<ImmutablePair<Integer, Integer>, String>> it = map.entrySet().iterator();
-    	for(ImmutablePair<Integer, Integer> item : expected) {
-    		Entry<ImmutablePair<Integer, Integer>, String> entry = it.next();
-        	assertEquals(item, entry.getKey());
-        	assertEquals(item.getLeft() + "" + item.getRight(), entry.getValue());	
-    	}
+        TreeMap<ImmutablePair<Integer, Integer>, String> map = new TreeMap<>();
+        map.put(ImmutablePair.of(1, 2), "12");
+        map.put(ImmutablePair.of(1, 1), "11");
+        map.put(ImmutablePair.of(0, 1), "01");
+        ArrayList<ImmutablePair<Integer, Integer>> expected = new ArrayList<>();
+        expected.add(ImmutablePair.of(0, 1));
+        expected.add(ImmutablePair.of(1, 1));
+        expected.add(ImmutablePair.of(1, 2));
+        Iterator<Entry<ImmutablePair<Integer, Integer>, String>> it = map.entrySet().iterator();
+        for(ImmutablePair<Integer, Integer> item : expected) {
+            Entry<ImmutablePair<Integer, Integer>, String> entry = it.next();
+            assertEquals(item, entry.getKey());
+            assertEquals(item.getLeft() + "" + item.getRight(), entry.getValue());	
+        }
     }
 }

--- a/src/test/java/org/apache/commons/lang3/tuple/ImmutablePairTest.java
+++ b/src/test/java/org/apache/commons/lang3/tuple/ImmutablePairTest.java
@@ -168,7 +168,7 @@ public class ImmutablePairTest {
         for(ImmutablePair<Integer, Integer> item : expected) {
             Entry<ImmutablePair<Integer, Integer>, String> entry = it.next();
             assertEquals(item, entry.getKey());
-            assertEquals(item.getLeft() + "" + item.getRight(), entry.getValue());	
+            assertEquals(item.getLeft() + "" + item.getRight(), entry.getValue());
         }
     }
 }

--- a/src/test/java/org/apache/commons/lang3/tuple/ImmutablePairTest.java
+++ b/src/test/java/org/apache/commons/lang3/tuple/ImmutablePairTest.java
@@ -141,7 +141,7 @@ public class ImmutablePairTest {
         assertEquals(origPair, deserializedPair);
         assertEquals(origPair.hashCode(), deserializedPair.hashCode());
     }
-    
+
     @Test
     public void testUseAsKeyOfHashMap() {
         HashMap<ImmutablePair<Object, Object>, String> map = new HashMap<>();
@@ -153,7 +153,7 @@ public class ImmutablePairTest {
         assertEquals(value1, map.get(key1));
         assertEquals(value1, map.get(ImmutablePair.of(o1, o2)));
     }
-    
+
     @Test
     public void testUseAsKeyOfTreeMap() {
         TreeMap<ImmutablePair<Integer, Integer>, String> map = new TreeMap<>();

--- a/src/test/java/org/apache/commons/lang3/tuple/ImmutableTripleTest.java
+++ b/src/test/java/org/apache/commons/lang3/tuple/ImmutableTripleTest.java
@@ -26,6 +26,11 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.TreeMap;
+import java.util.Map.Entry;
 
 import org.junit.jupiter.api.Test;
 
@@ -141,6 +146,37 @@ public class ImmutableTripleTest {
                 new ByteArrayInputStream(baos.toByteArray())).readObject();
         assertEquals(origTriple, deserializedTriple);
         assertEquals(origTriple.hashCode(), deserializedTriple.hashCode());
+    }
+
+    @Test
+    public void testUseAsKeyOfHashMap() {
+        HashMap<ImmutableTriple<Object, Object, Object>, String> map = new HashMap<>();
+        Object o1 = new Object();
+        Object o2 = new Object();
+        Object o3 = new Object();
+        ImmutableTriple<Object, Object, Object> key1 = ImmutableTriple.of(o1, o2, o3);
+        String value1 = "a1";
+        map.put(key1, value1);
+        assertEquals(value1, map.get(key1));
+        assertEquals(value1, map.get(ImmutableTriple.of(o1, o2, o3)));
+    }
+
+    @Test
+    public void testUseAsKeyOfTreeMap() {
+        TreeMap<ImmutableTriple<Integer, Integer, Integer>, String> map = new TreeMap<>();
+        map.put(ImmutableTriple.of(0, 1, 2), "012");
+        map.put(ImmutableTriple.of(0, 1, 1), "011");
+        map.put(ImmutableTriple.of(0, 0, 1), "001");
+        ArrayList<ImmutableTriple<Integer, Integer, Integer>> expected = new ArrayList<>();
+        expected.add(ImmutableTriple.of(0, 0, 1));
+        expected.add(ImmutableTriple.of(0, 1, 1));
+        expected.add(ImmutableTriple.of(0, 1, 2));
+        Iterator<Entry<ImmutableTriple<Integer, Integer, Integer>, String>> it = map.entrySet().iterator();
+        for(ImmutableTriple<Integer, Integer, Integer> item : expected) {
+            Entry<ImmutableTriple<Integer, Integer, Integer>, String> entry = it.next();
+            assertEquals(item, entry.getKey());
+            assertEquals(item.getLeft() + "" + item.getMiddle() + "" + item.getRight(), entry.getValue());
+        }
     }
 }
 


### PR DESCRIPTION
add tests for use ImmutableTriple as key in java.util.HashMap and java.util.TreeMap