### PR TITLE
Synchronize before looping over synchronized collection

### DIFF
--- a/src/main/java/org/apache/commons/lang3/CharSet.java
+++ b/src/main/java/org/apache/commons/lang3/CharSet.java
@@ -237,9 +237,11 @@ public class CharSet implements Serializable {
      * @return {@code true} if the set contains the characters
      */
     public boolean contains(final char ch) {
-        for (final CharRange range : set) {
-            if (range.contains(ch)) {
-                return true;
+        synchronized(set) {
+            for (final CharRange range : set) {
+                if (range.contains(ch)) {
+                    return true;
+                }
             }
         }
         return false;


### PR DESCRIPTION
In `CharSet.java`, `set = Collections.synchronizedSet(new HashSet<>())` is iterated over
without synchronization. According to [Java API] (https://docs.oracle.com/javase/6/docs/api/java/util/Collections.html#synchronizedCollection%28java.util.Collection%29), it is recommended that user manually synchronizes each iteration over the synchronized collection to reduce non-determinism. 

This pull request improves the condition by synchronizing a loop which loops over the synchronized collection.