### PR TITLE
Close/flush the `OutputStream` before calling `toByteArray()` on underlying `ByteArrayOutputStream`

### DIFF
--- a/src/test/java/org/apache/commons/lang3/tuple/ImmutablePairTest.java
+++ b/src/test/java/org/apache/commons/lang3/tuple/ImmutablePairTest.java
@@ -131,6 +131,7 @@ public class ImmutablePairTest {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         final ObjectOutputStream out = new ObjectOutputStream(baos);
         out.writeObject(origPair);
+        out.close();
         final ImmutablePair<Integer, String> deserializedPair = (ImmutablePair<Integer, String>) new ObjectInputStream(
                 new ByteArrayInputStream(baos.toByteArray())).readObject();
         assertEquals(origPair, deserializedPair);

--- a/src/test/java/org/apache/commons/lang3/tuple/ImmutableTripleTest.java
+++ b/src/test/java/org/apache/commons/lang3/tuple/ImmutableTripleTest.java
@@ -137,6 +137,7 @@ public class ImmutableTripleTest {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         final ObjectOutputStream out = new ObjectOutputStream(baos);
         out.writeObject(origTriple);
+        out.close();
         final ImmutableTriple<Integer, String, Boolean> deserializedTriple = (ImmutableTriple<Integer, String, Boolean>) new ObjectInputStream(
                 new ByteArrayInputStream(baos.toByteArray())).readObject();
         assertEquals(origTriple, deserializedTriple);

--- a/src/test/java/org/apache/commons/lang3/tuple/MutablePairTest.java
+++ b/src/test/java/org/apache/commons/lang3/tuple/MutablePairTest.java
@@ -99,6 +99,7 @@ public class MutablePairTest {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         final ObjectOutputStream out = new ObjectOutputStream(baos);
         out.writeObject(origPair);
+        out.close();
         final MutablePair<Integer, String> deserializedPair = (MutablePair<Integer, String>) new ObjectInputStream(
                 new ByteArrayInputStream(baos.toByteArray())).readObject();
         assertEquals(origPair, deserializedPair);

--- a/src/test/java/org/apache/commons/lang3/tuple/MutableTripleTest.java
+++ b/src/test/java/org/apache/commons/lang3/tuple/MutableTripleTest.java
@@ -110,6 +110,7 @@ public class MutableTripleTest {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         final ObjectOutputStream out = new ObjectOutputStream(baos);
         out.writeObject(origTriple);
+        out.close();
         final MutableTriple<Integer, String, Boolean> deserializedTriple = (MutableTriple<Integer, String, Boolean>) new ObjectInputStream(
                 new ByteArrayInputStream(baos.toByteArray())).readObject();
         assertEquals(origTriple, deserializedTriple);


### PR DESCRIPTION
When an `OutputStream` instance wraps an underlying `ByteArrayOutputStream` instance,
it is recommended to flush or close the `OutputStream` before invoking the underlying instances' `toByteArray()`. Although in some of these case it is not strictly necessary because the
`writeObject()` method is invoked right before `toByteArray()`, and `writeObject()` internally calls `flush()`/`drain()`. However, it is good practice to call `flush()`/`close()` explicitly as mentioned, for example, [here](http://stackoverflow.com/questions/2984538/how-to-use-bytearrayoutputstream-and-dataoutputstream-simultaneously-java).

This pull request adds a call to `close()` or `flush()` before calls to `toByteArray()`.