### PR TITLE
JUnit Jupiter upgrade 5.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -524,17 +524,7 @@
     <!-- testing -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-params</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -627,7 +617,7 @@
     <jmh.version>1.21</jmh.version>
     <uberjar.name>benchmarks</uberjar.name>
 
-    <junit.version>5.3.2</junit.version>
+    <junit.version>5.4.0</junit.version>
 
     <commons.jacoco.version>0.8.2</commons.jacoco.version>
 

--- a/src/test/java/org/apache/commons/lang3/ArrayUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/ArrayUtilsTest.java
@@ -1498,14 +1498,11 @@ public class ArrayUtilsTest {
 
     @Test
     public void testReverseDouble() {
-        // TODO: JUnit Jupiter 5.3.1 doesn't support delta=0.
-        // This should be replaced when it is supported in JUnit Jupiter 5.4.
-        // See https://github.com/junit-team/junit5/pull/1613 for details.
         double[] array = new double[]{0.3d, 0.4d, 0.5d};
         ArrayUtils.reverse(array);
-        assertTrue(array[0] == 0.5d);
-        assertTrue(array[1] == 0.4d);
-        assertTrue(array[2] == 0.3d);
+        assertEquals(0.5d, array[0]);
+        assertEquals(0.4d, array[1]);
+        assertEquals(0.3d, array[2]);
 
         array = null;
         ArrayUtils.reverse(array);
@@ -1514,14 +1511,11 @@ public class ArrayUtilsTest {
 
     @Test
     public void testReverseFloat() {
-        // TODO: JUnit Jupiter 5.3.1 doesn't support delta=0.
-        // This should be replaced when it is supported in JUnit Jupiter 5.4.
-        // See https://github.com/junit-team/junit5/pull/1613 for details.
         float[] array = new float[]{0.3f, 0.4f, 0.5f};
         ArrayUtils.reverse(array);
-        assertTrue(array[0] == 0.5f);
-        assertTrue(array[1] == 0.4f);
-        assertTrue(array[2] == 0.3f);
+        assertEquals(0.5f, array[0]);
+        assertEquals(0.4f, array[1]);
+        assertEquals(0.3f, array[2]);
 
         array = null;
         ArrayUtils.reverse(array);
@@ -1639,33 +1633,30 @@ public class ArrayUtilsTest {
 
     @Test
     public void testReverseDoubleRange() {
-        // TODO: JUnit Jupiter 5.3.1 doesn't support delta=0.
-        // This should be replaced when it is supported in JUnit Jupiter 5.4.
-        // See https://github.com/junit-team/junit5/pull/1613 for details.
         double[] array = new double[]{1, 2, 3};
         // The whole array
         ArrayUtils.reverse(array, 0, 3);
-        assertTrue(3 == array[0]);
-        assertTrue(2 == array[1]);
-        assertTrue(1 == array[2]);
+        assertEquals(3, array[0]);
+        assertEquals(2, array[1]);
+        assertEquals(1, array[2]);
         // a range
         array = new double[]{1, 2, 3};
         ArrayUtils.reverse(array, 0, 2);
-        assertTrue(2 == array[0]);
-        assertTrue(1 == array[1]);
-        assertTrue(3 == array[2]);
+        assertEquals(2, array[0]);
+        assertEquals(1, array[1]);
+        assertEquals(3, array[2]);
         // a range with a negative start
         array = new double[]{1, 2, 3};
         ArrayUtils.reverse(array, -1, 3);
-        assertTrue(3 == array[0]);
-        assertTrue(2 == array[1]);
-        assertTrue(1 == array[2]);
+        assertEquals(3, array[0]);
+        assertEquals(2, array[1]);
+        assertEquals(1, array[2]);
         // a range with a large stop index
         array = new double[]{1, 2, 3};
         ArrayUtils.reverse(array, -1, array.length + 1000);
-        assertTrue(3 == array[0]);
-        assertTrue(2 == array[1]);
-        assertTrue(1 == array[2]);
+        assertEquals(3, array[0]);
+        assertEquals(2, array[1]);
+        assertEquals(1, array[2]);
         // null
         array = null;
         ArrayUtils.reverse(array, 0, 3);
@@ -1674,33 +1665,30 @@ public class ArrayUtilsTest {
 
     @Test
     public void testReverseFloatRange() {
-        // TODO: JUnit Jupiter 5.3.1 doesn't support delta=0.
-        // This should be replaced when it is supported in JUnit Jupiter 5.4.
-        // See https://github.com/junit-team/junit5/pull/1613 for details.
         float[] array = new float[]{1, 2, 3};
         // The whole array
         ArrayUtils.reverse(array, 0, 3);
-        assertTrue(3 == array[0]);
-        assertTrue(2 == array[1]);
-        assertTrue(1 == array[2]);
+        assertEquals(3, array[0]);
+        assertEquals(2, array[1]);
+        assertEquals(1, array[2]);
         // a range
         array = new float[]{1, 2, 3};
         ArrayUtils.reverse(array, 0, 2);
-        assertTrue(2 == array[0]);
-        assertTrue(1 == array[1]);
-        assertTrue(3 == array[2]);
+        assertEquals(2, array[0]);
+        assertEquals(1, array[1]);
+        assertEquals(3, array[2]);
         // a range with a negative start
         array = new float[]{1, 2, 3};
         ArrayUtils.reverse(array, -1, 3);
-        assertTrue(3 == array[0]);
-        assertTrue(2 == array[1]);
-        assertTrue(1 == array[2]);
+        assertEquals(3, array[0]);
+        assertEquals(2, array[1]);
+        assertEquals(1, array[2]);
         // a range with a large stop index
         array = new float[]{1, 2, 3};
         ArrayUtils.reverse(array, -1, array.length + 1000);
-        assertTrue(3 == array[0]);
-        assertTrue(2 == array[1]);
-        assertTrue(1 == array[2]);
+        assertEquals(3, array[0]);
+        assertEquals(2, array[1]);
+        assertEquals(1, array[2]);
         // null
         array = null;
         ArrayUtils.reverse(array, 0, 3);
@@ -1956,14 +1944,11 @@ public class ArrayUtilsTest {
 
     @Test
     public void testSwapFloat() {
-        // TODO: JUnit Jupiter 5.3.1 doesn't support delta=0.
-        // This should be replaced when it is supported in JUnit Jupiter 5.4.
-        // See https://github.com/junit-team/junit5/pull/1613 for details.
         final float[] array = new float[]{1, 2, 3};
         ArrayUtils.swap(array, 0, 2);
-        assertTrue(3 == array[0]);
-        assertTrue(2 == array[1]);
-        assertTrue(1 == array[2]);
+        assertEquals(3, array[0]);
+        assertEquals(2, array[1]);
+        assertEquals(1, array[2]);
     }
 
     @Test
@@ -1982,57 +1967,51 @@ public class ArrayUtilsTest {
 
     @Test
     public void testSwapFloatRange() {
-        // TODO: JUnit Jupiter 5.3.1 doesn't support delta=0.
-        // This should be replaced when it is supported in JUnit Jupiter 5.4.
-        // See https://github.com/junit-team/junit5/pull/1613 for details.
         float[] array = new float[]{1, 2, 3, 4};
         ArrayUtils.swap(array, 0, 2, 2);
-        assertTrue(3 == array[0]);
-        assertTrue(4 == array[1]);
-        assertTrue(1 == array[2]);
-        assertTrue(2 == array[3]);
+        assertEquals(3, array[0]);
+        assertEquals(4, array[1]);
+        assertEquals(1, array[2]);
+        assertEquals(2, array[3]);
 
         array = new float[]{1, 2, 3};
         ArrayUtils.swap(array, 0, 3);
-        assertTrue(1 == array[0]);
-        assertTrue(2 == array[1]);
-        assertTrue(3 == array[2]);
+        assertEquals(1, array[0]);
+        assertEquals(2, array[1]);
+        assertEquals(3, array[2]);
 
         array = new float[]{1, 2, 3};
         ArrayUtils.swap(array, 0, 2, 2);
-        assertTrue(3 == array[0]);
-        assertTrue(2 == array[1]);
-        assertTrue(1 == array[2]);
+        assertEquals(3, array[0]);
+        assertEquals(2, array[1]);
+        assertEquals(1, array[2]);
 
         array = new float[]{1, 2, 3};
         ArrayUtils.swap(array, -1, 2, 2);
-        assertTrue(3 == array[0]);
-        assertTrue(2 == array[1]);
-        assertTrue(1 == array[2]);
+        assertEquals(3, array[0]);
+        assertEquals(2, array[1]);
+        assertEquals(1, array[2]);
 
         array = new float[]{1, 2, 3};
         ArrayUtils.swap(array, 0, -1, 2);
-        assertTrue(1 == array[0]);
-        assertTrue(2 == array[1]);
-        assertTrue(3 == array[2]);
+        assertEquals(1, array[0]);
+        assertEquals(2, array[1]);
+        assertEquals(3, array[2]);
 
         array = new float[]{1, 2, 3};
         ArrayUtils.swap(array, -1, -1, 2);
-        assertTrue(1 == array[0]);
-        assertTrue(2 == array[1]);
-        assertTrue(3 == array[2]);
+        assertEquals(1, array[0]);
+        assertEquals(2, array[1]);
+        assertEquals(3, array[2]);
     }
 
     @Test
     public void testSwapDouble() {
-        // TODO: JUnit Jupiter 5.3.1 doesn't support delta=0.
-        // This should be replaced when it is supported in JUnit Jupiter 5.4.
-        // See https://github.com/junit-team/junit5/pull/1613 for details.
         final double[] array = new double[]{1, 2, 3};
         ArrayUtils.swap(array, 0, 2);
-        assertTrue(3 == array[0]);
-        assertTrue(2 == array[1]);
-        assertTrue(1 == array[2]);
+        assertEquals(3, array[0]);
+        assertEquals(2, array[1]);
+        assertEquals(1, array[2]);
     }
 
     @Test
@@ -2051,45 +2030,42 @@ public class ArrayUtilsTest {
 
     @Test
     public void testSwapDoubleRange() {
-        // TODO: JUnit Jupiter 5.3.1 doesn't support delta=0.
-        // This should be replaced when it is supported in JUnit Jupiter 5.4.
-        // See https://github.com/junit-team/junit5/pull/1613 for details.
         double[] array = new double[]{1, 2, 3, 4};
         ArrayUtils.swap(array, 0, 2, 2);
-        assertTrue(3 == array[0]);
-        assertTrue(4 == array[1]);
-        assertTrue(1 == array[2]);
-        assertTrue(2 == array[3]);
+        assertEquals(3, array[0]);
+        assertEquals(4, array[1]);
+        assertEquals(1, array[2]);
+        assertEquals(2, array[3]);
 
         array = new double[]{1, 2, 3};
         ArrayUtils.swap(array, 0, 3);
-        assertTrue(1 == array[0]);
-        assertTrue(2 == array[1]);
-        assertTrue(3 == array[2]);
+        assertEquals(1, array[0]);
+        assertEquals(2, array[1]);
+        assertEquals(3, array[2]);
 
         array = new double[]{1, 2, 3};
         ArrayUtils.swap(array, 0, 2, 2);
-        assertTrue(3 == array[0]);
-        assertTrue(2 == array[1]);
-        assertTrue(1 == array[2]);
+        assertEquals(3, array[0]);
+        assertEquals(2, array[1]);
+        assertEquals(1, array[2]);
 
         array = new double[]{1, 2, 3};
         ArrayUtils.swap(array, -1, 2, 2);
-        assertTrue(3 == array[0]);
-        assertTrue(2 == array[1]);
-        assertTrue(1 == array[2]);
+        assertEquals(3, array[0]);
+        assertEquals(2, array[1]);
+        assertEquals(1, array[2]);
 
         array = new double[]{1, 2, 3};
         ArrayUtils.swap(array, 0, -1, 2);
-        assertTrue(1 == array[0]);
-        assertTrue(2 == array[1]);
-        assertTrue(3 == array[2]);
+        assertEquals(1, array[0]);
+        assertEquals(2, array[1]);
+        assertEquals(3, array[2]);
 
         array = new double[]{1, 2, 3};
         ArrayUtils.swap(array, -1, -1, 2);
-        assertTrue(1 == array[0]);
-        assertTrue(2 == array[1]);
-        assertTrue(3 == array[2]);
+        assertEquals(1, array[0]);
+        assertEquals(2, array[1]);
+        assertEquals(3, array[2]);
     }
 
     @Test
@@ -2437,63 +2413,54 @@ public class ArrayUtilsTest {
     //-----------------------------------------------------------------------
     @Test
     public void testShiftDouble() {
-        // TODO: JUnit Jupiter 5.3.1 doesn't support delta=0.
-        // This should be replaced when it is supported in JUnit Jupiter 5.4.
-        // See https://github.com/junit-team/junit5/pull/1613 for details.
         final double[] array = new double[]{1, 2, 3, 4};
         ArrayUtils.shift(array, 1);
-        assertTrue(4 == array[0]);
-        assertTrue(1 == array[1]);
-        assertTrue(2 == array[2]);
-        assertTrue(3 == array[3]);
+        assertEquals(4, array[0]);
+        assertEquals(1, array[1]);
+        assertEquals(2, array[2]);
+        assertEquals(3, array[3]);
         ArrayUtils.shift(array, -1);
-        assertTrue(1 == array[0]);
-        assertTrue(2 == array[1]);
-        assertTrue(3 == array[2]);
-        assertTrue(4 == array[3]);
+        assertEquals(1, array[0]);
+        assertEquals(2, array[1]);
+        assertEquals(3, array[2]);
+        assertEquals(4, array[3]);
         ArrayUtils.shift(array, 5);
-        assertTrue(4 == array[0]);
-        assertTrue(1 == array[1]);
-        assertTrue(2 == array[2]);
-        assertTrue(3 == array[3]);
+        assertEquals(4, array[0]);
+        assertEquals(1, array[1]);
+        assertEquals(2, array[2]);
+        assertEquals(3, array[3]);
         ArrayUtils.shift(array, -3);
-        assertTrue(3 == array[0]);
-        assertTrue(4 == array[1]);
-        assertTrue(1 == array[2]);
-        assertTrue(2 == array[3]);
+        assertEquals(3, array[0]);
+        assertEquals(4, array[1]);
+        assertEquals(1, array[2]);
+        assertEquals(2, array[3]);
     }
 
     @Test
     public void testShiftRangeDouble() {
-        // TODO: JUnit Jupiter 5.3.1 doesn't support delta=0.
-        // This should be replaced when it is supported in JUnit Jupiter 5.4.
-        // See https://github.com/junit-team/junit5/pull/1613 for details.
         final double[] array = new double[]{1, 2, 3, 4, 5};
         ArrayUtils.shift(array, 1, 3, 1);
-        assertTrue(1 == array[0]);
-        assertTrue(3 == array[1]);
-        assertTrue(2 == array[2]);
-        assertTrue(4 == array[3]);
-        assertTrue(5 == array[4]);
+        assertEquals(1, array[0]);
+        assertEquals(3, array[1]);
+        assertEquals(2, array[2]);
+        assertEquals(4, array[3]);
+        assertEquals(5, array[4]);
         ArrayUtils.shift(array, 1, 4, 2);
-        assertTrue(1 == array[0]);
-        assertTrue(2 == array[1]);
-        assertTrue(4 == array[2]);
-        assertTrue(3 == array[3]);
-        assertTrue(5 == array[4]);
+        assertEquals(1, array[0]);
+        assertEquals(2, array[1]);
+        assertEquals(4, array[2]);
+        assertEquals(3, array[3]);
+        assertEquals(5, array[4]);
     }
 
     @Test
     public void testShiftRangeNoElemDouble() {
-        // TODO: JUnit Jupiter 5.3.1 doesn't support delta=0.
-        // This should be replaced when it is supported in JUnit Jupiter 5.4.
-        // See https://github.com/junit-team/junit5/pull/1613 for details.
         final double[] array = new double[]{1, 2, 3, 4};
         ArrayUtils.shift(array, 1, 1, 1);
-        assertTrue(1 == array[0]);
-        assertTrue(2 == array[1]);
-        assertTrue(3 == array[2]);
-        assertTrue(4 == array[3]);
+        assertEquals(1, array[0]);
+        assertEquals(2, array[1]);
+        assertEquals(3, array[2]);
+        assertEquals(4, array[3]);
     }
 
     @Test
@@ -2513,81 +2480,69 @@ public class ArrayUtilsTest {
 
     @Test
     public void testShiftAllDouble() {
-        // TODO: JUnit Jupiter 5.3.1 doesn't support delta=0.
-        // This should be replaced when it is supported in JUnit Jupiter 5.4.
-        // See https://github.com/junit-team/junit5/pull/1613 for details.
         final double[] array = new double[]{1, 2, 3, 4};
         ArrayUtils.shift(array, 4);
-        assertTrue(1 == array[0]);
-        assertTrue(2 == array[1]);
-        assertTrue(3 == array[2]);
-        assertTrue(4 == array[3]);
+        assertEquals(1, array[0]);
+        assertEquals(2, array[1]);
+        assertEquals(3, array[2]);
+        assertEquals(4, array[3]);
         ArrayUtils.shift(array, -4);
-        assertTrue(1 == array[0]);
-        assertTrue(2 == array[1]);
-        assertTrue(3 == array[2]);
-        assertTrue(4 == array[3]);
+        assertEquals(1, array[0]);
+        assertEquals(2, array[1]);
+        assertEquals(3, array[2]);
+        assertEquals(4, array[3]);
     }
 
     @Test
     public void testShiftFloat() {
-        // TODO: JUnit Jupiter 5.3.1 doesn't support delta=0.
-        // This should be replaced when it is supported in JUnit Jupiter 5.4.
-        // See https://github.com/junit-team/junit5/pull/1613 for details.
         final float[] array = new float[]{1, 2, 3, 4};
         ArrayUtils.shift(array, 1);
-        assertTrue(4 == array[0]);
-        assertTrue(1 == array[1]);
-        assertTrue(2 == array[2]);
-        assertTrue(3 == array[3]);
+        assertEquals(4, array[0]);
+        assertEquals(1, array[1]);
+        assertEquals(2, array[2]);
+        assertEquals(3, array[3]);
         ArrayUtils.shift(array, -1);
-        assertTrue(1 == array[0]);
-        assertTrue(2 == array[1]);
-        assertTrue(3 == array[2]);
-        assertTrue(4 == array[3]);
+        assertEquals(1, array[0]);
+        assertEquals(2, array[1]);
+        assertEquals(3, array[2]);
+        assertEquals(4, array[3]);
         ArrayUtils.shift(array, 5);
-        assertTrue(4 == array[0]);
-        assertTrue(1 == array[1]);
-        assertTrue(2 == array[2]);
-        assertTrue(3 == array[3]);
+        assertEquals(4, array[0]);
+        assertEquals(1, array[1]);
+        assertEquals(2, array[2]);
+        assertEquals(3, array[3]);
         ArrayUtils.shift(array, -3);
-        assertTrue(3 == array[0]);
-        assertTrue(4 == array[1]);
-        assertTrue(1 == array[2]);
-        assertTrue(2 == array[3]);
+        assertEquals(3, array[0]);
+        assertEquals(4, array[1]);
+        assertEquals(1, array[2]);
+        assertEquals(2, array[3]);
     }
 
     @Test
     public void testShiftRangeFloat() {
-        // TODO: JUnit Jupiter 5.3.1 doesn't support delta=0.
-        // This should be replaced when it is supported in JUnit Jupiter 5.4.
-        // See https://github.com/junit-team/junit5/pull/1613 for details.
         final float[] array = new float[]{1, 2, 3, 4, 5};
         ArrayUtils.shift(array, 1, 3, 1);
-        assertTrue(1 == array[0]);
-        assertTrue(3 == array[1]);
-        assertTrue(2 == array[2]);
-        assertTrue(4 == array[3]);
-        assertTrue(5 == array[4]);
+        assertEquals(1, array[0]);
+        assertEquals(3, array[1]);
+        assertEquals(2, array[2]);
+        assertEquals(4, array[3]);
+        assertEquals(5, array[4]);
         ArrayUtils.shift(array, 1, 4, 2);
-        assertTrue(1 == array[0]);
-        assertTrue(2 == array[1]);
-        assertTrue(4 == array[2]);
-        assertTrue(3 == array[3]);
-        assertTrue(5 == array[4]);
+        assertEquals(1, array[0]);
+        assertEquals(2, array[1]);
+        assertEquals(4, array[2]);
+        assertEquals(3, array[3]);
+        assertEquals(5, array[4]);
     }
 
     @Test
     public void testShiftRangeNoElemFloat() {
-        // TODO: JUnit Jupiter 5.3.1 doesn't support delta=0.
-        // This should be replaced when it is supported in JUnit Jupiter 5.4.
-        // See https://github.com/junit-team/junit5/pull/1613 for details.
         final float[] array = new float[]{1, 2, 3, 4};
         ArrayUtils.shift(array, 1, 1, 1);
-        assertTrue(1 == array[0]);
-        assertTrue(2 == array[1]);
-        assertTrue(3 == array[2]);
-        assertTrue(4 == array[3]);
+        assertEquals(1, array[0]);
+        assertEquals(2, array[1]);
+        assertEquals(3, array[2]);
+        assertEquals(4, array[3]);
     }
 
     @Test
@@ -2607,20 +2562,17 @@ public class ArrayUtilsTest {
 
     @Test
     public void testShiftAllFloat() {
-        // TODO: JUnit Jupiter 5.3.1 doesn't support delta=0.
-        // This should be replaced when it is supported in JUnit Jupiter 5.4.
-        // See https://github.com/junit-team/junit5/pull/1613 for details.
         final float[] array = new float[]{1, 2, 3, 4};
         ArrayUtils.shift(array, 4);
-        assertTrue(1 == array[0]);
-        assertTrue(2== array[1]);
-        assertTrue(3 == array[2]);
-        assertTrue(4 == array[3]);
+        assertEquals(1, array[0]);
+        assertEquals(2, array[1]);
+        assertEquals(3, array[2]);
+        assertEquals(4, array[3]);
         ArrayUtils.shift(array, -4);
-        assertTrue(1 == array[0]);
-        assertTrue(2== array[1]);
-        assertTrue(3 == array[2]);
-        assertTrue(4 == array[3]);
+        assertEquals(1, array[0]);
+        assertEquals(2, array[1]);
+        assertEquals(3, array[2]);
+        assertEquals(4, array[3]);
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/ObjectUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/ObjectUtilsTest.java
@@ -557,17 +557,14 @@ public class ObjectUtilsTest {
         // bytecode to see if the literals were folded into the
         // class, or if the bytecode kept the method call.
 
-        // TODO: JUnit Jupiter 5.3.1 doesn't support delta=0.
-        // This should be replaced when it is supported in JUnit Jupiter 5.4.
-        // See https://github.com/junit-team/junit5/pull/1613 for details.
         assertTrue(ObjectUtils.CONST(true), "CONST(boolean)");
         assertEquals((byte) 3, ObjectUtils.CONST((byte) 3), "CONST(byte)");
         assertEquals((char) 3, ObjectUtils.CONST((char) 3), "CONST(char)");
         assertEquals((short) 3, ObjectUtils.CONST((short) 3), "CONST(short)");
         assertEquals(3, ObjectUtils.CONST(3), "CONST(int)");
         assertEquals(3L, ObjectUtils.CONST(3L), "CONST(long)");
-        assertTrue(3f == ObjectUtils.CONST(3f), "CONST(float)");
-        assertTrue(3.0 == ObjectUtils.CONST(3.0), "CONST(double)");
+        assertEquals(3f, ObjectUtils.CONST(3f), "CONST(float)");
+        assertEquals(3.0, ObjectUtils.CONST(3.0), "CONST(double)");
         assertEquals("abc", ObjectUtils.CONST("abc"), "CONST(Object)");
 
         // Make sure documentation examples from Javadoc all work
@@ -599,8 +596,8 @@ public class ObjectUtilsTest {
         assertEquals(123, MAGIC_INT);
         assertEquals(123, MAGIC_LONG1);
         assertEquals(3, MAGIC_LONG2);
-        assertTrue(1.0f == MAGIC_FLOAT);
-        assertTrue(1.0 == MAGIC_DOUBLE);
+        assertEquals(1.0f, MAGIC_FLOAT);
+        assertEquals(1.0, MAGIC_DOUBLE);
         assertEquals("abc", MAGIC_STRING);
         assertThrows(
                 IllegalArgumentException.class,

--- a/src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java
@@ -772,12 +772,9 @@ public class NumberUtilsTest {
 
     @Test
     public void testMinDouble() {
-        // TODO: JUnit Jupiter 5.3.1 doesn't support delta=0.
-        // This should be replaced when it is supported in JUnit Jupiter 5.4.
-        // See https://github.com/junit-team/junit5/pull/1613 for details.
-        assertTrue(5.12 == NumberUtils.min(5.12), "min(double[]) failed for array length 1");
-        assertTrue(6.23 == NumberUtils.min(6.23, 9.34), "min(double[]) failed for array length 2");
-        assertTrue(-10.45 == NumberUtils.min(-10.45, -5.56, 0, 5.67, 10.78), "min(double[]) failed for array length 5");
+        assertEquals(5.12, NumberUtils.min(5.12), "min(double[]) failed for array length 1");
+        assertEquals(6.23, NumberUtils.min(6.23, 9.34), "min(double[]) failed for array length 2");
+        assertEquals(-10.45, NumberUtils.min(-10.45, -5.56, 0, 5.67, 10.78), "min(double[]) failed for array length 5");
         assertEquals(-10, NumberUtils.min(new double[] { -10, -5, 0, 5, 10 }), 0.0001);
         assertEquals(-10, NumberUtils.min(new double[] { -5, 0, -10, 5, 10 }), 0.0001);
     }
@@ -794,12 +791,9 @@ public class NumberUtilsTest {
 
     @Test
     public void testMinFloat() {
-        // TODO: JUnit Jupiter 5.3.1 doesn't support delta=0.
-        // This should be replaced when it is supported in JUnit Jupiter 5.4.
-        // See https://github.com/junit-team/junit5/pull/1613 for details.
-        assertTrue(5.9f == NumberUtils.min(5.9f), "min(float[]) failed for array length 1");
-        assertTrue(6.8f == NumberUtils.min(6.8f, 9.7f), "min(float[]) failed for array length 2");
-        assertTrue(-10.6f == NumberUtils.min(-10.6f, -5.5f, 0, 5.4f, 10.3f), "min(float[]) failed for array length 5");
+        assertEquals(5.9f, NumberUtils.min(5.9f), "min(float[]) failed for array length 1");
+        assertEquals(6.8f, NumberUtils.min(6.8f, 9.7f), "min(float[]) failed for array length 2");
+        assertEquals(-10.6f, NumberUtils.min(-10.6f, -5.5f, 0, 5.4f, 10.3f), "min(float[]) failed for array length 5");
         assertEquals(-10, NumberUtils.min(new float[] { -10, -5, 0, 5, 10 }), 0.0001f);
         assertEquals(-10, NumberUtils.min(new float[] { -5, 0, -10, 5, 10 }), 0.0001f);
     }
@@ -901,12 +895,9 @@ public class NumberUtilsTest {
                 () -> NumberUtils.max(new double[0]),
                 "No exception was thrown for empty input.");
 
-        // TODO: JUnit Jupiter 5.3.1 doesn't support delta=0.
-        // This should be replaced when it is supported in JUnit Jupiter 5.4.
-        // See https://github.com/junit-team/junit5/pull/1613 for details.
-        assertTrue(5.1f == NumberUtils.max(new double[] { 5.1f }), "max(double[]) failed for array length 1");
-        assertTrue(9.2f == NumberUtils.max(new double[] { 6.3f, 9.2f }), "max(double[]) failed for array length 2");
-        assertTrue(10.4f == NumberUtils.max(new double[] { -10.5f, -5.6f, 0, 5.7f, 10.4f }), "max(double[]) failed for float length 5");
+        assertEquals(5.1f, NumberUtils.max(new double[]{5.1f}), "max(double[]) failed for array length 1");
+        assertEquals(9.2f, NumberUtils.max(new double[]{6.3f, 9.2f}), "max(double[]) failed for array length 2");
+        assertEquals(10.4f, NumberUtils.max(new double[]{-10.5f, -5.6f, 0, 5.7f, 10.4f}), "max(double[]) failed for float length 5");
         assertEquals(10, NumberUtils.max(new double[] { -10, -5, 0, 5, 10 }), 0.0001);
         assertEquals(10, NumberUtils.max(new double[] { -5, 0, 10, 5, -10 }), 0.0001);
     }
@@ -923,12 +914,9 @@ public class NumberUtilsTest {
 
     @Test
     public void testMaxFloat() {
-        // TODO: JUnit Jupiter 5.3.1 doesn't support delta=0.
-        // This should be replaced when it is supported in JUnit Jupiter 5.4.
-        // See https://github.com/junit-team/junit5/pull/1613 for details.
-        assertTrue(5.1f == NumberUtils.max(5.1f), "max(float[]) failed for array length 1");
-        assertTrue(9.2f == NumberUtils.max(6.3f, 9.2f), "max(float[]) failed for array length 2");
-        assertTrue(10.4f == NumberUtils.max(-10.5f, -5.6f, 0, 5.7f, 10.4f), "max(float[]) failed for float length 5");
+        assertEquals(5.1f, NumberUtils.max(5.1f), "max(float[]) failed for array length 1");
+        assertEquals(9.2f, NumberUtils.max(6.3f, 9.2f), "max(float[]) failed for array length 2");
+        assertEquals(10.4f, NumberUtils.max(-10.5f, -5.6f, 0, 5.7f, 10.4f), "max(float[]) failed for float length 5");
         assertEquals(10, NumberUtils.max(new float[] { -10, -5, 0, 5, 10 }), 0.0001f);
         assertEquals(10, NumberUtils.max(new float[] { -5, 0, 10, 5, -10 }), 0.0001f);
     }

--- a/src/test/java/org/apache/commons/lang3/mutable/MutableByteTest.java
+++ b/src/test/java/org/apache/commons/lang3/mutable/MutableByteTest.java
@@ -22,7 +22,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit tests.
@@ -123,12 +122,8 @@ public class MutableByteTest {
     @Test
     public void testPrimitiveValues() {
         final MutableByte mutNum = new MutableByte( (byte) 1 );
-
-        // TODO: JUnit Jupiter 5.3.1 doesn't support delta=0.
-        // This should be replaced when it is supported in JUnit Jupiter 5.4.
-        // See https://github.com/junit-team/junit5/pull/1613 for details.
-        assertTrue( 1.0F == mutNum.floatValue() );
-        assertTrue( 1.0 == mutNum.doubleValue() );
+        assertEquals(1.0F, mutNum.floatValue());
+        assertEquals(1.0, mutNum.doubleValue());
         assertEquals( (byte) 1, mutNum.byteValue() );
         assertEquals( (short) 1, mutNum.shortValue() );
         assertEquals( 1, mutNum.intValue() );

--- a/src/test/java/org/apache/commons/lang3/mutable/MutableDoubleTest.java
+++ b/src/test/java/org/apache/commons/lang3/mutable/MutableDoubleTest.java
@@ -135,12 +135,8 @@ public class MutableDoubleTest {
     @Test
     public void testPrimitiveValues() {
         final MutableDouble mutNum = new MutableDouble(1.7);
-
-        // TODO: JUnit Jupiter 5.3.1 doesn't support delta=0.
-        // This should be replaced when it is supported in JUnit Jupiter 5.4.
-        // See https://github.com/junit-team/junit5/pull/1613 for details.
-        assertTrue ( 1.7F == mutNum.floatValue() );
-        assertTrue( 1.7 == mutNum.doubleValue() );
+        assertEquals(1.7F, mutNum.floatValue());
+        assertEquals(1.7, mutNum.doubleValue());
         assertEquals( (byte) 1, mutNum.byteValue() );
         assertEquals( (short) 1, mutNum.shortValue() );
         assertEquals( 1, mutNum.intValue() );

--- a/src/test/java/org/apache/commons/lang3/mutable/MutableIntTest.java
+++ b/src/test/java/org/apache/commons/lang3/mutable/MutableIntTest.java
@@ -22,7 +22,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit tests.
@@ -130,14 +129,10 @@ public class MutableIntTest {
     @Test
     public void testPrimitiveValues() {
         final MutableInt mutNum = new MutableInt(1);
-
-        // TODO: JUnit Jupiter 5.3.1 doesn't support delta=0.
-        // This should be replaced when it is supported in JUnit Jupiter 5.4.
-        // See https://github.com/junit-team/junit5/pull/1613 for details.
         assertEquals( (byte) 1, mutNum.byteValue() );
         assertEquals( (short) 1, mutNum.shortValue() );
-        assertTrue( 1.0F == mutNum.floatValue() );
-        assertTrue( 1.0 == mutNum.doubleValue() );
+        assertEquals(1.0F, mutNum.floatValue());
+        assertEquals(1.0, mutNum.doubleValue());
         assertEquals( 1L, mutNum.longValue() );
     }
 

--- a/src/test/java/org/apache/commons/lang3/mutable/MutableLongTest.java
+++ b/src/test/java/org/apache/commons/lang3/mutable/MutableLongTest.java
@@ -22,7 +22,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit tests.
@@ -123,12 +122,8 @@ public class MutableLongTest {
     @Test
     public void testPrimitiveValues() {
         final MutableLong mutNum = new MutableLong(1L);
-
-        // TODO: JUnit Jupiter 5.3.1 doesn't support delta=0.
-        // This should be replaced when it is supported in JUnit Jupiter 5.4.
-        // See https://github.com/junit-team/junit5/pull/1613 for details.
-        assertTrue( 1.0F == mutNum.floatValue() );
-        assertTrue ( 1.0 == mutNum.doubleValue() );
+        assertEquals(1.0F, mutNum.floatValue());
+        assertEquals(1.0, mutNum.doubleValue());
         assertEquals( (byte) 1, mutNum.byteValue() );
         assertEquals( (short) 1, mutNum.shortValue() );
         assertEquals( 1, mutNum.intValue() );

--- a/src/test/java/org/apache/commons/lang3/mutable/MutableShortTest.java
+++ b/src/test/java/org/apache/commons/lang3/mutable/MutableShortTest.java
@@ -22,7 +22,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit tests.
@@ -109,12 +108,8 @@ public class MutableShortTest {
     @Test
     public void testPrimitiveValues() {
         final MutableShort mutNum = new MutableShort( (short) 1 );
-
-        // TODO: JUnit Jupiter 5.3.1 doesn't support delta=0.
-        // This should be replaced when it is supported in JUnit Jupiter 5.4.
-        // See https://github.com/junit-team/junit5/pull/1613 for details.
-        assertTrue ( 1.0F == mutNum.floatValue() );
-        assertTrue ( 1.0 == mutNum.doubleValue() );
+        assertEquals(1.0F, mutNum.floatValue());
+        assertEquals(1.0, mutNum.doubleValue());
         assertEquals( (byte) 1, mutNum.byteValue() );
         assertEquals( (short) 1, mutNum.shortValue() );
         assertEquals( 1, mutNum.intValue() );


### PR DESCRIPTION
This PR upgrades the usage of JUnit Jupiter to the recently released 5.4.0. It includes:

- Upgrading to 5.4.0
- Cleaning up the maven dependencies to use the new, simpler, `org.junit:junit-jupiter`
- Utilize new `assertEquals` methods that compare `double`s and `float`s with a delta of 0 instead of the hacks required in previous JUnit versions. 