### PR TITLE
Travis: Stop building with Java 9 and 10, as these are superseded by …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,6 @@ language: java
 
 jdk:
   - oraclejdk8
-  - oraclejdk9
-  - openjdk10
   - openjdk11
   - openjdk-ea
 


### PR DESCRIPTION
…Java 11 and not supported anymore.