### PR TITLE
Assertion cleanup

### DIFF
--- a/src/test/java/org/apache/commons/lang3/ArrayUtilsAddTest.java
+++ b/src/test/java/org/apache/commons/lang3/ArrayUtilsAddTest.java
@@ -17,14 +17,12 @@
 
 package org.apache.commons.lang3;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
 
@@ -49,14 +47,14 @@ public class ArrayUtilsAddTest {
     public void testAddObjectArrayBoolean() {
         boolean[] newArray;
         newArray = ArrayUtils.add(null, false);
-        assertTrue(Arrays.equals(new boolean[]{false}, newArray));
+        assertArrayEquals(new boolean[]{false}, newArray);
         assertEquals(Boolean.TYPE, newArray.getClass().getComponentType());
         newArray = ArrayUtils.add(null, true);
-        assertTrue(Arrays.equals(new boolean[]{true}, newArray));
+        assertArrayEquals(new boolean[]{true}, newArray);
         assertEquals(Boolean.TYPE, newArray.getClass().getComponentType());
         final boolean[] array1 = new boolean[]{true, false, true};
         newArray = ArrayUtils.add(array1, false);
-        assertTrue(Arrays.equals(new boolean[]{true, false, true, false}, newArray));
+        assertArrayEquals(new boolean[]{true, false, true, false}, newArray);
         assertEquals(Boolean.TYPE, newArray.getClass().getComponentType());
     }
 
@@ -64,17 +62,17 @@ public class ArrayUtilsAddTest {
     public void testAddObjectArrayByte() {
         byte[] newArray;
         newArray = ArrayUtils.add((byte[]) null, (byte) 0);
-        assertTrue(Arrays.equals(new byte[]{0}, newArray));
+        assertArrayEquals(new byte[]{0}, newArray);
         assertEquals(Byte.TYPE, newArray.getClass().getComponentType());
         newArray = ArrayUtils.add((byte[]) null, (byte) 1);
-        assertTrue(Arrays.equals(new byte[]{1}, newArray));
+        assertArrayEquals(new byte[]{1}, newArray);
         assertEquals(Byte.TYPE, newArray.getClass().getComponentType());
         final byte[] array1 = new byte[]{1, 2, 3};
         newArray = ArrayUtils.add(array1, (byte) 0);
-        assertTrue(Arrays.equals(new byte[]{1, 2, 3, 0}, newArray));
+        assertArrayEquals(new byte[]{1, 2, 3, 0}, newArray);
         assertEquals(Byte.TYPE, newArray.getClass().getComponentType());
         newArray = ArrayUtils.add(array1, (byte) 4);
-        assertTrue(Arrays.equals(new byte[]{1, 2, 3, 4}, newArray));
+        assertArrayEquals(new byte[]{1, 2, 3, 4}, newArray);
         assertEquals(Byte.TYPE, newArray.getClass().getComponentType());
     }
 
@@ -82,17 +80,17 @@ public class ArrayUtilsAddTest {
     public void testAddObjectArrayChar() {
         char[] newArray;
         newArray = ArrayUtils.add((char[]) null, (char) 0);
-        assertTrue(Arrays.equals(new char[]{0}, newArray));
+        assertArrayEquals(new char[]{0}, newArray);
         assertEquals(Character.TYPE, newArray.getClass().getComponentType());
         newArray = ArrayUtils.add((char[]) null, (char) 1);
-        assertTrue(Arrays.equals(new char[]{1}, newArray));
+        assertArrayEquals(new char[]{1}, newArray);
         assertEquals(Character.TYPE, newArray.getClass().getComponentType());
         final char[] array1 = new char[]{1, 2, 3};
         newArray = ArrayUtils.add(array1, (char) 0);
-        assertTrue(Arrays.equals(new char[]{1, 2, 3, 0}, newArray));
+        assertArrayEquals(new char[]{1, 2, 3, 0}, newArray);
         assertEquals(Character.TYPE, newArray.getClass().getComponentType());
         newArray = ArrayUtils.add(array1, (char) 4);
-        assertTrue(Arrays.equals(new char[]{1, 2, 3, 4}, newArray));
+        assertArrayEquals(new char[]{1, 2, 3, 4}, newArray);
         assertEquals(Character.TYPE, newArray.getClass().getComponentType());
     }
 
@@ -100,17 +98,17 @@ public class ArrayUtilsAddTest {
     public void testAddObjectArrayDouble() {
         double[] newArray;
         newArray = ArrayUtils.add((double[]) null, 0);
-        assertTrue(Arrays.equals(new double[]{0}, newArray));
+        assertArrayEquals(new double[]{0}, newArray);
         assertEquals(Double.TYPE, newArray.getClass().getComponentType());
         newArray = ArrayUtils.add((double[]) null, 1);
-        assertTrue(Arrays.equals(new double[]{1}, newArray));
+        assertArrayEquals(new double[]{1}, newArray);
         assertEquals(Double.TYPE, newArray.getClass().getComponentType());
         final double[] array1 = new double[]{1, 2, 3};
         newArray = ArrayUtils.add(array1, 0);
-        assertTrue(Arrays.equals(new double[]{1, 2, 3, 0}, newArray));
+        assertArrayEquals(new double[]{1, 2, 3, 0}, newArray);
         assertEquals(Double.TYPE, newArray.getClass().getComponentType());
         newArray = ArrayUtils.add(array1, 4);
-        assertTrue(Arrays.equals(new double[]{1, 2, 3, 4}, newArray));
+        assertArrayEquals(new double[]{1, 2, 3, 4}, newArray);
         assertEquals(Double.TYPE, newArray.getClass().getComponentType());
     }
 
@@ -118,17 +116,17 @@ public class ArrayUtilsAddTest {
     public void testAddObjectArrayFloat() {
         float[] newArray;
         newArray = ArrayUtils.add((float[]) null, 0);
-        assertTrue(Arrays.equals(new float[]{0}, newArray));
+        assertArrayEquals(new float[]{0}, newArray);
         assertEquals(Float.TYPE, newArray.getClass().getComponentType());
         newArray = ArrayUtils.add((float[]) null, 1);
-        assertTrue(Arrays.equals(new float[]{1}, newArray));
+        assertArrayEquals(new float[]{1}, newArray);
         assertEquals(Float.TYPE, newArray.getClass().getComponentType());
         final float[] array1 = new float[]{1, 2, 3};
         newArray = ArrayUtils.add(array1, 0);
-        assertTrue(Arrays.equals(new float[]{1, 2, 3, 0}, newArray));
+        assertArrayEquals(new float[]{1, 2, 3, 0}, newArray);
         assertEquals(Float.TYPE, newArray.getClass().getComponentType());
         newArray = ArrayUtils.add(array1, 4);
-        assertTrue(Arrays.equals(new float[]{1, 2, 3, 4}, newArray));
+        assertArrayEquals(new float[]{1, 2, 3, 4}, newArray);
         assertEquals(Float.TYPE, newArray.getClass().getComponentType());
     }
 
@@ -136,17 +134,17 @@ public class ArrayUtilsAddTest {
     public void testAddObjectArrayInt() {
         int[] newArray;
         newArray = ArrayUtils.add((int[]) null, 0);
-        assertTrue(Arrays.equals(new int[]{0}, newArray));
+        assertArrayEquals(new int[]{0}, newArray);
         assertEquals(Integer.TYPE, newArray.getClass().getComponentType());
         newArray = ArrayUtils.add((int[]) null, 1);
-        assertTrue(Arrays.equals(new int[]{1}, newArray));
+        assertArrayEquals(new int[]{1}, newArray);
         assertEquals(Integer.TYPE, newArray.getClass().getComponentType());
         final int[] array1 = new int[]{1, 2, 3};
         newArray = ArrayUtils.add(array1, 0);
-        assertTrue(Arrays.equals(new int[]{1, 2, 3, 0}, newArray));
+        assertArrayEquals(new int[]{1, 2, 3, 0}, newArray);
         assertEquals(Integer.TYPE, newArray.getClass().getComponentType());
         newArray = ArrayUtils.add(array1, 4);
-        assertTrue(Arrays.equals(new int[]{1, 2, 3, 4}, newArray));
+        assertArrayEquals(new int[]{1, 2, 3, 4}, newArray);
         assertEquals(Integer.TYPE, newArray.getClass().getComponentType());
     }
 
@@ -154,17 +152,17 @@ public class ArrayUtilsAddTest {
     public void testAddObjectArrayLong() {
         long[] newArray;
         newArray = ArrayUtils.add((long[]) null, 0);
-        assertTrue(Arrays.equals(new long[]{0}, newArray));
+        assertArrayEquals(new long[]{0}, newArray);
         assertEquals(Long.TYPE, newArray.getClass().getComponentType());
         newArray = ArrayUtils.add((long[]) null, 1);
-        assertTrue(Arrays.equals(new long[]{1}, newArray));
+        assertArrayEquals(new long[]{1}, newArray);
         assertEquals(Long.TYPE, newArray.getClass().getComponentType());
         final long[] array1 = new long[]{1, 2, 3};
         newArray = ArrayUtils.add(array1, 0);
-        assertTrue(Arrays.equals(new long[]{1, 2, 3, 0}, newArray));
+        assertArrayEquals(new long[]{1, 2, 3, 0}, newArray);
         assertEquals(Long.TYPE, newArray.getClass().getComponentType());
         newArray = ArrayUtils.add(array1, 4);
-        assertTrue(Arrays.equals(new long[]{1, 2, 3, 4}, newArray));
+        assertArrayEquals(new long[]{1, 2, 3, 4}, newArray);
         assertEquals(Long.TYPE, newArray.getClass().getComponentType());
     }
 
@@ -172,17 +170,17 @@ public class ArrayUtilsAddTest {
     public void testAddObjectArrayShort() {
         short[] newArray;
         newArray = ArrayUtils.add((short[]) null, (short) 0);
-        assertTrue(Arrays.equals(new short[]{0}, newArray));
+        assertArrayEquals(new short[]{0}, newArray);
         assertEquals(Short.TYPE, newArray.getClass().getComponentType());
         newArray = ArrayUtils.add((short[]) null, (short) 1);
-        assertTrue(Arrays.equals(new short[]{1}, newArray));
+        assertArrayEquals(new short[]{1}, newArray);
         assertEquals(Short.TYPE, newArray.getClass().getComponentType());
         final short[] array1 = new short[]{1, 2, 3};
         newArray = ArrayUtils.add(array1, (short) 0);
-        assertTrue(Arrays.equals(new short[]{1, 2, 3, 0}, newArray));
+        assertArrayEquals(new short[]{1, 2, 3, 0}, newArray);
         assertEquals(Short.TYPE, newArray.getClass().getComponentType());
         newArray = ArrayUtils.add(array1, (short) 4);
-        assertTrue(Arrays.equals(new short[]{1, 2, 3, 4}, newArray));
+        assertArrayEquals(new short[]{1, 2, 3, 4}, newArray);
         assertEquals(Short.TYPE, newArray.getClass().getComponentType());
     }
 
@@ -192,33 +190,33 @@ public class ArrayUtilsAddTest {
 
         //show that not casting is okay
         newArray = ArrayUtils.add((Object[]) null, "a");
-        assertTrue(Arrays.equals(new String[]{"a"}, newArray));
-        assertTrue(Arrays.equals(new Object[]{"a"}, newArray));
+        assertArrayEquals(new String[]{"a"}, newArray);
+        assertArrayEquals(new Object[]{"a"}, newArray);
         assertEquals(String.class, newArray.getClass().getComponentType());
 
         //show that not casting to Object[] is okay and will assume String based on "a"
         final String[] newStringArray = ArrayUtils.add(null, "a");
-        assertTrue(Arrays.equals(new String[]{"a"}, newStringArray));
-        assertTrue(Arrays.equals(new Object[]{"a"}, newStringArray));
+        assertArrayEquals(new String[]{"a"}, newStringArray);
+        assertArrayEquals(new Object[]{"a"}, newStringArray);
         assertEquals(String.class, newStringArray.getClass().getComponentType());
 
         final String[] stringArray1 = new String[]{"a", "b", "c"};
         newArray = ArrayUtils.add(stringArray1, null);
-        assertTrue(Arrays.equals(new String[]{"a", "b", "c", null}, newArray));
+        assertArrayEquals(new String[]{"a", "b", "c", null}, newArray);
         assertEquals(String.class, newArray.getClass().getComponentType());
 
         newArray = ArrayUtils.add(stringArray1, "d");
-        assertTrue(Arrays.equals(new String[]{"a", "b", "c", "d"}, newArray));
+        assertArrayEquals(new String[]{"a", "b", "c", "d"}, newArray);
         assertEquals(String.class, newArray.getClass().getComponentType());
 
         Number[] numberArray1 = new Number[]{Integer.valueOf(1), Double.valueOf(2)};
         newArray = ArrayUtils.add(numberArray1, Float.valueOf(3));
-        assertTrue(Arrays.equals(new Number[]{Integer.valueOf(1), Double.valueOf(2), Float.valueOf(3)}, newArray));
+        assertArrayEquals(new Number[]{Integer.valueOf(1), Double.valueOf(2), Float.valueOf(3)}, newArray);
         assertEquals(Number.class, newArray.getClass().getComponentType());
 
         numberArray1 = null;
         newArray = ArrayUtils.add(numberArray1, Float.valueOf(3));
-        assertTrue(Arrays.equals(new Float[]{Float.valueOf(3)}, newArray));
+        assertArrayEquals(new Float[]{Float.valueOf(3)}, newArray);
         assertEquals(Float.class, newArray.getClass().getComponentType());
     }
 
@@ -239,113 +237,89 @@ public class ArrayUtilsAddTest {
         final String[] stringArray2 = new String[]{"1", "2", "3"};
         newArray = ArrayUtils.addAll(stringArray1, (String[]) null);
         assertNotSame(stringArray1, newArray);
-        assertTrue(Arrays.equals(stringArray1, newArray));
-        assertTrue(Arrays.equals(new String[]{"a", "b", "c"}, newArray));
+        assertArrayEquals(stringArray1, newArray);
+        assertArrayEquals(new String[]{"a", "b", "c"}, newArray);
         assertEquals(String.class, newArray.getClass().getComponentType());
         newArray = ArrayUtils.addAll(null, stringArray2);
         assertNotSame(stringArray2, newArray);
-        assertTrue(Arrays.equals(stringArray2, newArray));
-        assertTrue(Arrays.equals(new String[]{"1", "2", "3"}, newArray));
+        assertArrayEquals(stringArray2, newArray);
+        assertArrayEquals(new String[]{"1", "2", "3"}, newArray);
         assertEquals(String.class, newArray.getClass().getComponentType());
         newArray = ArrayUtils.addAll(stringArray1, stringArray2);
-        assertTrue(Arrays.equals(new String[]{"a", "b", "c", "1", "2", "3"}, newArray));
+        assertArrayEquals(new String[]{"a", "b", "c", "1", "2", "3"}, newArray);
         assertEquals(String.class, newArray.getClass().getComponentType());
         newArray = ArrayUtils.addAll(ArrayUtils.EMPTY_STRING_ARRAY, (String[]) null);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_STRING_ARRAY, newArray));
-        assertTrue(Arrays.equals(new String[]{}, newArray));
+        assertArrayEquals(ArrayUtils.EMPTY_STRING_ARRAY, newArray);
+        assertArrayEquals(new String[]{}, newArray);
         assertEquals(String.class, newArray.getClass().getComponentType());
         newArray = ArrayUtils.addAll(null, ArrayUtils.EMPTY_STRING_ARRAY);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_STRING_ARRAY, newArray));
-        assertTrue(Arrays.equals(new String[]{}, newArray));
+        assertArrayEquals(ArrayUtils.EMPTY_STRING_ARRAY, newArray);
+        assertArrayEquals(new String[]{}, newArray);
         assertEquals(String.class, newArray.getClass().getComponentType());
         newArray = ArrayUtils.addAll(ArrayUtils.EMPTY_STRING_ARRAY, ArrayUtils.EMPTY_STRING_ARRAY);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_STRING_ARRAY, newArray));
-        assertTrue(Arrays.equals(new String[]{}, newArray));
+        assertArrayEquals(ArrayUtils.EMPTY_STRING_ARRAY, newArray);
+        assertArrayEquals(new String[]{}, newArray);
         assertEquals(String.class, newArray.getClass().getComponentType());
         final String[] stringArrayNull = new String []{null};
         newArray = ArrayUtils.addAll(stringArrayNull, stringArrayNull);
-        assertTrue(Arrays.equals(new String[]{null, null}, newArray));
+        assertArrayEquals(new String[]{null, null}, newArray);
         assertEquals(String.class, newArray.getClass().getComponentType());
 
         // boolean
-        assertTrue( Arrays.equals( new boolean[] { true, false, false, true },
-            ArrayUtils.addAll( new boolean[] { true, false }, false, true) ) );
+        assertArrayEquals(new boolean[]{true, false, false, true}, ArrayUtils.addAll(new boolean[]{true, false}, false, true));
 
-        assertTrue( Arrays.equals( new boolean[] { false, true },
-            ArrayUtils.addAll( null, new boolean[] { false, true } ) ) );
+        assertArrayEquals(new boolean[]{false, true}, ArrayUtils.addAll(null, new boolean[]{false, true}));
 
-        assertTrue( Arrays.equals( new boolean[] { true, false },
-            ArrayUtils.addAll( new boolean[] { true, false }, null ) ) );
+        assertArrayEquals(new boolean[]{true, false}, ArrayUtils.addAll(new boolean[]{true, false}, null));
 
         // char
-        assertTrue( Arrays.equals( new char[] { 'a', 'b', 'c', 'd' },
-            ArrayUtils.addAll( new char[] { 'a', 'b' }, 'c', 'd') ) );
+        assertArrayEquals(new char[]{'a', 'b', 'c', 'd'}, ArrayUtils.addAll(new char[]{'a', 'b'}, 'c', 'd'));
 
-        assertTrue( Arrays.equals( new char[] { 'c', 'd' },
-            ArrayUtils.addAll( null, new char[] { 'c', 'd' } ) ) );
+        assertArrayEquals(new char[]{'c', 'd'}, ArrayUtils.addAll(null, new char[]{'c', 'd'}));
 
-        assertTrue( Arrays.equals( new char[] { 'a', 'b' },
-            ArrayUtils.addAll( new char[] { 'a', 'b' }, null ) ) );
+        assertArrayEquals(new char[]{'a', 'b'}, ArrayUtils.addAll(new char[]{'a', 'b'}, null));
 
         // byte
-        assertTrue( Arrays.equals( new byte[] { (byte) 0, (byte) 1, (byte) 2, (byte) 3 },
-            ArrayUtils.addAll( new byte[] { (byte) 0, (byte) 1 }, (byte) 2, (byte) 3) ) );
+        assertArrayEquals(new byte[]{(byte) 0, (byte) 1, (byte) 2, (byte) 3}, ArrayUtils.addAll(new byte[]{(byte) 0, (byte) 1}, (byte) 2, (byte) 3));
 
-        assertTrue( Arrays.equals( new byte[] { (byte) 2, (byte) 3 },
-            ArrayUtils.addAll( null, new byte[] { (byte) 2, (byte) 3 } ) ) );
+        assertArrayEquals(new byte[]{(byte) 2, (byte) 3}, ArrayUtils.addAll(null, new byte[]{(byte) 2, (byte) 3}));
 
-        assertTrue( Arrays.equals( new byte[] { (byte) 0, (byte) 1 },
-            ArrayUtils.addAll( new byte[] { (byte) 0, (byte) 1 }, null ) ) );
+        assertArrayEquals(new byte[]{(byte) 0, (byte) 1}, ArrayUtils.addAll(new byte[]{(byte) 0, (byte) 1}, null));
 
         // short
-        assertTrue( Arrays.equals( new short[] { (short) 10, (short) 20, (short) 30, (short) 40 },
-            ArrayUtils.addAll( new short[] { (short) 10, (short) 20 }, (short) 30, (short) 40) ) );
+        assertArrayEquals(new short[]{(short) 10, (short) 20, (short) 30, (short) 40}, ArrayUtils.addAll(new short[]{(short) 10, (short) 20}, (short) 30, (short) 40));
 
-        assertTrue( Arrays.equals( new short[] { (short) 30, (short) 40 },
-            ArrayUtils.addAll( null, new short[] { (short) 30, (short) 40 } ) ) );
+        assertArrayEquals(new short[]{(short) 30, (short) 40}, ArrayUtils.addAll(null, new short[]{(short) 30, (short) 40}));
 
-        assertTrue( Arrays.equals( new short[] { (short) 10, (short) 20 },
-            ArrayUtils.addAll( new short[] { (short) 10, (short) 20 }, null ) ) );
+        assertArrayEquals(new short[]{(short) 10, (short) 20}, ArrayUtils.addAll(new short[]{(short) 10, (short) 20}, null));
 
         // int
-        assertTrue( Arrays.equals( new int[] { 1, 1000, -1000, -1 },
-            ArrayUtils.addAll( new int[] { 1, 1000 }, -1000, -1) ) );
+        assertArrayEquals(new int[]{1, 1000, -1000, -1}, ArrayUtils.addAll(new int[]{1, 1000}, -1000, -1));
 
-        assertTrue( Arrays.equals( new int[] { -1000, -1 },
-            ArrayUtils.addAll( null, new int[] { -1000, -1 } ) ) );
+        assertArrayEquals(new int[]{-1000, -1}, ArrayUtils.addAll(null, new int[]{-1000, -1}));
 
-        assertTrue( Arrays.equals( new int[] { 1, 1000 },
-            ArrayUtils.addAll( new int[] { 1, 1000 }, null ) ) );
+        assertArrayEquals(new int[]{1, 1000}, ArrayUtils.addAll(new int[]{1, 1000}, null));
 
         // long
-        assertTrue( Arrays.equals( new long[] { 1L, -1L, 1000L, -1000L },
-            ArrayUtils.addAll( new long[] { 1L, -1L }, 1000L, -1000L) ) );
+        assertArrayEquals(new long[]{1L, -1L, 1000L, -1000L}, ArrayUtils.addAll(new long[]{1L, -1L}, 1000L, -1000L));
 
-        assertTrue( Arrays.equals( new long[] { 1000L, -1000L },
-            ArrayUtils.addAll( null, new long[] { 1000L, -1000L } ) ) );
+        assertArrayEquals(new long[]{1000L, -1000L}, ArrayUtils.addAll(null, new long[]{1000L, -1000L}));
 
-        assertTrue( Arrays.equals( new long[] { 1L, -1L },
-            ArrayUtils.addAll( new long[] { 1L, -1L }, null ) ) );
+        assertArrayEquals(new long[]{1L, -1L}, ArrayUtils.addAll(new long[]{1L, -1L}, null));
 
         // float
-        assertTrue( Arrays.equals( new float[] { 10.5f, 10.1f, 1.6f, 0.01f },
-            ArrayUtils.addAll( new float[] { 10.5f, 10.1f }, 1.6f, 0.01f) ) );
+        assertArrayEquals(new float[]{10.5f, 10.1f, 1.6f, 0.01f}, ArrayUtils.addAll(new float[]{10.5f, 10.1f}, 1.6f, 0.01f));
 
-        assertTrue( Arrays.equals( new float[] { 1.6f, 0.01f },
-            ArrayUtils.addAll( null, new float[] { 1.6f, 0.01f } ) ) );
+        assertArrayEquals(new float[]{1.6f, 0.01f}, ArrayUtils.addAll(null, new float[]{1.6f, 0.01f}));
 
-        assertTrue( Arrays.equals( new float[] { 10.5f, 10.1f },
-            ArrayUtils.addAll( new float[] { 10.5f, 10.1f }, null ) ) );
+        assertArrayEquals(new float[]{10.5f, 10.1f}, ArrayUtils.addAll(new float[]{10.5f, 10.1f}, null));
 
         // double
-        assertTrue( Arrays.equals( new double[] { Math.PI, -Math.PI, 0, 9.99 },
-            ArrayUtils.addAll( new double[] { Math.PI, -Math.PI }, 0, 9.99) ) );
+        assertArrayEquals(new double[]{Math.PI, -Math.PI, 0, 9.99}, ArrayUtils.addAll(new double[]{Math.PI, -Math.PI}, 0, 9.99));
 
-        assertTrue( Arrays.equals( new double[] { 0, 9.99 },
-            ArrayUtils.addAll( null, new double[] { 0, 9.99 } ) ) );
+        assertArrayEquals(new double[]{0, 9.99}, ArrayUtils.addAll(null, new double[]{0, 9.99}));
 
-        assertTrue( Arrays.equals( new double[] { Math.PI, -Math.PI },
-            ArrayUtils.addAll( new double[] { Math.PI, -Math.PI }, null ) ) );
+        assertArrayEquals(new double[]{Math.PI, -Math.PI}, ArrayUtils.addAll(new double[]{Math.PI, -Math.PI}, null));
 
     }
 
@@ -354,21 +328,21 @@ public class ArrayUtilsAddTest {
     public void testAddObjectAtIndex() {
         Object[] newArray;
         newArray = ArrayUtils.add((Object[]) null, 0, "a");
-        assertTrue(Arrays.equals(new String[]{"a"}, newArray));
-        assertTrue(Arrays.equals(new Object[]{"a"}, newArray));
+        assertArrayEquals(new String[]{"a"}, newArray);
+        assertArrayEquals(new Object[]{"a"}, newArray);
         assertEquals(String.class, newArray.getClass().getComponentType());
         final String[] stringArray1 = new String[]{"a", "b", "c"};
         newArray = ArrayUtils.add(stringArray1, 0, null);
-        assertTrue(Arrays.equals(new String[]{null, "a", "b", "c"}, newArray));
+        assertArrayEquals(new String[]{null, "a", "b", "c"}, newArray);
         assertEquals(String.class, newArray.getClass().getComponentType());
         newArray = ArrayUtils.add(stringArray1, 1, null);
-        assertTrue(Arrays.equals(new String[]{"a", null, "b", "c"}, newArray));
+        assertArrayEquals(new String[]{"a", null, "b", "c"}, newArray);
         assertEquals(String.class, newArray.getClass().getComponentType());
         newArray = ArrayUtils.add(stringArray1, 3, null);
-        assertTrue(Arrays.equals(new String[]{"a", "b", "c", null}, newArray));
+        assertArrayEquals(new String[]{"a", "b", "c", null}, newArray);
         assertEquals(String.class, newArray.getClass().getComponentType());
         newArray = ArrayUtils.add(stringArray1, 3, "d");
-        assertTrue(Arrays.equals(new String[]{"a", "b", "c", "d"}, newArray));
+        assertArrayEquals(new String[]{"a", "b", "c", "d"}, newArray);
         assertEquals(String.class, newArray.getClass().getComponentType());
         assertEquals(String.class, newArray.getClass().getComponentType());
 
@@ -391,16 +365,16 @@ public class ArrayUtilsAddTest {
 
         // boolean tests
         boolean[] booleanArray = ArrayUtils.add( null, 0, true );
-        assertTrue( Arrays.equals( new boolean[] { true }, booleanArray ) );
+        assertArrayEquals(new boolean[]{true}, booleanArray);
         IndexOutOfBoundsException e =
                 assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.add( null, -1, true));
         assertEquals("Index: -1, Length: 0", e.getMessage());
         booleanArray = ArrayUtils.add( new boolean[] { true }, 0, false);
-        assertTrue( Arrays.equals( new boolean[] { false, true }, booleanArray ) );
+        assertArrayEquals(new boolean[]{false, true}, booleanArray);
         booleanArray = ArrayUtils.add( new boolean[] { false }, 1, true);
-        assertTrue( Arrays.equals( new boolean[] { false, true }, booleanArray ) );
+        assertArrayEquals(new boolean[]{false, true}, booleanArray);
         booleanArray = ArrayUtils.add( new boolean[] { true, false }, 1, true);
-        assertTrue( Arrays.equals( new boolean[] { true, true, false }, booleanArray ) );
+        assertArrayEquals(new boolean[]{true, true, false}, booleanArray);
         e = assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.add(new boolean[] { true, false }, 4, true));
         assertEquals("Index: 4, Length: 2", e.getMessage());
         e = assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.add(new boolean[] { true, false }, -1, true));
@@ -408,17 +382,17 @@ public class ArrayUtilsAddTest {
 
         // char tests
         char[] charArray = ArrayUtils.add( (char[]) null, 0, 'a' );
-        assertTrue( Arrays.equals( new char[] { 'a' }, charArray ) );
+        assertArrayEquals(new char[]{'a'}, charArray);
         e = assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.add( (char[]) null, -1, 'a' ));
         assertEquals("Index: -1, Length: 0", e.getMessage());
         charArray = ArrayUtils.add( new char[] { 'a' }, 0, 'b');
-        assertTrue( Arrays.equals( new char[] { 'b', 'a' }, charArray ) );
+        assertArrayEquals(new char[]{'b', 'a'}, charArray);
         charArray = ArrayUtils.add( new char[] { 'a', 'b' }, 0, 'c');
-        assertTrue( Arrays.equals( new char[] { 'c', 'a', 'b' }, charArray ) );
+        assertArrayEquals(new char[]{'c', 'a', 'b'}, charArray);
         charArray = ArrayUtils.add( new char[] { 'a', 'b' }, 1, 'k');
-        assertTrue( Arrays.equals( new char[] { 'a', 'k', 'b' }, charArray ) );
+        assertArrayEquals(new char[]{'a', 'k', 'b'}, charArray);
         charArray = ArrayUtils.add( new char[] { 'a', 'b', 'c' }, 1, 't');
-        assertTrue( Arrays.equals( new char[] { 'a', 't', 'b', 'c' }, charArray ) );
+        assertArrayEquals(new char[]{'a', 't', 'b', 'c'}, charArray);
         e = assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.add( new char[] { 'a', 'b' }, 4, 'c'));
         assertEquals("Index: 4, Length: 2", e.getMessage());
         e = assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.add( new char[] { 'a', 'b' }, -1, 'c'));
@@ -426,15 +400,15 @@ public class ArrayUtilsAddTest {
 
         // short tests
         short[] shortArray = ArrayUtils.add( new short[] { 1 }, 0, (short) 2);
-        assertTrue( Arrays.equals( new short[] { 2, 1 }, shortArray ) );
+        assertArrayEquals(new short[]{2, 1}, shortArray);
         e = assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.add( (short[]) null, -1, (short) 2));
         assertEquals("Index: -1, Length: 0", e.getMessage());
         shortArray = ArrayUtils.add( new short[] { 2, 6 }, 2, (short) 10);
-        assertTrue( Arrays.equals( new short[] { 2, 6, 10 }, shortArray ) );
+        assertArrayEquals(new short[]{2, 6, 10}, shortArray);
         shortArray = ArrayUtils.add( new short[] { 2, 6 }, 0, (short) -4);
-        assertTrue( Arrays.equals( new short[] { -4, 2, 6 }, shortArray ) );
+        assertArrayEquals(new short[]{-4, 2, 6}, shortArray);
         shortArray = ArrayUtils.add( new short[] { 2, 6, 3 }, 2, (short) 1);
-        assertTrue( Arrays.equals( new short[] { 2, 6, 1, 3 }, shortArray ) );
+        assertArrayEquals(new short[]{2, 6, 1, 3}, shortArray);
         e = assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.add( new short[] { 2, 6 }, 4, (short) 10));
         assertEquals("Index: 4, Length: 2", e.getMessage());
         e = assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.add( new short[] { 2, 6 }, -1, (short) 10));
@@ -442,15 +416,15 @@ public class ArrayUtilsAddTest {
 
         // byte tests
         byte[] byteArray = ArrayUtils.add( new byte[] { 1 }, 0, (byte) 2);
-        assertTrue( Arrays.equals( new byte[] { 2, 1 }, byteArray ) );
+        assertArrayEquals(new byte[]{2, 1}, byteArray);
         e = assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.add( (byte[]) null, -1, (byte) 2));
         assertEquals("Index: -1, Length: 0", e.getMessage());
         byteArray = ArrayUtils.add( new byte[] { 2, 6 }, 2, (byte) 3);
-        assertTrue( Arrays.equals( new byte[] { 2, 6, 3 }, byteArray ) );
+        assertArrayEquals(new byte[]{2, 6, 3}, byteArray);
         byteArray = ArrayUtils.add( new byte[] { 2, 6 }, 0, (byte) 1);
-        assertTrue( Arrays.equals( new byte[] { 1, 2, 6 }, byteArray ) );
+        assertArrayEquals(new byte[]{1, 2, 6}, byteArray);
         byteArray = ArrayUtils.add( new byte[] { 2, 6, 3 }, 2, (byte) 1);
-        assertTrue( Arrays.equals( new byte[] { 2, 6, 1, 3 }, byteArray ) );
+        assertArrayEquals(new byte[]{2, 6, 1, 3}, byteArray);
         e = assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.add( new byte[] { 2, 6 }, 4, (byte) 3));
         assertEquals("Index: 4, Length: 2", e.getMessage());
         e = assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.add( new byte[] { 2, 6 }, -1, (byte) 3));
@@ -458,15 +432,15 @@ public class ArrayUtilsAddTest {
 
         // int tests
         int[] intArray = ArrayUtils.add( new int[] { 1 }, 0, 2);
-        assertTrue( Arrays.equals( new int[] { 2, 1 }, intArray ) );
+        assertArrayEquals(new int[]{2, 1}, intArray);
         e = assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.add( (int[]) null, -1, 2));
         assertEquals("Index: -1, Length: 0", e.getMessage());
         intArray = ArrayUtils.add( new int[] { 2, 6 }, 2, 10);
-        assertTrue( Arrays.equals( new int[] { 2, 6, 10 }, intArray ) );
+        assertArrayEquals(new int[]{2, 6, 10}, intArray);
         intArray = ArrayUtils.add( new int[] { 2, 6 }, 0, -4);
-        assertTrue( Arrays.equals( new int[] { -4, 2, 6 }, intArray ) );
+        assertArrayEquals(new int[]{-4, 2, 6}, intArray);
         intArray = ArrayUtils.add( new int[] { 2, 6, 3 }, 2, 1);
-        assertTrue( Arrays.equals( new int[] { 2, 6, 1, 3 }, intArray ) );
+        assertArrayEquals(new int[]{2, 6, 1, 3}, intArray);
         e = assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.add( new int[] { 2, 6 }, 4, 10));
         assertEquals("Index: 4, Length: 2", e.getMessage());
         e = assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.add( new int[] { 2, 6 }, -1, 10));
@@ -474,15 +448,15 @@ public class ArrayUtilsAddTest {
 
         // long tests
         long[] longArray = ArrayUtils.add( new long[] { 1L }, 0, 2L);
-        assertTrue( Arrays.equals( new long[] { 2L, 1L }, longArray ) );
+        assertArrayEquals(new long[]{2L, 1L}, longArray);
         e = assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.add( (long[]) null, -1, 2L));
         assertEquals("Index: -1, Length: 0", e.getMessage());
         longArray = ArrayUtils.add( new long[] { 2L, 6L }, 2, 10L);
-        assertTrue( Arrays.equals( new long[] { 2L, 6L, 10L }, longArray ) );
+        assertArrayEquals(new long[]{2L, 6L, 10L}, longArray);
         longArray = ArrayUtils.add( new long[] { 2L, 6L }, 0, -4L);
-        assertTrue( Arrays.equals( new long[] { -4L, 2L, 6L }, longArray ) );
+        assertArrayEquals(new long[]{-4L, 2L, 6L}, longArray);
         longArray = ArrayUtils.add( new long[] { 2L, 6L, 3L }, 2, 1L);
-        assertTrue( Arrays.equals( new long[] { 2L, 6L, 1L, 3L }, longArray ) );
+        assertArrayEquals(new long[]{2L, 6L, 1L, 3L}, longArray);
         e = assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.add( new long[] { 2L, 6L }, 4, 10L));
         assertEquals("Index: 4, Length: 2", e.getMessage());
         e = assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.add( new long[] { 2L, 6L }, -1, 10L));
@@ -490,15 +464,15 @@ public class ArrayUtilsAddTest {
 
         // float tests
         float[] floatArray = ArrayUtils.add( new float[] { 1.1f }, 0, 2.2f);
-        assertTrue( Arrays.equals( new float[] { 2.2f, 1.1f }, floatArray ) );
+        assertArrayEquals(new float[]{2.2f, 1.1f}, floatArray);
         e = assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.add( (float[]) null, -1, 2.2f));
         assertEquals("Index: -1, Length: 0", e.getMessage());
         floatArray = ArrayUtils.add( new float[] { 2.3f, 6.4f }, 2, 10.5f);
-        assertTrue( Arrays.equals( new float[] { 2.3f, 6.4f, 10.5f }, floatArray ) );
+        assertArrayEquals(new float[]{2.3f, 6.4f, 10.5f}, floatArray);
         floatArray = ArrayUtils.add( new float[] { 2.6f, 6.7f }, 0, -4.8f);
-        assertTrue( Arrays.equals( new float[] { -4.8f, 2.6f, 6.7f }, floatArray ) );
+        assertArrayEquals(new float[]{-4.8f, 2.6f, 6.7f}, floatArray);
         floatArray = ArrayUtils.add( new float[] { 2.9f, 6.0f, 0.3f }, 2, 1.0f);
-        assertTrue( Arrays.equals( new float[] { 2.9f, 6.0f, 1.0f, 0.3f }, floatArray ) );
+        assertArrayEquals(new float[]{2.9f, 6.0f, 1.0f, 0.3f}, floatArray);
         e = assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.add( new float[] { 2.3f, 6.4f }, 4, 10.5f));
         assertEquals("Index: 4, Length: 2", e.getMessage());
         e = assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.add( new float[] { 2.3f, 6.4f }, -1, 10.5f));
@@ -506,15 +480,15 @@ public class ArrayUtilsAddTest {
 
         // double tests
         double[] doubleArray = ArrayUtils.add( new double[] { 1.1 }, 0, 2.2);
-        assertTrue( Arrays.equals( new double[] { 2.2, 1.1 }, doubleArray ) );
+        assertArrayEquals(new double[]{2.2, 1.1}, doubleArray);
         e = assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.add(null, -1, 2.2));
         assertEquals("Index: -1, Length: 0", e.getMessage());
         doubleArray = ArrayUtils.add( new double[] { 2.3, 6.4 }, 2, 10.5);
-        assertTrue( Arrays.equals( new double[] { 2.3, 6.4, 10.5 }, doubleArray ) );
+        assertArrayEquals(new double[]{2.3, 6.4, 10.5}, doubleArray);
         doubleArray = ArrayUtils.add( new double[] { 2.6, 6.7 }, 0, -4.8);
-        assertTrue( Arrays.equals( new double[] { -4.8, 2.6, 6.7 }, doubleArray ) );
+        assertArrayEquals(new double[]{-4.8, 2.6, 6.7}, doubleArray);
         doubleArray = ArrayUtils.add( new double[] { 2.9, 6.0, 0.3 }, 2, 1.0);
-        assertTrue( Arrays.equals( new double[] { 2.9, 6.0, 1.0, 0.3 }, doubleArray ) );
+        assertArrayEquals(new double[]{2.9, 6.0, 1.0, 0.3}, doubleArray);
         e = assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.add( new double[] { 2.3, 6.4 }, 4, 10.5));
         assertEquals("Index: 4, Length: 2", e.getMessage());
         e = assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.add( new double[] { 2.3, 6.4 }, -1, 10.5));

--- a/src/test/java/org/apache/commons/lang3/ArrayUtilsRemoveMultipleTest.java
+++ b/src/test/java/org/apache/commons/lang3/ArrayUtilsRemoveMultipleTest.java
@@ -22,9 +22,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
 
@@ -142,59 +139,59 @@ public class ArrayUtilsRemoveMultipleTest {
         boolean[] array;
 
         array = ArrayUtils.removeAll(new boolean[] { true }, 0);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_BOOLEAN_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_BOOLEAN_ARRAY, array);
         assertEquals(Boolean.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new boolean[] { true, false }, 0);
-        assertTrue(Arrays.equals(new boolean[] { false }, array));
+        assertArrayEquals(new boolean[]{false}, array);
         assertEquals(Boolean.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new boolean[] { true, false }, 1);
-        assertTrue(Arrays.equals(new boolean[] { true }, array));
+        assertArrayEquals(new boolean[]{true}, array);
         assertEquals(Boolean.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new boolean[] { true, false, true }, 1);
-        assertTrue(Arrays.equals(new boolean[] { true, true }, array));
+        assertArrayEquals(new boolean[]{true, true}, array);
         assertEquals(Boolean.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new boolean[] { true, false }, 0, 1);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_BOOLEAN_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_BOOLEAN_ARRAY, array);
         assertEquals(Boolean.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new boolean[] { true, false, false }, 0, 1);
-        assertTrue(Arrays.equals(new boolean[] { false }, array));
+        assertArrayEquals(new boolean[]{false}, array);
         assertEquals(Boolean.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new boolean[] { true, false, false }, 0, 2);
-        assertTrue(Arrays.equals(new boolean[] { false }, array));
+        assertArrayEquals(new boolean[]{false}, array);
         assertEquals(Boolean.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new boolean[] { true, false, false }, 1, 2);
-        assertTrue(Arrays.equals(new boolean[] { true }, array));
+        assertArrayEquals(new boolean[]{true}, array);
         assertEquals(Boolean.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new boolean[] { true, false, true, false, true }, 0, 2, 4);
-        assertTrue(Arrays.equals(new boolean[] { false, false }, array));
+        assertArrayEquals(new boolean[]{false, false}, array);
         assertEquals(Boolean.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new boolean[] { true, false, true, false, true }, 1, 3);
-        assertTrue(Arrays.equals(new boolean[] { true, true, true }, array));
+        assertArrayEquals(new boolean[]{true, true, true}, array);
         assertEquals(Boolean.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new boolean[] { true, false, true, false, true }, 1, 3, 4);
-        assertTrue(Arrays.equals(new boolean[] { true, true }, array));
+        assertArrayEquals(new boolean[]{true, true}, array);
         assertEquals(Boolean.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new boolean[] { true, false, true, false, true, false, true }, 0, 2, 4, 6);
-        assertTrue(Arrays.equals(new boolean[] { false, false, false }, array));
+        assertArrayEquals(new boolean[]{false, false, false}, array);
         assertEquals(Boolean.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new boolean[] { true, false, true, false, true, false, true }, 1, 3, 5);
-        assertTrue(Arrays.equals(new boolean[] { true, true, true, true }, array));
+        assertArrayEquals(new boolean[]{true, true, true, true}, array);
         assertEquals(Boolean.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new boolean[] { true, false, true, false, true, false, true }, 0, 1, 2);
-        assertTrue(Arrays.equals(new boolean[] { false, true, false, true }, array));
+        assertArrayEquals(new boolean[]{false, true, false, true}, array);
         assertEquals(Boolean.TYPE, array.getClass().getComponentType());
     }
 
@@ -203,7 +200,7 @@ public class ArrayUtilsRemoveMultipleTest {
         final boolean[] array1 = new boolean[] { true, false };
         final boolean[] array2 = ArrayUtils.removeAll(array1);
         assertNotSame(array1, array2);
-        assertTrue(Arrays.equals(array1, array2));
+        assertArrayEquals(array1, array2);
         assertEquals(boolean.class, array2.getClass().getComponentType());
     }
 
@@ -227,51 +224,51 @@ public class ArrayUtilsRemoveMultipleTest {
         byte[] array;
 
         array = ArrayUtils.removeAll(new byte[] { 1 }, 0);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_BYTE_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_BYTE_ARRAY, array);
         assertEquals(Byte.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new byte[] { 1, 2 }, 0);
-        assertTrue(Arrays.equals(new byte[] { 2 }, array));
+        assertArrayEquals(new byte[]{2}, array);
         assertEquals(Byte.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new byte[] { 1, 2 }, 1);
-        assertTrue(Arrays.equals(new byte[] { 1 }, array));
+        assertArrayEquals(new byte[]{1}, array);
         assertEquals(Byte.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new byte[] { 1, 2, 1 }, 1);
-        assertTrue(Arrays.equals(new byte[] { 1, 1 }, array));
+        assertArrayEquals(new byte[]{1, 1}, array);
         assertEquals(Byte.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new byte[] { 1, 2 }, 0, 1);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_BYTE_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_BYTE_ARRAY, array);
         assertEquals(Byte.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new byte[] { 1, 2, 3 }, 0, 1);
-        assertTrue(Arrays.equals(new byte[] { 3 }, array));
+        assertArrayEquals(new byte[]{3}, array);
         assertEquals(Byte.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new byte[] { 1, 2, 3 }, 1, 2);
-        assertTrue(Arrays.equals(new byte[] { 1 }, array));
+        assertArrayEquals(new byte[]{1}, array);
         assertEquals(Byte.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new byte[] { 1, 2, 3 }, 0, 2);
-        assertTrue(Arrays.equals(new byte[] { 2 }, array));
+        assertArrayEquals(new byte[]{2}, array);
         assertEquals(Byte.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new byte[] { 1, 2, 3, 4, 5 }, 1, 3);
-        assertTrue(Arrays.equals(new byte[] { 1, 3, 5 }, array));
+        assertArrayEquals(new byte[]{1, 3, 5}, array);
         assertEquals(Byte.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new byte[] { 1, 2, 3, 4, 5 }, 0, 2, 4);
-        assertTrue(Arrays.equals(new byte[] { 2, 4 }, array));
+        assertArrayEquals(new byte[]{2, 4}, array);
         assertEquals(Byte.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new byte[] { 1, 2, 3, 4, 5, 6, 7 }, 1, 3, 5);
-        assertTrue(Arrays.equals(new byte[] { 1, 3, 5, 7 }, array));
+        assertArrayEquals(new byte[]{1, 3, 5, 7}, array);
         assertEquals(Byte.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new byte[] { 1, 2, 3, 4, 5, 6, 7 }, 0, 2, 4, 6);
-        assertTrue(Arrays.equals(new byte[] { 2, 4, 6 }, array));
+        assertArrayEquals(new byte[]{2, 4, 6}, array);
         assertEquals(Byte.TYPE, array.getClass().getComponentType());
     }
 
@@ -304,51 +301,51 @@ public class ArrayUtilsRemoveMultipleTest {
         char[] array;
 
         array = ArrayUtils.removeAll(new char[] { 'a' }, 0);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_CHAR_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_CHAR_ARRAY, array);
         assertEquals(Character.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new char[] { 'a', 'b' }, 0);
-        assertTrue(Arrays.equals(new char[] { 'b' }, array));
+        assertArrayEquals(new char[]{'b'}, array);
         assertEquals(Character.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new char[] { 'a', 'b' }, 1);
-        assertTrue(Arrays.equals(new char[] { 'a' }, array));
+        assertArrayEquals(new char[]{'a'}, array);
         assertEquals(Character.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new char[] { 'a', 'b', 'c' }, 1);
-        assertTrue(Arrays.equals(new char[] { 'a', 'c' }, array));
+        assertArrayEquals(new char[]{'a', 'c'}, array);
         assertEquals(Character.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new char[] { 'a', 'b' }, 0, 1);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_CHAR_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_CHAR_ARRAY, array);
         assertEquals(Character.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new char[] { 'a', 'b', 'c' }, 0, 1);
-        assertTrue(Arrays.equals(new char[] { 'c' }, array));
+        assertArrayEquals(new char[]{'c'}, array);
         assertEquals(Character.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new char[] { 'a', 'b', 'c' }, 1, 2);
-        assertTrue(Arrays.equals(new char[] { 'a' }, array));
+        assertArrayEquals(new char[]{'a'}, array);
         assertEquals(Character.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new char[] { 'a', 'b', 'c' }, 0, 2);
-        assertTrue(Arrays.equals(new char[] { 'b' }, array));
+        assertArrayEquals(new char[]{'b'}, array);
         assertEquals(Character.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new char[] { 'a', 'b', 'c', 'd', 'e' }, 1, 3);
-        assertTrue(Arrays.equals(new char[] { 'a', 'c', 'e' }, array));
+        assertArrayEquals(new char[]{'a', 'c', 'e'}, array);
         assertEquals(Character.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new char[] { 'a', 'b', 'c', 'd', 'e' }, 0, 2, 4);
-        assertTrue(Arrays.equals(new char[] { 'b', 'd' }, array));
+        assertArrayEquals(new char[]{'b', 'd'}, array);
         assertEquals(Character.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new char[] { 'a', 'b', 'c', 'd', 'e', 'f', 'g' }, 1, 3, 5);
-        assertTrue(Arrays.equals(new char[] { 'a', 'c', 'e', 'g' }, array));
+        assertArrayEquals(new char[]{'a', 'c', 'e', 'g'}, array);
         assertEquals(Character.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new char[] { 'a', 'b', 'c', 'd', 'e', 'f', 'g' }, 0, 2, 4, 6);
-        assertTrue(Arrays.equals(new char[] { 'b', 'd', 'f' }, array));
+        assertArrayEquals(new char[]{'b', 'd', 'f'}, array);
         assertEquals(Character.TYPE, array.getClass().getComponentType());
     }
 
@@ -381,51 +378,51 @@ public class ArrayUtilsRemoveMultipleTest {
         double[] array;
 
         array = ArrayUtils.removeAll(new double[] { 1 }, 0);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_DOUBLE_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_DOUBLE_ARRAY, array);
         assertEquals(Double.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new double[] { 1, 2 }, 0);
-        assertTrue(Arrays.equals(new double[] { 2 }, array));
+        assertArrayEquals(new double[]{2}, array);
         assertEquals(Double.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new double[] { 1, 2 }, 1);
-        assertTrue(Arrays.equals(new double[] { 1 }, array));
+        assertArrayEquals(new double[]{1}, array);
         assertEquals(Double.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new double[] { 1, 2, 1 }, 1);
-        assertTrue(Arrays.equals(new double[] { 1, 1 }, array));
+        assertArrayEquals(new double[]{1, 1}, array);
         assertEquals(Double.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new double[] { 1, 2 }, 0, 1);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_DOUBLE_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_DOUBLE_ARRAY, array);
         assertEquals(Double.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new double[] { 1, 2, 3 }, 0, 1);
-        assertTrue(Arrays.equals(new double[] { 3 }, array));
+        assertArrayEquals(new double[]{3}, array);
         assertEquals(Double.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new double[] { 1, 2, 3 }, 1, 2);
-        assertTrue(Arrays.equals(new double[] { 1 }, array));
+        assertArrayEquals(new double[]{1}, array);
         assertEquals(Double.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new double[] { 1, 2, 3 }, 0, 2);
-        assertTrue(Arrays.equals(new double[] { 2 }, array));
+        assertArrayEquals(new double[]{2}, array);
         assertEquals(Double.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new double[] { 1, 2, 3, 4, 5 }, 1, 3);
-        assertTrue(Arrays.equals(new double[] { 1, 3, 5 }, array));
+        assertArrayEquals(new double[]{1, 3, 5}, array);
         assertEquals(Double.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new double[] { 1, 2, 3, 4, 5 }, 0, 2, 4);
-        assertTrue(Arrays.equals(new double[] { 2, 4 }, array));
+        assertArrayEquals(new double[]{2, 4}, array);
         assertEquals(Double.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new double[] { 1, 2, 3, 4, 5, 6, 7 }, 1, 3, 5);
-        assertTrue(Arrays.equals(new double[] { 1, 3, 5, 7 }, array));
+        assertArrayEquals(new double[]{1, 3, 5, 7}, array);
         assertEquals(Double.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new double[] { 1, 2, 3, 4, 5, 6, 7 }, 0, 2, 4, 6);
-        assertTrue(Arrays.equals(new double[] { 2, 4, 6 }, array));
+        assertArrayEquals(new double[]{2, 4, 6}, array);
         assertEquals(Double.TYPE, array.getClass().getComponentType());
     }
 
@@ -434,7 +431,7 @@ public class ArrayUtilsRemoveMultipleTest {
         final double[] array1 = new double[] { 1, 2 };
         final double[] array2 = ArrayUtils.removeAll(array1);
         assertNotSame(array1, array2);
-        assertTrue(Arrays.equals(array1, array2));
+        assertArrayEquals(array1, array2);
         assertEquals(double.class, array2.getClass().getComponentType());
     }
 
@@ -458,51 +455,51 @@ public class ArrayUtilsRemoveMultipleTest {
         float[] array;
 
         array = ArrayUtils.removeAll(new float[] { 1 }, 0);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_FLOAT_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_FLOAT_ARRAY, array);
         assertEquals(Float.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new float[] { 1, 2 }, 0);
-        assertTrue(Arrays.equals(new float[] { 2 }, array));
+        assertArrayEquals(new float[]{2}, array);
         assertEquals(Float.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new float[] { 1, 2 }, 1);
-        assertTrue(Arrays.equals(new float[] { 1 }, array));
+        assertArrayEquals(new float[]{1}, array);
         assertEquals(Float.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new float[] { 1, 2, 1 }, 1);
-        assertTrue(Arrays.equals(new float[] { 1, 1 }, array));
+        assertArrayEquals(new float[]{1, 1}, array);
         assertEquals(Float.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new float[] { 1, 2 }, 0, 1);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_FLOAT_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_FLOAT_ARRAY, array);
         assertEquals(Float.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new float[] { 1, 2, 3 }, 0, 1);
-        assertTrue(Arrays.equals(new float[] { 3 }, array));
+        assertArrayEquals(new float[]{3}, array);
         assertEquals(Float.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new float[] { 1, 2, 3 }, 1, 2);
-        assertTrue(Arrays.equals(new float[] { 1 }, array));
+        assertArrayEquals(new float[]{1}, array);
         assertEquals(Float.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new float[] { 1, 2, 3 }, 0, 2);
-        assertTrue(Arrays.equals(new float[] { 2 }, array));
+        assertArrayEquals(new float[]{2}, array);
         assertEquals(Float.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new float[] { 1, 2, 3, 4, 5 }, 1, 3);
-        assertTrue(Arrays.equals(new float[] { 1, 3, 5 }, array));
+        assertArrayEquals(new float[]{1, 3, 5}, array);
         assertEquals(Float.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new float[] { 1, 2, 3, 4, 5 }, 0, 2, 4);
-        assertTrue(Arrays.equals(new float[] { 2, 4 }, array));
+        assertArrayEquals(new float[]{2, 4}, array);
         assertEquals(Float.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new float[] { 1, 2, 3, 4, 5, 6, 7 }, 1, 3, 5);
-        assertTrue(Arrays.equals(new float[] { 1, 3, 5, 7 }, array));
+        assertArrayEquals(new float[]{1, 3, 5, 7}, array);
         assertEquals(Float.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new float[] { 1, 2, 3, 4, 5, 6, 7 }, 0, 2, 4, 6);
-        assertTrue(Arrays.equals(new float[] { 2, 4, 6 }, array));
+        assertArrayEquals(new float[]{2, 4, 6}, array);
         assertEquals(Float.TYPE, array.getClass().getComponentType());
     }
 
@@ -511,7 +508,7 @@ public class ArrayUtilsRemoveMultipleTest {
         final float[] array1 = new float[] { 1, 2 };
         final float[] array2 = ArrayUtils.removeAll(array1);
         assertNotSame(array1, array2);
-        assertTrue(Arrays.equals(array1, array2));
+        assertArrayEquals(array1, array2);
         assertEquals(float.class, array2.getClass().getComponentType());
     }
 
@@ -535,57 +532,57 @@ public class ArrayUtilsRemoveMultipleTest {
         int[] array;
 
         array = ArrayUtils.removeAll(ArrayUtils.EMPTY_INT_ARRAY, ArrayUtils.EMPTY_INT_ARRAY);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_INT_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_INT_ARRAY, array);
 
         array = ArrayUtils.removeAll(new int[] { 1 }, ArrayUtils.EMPTY_INT_ARRAY);
-        assertTrue(Arrays.equals(new int[] { 1 }, array));
+        assertArrayEquals(new int[]{1}, array);
 
         array = ArrayUtils.removeAll(new int[] { 1 }, 0);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_INT_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_INT_ARRAY, array);
         assertEquals(Integer.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new int[] { 1, 2 }, 0);
-        assertTrue(Arrays.equals(new int[] { 2 }, array));
+        assertArrayEquals(new int[]{2}, array);
         assertEquals(Integer.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new int[] { 1, 2 }, 1);
-        assertTrue(Arrays.equals(new int[] { 1 }, array));
+        assertArrayEquals(new int[]{1}, array);
         assertEquals(Integer.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new int[] { 1, 2, 1 }, 1);
-        assertTrue(Arrays.equals(new int[] { 1, 1 }, array));
+        assertArrayEquals(new int[]{1, 1}, array);
         assertEquals(Integer.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new int[] { 1, 2 }, 0, 1);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_INT_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_INT_ARRAY, array);
         assertEquals(Integer.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new int[] { 1, 2, 3 }, 0, 1);
-        assertTrue(Arrays.equals(new int[] { 3 }, array));
+        assertArrayEquals(new int[]{3}, array);
         assertEquals(Integer.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new int[] { 1, 2, 3 }, 1, 2);
-        assertTrue(Arrays.equals(new int[] { 1 }, array));
+        assertArrayEquals(new int[]{1}, array);
         assertEquals(Integer.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new int[] { 1, 2, 3 }, 0, 2);
-        assertTrue(Arrays.equals(new int[] { 2 }, array));
+        assertArrayEquals(new int[]{2}, array);
         assertEquals(Integer.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new int[] { 1, 2, 3, 4, 5 }, 1, 3);
-        assertTrue(Arrays.equals(new int[] { 1, 3, 5 }, array));
+        assertArrayEquals(new int[]{1, 3, 5}, array);
         assertEquals(Integer.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new int[] { 1, 2, 3, 4, 5 }, 0, 2, 4);
-        assertTrue(Arrays.equals(new int[] { 2, 4 }, array));
+        assertArrayEquals(new int[]{2, 4}, array);
         assertEquals(Integer.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new int[] { 1, 2, 3, 4, 5, 6, 7 }, 1, 3, 5);
-        assertTrue(Arrays.equals(new int[] { 1, 3, 5, 7 }, array));
+        assertArrayEquals(new int[]{1, 3, 5, 7}, array);
         assertEquals(Integer.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new int[] { 1, 2, 3, 4, 5, 6, 7 }, 0, 2, 4, 6);
-        assertTrue(Arrays.equals(new int[] { 2, 4, 6 }, array));
+        assertArrayEquals(new int[]{2, 4, 6}, array);
         assertEquals(Integer.TYPE, array.getClass().getComponentType());
     }
 
@@ -618,51 +615,51 @@ public class ArrayUtilsRemoveMultipleTest {
         long[] array;
 
         array = ArrayUtils.removeAll(new long[] { 1 }, 0);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_LONG_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_LONG_ARRAY, array);
         assertEquals(Long.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new long[] { 1, 2 }, 0);
-        assertTrue(Arrays.equals(new long[] { 2 }, array));
+        assertArrayEquals(new long[]{2}, array);
         assertEquals(Long.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new long[] { 1, 2 }, 1);
-        assertTrue(Arrays.equals(new long[] { 1 }, array));
+        assertArrayEquals(new long[]{1}, array);
         assertEquals(Long.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new long[] { 1, 2, 1 }, 1);
-        assertTrue(Arrays.equals(new long[] { 1, 1 }, array));
+        assertArrayEquals(new long[]{1, 1}, array);
         assertEquals(Long.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new long[] { 1, 2 }, 0, 1);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_LONG_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_LONG_ARRAY, array);
         assertEquals(Long.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new long[] { 1, 2, 3 }, 0, 1);
-        assertTrue(Arrays.equals(new long[] { 3 }, array));
+        assertArrayEquals(new long[]{3}, array);
         assertEquals(Long.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new long[] { 1, 2, 3 }, 1, 2);
-        assertTrue(Arrays.equals(new long[] { 1 }, array));
+        assertArrayEquals(new long[]{1}, array);
         assertEquals(Long.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new long[] { 1, 2, 3 }, 0, 2);
-        assertTrue(Arrays.equals(new long[] { 2 }, array));
+        assertArrayEquals(new long[]{2}, array);
         assertEquals(Long.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new long[] { 1, 2, 3, 4, 5 }, 1, 3);
-        assertTrue(Arrays.equals(new long[] { 1, 3, 5 }, array));
+        assertArrayEquals(new long[]{1, 3, 5}, array);
         assertEquals(Long.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new long[] { 1, 2, 3, 4, 5 }, 0, 2, 4);
-        assertTrue(Arrays.equals(new long[] { 2, 4 }, array));
+        assertArrayEquals(new long[]{2, 4}, array);
         assertEquals(Long.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new long[] { 1, 2, 3, 4, 5, 6, 7 }, 1, 3, 5);
-        assertTrue(Arrays.equals(new long[] { 1, 3, 5, 7 }, array));
+        assertArrayEquals(new long[]{1, 3, 5, 7}, array);
         assertEquals(Long.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new long[] { 1, 2, 3, 4, 5, 6, 7 }, 0, 2, 4, 6);
-        assertTrue(Arrays.equals(new long[] { 2, 4, 6 }, array));
+        assertArrayEquals(new long[]{2, 4, 6}, array);
         assertEquals(Long.TYPE, array.getClass().getComponentType());
     }
 
@@ -695,51 +692,51 @@ public class ArrayUtilsRemoveMultipleTest {
         short[] array;
 
         array = ArrayUtils.removeAll(new short[] { 1 }, 0);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_SHORT_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_SHORT_ARRAY, array);
         assertEquals(Short.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new short[] { 1, 2 }, 0);
-        assertTrue(Arrays.equals(new short[] { 2 }, array));
+        assertArrayEquals(new short[]{2}, array);
         assertEquals(Short.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new short[] { 1, 2 }, 1);
-        assertTrue(Arrays.equals(new short[] { 1 }, array));
+        assertArrayEquals(new short[]{1}, array);
         assertEquals(Short.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new short[] { 1, 2, 1 }, 1);
-        assertTrue(Arrays.equals(new short[] { 1, 1 }, array));
+        assertArrayEquals(new short[]{1, 1}, array);
         assertEquals(Short.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new short[] { 1, 2 }, 0, 1);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_SHORT_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_SHORT_ARRAY, array);
         assertEquals(Short.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new short[] { 1, 2, 3 }, 0, 1);
-        assertTrue(Arrays.equals(new short[] { 3 }, array));
+        assertArrayEquals(new short[]{3}, array);
         assertEquals(Short.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new short[] { 1, 2, 3 }, 1, 2);
-        assertTrue(Arrays.equals(new short[] { 1 }, array));
+        assertArrayEquals(new short[]{1}, array);
         assertEquals(Short.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new short[] { 1, 2, 3 }, 0, 2);
-        assertTrue(Arrays.equals(new short[] { 2 }, array));
+        assertArrayEquals(new short[]{2}, array);
         assertEquals(Short.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new short[] { 1, 2, 3, 4, 5 }, 1, 3);
-        assertTrue(Arrays.equals(new short[] { 1, 3, 5 }, array));
+        assertArrayEquals(new short[]{1, 3, 5}, array);
         assertEquals(Short.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new short[] { 1, 2, 3, 4, 5 }, 0, 2, 4);
-        assertTrue(Arrays.equals(new short[] { 2, 4 }, array));
+        assertArrayEquals(new short[]{2, 4}, array);
         assertEquals(Short.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new short[] { 1, 2, 3, 4, 5, 6, 7 }, 1, 3, 5);
-        assertTrue(Arrays.equals(new short[] { 1, 3, 5, 7 }, array));
+        assertArrayEquals(new short[]{1, 3, 5, 7}, array);
         assertEquals(Short.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeAll(new short[] { 1, 2, 3, 4, 5, 6, 7 }, 0, 2, 4, 6);
-        assertTrue(Arrays.equals(new short[] { 2, 4, 6 }, array));
+        assertArrayEquals(new short[]{2, 4, 6}, array);
         assertEquals(Short.TYPE, array.getClass().getComponentType());
     }
 
@@ -775,50 +772,50 @@ public class ArrayUtilsRemoveMultipleTest {
         assertNull(array);
 
         array = ArrayUtils.removeElements(ArrayUtils.EMPTY_OBJECT_ARRAY, "a");
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_OBJECT_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_OBJECT_ARRAY, array);
         assertEquals(Object.class, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new Object[] { "a" }, "a");
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_OBJECT_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_OBJECT_ARRAY, array);
         assertEquals(Object.class, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new Object[] { "a", "b" }, "a");
-        assertTrue(Arrays.equals(new Object[] { "b" }, array));
+        assertArrayEquals(new Object[]{"b"}, array);
         assertEquals(Object.class, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new Object[] { "a", "b", "a" }, "a");
-        assertTrue(Arrays.equals(new Object[] { "b", "a" }, array));
+        assertArrayEquals(new Object[]{"b", "a"}, array);
         assertEquals(Object.class, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements((Object[]) null, "a", "b");
         assertNull(array);
 
         array = ArrayUtils.removeElements(ArrayUtils.EMPTY_OBJECT_ARRAY, "a", "b");
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_OBJECT_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_OBJECT_ARRAY, array);
         assertEquals(Object.class, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new Object[] { "a" }, "a", "b");
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_OBJECT_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_OBJECT_ARRAY, array);
         assertEquals(Object.class, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new Object[] { "a", "b" }, "a", "c");
-        assertTrue(Arrays.equals(new Object[] { "b" }, array));
+        assertArrayEquals(new Object[]{"b"}, array);
         assertEquals(Object.class, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new Object[] { "a", "b", "a" }, "a");
-        assertTrue(Arrays.equals(new Object[] { "b", "a" }, array));
+        assertArrayEquals(new Object[]{"b", "a"}, array);
         assertEquals(Object.class, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new Object[] { "a", "b", "a" }, "a", "b");
-        assertTrue(Arrays.equals(new Object[] { "a" }, array));
+        assertArrayEquals(new Object[]{"a"}, array);
         assertEquals(Object.class, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new Object[] { "a", "b", "a" }, "a", "a");
-        assertTrue(Arrays.equals(new Object[] { "b" }, array));
+        assertArrayEquals(new Object[]{"b"}, array);
         assertEquals(Object.class, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new Object[] { "a", "b", "a" }, "a", "a", "a", "a");
-        assertTrue(Arrays.equals(new Object[] { "b" }, array));
+        assertArrayEquals(new Object[]{"b"}, array);
         assertEquals(Object.class, array.getClass().getComponentType());
     }
 
@@ -830,50 +827,50 @@ public class ArrayUtilsRemoveMultipleTest {
         assertNull(array);
 
         array = ArrayUtils.removeElements(ArrayUtils.EMPTY_BOOLEAN_ARRAY, true);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_BOOLEAN_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_BOOLEAN_ARRAY, array);
         assertEquals(Boolean.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new boolean[] { true }, true);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_BOOLEAN_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_BOOLEAN_ARRAY, array);
         assertEquals(Boolean.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new boolean[] { true, false }, true);
-        assertTrue(Arrays.equals(new boolean[] { false }, array));
+        assertArrayEquals(new boolean[]{false}, array);
         assertEquals(Boolean.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new boolean[] { true, false, true }, true);
-        assertTrue(Arrays.equals(new boolean[] { false, true }, array));
+        assertArrayEquals(new boolean[]{false, true}, array);
         assertEquals(Boolean.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements((boolean[]) null, true, false);
         assertNull(array);
 
         array = ArrayUtils.removeElements(ArrayUtils.EMPTY_BOOLEAN_ARRAY, true, false);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_BOOLEAN_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_BOOLEAN_ARRAY, array);
         assertEquals(Boolean.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new boolean[] { true }, true, false);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_BOOLEAN_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_BOOLEAN_ARRAY, array);
         assertEquals(Boolean.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new boolean[] { true, false }, true, false);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_BOOLEAN_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_BOOLEAN_ARRAY, array);
         assertEquals(Boolean.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new boolean[] { true, false }, true, true);
-        assertTrue(Arrays.equals(new boolean[] { false }, array));
+        assertArrayEquals(new boolean[]{false}, array);
         assertEquals(Boolean.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new boolean[] { true, false, true }, true, false);
-        assertTrue(Arrays.equals(new boolean[] { true }, array));
+        assertArrayEquals(new boolean[]{true}, array);
         assertEquals(Boolean.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new boolean[] { true, false, true }, true, true);
-        assertTrue(Arrays.equals(new boolean[] { false }, array));
+        assertArrayEquals(new boolean[]{false}, array);
         assertEquals(Boolean.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new boolean[] { true, false, true }, true, true, true, true);
-        assertTrue(Arrays.equals(new boolean[] { false }, array));
+        assertArrayEquals(new boolean[]{false}, array);
         assertEquals(Boolean.TYPE, array.getClass().getComponentType());
     }
 
@@ -885,50 +882,50 @@ public class ArrayUtilsRemoveMultipleTest {
         assertNull(array);
 
         array = ArrayUtils.removeElements(ArrayUtils.EMPTY_BYTE_ARRAY, (byte) 1);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_BYTE_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_BYTE_ARRAY, array);
         assertEquals(Byte.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new byte[] { 1 }, (byte) 1);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_BYTE_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_BYTE_ARRAY, array);
         assertEquals(Byte.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new byte[] { 1, 2 }, (byte) 1);
-        assertTrue(Arrays.equals(new byte[] { 2 }, array));
+        assertArrayEquals(new byte[]{2}, array);
         assertEquals(Byte.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new byte[] { 1, 2, 1 }, (byte) 1);
-        assertTrue(Arrays.equals(new byte[] { 2, 1 }, array));
+        assertArrayEquals(new byte[]{2, 1}, array);
         assertEquals(Byte.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements((byte[]) null, (byte) 1, (byte) 2);
         assertNull(array);
 
         array = ArrayUtils.removeElements(ArrayUtils.EMPTY_BYTE_ARRAY, (byte) 1, (byte) 2);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_BYTE_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_BYTE_ARRAY, array);
         assertEquals(Byte.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new byte[] { 1 }, (byte) 1, (byte) 2);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_BYTE_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_BYTE_ARRAY, array);
         assertEquals(Byte.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new byte[] { 1, 2 }, (byte) 1, (byte) 2);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_BYTE_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_BYTE_ARRAY, array);
         assertEquals(Byte.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new byte[] { 1, 2 }, (byte) 1, (byte) 1);
-        assertTrue(Arrays.equals(new byte[] { 2 }, array));
+        assertArrayEquals(new byte[]{2}, array);
         assertEquals(Byte.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new byte[] { 1, 2, 1 }, (byte) 1, (byte) 2);
-        assertTrue(Arrays.equals(new byte[] { 1 }, array));
+        assertArrayEquals(new byte[]{1}, array);
         assertEquals(Byte.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new byte[] { 1, 2, 1 }, (byte) 1, (byte) 1);
-        assertTrue(Arrays.equals(new byte[] { 2 }, array));
+        assertArrayEquals(new byte[]{2}, array);
         assertEquals(Byte.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new byte[] { 1, 2, 1 }, (byte) 1, (byte) 1, (byte) 1, (byte) 1);
-        assertTrue(Arrays.equals(new byte[] { 2 }, array));
+        assertArrayEquals(new byte[]{2}, array);
         assertEquals(Byte.TYPE, array.getClass().getComponentType());
     }
 
@@ -940,50 +937,50 @@ public class ArrayUtilsRemoveMultipleTest {
         assertNull(array);
 
         array = ArrayUtils.removeElements(ArrayUtils.EMPTY_CHAR_ARRAY, 'a');
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_CHAR_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_CHAR_ARRAY, array);
         assertEquals(Character.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new char[] { 'a' }, 'a');
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_CHAR_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_CHAR_ARRAY, array);
         assertEquals(Character.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new char[] { 'a', 'b' }, 'a');
-        assertTrue(Arrays.equals(new char[] { 'b' }, array));
+        assertArrayEquals(new char[]{'b'}, array);
         assertEquals(Character.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new char[] { 'a', 'b', 'a' }, 'a');
-        assertTrue(Arrays.equals(new char[] { 'b', 'a' }, array));
+        assertArrayEquals(new char[]{'b', 'a'}, array);
         assertEquals(Character.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements((char[]) null, 'a', 'b');
         assertNull(array);
 
         array = ArrayUtils.removeElements(ArrayUtils.EMPTY_CHAR_ARRAY, 'a', 'b');
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_CHAR_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_CHAR_ARRAY, array);
         assertEquals(Character.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new char[] { 'a' }, 'a', 'b');
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_CHAR_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_CHAR_ARRAY, array);
         assertEquals(Character.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new char[] { 'a', 'b' }, 'a', 'b');
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_CHAR_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_CHAR_ARRAY, array);
         assertEquals(Character.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new char[] { 'a', 'b' }, 'a', 'a');
-        assertTrue(Arrays.equals(new char[] { 'b' }, array));
+        assertArrayEquals(new char[]{'b'}, array);
         assertEquals(Character.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new char[] { 'a', 'b', 'a' }, 'a', 'b');
-        assertTrue(Arrays.equals(new char[] { 'a' }, array));
+        assertArrayEquals(new char[]{'a'}, array);
         assertEquals(Character.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new char[] { 'a', 'b', 'a' }, 'a', 'a');
-        assertTrue(Arrays.equals(new char[] { 'b' }, array));
+        assertArrayEquals(new char[]{'b'}, array);
         assertEquals(Character.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new char[] { 'a', 'b', 'a' }, 'a', 'a', 'a', 'a');
-        assertTrue(Arrays.equals(new char[] { 'b' }, array));
+        assertArrayEquals(new char[]{'b'}, array);
         assertEquals(Character.TYPE, array.getClass().getComponentType());
     }
 
@@ -996,50 +993,50 @@ public class ArrayUtilsRemoveMultipleTest {
         assertNull(array);
 
         array = ArrayUtils.removeElements(ArrayUtils.EMPTY_DOUBLE_ARRAY, (double) 1);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_DOUBLE_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_DOUBLE_ARRAY, array);
         assertEquals(Double.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new double[] { 1 }, (double) 1);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_DOUBLE_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_DOUBLE_ARRAY, array);
         assertEquals(Double.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new double[] { 1, 2 }, (double) 1);
-        assertTrue(Arrays.equals(new double[] { 2 }, array));
+        assertArrayEquals(new double[]{2}, array);
         assertEquals(Double.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new double[] { 1, 2, 1 }, (double) 1);
-        assertTrue(Arrays.equals(new double[] { 2, 1 }, array));
+        assertArrayEquals(new double[]{2, 1}, array);
         assertEquals(Double.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements((double[]) null, (double) 1, (double) 2);
         assertNull(array);
 
         array = ArrayUtils.removeElements(ArrayUtils.EMPTY_DOUBLE_ARRAY, (double) 1, (double) 2);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_DOUBLE_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_DOUBLE_ARRAY, array);
         assertEquals(Double.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new double[] { 1 }, (double) 1, (double) 2);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_DOUBLE_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_DOUBLE_ARRAY, array);
         assertEquals(Double.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new double[] { 1, 2 }, (double) 1, (double) 2);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_DOUBLE_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_DOUBLE_ARRAY, array);
         assertEquals(Double.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new double[] { 1, 2 }, (double) 1, (double) 1);
-        assertTrue(Arrays.equals(new double[] { 2 }, array));
+        assertArrayEquals(new double[]{2}, array);
         assertEquals(Double.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new double[] { 1, 2, 1 }, (double) 1, (double) 2);
-        assertTrue(Arrays.equals(new double[] { 1 }, array));
+        assertArrayEquals(new double[]{1}, array);
         assertEquals(Double.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new double[] { 1, 2, 1 }, (double) 1, (double) 1);
-        assertTrue(Arrays.equals(new double[] { 2 }, array));
+        assertArrayEquals(new double[]{2}, array);
         assertEquals(Double.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new double[] { 1, 2, 1 }, (double) 1, (double) 1, (double) 1, (double) 1);
-        assertTrue(Arrays.equals(new double[] { 2 }, array));
+        assertArrayEquals(new double[]{2}, array);
         assertEquals(Double.TYPE, array.getClass().getComponentType());
     }
 
@@ -1052,50 +1049,50 @@ public class ArrayUtilsRemoveMultipleTest {
         assertNull(array);
 
         array = ArrayUtils.removeElements(ArrayUtils.EMPTY_FLOAT_ARRAY, (float) 1);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_FLOAT_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_FLOAT_ARRAY, array);
         assertEquals(Float.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new float[] { 1 }, (float) 1);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_FLOAT_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_FLOAT_ARRAY, array);
         assertEquals(Float.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new float[] { 1, 2 }, (float) 1);
-        assertTrue(Arrays.equals(new float[] { 2 }, array));
+        assertArrayEquals(new float[]{2}, array);
         assertEquals(Float.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new float[] { 1, 2, 1 }, (float) 1);
-        assertTrue(Arrays.equals(new float[] { 2, 1 }, array));
+        assertArrayEquals(new float[]{2, 1}, array);
         assertEquals(Float.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements((float[]) null, (float) 1, (float) 1);
         assertNull(array);
 
         array = ArrayUtils.removeElements(ArrayUtils.EMPTY_FLOAT_ARRAY, (float) 1, (float) 1);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_FLOAT_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_FLOAT_ARRAY, array);
         assertEquals(Float.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new float[] { 1 }, (float) 1, (float) 1);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_FLOAT_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_FLOAT_ARRAY, array);
         assertEquals(Float.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new float[] { 1, 2 }, (float) 1, (float) 2);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_FLOAT_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_FLOAT_ARRAY, array);
         assertEquals(Float.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new float[] { 1, 2 }, (float) 1, (float) 1);
-        assertTrue(Arrays.equals(new float[] { 2 }, array));
+        assertArrayEquals(new float[]{2}, array);
         assertEquals(Float.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new float[] { 1, 2, 1 }, (float) 1, (float) 1);
-        assertTrue(Arrays.equals(new float[] { 2 }, array));
+        assertArrayEquals(new float[]{2}, array);
         assertEquals(Float.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new float[] { 1, 2, 1 }, (float) 1, (float) 2);
-        assertTrue(Arrays.equals(new float[] { 1 }, array));
+        assertArrayEquals(new float[]{1}, array);
         assertEquals(Float.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new float[] { 1, 2, 1 }, (float) 1, (float) 1, (float) 1, (float) 1);
-        assertTrue(Arrays.equals(new float[] { 2 }, array));
+        assertArrayEquals(new float[]{2}, array);
         assertEquals(Float.TYPE, array.getClass().getComponentType());
     }
 
@@ -1107,50 +1104,50 @@ public class ArrayUtilsRemoveMultipleTest {
         assertNull(array);
 
         array = ArrayUtils.removeElements(ArrayUtils.EMPTY_INT_ARRAY, 1);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_INT_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_INT_ARRAY, array);
         assertEquals(Integer.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new int[] { 1 }, 1);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_INT_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_INT_ARRAY, array);
         assertEquals(Integer.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new int[] { 1, 2 }, 1);
-        assertTrue(Arrays.equals(new int[] { 2 }, array));
+        assertArrayEquals(new int[]{2}, array);
         assertEquals(Integer.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new int[] { 1, 2, 1 }, 1);
-        assertTrue(Arrays.equals(new int[] { 2, 1 }, array));
+        assertArrayEquals(new int[]{2, 1}, array);
         assertEquals(Integer.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements((int[]) null, 1);
         assertNull(array);
 
         array = ArrayUtils.removeElements(ArrayUtils.EMPTY_INT_ARRAY, 1, 1);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_INT_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_INT_ARRAY, array);
         assertEquals(Integer.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new int[] { 1 }, 1, 1);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_INT_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_INT_ARRAY, array);
         assertEquals(Integer.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new int[] { 1, 2 }, 1, 2);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_INT_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_INT_ARRAY, array);
         assertEquals(Integer.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new int[] { 1, 2 }, 1, 1);
-        assertTrue(Arrays.equals(new int[] { 2 }, array));
+        assertArrayEquals(new int[]{2}, array);
         assertEquals(Integer.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new int[] { 1, 2, 1 }, 1, 2);
-        assertTrue(Arrays.equals(new int[] { 1 }, array));
+        assertArrayEquals(new int[]{1}, array);
         assertEquals(Integer.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new int[] { 1, 2, 1 }, 1, 1);
-        assertTrue(Arrays.equals(new int[] { 2 }, array));
+        assertArrayEquals(new int[]{2}, array);
         assertEquals(Integer.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new int[] { 1, 2, 1 }, 1, 1, 1, 1);
-        assertTrue(Arrays.equals(new int[] { 2 }, array));
+        assertArrayEquals(new int[]{2}, array);
         assertEquals(Integer.TYPE, array.getClass().getComponentType());
     }
 
@@ -1163,50 +1160,50 @@ public class ArrayUtilsRemoveMultipleTest {
         assertNull(array);
 
         array = ArrayUtils.removeElements(ArrayUtils.EMPTY_LONG_ARRAY, 1L);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_LONG_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_LONG_ARRAY, array);
         assertEquals(Long.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new long[] { 1 }, 1L);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_LONG_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_LONG_ARRAY, array);
         assertEquals(Long.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new long[] { 1, 2 }, 1L);
-        assertTrue(Arrays.equals(new long[] { 2 }, array));
+        assertArrayEquals(new long[]{2}, array);
         assertEquals(Long.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new long[] { 1, 2, 1 }, 1L);
-        assertTrue(Arrays.equals(new long[] { 2, 1 }, array));
+        assertArrayEquals(new long[]{2, 1}, array);
         assertEquals(Long.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements((long[]) null, 1L, 1L);
         assertNull(array);
 
         array = ArrayUtils.removeElements(ArrayUtils.EMPTY_LONG_ARRAY, 1L, 1L);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_LONG_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_LONG_ARRAY, array);
         assertEquals(Long.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new long[] { 1 }, 1L, 1L);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_LONG_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_LONG_ARRAY, array);
         assertEquals(Long.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new long[] { 1, 2 }, 1L, 2L);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_LONG_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_LONG_ARRAY, array);
         assertEquals(Long.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new long[] { 1, 2 }, 1L, 1L);
-        assertTrue(Arrays.equals(new long[] { 2 }, array));
+        assertArrayEquals(new long[]{2}, array);
         assertEquals(Long.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new long[] { 1, 2, 1 }, 1L, 1L);
-        assertTrue(Arrays.equals(new long[] { 2 }, array));
+        assertArrayEquals(new long[]{2}, array);
         assertEquals(Long.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new long[] { 1, 2, 1 }, 1L, 2L);
-        assertTrue(Arrays.equals(new long[] { 1 }, array));
+        assertArrayEquals(new long[]{1}, array);
         assertEquals(Long.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new long[] { 1, 2, 1 }, 1L, 1L, 1L, 1L);
-        assertTrue(Arrays.equals(new long[] { 2 }, array));
+        assertArrayEquals(new long[]{2}, array);
         assertEquals(Long.TYPE, array.getClass().getComponentType());
     }
 
@@ -1218,50 +1215,50 @@ public class ArrayUtilsRemoveMultipleTest {
         assertNull(array);
 
         array = ArrayUtils.removeElements(ArrayUtils.EMPTY_SHORT_ARRAY, (short) 1);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_SHORT_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_SHORT_ARRAY, array);
         assertEquals(Short.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new short[] { 1 }, (short) 1);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_SHORT_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_SHORT_ARRAY, array);
         assertEquals(Short.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new short[] { 1, 2 }, (short) 1);
-        assertTrue(Arrays.equals(new short[] { 2 }, array));
+        assertArrayEquals(new short[]{2}, array);
         assertEquals(Short.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new short[] { 1, 2, 1 }, (short) 1);
-        assertTrue(Arrays.equals(new short[] { 2, 1 }, array));
+        assertArrayEquals(new short[]{2, 1}, array);
         assertEquals(Short.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements((short[]) null, (short) 1, (short) 1);
         assertNull(array);
 
         array = ArrayUtils.removeElements(ArrayUtils.EMPTY_SHORT_ARRAY, (short) 1, (short) 1);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_SHORT_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_SHORT_ARRAY, array);
         assertEquals(Short.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new short[] { 1 }, (short) 1, (short) 1);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_SHORT_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_SHORT_ARRAY, array);
         assertEquals(Short.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new short[] { 1, 2 }, (short) 1, (short) 2);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_SHORT_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_SHORT_ARRAY, array);
         assertEquals(Short.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new short[] { 1, 2 }, (short) 1, (short) 1);
-        assertTrue(Arrays.equals(new short[] { 2 }, array));
+        assertArrayEquals(new short[]{2}, array);
         assertEquals(Short.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new short[] { 1, 2, 1 }, (short) 1, (short) 1);
-        assertTrue(Arrays.equals(new short[] { 2 }, array));
+        assertArrayEquals(new short[]{2}, array);
         assertEquals(Short.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new short[] { 1, 2, 1 }, (short) 1, (short) 2);
-        assertTrue(Arrays.equals(new short[] { 1 }, array));
+        assertArrayEquals(new short[]{1}, array);
         assertEquals(Short.TYPE, array.getClass().getComponentType());
 
         array = ArrayUtils.removeElements(new short[] { 1, 2, 1 }, (short) 1, (short) 1, (short) 1, (short) 1);
-        assertTrue(Arrays.equals(new short[] { 2 }, array));
+        assertArrayEquals(new short[]{2}, array);
         assertEquals(Short.TYPE, array.getClass().getComponentType());
     }
 

--- a/src/test/java/org/apache/commons/lang3/ArrayUtilsRemoveTest.java
+++ b/src/test/java/org/apache/commons/lang3/ArrayUtilsRemoveTest.java
@@ -17,12 +17,10 @@
 
 package org.apache.commons.lang3;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
 
@@ -35,16 +33,16 @@ public class ArrayUtilsRemoveTest {
     public void testRemoveObjectArray() {
         Object[] array;
         array = ArrayUtils.remove(new Object[] {"a"}, 0);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_OBJECT_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_OBJECT_ARRAY, array);
         assertEquals(Object.class, array.getClass().getComponentType());
         array = ArrayUtils.remove(new Object[] {"a", "b"}, 0);
-        assertTrue(Arrays.equals(new Object[] {"b"}, array));
+        assertArrayEquals(new Object[]{"b"}, array);
         assertEquals(Object.class, array.getClass().getComponentType());
         array = ArrayUtils.remove(new Object[] {"a", "b"}, 1);
-        assertTrue(Arrays.equals(new Object[] {"a"}, array));
+        assertArrayEquals(new Object[]{"a"}, array);
         assertEquals(Object.class, array.getClass().getComponentType());
         array = ArrayUtils.remove(new Object[] {"a", "b", "c"}, 1);
-        assertTrue(Arrays.equals(new Object[] {"a", "c"}, array));
+        assertArrayEquals(new Object[]{"a", "c"}, array);
         assertEquals(Object.class, array.getClass().getComponentType());
         assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.remove(new Object[] {"a", "b"}, -1));
         assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.remove(new Object[] {"a", "b"}, 2));
@@ -71,16 +69,16 @@ public class ArrayUtilsRemoveTest {
     public void testRemoveBooleanArray() {
         boolean[] array;
         array = ArrayUtils.remove(new boolean[] {true}, 0);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_BOOLEAN_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_BOOLEAN_ARRAY, array);
         assertEquals(Boolean.TYPE, array.getClass().getComponentType());
         array = ArrayUtils.remove(new boolean[] {true, false}, 0);
-        assertTrue(Arrays.equals(new boolean[] {false}, array));
+        assertArrayEquals(new boolean[]{false}, array);
         assertEquals(Boolean.TYPE, array.getClass().getComponentType());
         array = ArrayUtils.remove(new boolean[] {true, false}, 1);
-        assertTrue(Arrays.equals(new boolean[] {true}, array));
+        assertArrayEquals(new boolean[]{true}, array);
         assertEquals(Boolean.TYPE, array.getClass().getComponentType());
         array = ArrayUtils.remove(new boolean[] {true, false, true}, 1);
-        assertTrue(Arrays.equals(new boolean[] {true, true}, array));
+        assertArrayEquals(new boolean[]{true, true}, array);
         assertEquals(Boolean.TYPE, array.getClass().getComponentType());
         assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.remove(new boolean[] {true, false}, -1));
         assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.remove(new boolean[] {true, false}, 2));
@@ -91,16 +89,16 @@ public class ArrayUtilsRemoveTest {
     public void testRemoveByteArray() {
         byte[] array;
         array = ArrayUtils.remove(new byte[] {1}, 0);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_BYTE_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_BYTE_ARRAY, array);
         assertEquals(Byte.TYPE, array.getClass().getComponentType());
         array = ArrayUtils.remove(new byte[] {1, 2}, 0);
-        assertTrue(Arrays.equals(new byte[] {2}, array));
+        assertArrayEquals(new byte[]{2}, array);
         assertEquals(Byte.TYPE, array.getClass().getComponentType());
         array = ArrayUtils.remove(new byte[] {1, 2}, 1);
-        assertTrue(Arrays.equals(new byte[] {1}, array));
+        assertArrayEquals(new byte[]{1}, array);
         assertEquals(Byte.TYPE, array.getClass().getComponentType());
         array = ArrayUtils.remove(new byte[] {1, 2, 1}, 1);
-        assertTrue(Arrays.equals(new byte[] {1, 1}, array));
+        assertArrayEquals(new byte[]{1, 1}, array);
         assertEquals(Byte.TYPE, array.getClass().getComponentType());
         assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.remove(new byte[] {1, 2}, -1));
         assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.remove(new byte[] {1, 2}, 2));
@@ -111,16 +109,16 @@ public class ArrayUtilsRemoveTest {
     public void testRemoveCharArray() {
         char[] array;
         array = ArrayUtils.remove(new char[] {'a'}, 0);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_CHAR_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_CHAR_ARRAY, array);
         assertEquals(Character.TYPE, array.getClass().getComponentType());
         array = ArrayUtils.remove(new char[] {'a', 'b'}, 0);
-        assertTrue(Arrays.equals(new char[] {'b'}, array));
+        assertArrayEquals(new char[]{'b'}, array);
         assertEquals(Character.TYPE, array.getClass().getComponentType());
         array = ArrayUtils.remove(new char[] {'a', 'b'}, 1);
-        assertTrue(Arrays.equals(new char[] {'a'}, array));
+        assertArrayEquals(new char[]{'a'}, array);
         assertEquals(Character.TYPE, array.getClass().getComponentType());
         array = ArrayUtils.remove(new char[] {'a', 'b', 'c'}, 1);
-        assertTrue(Arrays.equals(new char[] {'a', 'c'}, array));
+        assertArrayEquals(new char[]{'a', 'c'}, array);
         assertEquals(Character.TYPE, array.getClass().getComponentType());
         assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.remove(new char[] {'a', 'b'}, -1));
         assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.remove(new char[] {'a', 'b'}, 2));
@@ -131,16 +129,16 @@ public class ArrayUtilsRemoveTest {
     public void testRemoveDoubleArray() {
         double[] array;
         array = ArrayUtils.remove(new double[] {1}, 0);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_DOUBLE_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_DOUBLE_ARRAY, array);
         assertEquals(Double.TYPE, array.getClass().getComponentType());
         array = ArrayUtils.remove(new double[] {1, 2}, 0);
-        assertTrue(Arrays.equals(new double[] {2}, array));
+        assertArrayEquals(new double[]{2}, array);
         assertEquals(Double.TYPE, array.getClass().getComponentType());
         array = ArrayUtils.remove(new double[] {1, 2}, 1);
-        assertTrue(Arrays.equals(new double[] {1}, array));
+        assertArrayEquals(new double[]{1}, array);
         assertEquals(Double.TYPE, array.getClass().getComponentType());
         array = ArrayUtils.remove(new double[] {1, 2, 1}, 1);
-        assertTrue(Arrays.equals(new double[] {1, 1}, array));
+        assertArrayEquals(new double[]{1, 1}, array);
         assertEquals(Double.TYPE, array.getClass().getComponentType());
         assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.remove(new double[] {1, 2}, -1));
         assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.remove(new double[] {1, 2}, 2));
@@ -151,16 +149,16 @@ public class ArrayUtilsRemoveTest {
     public void testRemoveFloatArray() {
         float[] array;
         array = ArrayUtils.remove(new float[] {1}, 0);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_FLOAT_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_FLOAT_ARRAY, array);
         assertEquals(Float.TYPE, array.getClass().getComponentType());
         array = ArrayUtils.remove(new float[] {1, 2}, 0);
-        assertTrue(Arrays.equals(new float[] {2}, array));
+        assertArrayEquals(new float[]{2}, array);
         assertEquals(Float.TYPE, array.getClass().getComponentType());
         array = ArrayUtils.remove(new float[] {1, 2}, 1);
-        assertTrue(Arrays.equals(new float[] {1}, array));
+        assertArrayEquals(new float[]{1}, array);
         assertEquals(Float.TYPE, array.getClass().getComponentType());
         array = ArrayUtils.remove(new float[] {1, 2, 1}, 1);
-        assertTrue(Arrays.equals(new float[] {1, 1}, array));
+        assertArrayEquals(new float[]{1, 1}, array);
         assertEquals(Float.TYPE, array.getClass().getComponentType());
         assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.remove(new float[] {1, 2}, -1));
         assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.remove(new float[] {1, 2}, 2));
@@ -171,16 +169,16 @@ public class ArrayUtilsRemoveTest {
     public void testRemoveIntArray() {
         int[] array;
         array = ArrayUtils.remove(new int[] {1}, 0);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_INT_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_INT_ARRAY, array);
         assertEquals(Integer.TYPE, array.getClass().getComponentType());
         array = ArrayUtils.remove(new int[] {1, 2}, 0);
-        assertTrue(Arrays.equals(new int[] {2}, array));
+        assertArrayEquals(new int[]{2}, array);
         assertEquals(Integer.TYPE, array.getClass().getComponentType());
         array = ArrayUtils.remove(new int[] {1, 2}, 1);
-        assertTrue(Arrays.equals(new int[] {1}, array));
+        assertArrayEquals(new int[]{1}, array);
         assertEquals(Integer.TYPE, array.getClass().getComponentType());
         array = ArrayUtils.remove(new int[] {1, 2, 1}, 1);
-        assertTrue(Arrays.equals(new int[] {1, 1}, array));
+        assertArrayEquals(new int[]{1, 1}, array);
         assertEquals(Integer.TYPE, array.getClass().getComponentType());
         assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.remove(new int[] {1, 2}, -1));
         assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.remove(new int[] {1, 2}, 2));
@@ -191,16 +189,16 @@ public class ArrayUtilsRemoveTest {
     public void testRemoveLongArray() {
         long[] array;
         array = ArrayUtils.remove(new long[] {1}, 0);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_LONG_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_LONG_ARRAY, array);
         assertEquals(Long.TYPE, array.getClass().getComponentType());
         array = ArrayUtils.remove(new long[] {1, 2}, 0);
-        assertTrue(Arrays.equals(new long[] {2}, array));
+        assertArrayEquals(new long[]{2}, array);
         assertEquals(Long.TYPE, array.getClass().getComponentType());
         array = ArrayUtils.remove(new long[] {1, 2}, 1);
-        assertTrue(Arrays.equals(new long[] {1}, array));
+        assertArrayEquals(new long[]{1}, array);
         assertEquals(Long.TYPE, array.getClass().getComponentType());
         array = ArrayUtils.remove(new long[] {1, 2, 1}, 1);
-        assertTrue(Arrays.equals(new long[] {1, 1}, array));
+        assertArrayEquals(new long[]{1, 1}, array);
         assertEquals(Long.TYPE, array.getClass().getComponentType());
         assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.remove(new long[] {1, 2}, -1));
         assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.remove(new long[] {1, 2}, 2));
@@ -211,16 +209,16 @@ public class ArrayUtilsRemoveTest {
     public void testRemoveShortArray() {
         short[] array;
         array = ArrayUtils.remove(new short[] {1}, 0);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_SHORT_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_SHORT_ARRAY, array);
         assertEquals(Short.TYPE, array.getClass().getComponentType());
         array = ArrayUtils.remove(new short[] {1, 2}, 0);
-        assertTrue(Arrays.equals(new short[] {2}, array));
+        assertArrayEquals(new short[]{2}, array);
         assertEquals(Short.TYPE, array.getClass().getComponentType());
         array = ArrayUtils.remove(new short[] {1, 2}, 1);
-        assertTrue(Arrays.equals(new short[] {1}, array));
+        assertArrayEquals(new short[]{1}, array);
         assertEquals(Short.TYPE, array.getClass().getComponentType());
         array = ArrayUtils.remove(new short[] {1, 2, 1}, 1);
-        assertTrue(Arrays.equals(new short[] {1, 1}, array));
+        assertArrayEquals(new short[]{1, 1}, array);
         assertEquals(Short.TYPE, array.getClass().getComponentType());
         assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.remove(new short[] {1, 2}, -1));
         assertThrows(IndexOutOfBoundsException.class, () -> ArrayUtils.remove(new short[] {1, 2}, 2));
@@ -233,16 +231,16 @@ public class ArrayUtilsRemoveTest {
         array = ArrayUtils.removeElement(null, "a");
         assertNull(array);
         array = ArrayUtils.removeElement(ArrayUtils.EMPTY_OBJECT_ARRAY, "a");
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_OBJECT_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_OBJECT_ARRAY, array);
         assertEquals(Object.class, array.getClass().getComponentType());
         array = ArrayUtils.removeElement(new Object[] {"a"}, "a");
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_OBJECT_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_OBJECT_ARRAY, array);
         assertEquals(Object.class, array.getClass().getComponentType());
         array = ArrayUtils.removeElement(new Object[] {"a", "b"}, "a");
-        assertTrue(Arrays.equals(new Object[] {"b"}, array));
+        assertArrayEquals(new Object[]{"b"}, array);
         assertEquals(Object.class, array.getClass().getComponentType());
         array = ArrayUtils.removeElement(new Object[] {"a", "b", "a"}, "a");
-        assertTrue(Arrays.equals(new Object[] {"b", "a"}, array));
+        assertArrayEquals(new Object[]{"b", "a"}, array);
         assertEquals(Object.class, array.getClass().getComponentType());
     }
 
@@ -252,16 +250,16 @@ public class ArrayUtilsRemoveTest {
         array = ArrayUtils.removeElement(null, true);
         assertNull(array);
         array = ArrayUtils.removeElement(ArrayUtils.EMPTY_BOOLEAN_ARRAY, true);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_BOOLEAN_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_BOOLEAN_ARRAY, array);
         assertEquals(Boolean.TYPE, array.getClass().getComponentType());
         array = ArrayUtils.removeElement(new boolean[] {true}, true);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_BOOLEAN_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_BOOLEAN_ARRAY, array);
         assertEquals(Boolean.TYPE, array.getClass().getComponentType());
         array = ArrayUtils.removeElement(new boolean[] {true, false}, true);
-        assertTrue(Arrays.equals(new boolean[] {false}, array));
+        assertArrayEquals(new boolean[]{false}, array);
         assertEquals(Boolean.TYPE, array.getClass().getComponentType());
         array = ArrayUtils.removeElement(new boolean[] {true, false, true}, true);
-        assertTrue(Arrays.equals(new boolean[] {false, true}, array));
+        assertArrayEquals(new boolean[]{false, true}, array);
         assertEquals(Boolean.TYPE, array.getClass().getComponentType());
     }
 
@@ -271,16 +269,16 @@ public class ArrayUtilsRemoveTest {
         array = ArrayUtils.removeElement((byte[]) null, (byte) 1);
         assertNull(array);
         array = ArrayUtils.removeElement(ArrayUtils.EMPTY_BYTE_ARRAY, (byte) 1);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_BYTE_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_BYTE_ARRAY, array);
         assertEquals(Byte.TYPE, array.getClass().getComponentType());
         array = ArrayUtils.removeElement(new byte[] {1}, (byte) 1);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_BYTE_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_BYTE_ARRAY, array);
         assertEquals(Byte.TYPE, array.getClass().getComponentType());
         array = ArrayUtils.removeElement(new byte[] {1, 2}, (byte) 1);
-        assertTrue(Arrays.equals(new byte[] {2}, array));
+        assertArrayEquals(new byte[]{2}, array);
         assertEquals(Byte.TYPE, array.getClass().getComponentType());
         array = ArrayUtils.removeElement(new byte[] {1, 2, 1}, (byte) 1);
-        assertTrue(Arrays.equals(new byte[] {2, 1}, array));
+        assertArrayEquals(new byte[]{2, 1}, array);
         assertEquals(Byte.TYPE, array.getClass().getComponentType());
     }
 
@@ -290,16 +288,16 @@ public class ArrayUtilsRemoveTest {
         array = ArrayUtils.removeElement((char[]) null, 'a');
         assertNull(array);
         array = ArrayUtils.removeElement(ArrayUtils.EMPTY_CHAR_ARRAY, 'a');
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_CHAR_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_CHAR_ARRAY, array);
         assertEquals(Character.TYPE, array.getClass().getComponentType());
         array = ArrayUtils.removeElement(new char[] {'a'}, 'a');
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_CHAR_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_CHAR_ARRAY, array);
         assertEquals(Character.TYPE, array.getClass().getComponentType());
         array = ArrayUtils.removeElement(new char[] {'a', 'b'}, 'a');
-        assertTrue(Arrays.equals(new char[] {'b'}, array));
+        assertArrayEquals(new char[]{'b'}, array);
         assertEquals(Character.TYPE, array.getClass().getComponentType());
         array = ArrayUtils.removeElement(new char[] {'a', 'b', 'a'}, 'a');
-        assertTrue(Arrays.equals(new char[] {'b', 'a'}, array));
+        assertArrayEquals(new char[]{'b', 'a'}, array);
         assertEquals(Character.TYPE, array.getClass().getComponentType());
     }
 
@@ -310,16 +308,16 @@ public class ArrayUtilsRemoveTest {
         array = ArrayUtils.removeElement(null, (double) 1);
         assertNull(array);
         array = ArrayUtils.removeElement(ArrayUtils.EMPTY_DOUBLE_ARRAY, (double) 1);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_DOUBLE_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_DOUBLE_ARRAY, array);
         assertEquals(Double.TYPE, array.getClass().getComponentType());
         array = ArrayUtils.removeElement(new double[] {1}, (double) 1);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_DOUBLE_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_DOUBLE_ARRAY, array);
         assertEquals(Double.TYPE, array.getClass().getComponentType());
         array = ArrayUtils.removeElement(new double[] {1, 2}, (double) 1);
-        assertTrue(Arrays.equals(new double[] {2}, array));
+        assertArrayEquals(new double[]{2}, array);
         assertEquals(Double.TYPE, array.getClass().getComponentType());
         array = ArrayUtils.removeElement(new double[] {1, 2, 1}, (double) 1);
-        assertTrue(Arrays.equals(new double[] {2, 1}, array));
+        assertArrayEquals(new double[]{2, 1}, array);
         assertEquals(Double.TYPE, array.getClass().getComponentType());
     }
 
@@ -330,16 +328,16 @@ public class ArrayUtilsRemoveTest {
         array = ArrayUtils.removeElement((float[]) null, (float) 1);
         assertNull(array);
         array = ArrayUtils.removeElement(ArrayUtils.EMPTY_FLOAT_ARRAY, (float) 1);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_FLOAT_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_FLOAT_ARRAY, array);
         assertEquals(Float.TYPE, array.getClass().getComponentType());
         array = ArrayUtils.removeElement(new float[] {1}, (float) 1);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_FLOAT_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_FLOAT_ARRAY, array);
         assertEquals(Float.TYPE, array.getClass().getComponentType());
         array = ArrayUtils.removeElement(new float[] {1, 2}, (float) 1);
-        assertTrue(Arrays.equals(new float[] {2}, array));
+        assertArrayEquals(new float[]{2}, array);
         assertEquals(Float.TYPE, array.getClass().getComponentType());
         array = ArrayUtils.removeElement(new float[] {1, 2, 1}, (float) 1);
-        assertTrue(Arrays.equals(new float[] {2, 1}, array));
+        assertArrayEquals(new float[]{2, 1}, array);
         assertEquals(Float.TYPE, array.getClass().getComponentType());
     }
 
@@ -349,16 +347,16 @@ public class ArrayUtilsRemoveTest {
         array = ArrayUtils.removeElement((int[]) null, 1);
         assertNull(array);
         array = ArrayUtils.removeElement(ArrayUtils.EMPTY_INT_ARRAY, 1);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_INT_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_INT_ARRAY, array);
         assertEquals(Integer.TYPE, array.getClass().getComponentType());
         array = ArrayUtils.removeElement(new int[] {1}, 1);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_INT_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_INT_ARRAY, array);
         assertEquals(Integer.TYPE, array.getClass().getComponentType());
         array = ArrayUtils.removeElement(new int[] {1, 2}, 1);
-        assertTrue(Arrays.equals(new int[] {2}, array));
+        assertArrayEquals(new int[]{2}, array);
         assertEquals(Integer.TYPE, array.getClass().getComponentType());
         array = ArrayUtils.removeElement(new int[] {1, 2, 1}, 1);
-        assertTrue(Arrays.equals(new int[] {2, 1}, array));
+        assertArrayEquals(new int[]{2, 1}, array);
         assertEquals(Integer.TYPE, array.getClass().getComponentType());
     }
 
@@ -369,16 +367,16 @@ public class ArrayUtilsRemoveTest {
         array = ArrayUtils.removeElement((long[]) null, 1L);
         assertNull(array);
         array = ArrayUtils.removeElement(ArrayUtils.EMPTY_LONG_ARRAY, 1L);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_LONG_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_LONG_ARRAY, array);
         assertEquals(Long.TYPE, array.getClass().getComponentType());
         array = ArrayUtils.removeElement(new long[] {1}, 1L);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_LONG_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_LONG_ARRAY, array);
         assertEquals(Long.TYPE, array.getClass().getComponentType());
         array = ArrayUtils.removeElement(new long[] {1, 2}, 1L);
-        assertTrue(Arrays.equals(new long[] {2}, array));
+        assertArrayEquals(new long[]{2}, array);
         assertEquals(Long.TYPE, array.getClass().getComponentType());
         array = ArrayUtils.removeElement(new long[] {1, 2, 1}, 1L);
-        assertTrue(Arrays.equals(new long[] {2, 1}, array));
+        assertArrayEquals(new long[]{2, 1}, array);
         assertEquals(Long.TYPE, array.getClass().getComponentType());
     }
 
@@ -388,16 +386,16 @@ public class ArrayUtilsRemoveTest {
         array = ArrayUtils.removeElement((short[]) null, (short) 1);
         assertNull(array);
         array = ArrayUtils.removeElement(ArrayUtils.EMPTY_SHORT_ARRAY, (short) 1);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_SHORT_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_SHORT_ARRAY, array);
         assertEquals(Short.TYPE, array.getClass().getComponentType());
         array = ArrayUtils.removeElement(new short[] {1}, (short) 1);
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_SHORT_ARRAY, array));
+        assertArrayEquals(ArrayUtils.EMPTY_SHORT_ARRAY, array);
         assertEquals(Short.TYPE, array.getClass().getComponentType());
         array = ArrayUtils.removeElement(new short[] {1, 2}, (short) 1);
-        assertTrue(Arrays.equals(new short[] {2}, array));
+        assertArrayEquals(new short[]{2}, array);
         assertEquals(Short.TYPE, array.getClass().getComponentType());
         array = ArrayUtils.removeElement(new short[] {1, 2, 1}, (short) 1);
-        assertTrue(Arrays.equals(new short[] {2, 1}, array));
+        assertArrayEquals(new short[]{2, 1}, array);
         assertEquals(Short.TYPE, array.getClass().getComponentType());
     }
 
@@ -408,19 +406,19 @@ public class ArrayUtilsRemoveTest {
         assertNull(ArrayUtils.removeAllOccurences(a, true));
 
         a = new boolean[0];
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_BOOLEAN_ARRAY, ArrayUtils.removeAllOccurences(a, true)));
+        assertArrayEquals(ArrayUtils.EMPTY_BOOLEAN_ARRAY, ArrayUtils.removeAllOccurences(a, true));
 
         a = new boolean[] { true };
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_BOOLEAN_ARRAY, ArrayUtils.removeAllOccurences(a, true)));
+        assertArrayEquals(ArrayUtils.EMPTY_BOOLEAN_ARRAY, ArrayUtils.removeAllOccurences(a, true));
 
         a = new boolean[] { true, true };
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_BOOLEAN_ARRAY, ArrayUtils.removeAllOccurences(a, true)));
+        assertArrayEquals(ArrayUtils.EMPTY_BOOLEAN_ARRAY, ArrayUtils.removeAllOccurences(a, true));
 
         a = new boolean[] { false, true, true, false, true };
-        assertTrue(Arrays.equals(new boolean[] { false, false }, ArrayUtils.removeAllOccurences(a, true)));
+        assertArrayEquals(new boolean[]{false, false}, ArrayUtils.removeAllOccurences(a, true));
 
         a = new boolean[] { false, true, true, false, true };
-        assertTrue(Arrays.equals(new boolean[] { true, true, true }, ArrayUtils.removeAllOccurences(a, false)));
+        assertArrayEquals(new boolean[]{true, true, true}, ArrayUtils.removeAllOccurences(a, false));
     }
 
     @Test
@@ -429,19 +427,19 @@ public class ArrayUtilsRemoveTest {
         assertNull(ArrayUtils.removeAllOccurences(a, '2'));
 
         a = new char[0];
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_CHAR_ARRAY, ArrayUtils.removeAllOccurences(a, '2')));
+        assertArrayEquals(ArrayUtils.EMPTY_CHAR_ARRAY, ArrayUtils.removeAllOccurences(a, '2'));
 
         a = new char[] { '2' };
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_CHAR_ARRAY, ArrayUtils.removeAllOccurences(a, '2')));
+        assertArrayEquals(ArrayUtils.EMPTY_CHAR_ARRAY, ArrayUtils.removeAllOccurences(a, '2'));
 
         a = new char[] { '2', '2' };
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_CHAR_ARRAY, ArrayUtils.removeAllOccurences(a, '2')));
+        assertArrayEquals(ArrayUtils.EMPTY_CHAR_ARRAY, ArrayUtils.removeAllOccurences(a, '2'));
 
         a = new char[] { '1', '2', '2', '3', '2' };
-        assertTrue(Arrays.equals(new char[] { '1', '3' }, ArrayUtils.removeAllOccurences(a, '2')));
+        assertArrayEquals(new char[]{'1', '3'}, ArrayUtils.removeAllOccurences(a, '2'));
 
         a = new char[] { '1', '2', '2', '3', '2' };
-        assertTrue(Arrays.equals(new char[] { '1', '2', '2', '3', '2' }, ArrayUtils.removeAllOccurences(a, '4')));
+        assertArrayEquals(new char[]{'1', '2', '2', '3', '2'}, ArrayUtils.removeAllOccurences(a, '4'));
     }
 
     @Test
@@ -450,19 +448,19 @@ public class ArrayUtilsRemoveTest {
         assertNull(ArrayUtils.removeAllOccurences(a, (byte) 2));
 
         a = new byte[0];
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_BYTE_ARRAY, ArrayUtils.removeAllOccurences(a, (byte) 2)));
+        assertArrayEquals(ArrayUtils.EMPTY_BYTE_ARRAY, ArrayUtils.removeAllOccurences(a, (byte) 2));
 
         a = new byte[] { 2 };
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_BYTE_ARRAY, ArrayUtils.removeAllOccurences(a, (byte) 2)));
+        assertArrayEquals(ArrayUtils.EMPTY_BYTE_ARRAY, ArrayUtils.removeAllOccurences(a, (byte) 2));
 
         a = new byte[] { 2, 2 };
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_BYTE_ARRAY, ArrayUtils.removeAllOccurences(a, (byte) 2)));
+        assertArrayEquals(ArrayUtils.EMPTY_BYTE_ARRAY, ArrayUtils.removeAllOccurences(a, (byte) 2));
 
         a = new byte[] { 1, 2, 2, 3, 2 };
-        assertTrue(Arrays.equals(new byte[] { 1, 3 }, ArrayUtils.removeAllOccurences(a, (byte) 2)));
+        assertArrayEquals(new byte[]{1, 3}, ArrayUtils.removeAllOccurences(a, (byte) 2));
 
         a = new byte[] { 1, 2, 2, 3, 2 };
-        assertTrue(Arrays.equals(new byte[] { 1, 2, 2, 3, 2 }, ArrayUtils.removeAllOccurences(a, (byte) 4)));
+        assertArrayEquals(new byte[]{1, 2, 2, 3, 2}, ArrayUtils.removeAllOccurences(a, (byte) 4));
     }
 
     @Test
@@ -471,19 +469,19 @@ public class ArrayUtilsRemoveTest {
         assertNull(ArrayUtils.removeAllOccurences(a, (short) 2));
 
         a = new short[0];
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_SHORT_ARRAY, ArrayUtils.removeAllOccurences(a, (short) 2)));
+        assertArrayEquals(ArrayUtils.EMPTY_SHORT_ARRAY, ArrayUtils.removeAllOccurences(a, (short) 2));
 
         a = new short[] { 2 };
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_SHORT_ARRAY, ArrayUtils.removeAllOccurences(a, (short) 2)));
+        assertArrayEquals(ArrayUtils.EMPTY_SHORT_ARRAY, ArrayUtils.removeAllOccurences(a, (short) 2));
 
         a = new short[] { 2, 2 };
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_SHORT_ARRAY, ArrayUtils.removeAllOccurences(a, (short) 2)));
+        assertArrayEquals(ArrayUtils.EMPTY_SHORT_ARRAY, ArrayUtils.removeAllOccurences(a, (short) 2));
 
         a = new short[] { 1, 2, 2, 3, 2 };
-        assertTrue(Arrays.equals(new short[] { 1, 3 }, ArrayUtils.removeAllOccurences(a, (short) 2)));
+        assertArrayEquals(new short[]{1, 3}, ArrayUtils.removeAllOccurences(a, (short) 2));
 
         a = new short[] { 1, 2, 2, 3, 2 };
-        assertTrue(Arrays.equals(new short[] { 1, 2, 2, 3, 2 }, ArrayUtils.removeAllOccurences(a, (short) 4)));
+        assertArrayEquals(new short[]{1, 2, 2, 3, 2}, ArrayUtils.removeAllOccurences(a, (short) 4));
     }
 
     @Test
@@ -492,19 +490,19 @@ public class ArrayUtilsRemoveTest {
         assertNull(ArrayUtils.removeAllOccurences(a, 2));
 
         a = new int[0];
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_INT_ARRAY, ArrayUtils.removeAllOccurences(a, 2)));
+        assertArrayEquals(ArrayUtils.EMPTY_INT_ARRAY, ArrayUtils.removeAllOccurences(a, 2));
 
         a = new int[] { 2 };
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_INT_ARRAY, ArrayUtils.removeAllOccurences(a, 2)));
+        assertArrayEquals(ArrayUtils.EMPTY_INT_ARRAY, ArrayUtils.removeAllOccurences(a, 2));
 
         a = new int[] { 2, 2 };
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_INT_ARRAY, ArrayUtils.removeAllOccurences(a, 2)));
+        assertArrayEquals(ArrayUtils.EMPTY_INT_ARRAY, ArrayUtils.removeAllOccurences(a, 2));
 
         a = new int[] { 1, 2, 2, 3, 2 };
-        assertTrue(Arrays.equals(new int[] { 1, 3 }, ArrayUtils.removeAllOccurences(a, 2)));
+        assertArrayEquals(new int[]{1, 3}, ArrayUtils.removeAllOccurences(a, 2));
 
         a = new int[] { 1, 2, 2, 3, 2 };
-        assertTrue(Arrays.equals(new int[] { 1, 2, 2, 3, 2 }, ArrayUtils.removeAllOccurences(a, 4)));
+        assertArrayEquals(new int[]{1, 2, 2, 3, 2}, ArrayUtils.removeAllOccurences(a, 4));
     }
 
     @Test
@@ -513,19 +511,19 @@ public class ArrayUtilsRemoveTest {
         assertNull(ArrayUtils.removeAllOccurences(a, 2));
 
         a = new long[0];
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_LONG_ARRAY, ArrayUtils.removeAllOccurences(a, 2)));
+        assertArrayEquals(ArrayUtils.EMPTY_LONG_ARRAY, ArrayUtils.removeAllOccurences(a, 2));
 
         a = new long[] { 2 };
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_LONG_ARRAY, ArrayUtils.removeAllOccurences(a, 2)));
+        assertArrayEquals(ArrayUtils.EMPTY_LONG_ARRAY, ArrayUtils.removeAllOccurences(a, 2));
 
         a = new long[] { 2, 2 };
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_LONG_ARRAY, ArrayUtils.removeAllOccurences(a, 2)));
+        assertArrayEquals(ArrayUtils.EMPTY_LONG_ARRAY, ArrayUtils.removeAllOccurences(a, 2));
 
         a = new long[] { 1, 2, 2, 3, 2 };
-        assertTrue(Arrays.equals(new long[] { 1, 3 }, ArrayUtils.removeAllOccurences(a, 2)));
+        assertArrayEquals(new long[]{1, 3}, ArrayUtils.removeAllOccurences(a, 2));
 
         a = new long[] { 1, 2, 2, 3, 2 };
-        assertTrue(Arrays.equals(new long[] { 1, 2, 2, 3, 2 }, ArrayUtils.removeAllOccurences(a, 4)));
+        assertArrayEquals(new long[]{1, 2, 2, 3, 2}, ArrayUtils.removeAllOccurences(a, 4));
     }
 
     @Test
@@ -534,19 +532,19 @@ public class ArrayUtilsRemoveTest {
         assertNull(ArrayUtils.removeAllOccurences(a, 2));
 
         a = new float[0];
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_FLOAT_ARRAY, ArrayUtils.removeAllOccurences(a, 2)));
+        assertArrayEquals(ArrayUtils.EMPTY_FLOAT_ARRAY, ArrayUtils.removeAllOccurences(a, 2));
 
         a = new float[] { 2 };
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_FLOAT_ARRAY, ArrayUtils.removeAllOccurences(a, 2)));
+        assertArrayEquals(ArrayUtils.EMPTY_FLOAT_ARRAY, ArrayUtils.removeAllOccurences(a, 2));
 
         a = new float[] { 2, 2 };
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_FLOAT_ARRAY, ArrayUtils.removeAllOccurences(a, 2)));
+        assertArrayEquals(ArrayUtils.EMPTY_FLOAT_ARRAY, ArrayUtils.removeAllOccurences(a, 2));
 
         a = new float[] { 1, 2, 2, 3, 2 };
-        assertTrue(Arrays.equals(new float[] { 1, 3 }, ArrayUtils.removeAllOccurences(a, 2)));
+        assertArrayEquals(new float[]{1, 3}, ArrayUtils.removeAllOccurences(a, 2));
 
         a = new float[] { 1, 2, 2, 3, 2 };
-        assertTrue(Arrays.equals(new float[] { 1, 2, 2, 3, 2 }, ArrayUtils.removeAllOccurences(a, 4)));
+        assertArrayEquals(new float[]{1, 2, 2, 3, 2}, ArrayUtils.removeAllOccurences(a, 4));
     }
 
     @Test
@@ -555,19 +553,19 @@ public class ArrayUtilsRemoveTest {
         assertNull(ArrayUtils.removeAllOccurences(a, 2));
 
         a = new double[0];
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_DOUBLE_ARRAY, ArrayUtils.removeAllOccurences(a, 2)));
+        assertArrayEquals(ArrayUtils.EMPTY_DOUBLE_ARRAY, ArrayUtils.removeAllOccurences(a, 2));
 
         a = new double[] { 2 };
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_DOUBLE_ARRAY, ArrayUtils.removeAllOccurences(a, 2)));
+        assertArrayEquals(ArrayUtils.EMPTY_DOUBLE_ARRAY, ArrayUtils.removeAllOccurences(a, 2));
 
         a = new double[] { 2, 2 };
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_DOUBLE_ARRAY, ArrayUtils.removeAllOccurences(a, 2)));
+        assertArrayEquals(ArrayUtils.EMPTY_DOUBLE_ARRAY, ArrayUtils.removeAllOccurences(a, 2));
 
         a = new double[] { 1, 2, 2, 3, 2 };
-        assertTrue(Arrays.equals(new double[] { 1, 3 }, ArrayUtils.removeAllOccurences(a, 2)));
+        assertArrayEquals(new double[]{1, 3}, ArrayUtils.removeAllOccurences(a, 2));
 
         a = new double[] { 1, 2, 2, 3, 2 };
-        assertTrue(Arrays.equals(new double[] { 1, 2, 2, 3, 2 }, ArrayUtils.removeAllOccurences(a, 4)));
+        assertArrayEquals(new double[]{1, 2, 2, 3, 2}, ArrayUtils.removeAllOccurences(a, 4));
     }
 
     @Test
@@ -576,18 +574,18 @@ public class ArrayUtilsRemoveTest {
         assertNull(ArrayUtils.removeAllOccurences(a, "2"));
 
         a = new String[0];
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_STRING_ARRAY, ArrayUtils.removeAllOccurences(a, "2")));
+        assertArrayEquals(ArrayUtils.EMPTY_STRING_ARRAY, ArrayUtils.removeAllOccurences(a, "2"));
 
         a = new String[] { "2" };
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_STRING_ARRAY, ArrayUtils.removeAllOccurences(a, "2")));
+        assertArrayEquals(ArrayUtils.EMPTY_STRING_ARRAY, ArrayUtils.removeAllOccurences(a, "2"));
 
         a = new String[] { "2", "2" };
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_STRING_ARRAY, ArrayUtils.removeAllOccurences(a, "2")));
+        assertArrayEquals(ArrayUtils.EMPTY_STRING_ARRAY, ArrayUtils.removeAllOccurences(a, "2"));
 
         a = new String[] { "1", "2", "2", "3", "2" };
-        assertTrue(Arrays.equals(new String[] { "1", "3" }, ArrayUtils.removeAllOccurences(a, "2")));
+        assertArrayEquals(new String[]{"1", "3"}, ArrayUtils.removeAllOccurences(a, "2"));
 
         a = new String[] { "1", "2", "2", "3", "2" };
-        assertTrue(Arrays.equals(new String[] { "1", "2", "2", "3", "2" }, ArrayUtils.removeAllOccurences(a, "4")));
+        assertArrayEquals(new String[]{"1", "2", "2", "3", "2"}, ArrayUtils.removeAllOccurences(a, "4"));
     }
 }

--- a/src/test/java/org/apache/commons/lang3/ArrayUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/ArrayUtilsTest.java
@@ -19,6 +19,7 @@ package org.apache.commons.lang3;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -78,7 +79,7 @@ public class ArrayUtilsTest {
         final long[][] array1 = new long[][]{{2, 5}, {4, 5}};
         final long[][] array2 = new long[][]{{2, 5}, {4, 6}};
         assertEquals(ArrayUtils.hashCode(array1), ArrayUtils.hashCode(array1));
-        assertFalse(ArrayUtils.hashCode(array1) == ArrayUtils.hashCode(array2));
+        assertNotEquals(ArrayUtils.hashCode(array1), ArrayUtils.hashCode(array2));
 
         final Object[] array3 = new Object[]{new String(new char[]{'A', 'B'})};
         final Object[] array4 = new Object[]{"AB"};
@@ -271,13 +272,13 @@ public class ArrayUtilsTest {
         assertArrayEquals(null, ArrayUtils.clone((Object[]) null));
         Object[] original1 = new Object[0];
         Object[] cloned1 = ArrayUtils.clone(original1);
-        assertTrue(Arrays.equals(original1, cloned1));
+        assertArrayEquals(original1, cloned1);
         assertNotSame(original1, cloned1);
 
         final StringBuilder builder = new StringBuilder("pick");
         original1 = new Object[]{builder, "a", new String[]{"stick"}};
         cloned1 = ArrayUtils.clone(original1);
-        assertTrue(Arrays.equals(original1, cloned1));
+        assertArrayEquals(original1, cloned1);
         assertNotSame(original1, cloned1);
         assertSame(original1[0], cloned1[0]);
         assertSame(original1[1], cloned1[1]);
@@ -289,7 +290,7 @@ public class ArrayUtilsTest {
         assertNull(ArrayUtils.clone((boolean[]) null));
         final boolean[] original = new boolean[]{true, false};
         final boolean[] cloned = ArrayUtils.clone(original);
-        assertTrue(Arrays.equals(original, cloned));
+        assertArrayEquals(original, cloned);
         assertNotSame(original, cloned);
     }
 
@@ -298,7 +299,7 @@ public class ArrayUtilsTest {
         assertNull(ArrayUtils.clone((long[]) null));
         final long[] original = new long[]{0L, 1L};
         final long[] cloned = ArrayUtils.clone(original);
-        assertTrue(Arrays.equals(original, cloned));
+        assertArrayEquals(original, cloned);
         assertNotSame(original, cloned);
     }
 
@@ -307,7 +308,7 @@ public class ArrayUtilsTest {
         assertNull(ArrayUtils.clone((int[]) null));
         final int[] original = new int[]{5, 8};
         final int[] cloned = ArrayUtils.clone(original);
-        assertTrue(Arrays.equals(original, cloned));
+        assertArrayEquals(original, cloned);
         assertNotSame(original, cloned);
     }
 
@@ -316,7 +317,7 @@ public class ArrayUtilsTest {
         assertNull(ArrayUtils.clone((short[]) null));
         final short[] original = new short[]{1, 4};
         final short[] cloned = ArrayUtils.clone(original);
-        assertTrue(Arrays.equals(original, cloned));
+        assertArrayEquals(original, cloned);
         assertNotSame(original, cloned);
     }
 
@@ -325,7 +326,7 @@ public class ArrayUtilsTest {
         assertNull(ArrayUtils.clone((char[]) null));
         final char[] original = new char[]{'a', '4'};
         final char[] cloned = ArrayUtils.clone(original);
-        assertTrue(Arrays.equals(original, cloned));
+        assertArrayEquals(original, cloned);
         assertNotSame(original, cloned);
     }
 
@@ -334,7 +335,7 @@ public class ArrayUtilsTest {
         assertNull(ArrayUtils.clone((byte[]) null));
         final byte[] original = new byte[]{1, 6};
         final byte[] cloned = ArrayUtils.clone(original);
-        assertTrue(Arrays.equals(original, cloned));
+        assertArrayEquals(original, cloned);
         assertNotSame(original, cloned);
     }
 
@@ -343,7 +344,7 @@ public class ArrayUtilsTest {
         assertNull(ArrayUtils.clone((double[]) null));
         final double[] original = new double[]{2.4d, 5.7d};
         final double[] cloned = ArrayUtils.clone(original);
-        assertTrue(Arrays.equals(original, cloned));
+        assertArrayEquals(original, cloned);
         assertNotSame(original, cloned);
     }
 
@@ -352,7 +353,7 @@ public class ArrayUtilsTest {
         assertNull(ArrayUtils.clone((float[]) null));
         final float[] original = new float[]{2.6f, 6.4f};
         final float[] cloned = ArrayUtils.clone(original);
-        assertTrue(Arrays.equals(original, cloned));
+        assertArrayEquals(original, cloned);
         assertNotSame(original, cloned);
     }
 
@@ -3824,10 +3825,7 @@ public class ArrayUtilsTest {
         final Boolean[] b = null;
         assertNull(ArrayUtils.toPrimitive(b));
         assertSame(ArrayUtils.EMPTY_BOOLEAN_ARRAY, ArrayUtils.toPrimitive(new Boolean[0]));
-        assertTrue(Arrays.equals(
-                new boolean[]{true, false, true},
-                ArrayUtils.toPrimitive(new Boolean[]{Boolean.TRUE, Boolean.FALSE, Boolean.TRUE}))
-        );
+        assertArrayEquals(new boolean[]{true, false, true}, ArrayUtils.toPrimitive(new Boolean[]{Boolean.TRUE, Boolean.FALSE, Boolean.TRUE}));
 
         assertThrows(NullPointerException.class, () -> ArrayUtils.toPrimitive(new Boolean[]{Boolean.TRUE, null}));
     }
@@ -3836,18 +3834,9 @@ public class ArrayUtilsTest {
     public void testToPrimitive_boolean_boolean() {
         assertNull(ArrayUtils.toPrimitive(null, false));
         assertSame(ArrayUtils.EMPTY_BOOLEAN_ARRAY, ArrayUtils.toPrimitive(new Boolean[0], false));
-        assertTrue(Arrays.equals(
-                new boolean[]{true, false, true},
-                ArrayUtils.toPrimitive(new Boolean[]{Boolean.TRUE, Boolean.FALSE, Boolean.TRUE}, false))
-        );
-        assertTrue(Arrays.equals(
-                new boolean[]{true, false, false},
-                ArrayUtils.toPrimitive(new Boolean[]{Boolean.TRUE, null, Boolean.FALSE}, false))
-        );
-        assertTrue(Arrays.equals(
-                new boolean[]{true, true, false},
-                ArrayUtils.toPrimitive(new Boolean[]{Boolean.TRUE, null, Boolean.FALSE}, true))
-        );
+        assertArrayEquals(new boolean[]{true, false, true}, ArrayUtils.toPrimitive(new Boolean[]{Boolean.TRUE, Boolean.FALSE, Boolean.TRUE}, false));
+        assertArrayEquals(new boolean[]{true, false, false}, ArrayUtils.toPrimitive(new Boolean[]{Boolean.TRUE, null, Boolean.FALSE}, false));
+        assertArrayEquals(new boolean[]{true, true, false}, ArrayUtils.toPrimitive(new Boolean[]{Boolean.TRUE, null, Boolean.FALSE}, true));
     }
 
     @Test
@@ -3855,10 +3844,7 @@ public class ArrayUtilsTest {
         final boolean[] b = null;
         assertArrayEquals(null, ArrayUtils.toObject(b));
         assertSame(ArrayUtils.EMPTY_BOOLEAN_OBJECT_ARRAY, ArrayUtils.toObject(new boolean[0]));
-        assertTrue(Arrays.equals(
-                new Boolean[]{Boolean.TRUE, Boolean.FALSE, Boolean.TRUE},
-                ArrayUtils.toObject(new boolean[]{true, false, true}))
-        );
+        assertArrayEquals(new Boolean[]{Boolean.TRUE, Boolean.FALSE, Boolean.TRUE}, ArrayUtils.toObject(new boolean[]{true, false, true}));
     }
 
     // testToPrimitive/Object for byte
@@ -3870,11 +3856,8 @@ public class ArrayUtilsTest {
 
         assertSame(ArrayUtils.EMPTY_CHAR_ARRAY, ArrayUtils.toPrimitive(new Character[0]));
 
-        assertTrue(Arrays.equals(
-                new char[]{Character.MIN_VALUE, Character.MAX_VALUE, '0'},
-                ArrayUtils.toPrimitive(new Character[]{new Character(Character.MIN_VALUE),
-                        new Character(Character.MAX_VALUE), new Character('0')}))
-        );
+        assertArrayEquals(new char[]{Character.MIN_VALUE, Character.MAX_VALUE, '0'}, ArrayUtils.toPrimitive(new Character[]{new Character(Character.MIN_VALUE),
+                new Character(Character.MAX_VALUE), new Character('0')}));
 
         assertThrows(NullPointerException.class,
                 () -> ArrayUtils.toPrimitive(new Character[]{new Character(Character.MIN_VALUE), null}));
@@ -3888,18 +3871,12 @@ public class ArrayUtilsTest {
         assertSame(ArrayUtils.EMPTY_CHAR_ARRAY,
                 ArrayUtils.toPrimitive(new Character[0], (char) 0));
 
-        assertTrue(Arrays.equals(
-                new char[]{Character.MIN_VALUE, Character.MAX_VALUE, '0'},
-                ArrayUtils.toPrimitive(new Character[]{new Character(Character.MIN_VALUE),
-                                new Character(Character.MAX_VALUE), new Character('0')},
-                        Character.MIN_VALUE))
-        );
+        assertArrayEquals(new char[]{Character.MIN_VALUE, Character.MAX_VALUE, '0'}, ArrayUtils.toPrimitive(new Character[]{new Character(Character.MIN_VALUE),
+                        new Character(Character.MAX_VALUE), new Character('0')},
+                Character.MIN_VALUE));
 
-        assertTrue(Arrays.equals(
-                new char[]{Character.MIN_VALUE, Character.MAX_VALUE, '0'},
-                ArrayUtils.toPrimitive(new Character[]{new Character(Character.MIN_VALUE), null,
-                        new Character('0')}, Character.MAX_VALUE))
-        );
+        assertArrayEquals(new char[]{Character.MIN_VALUE, Character.MAX_VALUE, '0'}, ArrayUtils.toPrimitive(new Character[]{new Character(Character.MIN_VALUE), null,
+                new Character('0')}, Character.MAX_VALUE));
     }
 
     @Test
@@ -3910,12 +3887,9 @@ public class ArrayUtilsTest {
         assertSame(ArrayUtils.EMPTY_CHARACTER_OBJECT_ARRAY,
                 ArrayUtils.toObject(new char[0]));
 
-        assertTrue(Arrays.equals(
-                new Character[]{new Character(Character.MIN_VALUE),
-                        new Character(Character.MAX_VALUE), new Character('0')},
-                ArrayUtils.toObject(new char[]{Character.MIN_VALUE, Character.MAX_VALUE,
-                        '0'}))
-        );
+        assertArrayEquals(new Character[]{new Character(Character.MIN_VALUE),
+                new Character(Character.MAX_VALUE), new Character('0')}, ArrayUtils.toObject(new char[]{Character.MIN_VALUE, Character.MAX_VALUE,
+                '0'}));
     }
 
     // testToPrimitive/Object for byte
@@ -3927,11 +3901,8 @@ public class ArrayUtilsTest {
 
         assertSame(ArrayUtils.EMPTY_BYTE_ARRAY, ArrayUtils.toPrimitive(new Byte[0]));
 
-        assertTrue(Arrays.equals(
-                new byte[]{Byte.MIN_VALUE, Byte.MAX_VALUE, (byte) 9999999},
-                ArrayUtils.toPrimitive(new Byte[]{Byte.valueOf(Byte.MIN_VALUE),
-                        Byte.valueOf(Byte.MAX_VALUE), Byte.valueOf((byte) 9999999)}))
-        );
+        assertArrayEquals(new byte[]{Byte.MIN_VALUE, Byte.MAX_VALUE, (byte) 9999999}, ArrayUtils.toPrimitive(new Byte[]{Byte.valueOf(Byte.MIN_VALUE),
+                Byte.valueOf(Byte.MAX_VALUE), Byte.valueOf((byte) 9999999)}));
 
         assertThrows(NullPointerException.class,
                 () -> ArrayUtils.toPrimitive(new Byte[]{Byte.valueOf(Byte.MIN_VALUE), null}));
@@ -3945,18 +3916,12 @@ public class ArrayUtilsTest {
         assertSame(ArrayUtils.EMPTY_BYTE_ARRAY,
                 ArrayUtils.toPrimitive(new Byte[0], (byte) 1));
 
-        assertTrue(Arrays.equals(
-                new byte[]{Byte.MIN_VALUE, Byte.MAX_VALUE, (byte) 9999999},
-                ArrayUtils.toPrimitive(new Byte[]{Byte.valueOf(Byte.MIN_VALUE),
-                                Byte.valueOf(Byte.MAX_VALUE), Byte.valueOf((byte) 9999999)},
-                        Byte.MIN_VALUE))
-        );
+        assertArrayEquals(new byte[]{Byte.MIN_VALUE, Byte.MAX_VALUE, (byte) 9999999}, ArrayUtils.toPrimitive(new Byte[]{Byte.valueOf(Byte.MIN_VALUE),
+                        Byte.valueOf(Byte.MAX_VALUE), Byte.valueOf((byte) 9999999)},
+                Byte.MIN_VALUE));
 
-        assertTrue(Arrays.equals(
-                new byte[]{Byte.MIN_VALUE, Byte.MAX_VALUE, (byte) 9999999},
-                ArrayUtils.toPrimitive(new Byte[]{Byte.valueOf(Byte.MIN_VALUE), null,
-                        Byte.valueOf((byte) 9999999)}, Byte.MAX_VALUE))
-        );
+        assertArrayEquals(new byte[]{Byte.MIN_VALUE, Byte.MAX_VALUE, (byte) 9999999}, ArrayUtils.toPrimitive(new Byte[]{Byte.valueOf(Byte.MIN_VALUE), null,
+                Byte.valueOf((byte) 9999999)}, Byte.MAX_VALUE));
     }
 
     @Test
@@ -3967,12 +3932,9 @@ public class ArrayUtilsTest {
         assertSame(ArrayUtils.EMPTY_BYTE_OBJECT_ARRAY,
                 ArrayUtils.toObject(new byte[0]));
 
-        assertTrue(Arrays.equals(
-                new Byte[]{Byte.valueOf(Byte.MIN_VALUE),
-                        Byte.valueOf(Byte.MAX_VALUE), Byte.valueOf((byte) 9999999)},
-                ArrayUtils.toObject(new byte[]{Byte.MIN_VALUE, Byte.MAX_VALUE,
-                        (byte) 9999999}))
-        );
+        assertArrayEquals(new Byte[]{Byte.valueOf(Byte.MIN_VALUE),
+                Byte.valueOf(Byte.MAX_VALUE), Byte.valueOf((byte) 9999999)}, ArrayUtils.toObject(new byte[]{Byte.MIN_VALUE, Byte.MAX_VALUE,
+                (byte) 9999999}));
     }
 
     // testToPrimitive/Object for short
@@ -3984,11 +3946,8 @@ public class ArrayUtilsTest {
 
         assertSame(ArrayUtils.EMPTY_SHORT_ARRAY, ArrayUtils.toPrimitive(new Short[0]));
 
-        assertTrue(Arrays.equals(
-                new short[]{Short.MIN_VALUE, Short.MAX_VALUE, (short) 9999999},
-                ArrayUtils.toPrimitive(new Short[]{Short.valueOf(Short.MIN_VALUE),
-                        Short.valueOf(Short.MAX_VALUE), Short.valueOf((short) 9999999)}))
-        );
+        assertArrayEquals(new short[]{Short.MIN_VALUE, Short.MAX_VALUE, (short) 9999999}, ArrayUtils.toPrimitive(new Short[]{Short.valueOf(Short.MIN_VALUE),
+                Short.valueOf(Short.MAX_VALUE), Short.valueOf((short) 9999999)}));
 
         assertThrows(NullPointerException.class,
                 () -> ArrayUtils.toPrimitive(new Short[]{Short.valueOf(Short.MIN_VALUE), null}));
@@ -4002,17 +3961,11 @@ public class ArrayUtilsTest {
         assertSame(ArrayUtils.EMPTY_SHORT_ARRAY, ArrayUtils.toPrimitive(new Short[0],
                 Short.MIN_VALUE));
 
-        assertTrue(Arrays.equals(
-                new short[]{Short.MIN_VALUE, Short.MAX_VALUE, (short) 9999999},
-                ArrayUtils.toPrimitive(new Short[]{Short.valueOf(Short.MIN_VALUE),
-                        Short.valueOf(Short.MAX_VALUE), Short.valueOf((short) 9999999)}, Short.MIN_VALUE))
-        );
+        assertArrayEquals(new short[]{Short.MIN_VALUE, Short.MAX_VALUE, (short) 9999999}, ArrayUtils.toPrimitive(new Short[]{Short.valueOf(Short.MIN_VALUE),
+                Short.valueOf(Short.MAX_VALUE), Short.valueOf((short) 9999999)}, Short.MIN_VALUE));
 
-        assertTrue(Arrays.equals(
-                new short[]{Short.MIN_VALUE, Short.MAX_VALUE, (short) 9999999},
-                ArrayUtils.toPrimitive(new Short[]{Short.valueOf(Short.MIN_VALUE), null,
-                        Short.valueOf((short) 9999999)}, Short.MAX_VALUE))
-        );
+        assertArrayEquals(new short[]{Short.MIN_VALUE, Short.MAX_VALUE, (short) 9999999}, ArrayUtils.toPrimitive(new Short[]{Short.valueOf(Short.MIN_VALUE), null,
+                Short.valueOf((short) 9999999)}, Short.MAX_VALUE));
     }
 
     @Test
@@ -4023,12 +3976,9 @@ public class ArrayUtilsTest {
         assertSame(ArrayUtils.EMPTY_SHORT_OBJECT_ARRAY,
                 ArrayUtils.toObject(new short[0]));
 
-        assertTrue(Arrays.equals(
-                new Short[]{Short.valueOf(Short.MIN_VALUE), Short.valueOf(Short.MAX_VALUE),
-                        Short.valueOf((short) 9999999)},
-                ArrayUtils.toObject(new short[]{Short.MIN_VALUE, Short.MAX_VALUE,
-                        (short) 9999999}))
-        );
+        assertArrayEquals(new Short[]{Short.valueOf(Short.MIN_VALUE), Short.valueOf(Short.MAX_VALUE),
+                Short.valueOf((short) 9999999)}, ArrayUtils.toObject(new short[]{Short.MIN_VALUE, Short.MAX_VALUE,
+                (short) 9999999}));
     }
 
     //  testToPrimitive/Object for int
@@ -4038,11 +3988,8 @@ public class ArrayUtilsTest {
         final Integer[] b = null;
         assertNull(ArrayUtils.toPrimitive(b));
         assertSame(ArrayUtils.EMPTY_INT_ARRAY, ArrayUtils.toPrimitive(new Integer[0]));
-        assertTrue(Arrays.equals(
-                new int[]{Integer.MIN_VALUE, Integer.MAX_VALUE, 9999999},
-                ArrayUtils.toPrimitive(new Integer[]{Integer.valueOf(Integer.MIN_VALUE),
-                        Integer.valueOf(Integer.MAX_VALUE), Integer.valueOf(9999999)}))
-        );
+        assertArrayEquals(new int[]{Integer.MIN_VALUE, Integer.MAX_VALUE, 9999999}, ArrayUtils.toPrimitive(new Integer[]{Integer.valueOf(Integer.MIN_VALUE),
+                Integer.valueOf(Integer.MAX_VALUE), Integer.valueOf(9999999)}));
 
         assertThrows(NullPointerException.class,
                 () -> ArrayUtils.toPrimitive(new Integer[]{Integer.valueOf(Integer.MIN_VALUE), null}));
@@ -4054,15 +4001,10 @@ public class ArrayUtilsTest {
         assertNull(ArrayUtils.toPrimitive(l, Integer.MIN_VALUE));
         assertSame(ArrayUtils.EMPTY_INT_ARRAY,
                 ArrayUtils.toPrimitive(new Integer[0], 1));
-        assertTrue(Arrays.equals(
-                new int[]{Integer.MIN_VALUE, Integer.MAX_VALUE, 9999999},
-                ArrayUtils.toPrimitive(new Integer[]{Integer.valueOf(Integer.MIN_VALUE),
-                        Integer.valueOf(Integer.MAX_VALUE), Integer.valueOf(9999999)}, 1)));
-        assertTrue(Arrays.equals(
-                new int[]{Integer.MIN_VALUE, Integer.MAX_VALUE, 9999999},
-                ArrayUtils.toPrimitive(new Integer[]{Integer.valueOf(Integer.MIN_VALUE),
-                        null, Integer.valueOf(9999999)}, Integer.MAX_VALUE))
-        );
+        assertArrayEquals(new int[]{Integer.MIN_VALUE, Integer.MAX_VALUE, 9999999}, ArrayUtils.toPrimitive(new Integer[]{Integer.valueOf(Integer.MIN_VALUE),
+                Integer.valueOf(Integer.MAX_VALUE), Integer.valueOf(9999999)}, 1));
+        assertArrayEquals(new int[]{Integer.MIN_VALUE, Integer.MAX_VALUE, 9999999}, ArrayUtils.toPrimitive(new Integer[]{Integer.valueOf(Integer.MIN_VALUE),
+                null, Integer.valueOf(9999999)}, Integer.MAX_VALUE));
     }
 
     @Test
@@ -4080,14 +4022,11 @@ public class ArrayUtilsTest {
                 ArrayUtils.EMPTY_INTEGER_OBJECT_ARRAY,
                 ArrayUtils.toObject(new int[0]));
 
-        assertTrue(
-                Arrays.equals(
-                        new Integer[]{
-                                Integer.valueOf(Integer.MIN_VALUE),
-                                Integer.valueOf(Integer.MAX_VALUE),
-                                Integer.valueOf(9999999)},
-                        ArrayUtils.toObject(
-                                new int[]{Integer.MIN_VALUE, Integer.MAX_VALUE, 9999999})));
+        assertArrayEquals(new Integer[]{
+                Integer.valueOf(Integer.MIN_VALUE),
+                Integer.valueOf(Integer.MAX_VALUE),
+                Integer.valueOf(9999999)}, ArrayUtils.toObject(
+                new int[]{Integer.MIN_VALUE, Integer.MAX_VALUE, 9999999}));
     }
 
     //  testToPrimitive/Object for long
@@ -4100,11 +4039,8 @@ public class ArrayUtilsTest {
         assertSame(ArrayUtils.EMPTY_LONG_ARRAY,
                 ArrayUtils.toPrimitive(new Long[0]));
 
-        assertTrue(Arrays.equals(
-                new long[]{Long.MIN_VALUE, Long.MAX_VALUE, 9999999},
-                ArrayUtils.toPrimitive(new Long[]{Long.valueOf(Long.MIN_VALUE),
-                        Long.valueOf(Long.MAX_VALUE), Long.valueOf(9999999)}))
-        );
+        assertArrayEquals(new long[]{Long.MIN_VALUE, Long.MAX_VALUE, 9999999}, ArrayUtils.toPrimitive(new Long[]{Long.valueOf(Long.MIN_VALUE),
+                Long.valueOf(Long.MAX_VALUE), Long.valueOf(9999999)}));
 
         assertThrows(NullPointerException.class,
                 () -> ArrayUtils.toPrimitive(new Long[]{Long.valueOf(Long.MIN_VALUE), null}));
@@ -4118,16 +4054,11 @@ public class ArrayUtilsTest {
         assertSame(ArrayUtils.EMPTY_LONG_ARRAY,
                 ArrayUtils.toPrimitive(new Long[0], 1));
 
-        assertTrue(Arrays.equals(
-                new long[]{Long.MIN_VALUE, Long.MAX_VALUE, 9999999},
-                ArrayUtils.toPrimitive(new Long[]{Long.valueOf(Long.MIN_VALUE),
-                        Long.valueOf(Long.MAX_VALUE), Long.valueOf(9999999)}, 1)));
+        assertArrayEquals(new long[]{Long.MIN_VALUE, Long.MAX_VALUE, 9999999}, ArrayUtils.toPrimitive(new Long[]{Long.valueOf(Long.MIN_VALUE),
+                Long.valueOf(Long.MAX_VALUE), Long.valueOf(9999999)}, 1));
 
-        assertTrue(Arrays.equals(
-                new long[]{Long.MIN_VALUE, Long.MAX_VALUE, 9999999},
-                ArrayUtils.toPrimitive(new Long[]{Long.valueOf(Long.MIN_VALUE),
-                        null, Long.valueOf(9999999)}, Long.MAX_VALUE))
-        );
+        assertArrayEquals(new long[]{Long.MIN_VALUE, Long.MAX_VALUE, 9999999}, ArrayUtils.toPrimitive(new Long[]{Long.valueOf(Long.MIN_VALUE),
+                null, Long.valueOf(9999999)}, Long.MAX_VALUE));
     }
 
     @Test
@@ -4139,14 +4070,11 @@ public class ArrayUtilsTest {
                 ArrayUtils.EMPTY_LONG_OBJECT_ARRAY,
                 ArrayUtils.toObject(new long[0]));
 
-        assertTrue(
-                Arrays.equals(
-                        new Long[]{
-                                Long.valueOf(Long.MIN_VALUE),
-                                Long.valueOf(Long.MAX_VALUE),
-                                Long.valueOf(9999999)},
-                        ArrayUtils.toObject(
-                                new long[]{Long.MIN_VALUE, Long.MAX_VALUE, 9999999})));
+        assertArrayEquals(new Long[]{
+                Long.valueOf(Long.MIN_VALUE),
+                Long.valueOf(Long.MAX_VALUE),
+                Long.valueOf(9999999)}, ArrayUtils.toObject(
+                new long[]{Long.MIN_VALUE, Long.MAX_VALUE, 9999999}));
     }
 
     //  testToPrimitive/Object for float
@@ -4159,11 +4087,8 @@ public class ArrayUtilsTest {
         assertSame(ArrayUtils.EMPTY_FLOAT_ARRAY,
                 ArrayUtils.toPrimitive(new Float[0]));
 
-        assertTrue(Arrays.equals(
-                new float[]{Float.MIN_VALUE, Float.MAX_VALUE, 9999999},
-                ArrayUtils.toPrimitive(new Float[]{Float.valueOf(Float.MIN_VALUE),
-                        Float.valueOf(Float.MAX_VALUE), Float.valueOf(9999999)}))
-        );
+        assertArrayEquals(new float[]{Float.MIN_VALUE, Float.MAX_VALUE, 9999999}, ArrayUtils.toPrimitive(new Float[]{Float.valueOf(Float.MIN_VALUE),
+                Float.valueOf(Float.MAX_VALUE), Float.valueOf(9999999)}));
 
         assertThrows(NullPointerException.class,
                 () -> ArrayUtils.toPrimitive(new Float[]{Float.valueOf(Float.MIN_VALUE), null}));
@@ -4177,16 +4102,11 @@ public class ArrayUtilsTest {
         assertSame(ArrayUtils.EMPTY_FLOAT_ARRAY,
                 ArrayUtils.toPrimitive(new Float[0], 1));
 
-        assertTrue(Arrays.equals(
-                new float[]{Float.MIN_VALUE, Float.MAX_VALUE, 9999999},
-                ArrayUtils.toPrimitive(new Float[]{Float.valueOf(Float.MIN_VALUE),
-                        Float.valueOf(Float.MAX_VALUE), Float.valueOf(9999999)}, 1)));
+        assertArrayEquals(new float[]{Float.MIN_VALUE, Float.MAX_VALUE, 9999999}, ArrayUtils.toPrimitive(new Float[]{Float.valueOf(Float.MIN_VALUE),
+                Float.valueOf(Float.MAX_VALUE), Float.valueOf(9999999)}, 1));
 
-        assertTrue(Arrays.equals(
-                new float[]{Float.MIN_VALUE, Float.MAX_VALUE, 9999999},
-                ArrayUtils.toPrimitive(new Float[]{Float.valueOf(Float.MIN_VALUE),
-                        null, Float.valueOf(9999999)}, Float.MAX_VALUE))
-        );
+        assertArrayEquals(new float[]{Float.MIN_VALUE, Float.MAX_VALUE, 9999999}, ArrayUtils.toPrimitive(new Float[]{Float.valueOf(Float.MIN_VALUE),
+                null, Float.valueOf(9999999)}, Float.MAX_VALUE));
     }
 
     @Test
@@ -4198,14 +4118,11 @@ public class ArrayUtilsTest {
                 ArrayUtils.EMPTY_FLOAT_OBJECT_ARRAY,
                 ArrayUtils.toObject(new float[0]));
 
-        assertTrue(
-                Arrays.equals(
-                        new Float[]{
-                                Float.valueOf(Float.MIN_VALUE),
-                                Float.valueOf(Float.MAX_VALUE),
-                                Float.valueOf(9999999)},
-                        ArrayUtils.toObject(
-                                new float[]{Float.MIN_VALUE, Float.MAX_VALUE, 9999999})));
+        assertArrayEquals(new Float[]{
+                Float.valueOf(Float.MIN_VALUE),
+                Float.valueOf(Float.MAX_VALUE),
+                Float.valueOf(9999999)}, ArrayUtils.toObject(
+                new float[]{Float.MIN_VALUE, Float.MAX_VALUE, 9999999}));
     }
 
     //  testToPrimitive/Object for double
@@ -4218,11 +4135,8 @@ public class ArrayUtilsTest {
         assertSame(ArrayUtils.EMPTY_DOUBLE_ARRAY,
                 ArrayUtils.toPrimitive(new Double[0]));
 
-        assertTrue(Arrays.equals(
-                new double[]{Double.MIN_VALUE, Double.MAX_VALUE, 9999999},
-                ArrayUtils.toPrimitive(new Double[]{Double.valueOf(Double.MIN_VALUE),
-                        Double.valueOf(Double.MAX_VALUE), Double.valueOf(9999999)}))
-        );
+        assertArrayEquals(new double[]{Double.MIN_VALUE, Double.MAX_VALUE, 9999999}, ArrayUtils.toPrimitive(new Double[]{Double.valueOf(Double.MIN_VALUE),
+                Double.valueOf(Double.MAX_VALUE), Double.valueOf(9999999)}));
 
         assertThrows(NullPointerException.class,
                 () -> ArrayUtils.toPrimitive(new Float[]{Float.valueOf(Float.MIN_VALUE), null}));
@@ -4236,16 +4150,11 @@ public class ArrayUtilsTest {
         assertSame(ArrayUtils.EMPTY_DOUBLE_ARRAY,
                 ArrayUtils.toPrimitive(new Double[0], 1));
 
-        assertTrue(Arrays.equals(
-                new double[]{Double.MIN_VALUE, Double.MAX_VALUE, 9999999},
-                ArrayUtils.toPrimitive(new Double[]{Double.valueOf(Double.MIN_VALUE),
-                        Double.valueOf(Double.MAX_VALUE), Double.valueOf(9999999)}, 1)));
+        assertArrayEquals(new double[]{Double.MIN_VALUE, Double.MAX_VALUE, 9999999}, ArrayUtils.toPrimitive(new Double[]{Double.valueOf(Double.MIN_VALUE),
+                Double.valueOf(Double.MAX_VALUE), Double.valueOf(9999999)}, 1));
 
-        assertTrue(Arrays.equals(
-                new double[]{Double.MIN_VALUE, Double.MAX_VALUE, 9999999},
-                ArrayUtils.toPrimitive(new Double[]{Double.valueOf(Double.MIN_VALUE),
-                        null, Double.valueOf(9999999)}, Double.MAX_VALUE))
-        );
+        assertArrayEquals(new double[]{Double.MIN_VALUE, Double.MAX_VALUE, 9999999}, ArrayUtils.toPrimitive(new Double[]{Double.valueOf(Double.MIN_VALUE),
+                null, Double.valueOf(9999999)}, Double.MAX_VALUE));
     }
 
     @Test
@@ -4257,14 +4166,11 @@ public class ArrayUtilsTest {
                 ArrayUtils.EMPTY_DOUBLE_OBJECT_ARRAY,
                 ArrayUtils.toObject(new double[0]));
 
-        assertTrue(
-                Arrays.equals(
-                        new Double[]{
-                                Double.valueOf(Double.MIN_VALUE),
-                                Double.valueOf(Double.MAX_VALUE),
-                                Double.valueOf(9999999)},
-                        ArrayUtils.toObject(
-                                new double[]{Double.MIN_VALUE, Double.MAX_VALUE, 9999999})));
+        assertArrayEquals(new Double[]{
+                Double.valueOf(Double.MIN_VALUE),
+                Double.valueOf(Double.MAX_VALUE),
+                Double.valueOf(9999999)}, ArrayUtils.toObject(
+                new double[]{Double.MIN_VALUE, Double.MAX_VALUE, 9999999}));
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/apache/commons/lang3/CharRangeTest.java
+++ b/src/test/java/org/apache/commons/lang3/CharRangeTest.java
@@ -154,12 +154,12 @@ public class CharRangeTest  {
         assertEquals(rangenotbf.hashCode(), rangenotbf.hashCode());
         assertEquals(rangenotbf.hashCode(), CharRange.isIn('b', 'f').hashCode());
 
-        assertFalse(rangea.hashCode() == rangeae.hashCode());
-        assertFalse(rangea.hashCode() == rangenotbf.hashCode());
-        assertFalse(rangeae.hashCode() == rangea.hashCode());
-        assertFalse(rangeae.hashCode() == rangenotbf.hashCode());
-        assertFalse(rangenotbf.hashCode() == rangea.hashCode());
-        assertFalse(rangenotbf.hashCode() == rangeae.hashCode());
+        assertNotEquals(rangea.hashCode(), rangeae.hashCode());
+        assertNotEquals(rangea.hashCode(), rangenotbf.hashCode());
+        assertNotEquals(rangeae.hashCode(), rangea.hashCode());
+        assertNotEquals(rangeae.hashCode(), rangenotbf.hashCode());
+        assertNotEquals(rangenotbf.hashCode(), rangea.hashCode());
+        assertNotEquals(rangenotbf.hashCode(), rangeae.hashCode());
     }
 
     //-----------------------------------------------------------------------
@@ -344,7 +344,7 @@ public class CharRangeTest  {
         assertTrue(notaIt.hasNext());
         while (notaIt.hasNext()) {
             final Character c = notaIt.next();
-            assertFalse('a' == c.charValue());
+            assertNotEquals('a', c.charValue());
         }
 
         final Iterator<Character> emptySetIt = emptySet.iterator();

--- a/src/test/java/org/apache/commons/lang3/ClassUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/ClassUtilsTest.java
@@ -30,7 +30,6 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -1294,9 +1293,9 @@ public class ClassUtilsTest  {
 //        assertNull("null -> null", ClassUtils.primitivesToWrappers(null)); // generates warning
         assertNull(ClassUtils.primitivesToWrappers((Class<?>[]) null), "null -> null"); // equivalent cast to avoid warning
         // Other possible casts for null
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_CLASS_ARRAY, ClassUtils.primitivesToWrappers()), "empty -> empty");
+        assertArrayEquals(ArrayUtils.EMPTY_CLASS_ARRAY, ClassUtils.primitivesToWrappers(), "empty -> empty");
         final Class<?>[] castNull = ClassUtils.primitivesToWrappers((Class<?>) null); // == new Class<?>[]{null}
-        assertTrue(Arrays.equals(new Class<?>[]{null}, castNull), "(Class<?>) null -> [null]");
+        assertArrayEquals(new Class<?>[]{null}, castNull, "(Class<?>) null -> [null]");
         // test empty array is returned unchanged
         assertArrayEquals(ArrayUtils.EMPTY_CLASS_ARRAY, ClassUtils.primitivesToWrappers(ArrayUtils.EMPTY_CLASS_ARRAY),
                 "empty -> empty");
@@ -1364,17 +1363,15 @@ public class ClassUtilsTest  {
         assertNull(ClassUtils.toClass((Object[]) null)); // equivalent explicit cast
 
         // Additional varargs tests
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_CLASS_ARRAY, ClassUtils.toClass()), "empty -> empty");
+        assertArrayEquals(ArrayUtils.EMPTY_CLASS_ARRAY, ClassUtils.toClass(), "empty -> empty");
         final Class<?>[] castNull = ClassUtils.toClass((Object) null); // == new Object[]{null}
-        assertTrue(Arrays.equals(new Object[]{null}, castNull), "(Object) null -> [null]");
+        assertArrayEquals(new Object[]{null}, castNull, "(Object) null -> [null]");
 
         assertSame(ArrayUtils.EMPTY_CLASS_ARRAY, ClassUtils.toClass(ArrayUtils.EMPTY_OBJECT_ARRAY));
 
-        assertTrue(Arrays.equals(new Class[] { String.class, Integer.class, Double.class },
-                ClassUtils.toClass("Test", Integer.valueOf(1), Double.valueOf(99d))));
+        assertArrayEquals(new Class[]{String.class, Integer.class, Double.class}, ClassUtils.toClass("Test", Integer.valueOf(1), Double.valueOf(99d)));
 
-        assertTrue(Arrays.equals(new Class[] { String.class, null, Double.class },
-                ClassUtils.toClass("Test", null, Double.valueOf(99d))));
+        assertArrayEquals(new Class[]{String.class, null, Double.class}, ClassUtils.toClass("Test", null, Double.valueOf(99d)));
     }
 
     @Test
@@ -1414,9 +1411,9 @@ public class ClassUtilsTest  {
 //        assertNull("Wrong result for null input", ClassUtils.wrappersToPrimitives(null)); // generates warning
         assertNull(ClassUtils.wrappersToPrimitives((Class<?>[]) null), "Wrong result for null input"); // equivalent cast
         // Other possible casts for null
-        assertTrue(Arrays.equals(ArrayUtils.EMPTY_CLASS_ARRAY, ClassUtils.wrappersToPrimitives()), "empty -> empty");
+        assertArrayEquals(ArrayUtils.EMPTY_CLASS_ARRAY, ClassUtils.wrappersToPrimitives(), "empty -> empty");
         final Class<?>[] castNull = ClassUtils.wrappersToPrimitives((Class<?>) null); // == new Class<?>[]{null}
-        assertTrue(Arrays.equals(new Class<?>[]{null}, castNull), "(Class<?>) null -> [null]");
+        assertArrayEquals(new Class<?>[]{null}, castNull, "(Class<?>) null -> [null]");
 }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/FunctionsTest.java
+++ b/src/test/java/org/apache/commons/lang3/FunctionsTest.java
@@ -26,8 +26,8 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 class FunctionsTest {
     public static class SomeException extends Exception {
@@ -117,30 +117,24 @@ class FunctionsTest {
     @Test
     void testRunnable() {
         FailureOnOddInvocations.invocation = 0;
-        try {
-            Functions.run(FailureOnOddInvocations::new);
-            fail("Expected Exception");
-        } catch (UndeclaredThrowableException e) {
-            final Throwable cause = e.getCause();
-            assertNotNull(cause);
-            assertTrue(cause instanceof SomeException);
-            assertEquals("Odd Invocation: 1", cause.getMessage());
-        }
+        UndeclaredThrowableException e = assertThrows(UndeclaredThrowableException.class, () ->  Functions.run(FailureOnOddInvocations::new));
+        final Throwable cause = e.getCause();
+        assertNotNull(cause);
+        assertTrue(cause instanceof SomeException);
+        assertEquals("Odd Invocation: 1", cause.getMessage());
+
+        // Even invocation, should not throw an exception
         Functions.run(FailureOnOddInvocations::new);
     }
 
     @Test
     void testCallable() {
         FailureOnOddInvocations.invocation = 0;
-        try {
-            Functions.call(FailureOnOddInvocations::new);
-            fail("Expected Exception");
-        } catch (UndeclaredThrowableException e) {
-            final Throwable cause = e.getCause();
-            assertNotNull(cause);
-            assertTrue(cause instanceof SomeException);
-            assertEquals("Odd Invocation: 1", cause.getMessage());
-        }
+        UndeclaredThrowableException e = assertThrows(UndeclaredThrowableException.class, () ->  Functions.run(FailureOnOddInvocations::new));
+        final Throwable cause = e.getCause();
+        assertNotNull(cause);
+        assertTrue(cause instanceof SomeException);
+        assertEquals("Odd Invocation: 1", cause.getMessage());
         final FailureOnOddInvocations instance = Functions.call(FailureOnOddInvocations::new);
         assertNotNull(instance);
     }
@@ -149,30 +143,21 @@ class FunctionsTest {
     void testAcceptConsumer() {
         final IllegalStateException ise = new IllegalStateException();
         final Testable testable = new Testable(ise);
-        try {
-            Functions.accept(Testable::test, testable);
-            fail("Expected Exception");
-        } catch (IllegalStateException e) {
-            assertSame(ise, e);
-        }
+        Throwable e = assertThrows(IllegalStateException.class, () -> Functions.accept(Testable::test, testable));
+        assertSame(ise, e);
+
         final Error error = new OutOfMemoryError();
         testable.setThrowable(error);
-        try {
-            Functions.accept(Testable::test, testable);
-        } catch (OutOfMemoryError e) {
-            assertSame(error, e);
-        }
+        e = assertThrows(OutOfMemoryError.class, () -> Functions.accept(Testable::test, testable));
+        assertSame(error, e);
+
         final IOException ioe = new IOException("Unknown I/O error");
         testable.setThrowable(ioe);
-        try {
-            Functions.accept(Testable::test, testable);
-            fail("Expected Exception");
-        } catch (UncheckedIOException e) {
-            final Throwable t = e.getCause();
-            assertNotNull(t);
-            assertTrue(t instanceof IOException);
-            assertSame(ioe, t);
-        }
+        e = assertThrows(UncheckedIOException.class, () -> Functions.accept(Testable::test, testable));
+        final Throwable t = e.getCause();
+        assertNotNull(t);
+        assertSame(ioe, t);
+
         testable.setThrowable(null);
         Functions.accept(Testable::test, testable);
     }
@@ -181,29 +166,20 @@ class FunctionsTest {
     void testAcceptBiConsumer() {
         final IllegalStateException ise = new IllegalStateException();
         final Testable testable = new Testable(null);
-        try {
-            Functions.accept(Testable::test, testable, ise);
-            fail("Expected Exception");
-        } catch (IllegalStateException e) {
-            assertSame(ise, e);
-        }
+        Throwable e = assertThrows(IllegalStateException.class, () -> Functions.accept(Testable::test, testable, ise));
+        assertSame(ise, e);
+
         final Error error = new OutOfMemoryError();
-        try {
-            Functions.accept(Testable::test, testable, error);
-        } catch (OutOfMemoryError e) {
-            assertSame(error, e);
-        }
+        e = assertThrows(OutOfMemoryError.class, () -> Functions.accept(Testable::test, testable, error));
+        assertSame(error, e);
+
         final IOException ioe = new IOException("Unknown I/O error");
         testable.setThrowable(ioe);
-        try {
-            Functions.accept(Testable::test, testable, ioe);
-            fail("Expected Exception");
-        } catch (UncheckedIOException e) {
-            final Throwable t = e.getCause();
-            assertNotNull(t);
-            assertTrue(t instanceof IOException);
-            assertSame(ioe, t);
-        }
+        e = assertThrows(UncheckedIOException.class, () -> Functions.accept(Testable::test, testable, ioe));
+        final Throwable t = e.getCause();
+        assertNotNull(t);
+        assertSame(ioe, t);
+
         testable.setThrowable(null);
         Functions.accept(Testable::test, testable, (Throwable) null);
     }
@@ -212,30 +188,21 @@ class FunctionsTest {
     public void testApplyFunction() {
         final IllegalStateException ise = new IllegalStateException();
         final Testable testable = new Testable(ise);
-        try {
-            Functions.apply(Testable::testInt, testable);
-            fail("Expected Exception");
-        } catch (IllegalStateException e) {
-            assertSame(ise, e);
-        }
+        Throwable e = assertThrows(IllegalStateException.class, () -> Functions.apply(Testable::testInt, testable));
+        assertSame(ise, e);
+
         final Error error = new OutOfMemoryError();
         testable.setThrowable(error);
-        try {
-            Functions.apply(Testable::testInt, testable);
-        } catch (OutOfMemoryError e) {
-            assertSame(error, e);
-        }
+        e = assertThrows(OutOfMemoryError.class, () -> Functions.apply(Testable::testInt, testable));
+        assertSame(error, e);
+
         final IOException ioe = new IOException("Unknown I/O error");
         testable.setThrowable(ioe);
-        try {
-            Functions.apply(Testable::testInt, testable);
-            fail("Expected Exception");
-        } catch (UncheckedIOException e) {
-            final Throwable t = e.getCause();
-            assertNotNull(t);
-            assertTrue(t instanceof IOException);
-            assertSame(ioe, t);
-        }
+        e = assertThrows(UncheckedIOException.class, () -> Functions.apply(Testable::testInt, testable));
+        final Throwable t = e.getCause();
+        assertNotNull(t);
+        assertSame(ioe, t);
+
         testable.setThrowable(null);
         final Integer i = Functions.apply(Testable::testInt, testable);
         assertNotNull(i);
@@ -246,28 +213,19 @@ class FunctionsTest {
     public void testApplyBiFunction() {
         final IllegalStateException ise = new IllegalStateException();
         final Testable testable = new Testable(null);
-        try {
-            Functions.apply(Testable::testInt, testable, ise);
-            fail("Expected Exception");
-        } catch (IllegalStateException e) {
-            assertSame(ise, e);
-        }
+        Throwable e = assertThrows(IllegalStateException.class, () -> Functions.apply(Testable::testInt, testable, ise));
+        assertSame(ise, e);
+
         final Error error = new OutOfMemoryError();
-        try {
-            Functions.apply(Testable::testInt, testable, error);
-        } catch (OutOfMemoryError e) {
-            assertSame(error, e);
-        }
+        e = assertThrows(OutOfMemoryError.class, () -> Functions.apply(Testable::testInt, testable, error));
+        assertSame(error, e);
+
         final IOException ioe = new IOException("Unknown I/O error");
-        try {
-            Functions.apply(Testable::testInt, testable, ioe);
-            fail("Expected Exception");
-        } catch (UncheckedIOException e) {
-            final Throwable t = e.getCause();
-            assertNotNull(t);
-            assertTrue(t instanceof IOException);
-            assertSame(ioe, t);
-        }
+        e = assertThrows(UncheckedIOException.class, () -> Functions.apply(Testable::testInt, testable, ioe));
+        final Throwable t = e.getCause();
+        assertNotNull(t);
+        assertSame(ioe, t);
+
         final Integer i = Functions.apply(Testable::testInt, testable, (Throwable) null);
         assertNotNull(i);
         assertEquals(0, i.intValue());
@@ -278,31 +236,22 @@ class FunctionsTest {
         final CloseableObject co = new CloseableObject();
         final FailableConsumer<Throwable, ? extends Throwable> consumer = co::run;
         final IllegalStateException ise = new IllegalStateException();
-        try {
-            Functions.tryWithResources(() -> consumer.accept(ise), co::close);
-            fail("Expected Exception");
-        } catch (IllegalStateException e) {
-            assertSame(ise, e);
-        }
+        Throwable e = assertThrows(IllegalStateException.class, () -> Functions.tryWithResources(() -> consumer.accept(ise), co::close));
+        assertSame(ise, e);
+
         assertTrue(co.isClosed());
         co.reset();
         final Error error = new OutOfMemoryError();
-        try {
-            Functions.tryWithResources(() -> consumer.accept(error), co::close);
-            fail("Expected Exception");
-        } catch (OutOfMemoryError e) {
-            assertSame(error, e);
-        }
+        e = assertThrows(OutOfMemoryError.class, () -> Functions.tryWithResources(() -> consumer.accept(error), co::close));
+        assertSame(error, e);
+
         assertTrue(co.isClosed());
         co.reset();
         final IOException ioe = new IOException("Unknown I/O error");
-        try {
-            Functions.tryWithResources(() -> consumer.accept(ioe), co::close);
-            fail("Expected Exception");
-        } catch (UncheckedIOException e) {
-            final IOException cause = e.getCause();
-            assertSame(ioe, cause);
-        }
+        UncheckedIOException uioe = assertThrows(UncheckedIOException.class, () ->  Functions.tryWithResources(() -> consumer.accept(ioe), co::close));
+        final IOException cause = uioe.getCause();
+        assertSame(ioe, cause);
+
         assertTrue(co.isClosed());
         co.reset();
         Functions.tryWithResources(() -> consumer.accept(null), co::close);

--- a/src/test/java/org/apache/commons/lang3/ObjectUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/ObjectUtilsTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.commons.lang3;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -518,7 +519,7 @@ public class ObjectUtilsTest {
      */
     @Test
     public void testCloneOfPrimitiveArray() {
-        assertTrue(Arrays.equals(new int[]{1}, ObjectUtils.clone(new int[]{1})));
+        assertArrayEquals(new int[]{1}, ObjectUtils.clone(new int[]{1}));
     }
 
     /**

--- a/src/test/java/org/apache/commons/lang3/RangeTest.java
+++ b/src/test/java/org/apache/commons/lang3/RangeTest.java
@@ -159,7 +159,7 @@ public class RangeTest {
     @Test
     public void testHashCode() {
         assertEquals(byteRange.hashCode(), byteRange2.hashCode());
-        assertFalse(byteRange.hashCode() == byteRange3.hashCode());
+        assertNotEquals(byteRange.hashCode(), byteRange3.hashCode());
 
         assertEquals(intRange.hashCode(), intRange.hashCode());
         assertTrue(intRange.hashCode() != 0);

--- a/src/test/java/org/apache/commons/lang3/StringUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringUtilsTest.java
@@ -2415,15 +2415,15 @@ public class StringUtilsTest {
 
     @Test
     public void testGetJaroWinklerDistance_StringString() {
-        assertTrue(0.93d == StringUtils.getJaroWinklerDistance("frog", "fog"));
-        assertTrue(0.0d == StringUtils.getJaroWinklerDistance("fly", "ant"));
-        assertTrue(0.44d == StringUtils.getJaroWinklerDistance("elephant", "hippo"));
-        assertTrue(0.84d == StringUtils.getJaroWinklerDistance("dwayne", "duane"));
-        assertTrue(0.93d == StringUtils.getJaroWinklerDistance("ABC Corporation", "ABC Corp"));
-        assertTrue(0.95d == StringUtils.getJaroWinklerDistance("D N H Enterprises Inc", "D & H Enterprises, Inc."));
-        assertTrue(0.92d == StringUtils.getJaroWinklerDistance("My Gym Children's Fitness Center", "My Gym. Childrens Fitness"));
-        assertTrue(0.88d == StringUtils.getJaroWinklerDistance("PENNSYLVANIA", "PENNCISYLVNIA"));
-        assertTrue(0.63d == StringUtils.getJaroWinklerDistance("Haus Ingeborg", "Ingeborg Esser"));
+        assertEquals(0.93d, StringUtils.getJaroWinklerDistance("frog", "fog"));
+        assertEquals(0.0d, StringUtils.getJaroWinklerDistance("fly", "ant"));
+        assertEquals(0.44d, StringUtils.getJaroWinklerDistance("elephant", "hippo"));
+        assertEquals(0.84d, StringUtils.getJaroWinklerDistance("dwayne", "duane"));
+        assertEquals(0.93d, StringUtils.getJaroWinklerDistance("ABC Corporation", "ABC Corp"));
+        assertEquals(0.95d, StringUtils.getJaroWinklerDistance("D N H Enterprises Inc", "D & H Enterprises, Inc."));
+        assertEquals(0.92d, StringUtils.getJaroWinklerDistance("My Gym Children's Fitness Center", "My Gym. Childrens Fitness"));
+        assertEquals(0.88d, StringUtils.getJaroWinklerDistance("PENNSYLVANIA", "PENNCISYLVNIA"));
+        assertEquals(0.63d, StringUtils.getJaroWinklerDistance("Haus Ingeborg", "Ingeborg Esser"));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/builder/EqualsBuilderTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/EqualsBuilderTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.commons.lang3.builder;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -23,7 +24,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.Method;
-import java.util.Arrays;
 
 import org.apache.commons.lang3.reflect.MethodUtils;
 import org.junit.jupiter.api.Test;
@@ -1194,10 +1194,10 @@ public class EqualsBuilderTest {
         final Object[] y = new Object[]{new TestBCanEqualA(1)};
 
         // sanity checks:
-        assertTrue(Arrays.equals(x, x));
-        assertTrue(Arrays.equals(y, y));
-        assertTrue(Arrays.equals(x, y));
-        assertTrue(Arrays.equals(y, x));
+        assertArrayEquals(x, x);
+        assertArrayEquals(y, y);
+        assertArrayEquals(x, y);
+        assertArrayEquals(y, x);
         // real tests:
         assertEquals(x[0], x[0]);
         assertEquals(y[0], y[0]);

--- a/src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java
@@ -98,19 +98,19 @@ public class NumberUtilsTest {
      */
     @Test
     public void testToFloatString() {
-        assertTrue(NumberUtils.toFloat("-1.2345") == -1.2345f, "toFloat(String) 1 failed");
-        assertTrue(NumberUtils.toFloat("1.2345") == 1.2345f, "toFloat(String) 2 failed");
-        assertTrue(NumberUtils.toFloat("abc") == 0.0f, "toFloat(String) 3 failed");
+        assertEquals(NumberUtils.toFloat("-1.2345"), -1.2345f, "toFloat(String) 1 failed");
+        assertEquals(1.2345f, NumberUtils.toFloat("1.2345"), "toFloat(String) 2 failed");
+        assertEquals(0.0f, NumberUtils.toFloat("abc"), "toFloat(String) 3 failed");
         // LANG-1060
-        assertTrue(NumberUtils.toFloat("-001.2345") == -1.2345f, "toFloat(String) 4 failed");
-        assertTrue(NumberUtils.toFloat("+001.2345") == 1.2345f, "toFloat(String) 5 failed");
-        assertTrue(NumberUtils.toFloat("001.2345") == 1.2345f, "toFloat(String) 6 failed");
-        assertTrue(NumberUtils.toFloat("000.00") == 0f, "toFloat(String) 7 failed");
+        assertEquals(NumberUtils.toFloat("-001.2345"), -1.2345f, "toFloat(String) 4 failed");
+        assertEquals(1.2345f, NumberUtils.toFloat("+001.2345"), "toFloat(String) 5 failed");
+        assertEquals(1.2345f, NumberUtils.toFloat("001.2345"), "toFloat(String) 6 failed");
+        assertEquals(0f, NumberUtils.toFloat("000.00"), "toFloat(String) 7 failed");
 
-        assertTrue(NumberUtils.toFloat(Float.MAX_VALUE+"") ==  Float.MAX_VALUE, "toFloat(Float.MAX_VALUE) failed");
-        assertTrue(NumberUtils.toFloat(Float.MIN_VALUE+"") == Float.MIN_VALUE, "toFloat(Float.MIN_VALUE) failed");
-        assertTrue(NumberUtils.toFloat("") == 0.0f, "toFloat(empty) failed");
-        assertTrue(NumberUtils.toFloat(null) == 0.0f, "toFloat(null) failed");
+        assertEquals(NumberUtils.toFloat(Float.MAX_VALUE + ""), Float.MAX_VALUE, "toFloat(Float.MAX_VALUE) failed");
+        assertEquals(NumberUtils.toFloat(Float.MIN_VALUE + ""), Float.MIN_VALUE, "toFloat(Float.MIN_VALUE) failed");
+        assertEquals(0.0f, NumberUtils.toFloat(""), "toFloat(empty) failed");
+        assertEquals(0.0f, NumberUtils.toFloat(null), "toFloat(null) failed");
     }
 
     /**
@@ -118,12 +118,12 @@ public class NumberUtilsTest {
      */
     @Test
     public void testToFloatStringF() {
-        assertTrue(NumberUtils.toFloat("1.2345", 5.1f) == 1.2345f, "toFloat(String, int) 1 failed");
-        assertTrue(NumberUtils.toFloat("a", 5.0f) == 5.0f, "toFloat(String, int) 2 failed");
+        assertEquals(1.2345f, NumberUtils.toFloat("1.2345", 5.1f), "toFloat(String, int) 1 failed");
+        assertEquals(5.0f, NumberUtils.toFloat("a", 5.0f), "toFloat(String, int) 2 failed");
         // LANG-1060
-        assertTrue(NumberUtils.toFloat("-001Z.2345", 5.0f) == 5.0f, "toFloat(String, int) 3 failed");
-        assertTrue(NumberUtils.toFloat("+001AB.2345", 5.0f) == 5.0f, "toFloat(String, int) 4 failed");
-        assertTrue(NumberUtils.toFloat("001Z.2345", 5.0f) == 5.0f, "toFloat(String, int) 5 failed");
+        assertEquals(5.0f, NumberUtils.toFloat("-001Z.2345", 5.0f), "toFloat(String, int) 3 failed");
+        assertEquals(5.0f, NumberUtils.toFloat("+001AB.2345", 5.0f), "toFloat(String, int) 4 failed");
+        assertEquals(5.0f, NumberUtils.toFloat("001Z.2345", 5.0f), "toFloat(String, int) 5 failed");
     }
 
     /**
@@ -153,19 +153,19 @@ public class NumberUtilsTest {
      */
     @Test
     public void testStringToDoubleString() {
-        assertTrue(NumberUtils.toDouble("-1.2345") == -1.2345d, "toDouble(String) 1 failed");
-        assertTrue(NumberUtils.toDouble("1.2345") == 1.2345d, "toDouble(String) 2 failed");
-        assertTrue(NumberUtils.toDouble("abc") == 0.0d, "toDouble(String) 3 failed");
+        assertEquals(NumberUtils.toDouble("-1.2345"), -1.2345d, "toDouble(String) 1 failed");
+        assertEquals(1.2345d, NumberUtils.toDouble("1.2345"), "toDouble(String) 2 failed");
+        assertEquals(0.0d, NumberUtils.toDouble("abc"), "toDouble(String) 3 failed");
         // LANG-1060
-        assertTrue(NumberUtils.toDouble("-001.2345") == -1.2345d, "toDouble(String) 4 failed");
-        assertTrue(NumberUtils.toDouble("+001.2345") == 1.2345d, "toDouble(String) 5 failed");
-        assertTrue(NumberUtils.toDouble("001.2345") == 1.2345d, "toDouble(String) 6 failed");
-        assertTrue(NumberUtils.toDouble("000.00000") == 0d, "toDouble(String) 7 failed");
+        assertEquals(NumberUtils.toDouble("-001.2345"), -1.2345d, "toDouble(String) 4 failed");
+        assertEquals(1.2345d, NumberUtils.toDouble("+001.2345"), "toDouble(String) 5 failed");
+        assertEquals(1.2345d, NumberUtils.toDouble("001.2345"), "toDouble(String) 6 failed");
+        assertEquals(0d, NumberUtils.toDouble("000.00000"), "toDouble(String) 7 failed");
 
-        assertTrue(NumberUtils.toDouble(Double.MAX_VALUE+"") == Double.MAX_VALUE, "toDouble(Double.MAX_VALUE) failed");
-        assertTrue(NumberUtils.toDouble(Double.MIN_VALUE+"") == Double.MIN_VALUE, "toDouble(Double.MIN_VALUE) failed");
-        assertTrue(NumberUtils.toDouble("") == 0.0d, "toDouble(empty) failed");
-        assertTrue(NumberUtils.toDouble((String) null) == 0.0d, "toDouble(null) failed");
+        assertEquals(NumberUtils.toDouble(Double.MAX_VALUE + ""), Double.MAX_VALUE, "toDouble(Double.MAX_VALUE) failed");
+        assertEquals(NumberUtils.toDouble(Double.MIN_VALUE + ""), Double.MIN_VALUE, "toDouble(Double.MIN_VALUE) failed");
+        assertEquals(0.0d, NumberUtils.toDouble(""), "toDouble(empty) failed");
+        assertEquals(0.0d, NumberUtils.toDouble((String) null), "toDouble(null) failed");
     }
 
     /**
@@ -173,13 +173,13 @@ public class NumberUtilsTest {
      */
     @Test
     public void testStringToDoubleStringD() {
-        assertTrue(NumberUtils.toDouble("1.2345", 5.1d) == 1.2345d, "toDouble(String, int) 1 failed");
-        assertTrue(NumberUtils.toDouble("a", 5.0d) == 5.0d, "toDouble(String, int) 2 failed");
+        assertEquals(1.2345d, NumberUtils.toDouble("1.2345", 5.1d), "toDouble(String, int) 1 failed");
+        assertEquals(5.0d, NumberUtils.toDouble("a", 5.0d), "toDouble(String, int) 2 failed");
         // LANG-1060
-        assertTrue(NumberUtils.toDouble("001.2345", 5.1d) == 1.2345d, "toDouble(String, int) 3 failed");
-        assertTrue(NumberUtils.toDouble("-001.2345", 5.1d) == -1.2345d, "toDouble(String, int) 4 failed");
-        assertTrue(NumberUtils.toDouble("+001.2345", 5.1d) == 1.2345d, "toDouble(String, int) 5 failed");
-        assertTrue(NumberUtils.toDouble("000.00", 5.1d) == 0d, "toDouble(String, int) 7 failed");
+        assertEquals(1.2345d, NumberUtils.toDouble("001.2345", 5.1d), "toDouble(String, int) 3 failed");
+        assertEquals(NumberUtils.toDouble("-001.2345", 5.1d), -1.2345d, "toDouble(String, int) 4 failed");
+        assertEquals(1.2345d, NumberUtils.toDouble("+001.2345", 5.1d), "toDouble(String, int) 5 failed");
+        assertEquals(0d, NumberUtils.toDouble("000.00", 5.1d), "toDouble(String, int) 7 failed");
     }
 
     /**
@@ -187,8 +187,8 @@ public class NumberUtilsTest {
      */
     @Test
     public void testBigIntegerToDoubleBigInteger() {
-        assertTrue(NumberUtils.toDouble((BigDecimal) null) == 0.0d, "toDouble(BigInteger) 1 failed");
-        assertTrue(NumberUtils.toDouble(BigDecimal.valueOf(8.5d)) == 8.5d, "toDouble(BigInteger) 2 failed");
+        assertEquals(0.0d, NumberUtils.toDouble((BigDecimal) null), "toDouble(BigInteger) 1 failed");
+        assertEquals(8.5d, NumberUtils.toDouble(BigDecimal.valueOf(8.5d)), "toDouble(BigInteger) 2 failed");
     }
 
     /**
@@ -196,8 +196,8 @@ public class NumberUtilsTest {
      */
     @Test
     public void testBigIntegerToDoubleBigIntegerD() {
-        assertTrue(NumberUtils.toDouble((BigDecimal) null, 1.1d) == 1.1d, "toDouble(BigInteger) 1 failed");
-        assertTrue(NumberUtils.toDouble(BigDecimal.valueOf(8.5d), 1.1d) == 8.5d, "toDouble(BigInteger) 2 failed");
+        assertEquals(1.1d, NumberUtils.toDouble((BigDecimal) null, 1.1d), "toDouble(BigInteger) 1 failed");
+        assertEquals(8.5d, NumberUtils.toDouble(BigDecimal.valueOf(8.5d), 1.1d), "toDouble(BigInteger) 2 failed");
     }
 
      /**
@@ -1511,12 +1511,12 @@ public class NumberUtilsTest {
         assertEquals(0, NumberUtils.BYTE_ZERO.byteValue());
         assertEquals(1, NumberUtils.BYTE_ONE.byteValue());
         assertEquals(NumberUtils.BYTE_MINUS_ONE.byteValue(), -1);
-        assertTrue(0.0d == NumberUtils.DOUBLE_ZERO.doubleValue());
-        assertTrue(1.0d == NumberUtils.DOUBLE_ONE.doubleValue());
-        assertTrue(NumberUtils.DOUBLE_MINUS_ONE.doubleValue() == -1.0d);
-        assertTrue(0.0f == NumberUtils.FLOAT_ZERO.floatValue());
-        assertTrue(1.0f == NumberUtils.FLOAT_ONE.floatValue());
-        assertTrue(NumberUtils.FLOAT_MINUS_ONE.floatValue() == -1.0f);
+        assertEquals(0.0d, NumberUtils.DOUBLE_ZERO.doubleValue());
+        assertEquals(1.0d, NumberUtils.DOUBLE_ONE.doubleValue());
+        assertEquals(NumberUtils.DOUBLE_MINUS_ONE.doubleValue(), -1.0d);
+        assertEquals(0.0f, NumberUtils.FLOAT_ZERO.floatValue());
+        assertEquals(1.0f, NumberUtils.FLOAT_ONE.floatValue());
+        assertEquals(NumberUtils.FLOAT_MINUS_ONE.floatValue(), -1.0f);
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/mutable/MutableBooleanTest.java
+++ b/src/test/java/org/apache/commons/lang3/mutable/MutableBooleanTest.java
@@ -131,7 +131,7 @@ public class MutableBooleanTest {
 
         assertEquals(mutBoolA.hashCode(), mutBoolA.hashCode());
         assertEquals(mutBoolA.hashCode(), mutBoolB.hashCode());
-        assertFalse(mutBoolA.hashCode() == mutBoolC.hashCode());
+        assertNotEquals(mutBoolA.hashCode(), mutBoolC.hashCode());
         assertEquals(mutBoolA.hashCode(), Boolean.FALSE.hashCode());
         assertEquals(mutBoolC.hashCode(), Boolean.TRUE.hashCode());
     }

--- a/src/test/java/org/apache/commons/lang3/mutable/MutableByteTest.java
+++ b/src/test/java/org/apache/commons/lang3/mutable/MutableByteTest.java
@@ -19,7 +19,6 @@ package org.apache.commons.lang3.mutable;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -100,7 +99,7 @@ public class MutableByteTest {
 
         assertEquals(mutNumA.hashCode(), mutNumA.hashCode());
         assertEquals(mutNumA.hashCode(), mutNumB.hashCode());
-        assertFalse(mutNumA.hashCode() == mutNumC.hashCode());
+        assertNotEquals(mutNumA.hashCode(), mutNumC.hashCode());
         assertEquals(mutNumA.hashCode(), Byte.valueOf((byte) 0).hashCode());
     }
 

--- a/src/test/java/org/apache/commons/lang3/mutable/MutableDoubleTest.java
+++ b/src/test/java/org/apache/commons/lang3/mutable/MutableDoubleTest.java
@@ -19,7 +19,6 @@ package org.apache.commons.lang3.mutable;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -113,7 +112,7 @@ public class MutableDoubleTest {
 
         assertEquals(mutNumA.hashCode(), mutNumA.hashCode());
         assertEquals(mutNumA.hashCode(), mutNumB.hashCode());
-        assertFalse(mutNumA.hashCode() == mutNumC.hashCode());
+        assertNotEquals(mutNumA.hashCode(), mutNumC.hashCode());
         assertEquals(mutNumA.hashCode(), Double.valueOf(0d).hashCode());
     }
 

--- a/src/test/java/org/apache/commons/lang3/mutable/MutableFloatTest.java
+++ b/src/test/java/org/apache/commons/lang3/mutable/MutableFloatTest.java
@@ -19,7 +19,6 @@ package org.apache.commons.lang3.mutable;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -113,7 +112,7 @@ public class MutableFloatTest {
 
         assertEquals(mutNumA.hashCode(), mutNumA.hashCode());
         assertEquals(mutNumA.hashCode(), mutNumB.hashCode());
-        assertFalse(mutNumA.hashCode() == mutNumC.hashCode());
+        assertNotEquals(mutNumA.hashCode(), mutNumC.hashCode());
         assertEquals(mutNumA.hashCode(), Float.valueOf(0f).hashCode());
     }
 

--- a/src/test/java/org/apache/commons/lang3/mutable/MutableIntTest.java
+++ b/src/test/java/org/apache/commons/lang3/mutable/MutableIntTest.java
@@ -19,7 +19,6 @@ package org.apache.commons.lang3.mutable;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -107,7 +106,7 @@ public class MutableIntTest {
 
         assertEquals(mutNumA.hashCode(), mutNumA.hashCode());
         assertEquals(mutNumA.hashCode(), mutNumB.hashCode());
-        assertFalse(mutNumA.hashCode() == mutNumC.hashCode());
+        assertNotEquals(mutNumA.hashCode(), mutNumC.hashCode());
         assertEquals(mutNumA.hashCode(), Integer.valueOf(0).hashCode());
     }
 

--- a/src/test/java/org/apache/commons/lang3/mutable/MutableLongTest.java
+++ b/src/test/java/org/apache/commons/lang3/mutable/MutableLongTest.java
@@ -19,7 +19,6 @@ package org.apache.commons.lang3.mutable;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -100,7 +99,7 @@ public class MutableLongTest {
 
         assertEquals(mutNumA.hashCode(), mutNumA.hashCode());
         assertEquals(mutNumA.hashCode(), mutNumB.hashCode());
-        assertFalse(mutNumA.hashCode() == mutNumC.hashCode());
+        assertNotEquals(mutNumA.hashCode(), mutNumC.hashCode());
         assertEquals(mutNumA.hashCode(), Long.valueOf(0).hashCode());
     }
 

--- a/src/test/java/org/apache/commons/lang3/mutable/MutableObjectTest.java
+++ b/src/test/java/org/apache/commons/lang3/mutable/MutableObjectTest.java
@@ -17,10 +17,9 @@
 package org.apache.commons.lang3.mutable;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
@@ -62,19 +61,19 @@ public class MutableObjectTest {
         final MutableObject<String> mutNumC = new MutableObject<>("BETA");
         final MutableObject<String> mutNumD = new MutableObject<>(null);
 
-        assertTrue(mutNumA.equals(mutNumA));
-        assertTrue(mutNumA.equals(mutNumB));
-        assertTrue(mutNumB.equals(mutNumA));
-        assertTrue(mutNumB.equals(mutNumB));
-        assertFalse(mutNumA.equals(mutNumC));
-        assertFalse(mutNumB.equals(mutNumC));
-        assertTrue(mutNumC.equals(mutNumC));
-        assertFalse(mutNumA.equals(mutNumD));
-        assertTrue(mutNumD.equals(mutNumD));
+        assertEquals(mutNumA, mutNumA);
+        assertEquals(mutNumA, mutNumB);
+        assertEquals(mutNumB, mutNumA);
+        assertEquals(mutNumB, mutNumB);
+        assertNotEquals(mutNumA, mutNumC);
+        assertNotEquals(mutNumB, mutNumC);
+        assertEquals(mutNumC, mutNumC);
+        assertNotEquals(mutNumA, mutNumD);
+        assertEquals(mutNumD, mutNumD);
 
-        assertFalse(mutNumA.equals(null));
-        assertFalse(mutNumA.equals(new Object()));
-        assertFalse(mutNumA.equals("0"));
+        assertNotEquals(null, mutNumA);
+        assertNotEquals(mutNumA, new Object());
+        assertNotEquals("0", mutNumA);
     }
 
     @Test
@@ -84,11 +83,11 @@ public class MutableObjectTest {
         final MutableObject<String> mutNumC = new MutableObject<>("BETA");
         final MutableObject<String> mutNumD = new MutableObject<>(null);
 
-        assertTrue(mutNumA.hashCode() == mutNumA.hashCode());
-        assertTrue(mutNumA.hashCode() == mutNumB.hashCode());
-        assertFalse(mutNumA.hashCode() == mutNumC.hashCode());
-        assertFalse(mutNumA.hashCode() == mutNumD.hashCode());
-        assertTrue(mutNumA.hashCode() == "ALPHA".hashCode());
+        assertEquals(mutNumA.hashCode(), mutNumA.hashCode());
+        assertEquals(mutNumA.hashCode(), mutNumB.hashCode());
+        assertNotEquals(mutNumA.hashCode(), mutNumC.hashCode());
+        assertNotEquals(mutNumA.hashCode(), mutNumD.hashCode());
+        assertEquals(mutNumA.hashCode(), "ALPHA".hashCode());
         assertEquals(0, mutNumD.hashCode());
     }
 

--- a/src/test/java/org/apache/commons/lang3/mutable/MutableShortTest.java
+++ b/src/test/java/org/apache/commons/lang3/mutable/MutableShortTest.java
@@ -19,7 +19,6 @@ package org.apache.commons.lang3.mutable;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -91,7 +90,7 @@ public class MutableShortTest {
 
         assertEquals(mutNumA.hashCode(), mutNumA.hashCode());
         assertEquals(mutNumA.hashCode(), mutNumB.hashCode());
-        assertFalse(mutNumA.hashCode() == mutNumC.hashCode());
+        assertNotEquals(mutNumA.hashCode(), mutNumC.hashCode());
         assertEquals(mutNumA.hashCode(), Short.valueOf((short) 0).hashCode());
     }
 

--- a/src/test/java/org/apache/commons/lang3/reflect/ConstructorUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/reflect/ConstructorUtilsTest.java
@@ -21,7 +21,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.Constructor;
 import java.util.Arrays;
@@ -269,8 +268,7 @@ public class ConstructorUtilsTest {
             final Class<?>[] requestTypes, final Class<?>[] actualTypes) {
         final Constructor<?> c = ConstructorUtils.getMatchingAccessibleConstructor(cls,
                 requestTypes);
-        assertTrue(Arrays.equals(actualTypes, c.getParameterTypes()),
-                toString(c.getParameterTypes()) + " not equals " + toString(actualTypes));
+        assertArrayEquals(actualTypes, c.getParameterTypes(), toString(c.getParameterTypes()) + " not equals " + toString(actualTypes));
     }
 
     private String toString(final Class<?>[] c) {

--- a/src/test/java/org/apache/commons/lang3/reflect/MethodUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/reflect/MethodUtilsTest.java
@@ -892,8 +892,7 @@ public class MethodUtilsTest {
                 requestTypes);
         assertNotNull(m, "could not find any matches for " + methodName
                 + " (" + (requestTypes == null ? null : toString(requestTypes)) + ")");
-        assertTrue(Arrays.equals(actualTypes, m.getParameterTypes()),
-                toString(m.getParameterTypes()) + " not equals " + toString(actualTypes));
+        assertArrayEquals(actualTypes, m.getParameterTypes(), toString(m.getParameterTypes()) + " not equals " + toString(actualTypes));
     }
 
     private String toString(final Class<?>[] c) {

--- a/src/test/java/org/apache/commons/lang3/text/ExtendedMessageFormatTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/ExtendedMessageFormatTest.java
@@ -20,7 +20,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.text.DateFormat;
@@ -317,12 +316,12 @@ public class ExtendedMessageFormatTest {
         // Different pattern
         other = new ExtendedMessageFormat("X" + pattern, Locale.US, fmtRegistry);
         assertNotEquals(emf, other, "pattern, equals()");
-        assertFalse(emf.hashCode() == other.hashCode(), "pattern, hashcode()");
+        assertNotEquals(emf.hashCode(), other.hashCode(), "pattern, hashcode()");
 
         // Different registry
         other = new ExtendedMessageFormat(pattern, Locale.US, otherRegitry);
         assertNotEquals(emf, other, "registry, equals()");
-        assertFalse(emf.hashCode() == other.hashCode(), "registry, hashcode()");
+        assertNotEquals(emf.hashCode(), other.hashCode(), "registry, hashcode()");
 
         // Different Locale
         other = new ExtendedMessageFormat(pattern, Locale.FRANCE, fmtRegistry);

--- a/src/test/java/org/apache/commons/lang3/text/StrBuilderTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/StrBuilderTest.java
@@ -19,6 +19,7 @@ package org.apache.commons.lang3.text;
 
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -35,7 +36,6 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.nio.CharBuffer;
-import java.util.Arrays;
 
 import org.apache.commons.lang3.ArrayUtils;
 
@@ -457,7 +457,7 @@ public class StrBuilderTest {
         sb.append("junit");
         a = sb.toCharArray();
         assertEquals(5, a.length, "toCharArray() result incorrect length");
-        assertTrue(Arrays.equals("junit".toCharArray(), a), "toCharArray() result does not match");
+        assertArrayEquals("junit".toCharArray(), a, "toCharArray() result does not match");
     }
 
     @Test
@@ -468,15 +468,15 @@ public class StrBuilderTest {
         sb.append("junit");
         char[] a = sb.toCharArray(0, 20); // too large test
         assertEquals(5, a.length, "toCharArray(int, int) result incorrect length");
-        assertTrue(Arrays.equals("junit".toCharArray(), a), "toCharArray(int, int) result does not match");
+        assertArrayEquals("junit".toCharArray(), a, "toCharArray(int, int) result does not match");
 
         a = sb.toCharArray(0, 4);
         assertEquals(4, a.length, "toCharArray(int, int) result incorrect length");
-        assertTrue(Arrays.equals("juni".toCharArray(), a), "toCharArray(int, int) result does not match");
+        assertArrayEquals("juni".toCharArray(), a, "toCharArray(int, int) result does not match");
 
         a = sb.toCharArray(0, 4);
         assertEquals(4, a.length, "toCharArray(int, int) result incorrect length");
-        assertTrue(Arrays.equals("juni".toCharArray(), a), "toCharArray(int, int) result does not match");
+        assertArrayEquals("juni".toCharArray(), a, "toCharArray(int, int) result does not match");
 
         a = sb.toCharArray(0, 1);
         assertNotNull(a, "toCharArray(int, int) result is null");
@@ -495,17 +495,17 @@ public class StrBuilderTest {
         char[] input = new char[10];
         char[] a = sb.getChars(input);
         assertSame (input, a);
-        assertTrue(Arrays.equals(new char[10], a));
+        assertArrayEquals(new char[10], a);
 
         sb.append("junit");
         a = sb.getChars(input);
         assertSame(input, a);
-        assertTrue(Arrays.equals(new char[] {'j', 'u', 'n', 'i', 't', 0, 0, 0, 0, 0}, a));
+        assertArrayEquals(new char[]{'j', 'u', 'n', 'i', 't', 0, 0, 0, 0, 0}, a);
 
         a = sb.getChars(null);
         assertNotSame(input, a);
         assertEquals(5, a.length);
-        assertTrue(Arrays.equals("junit".toCharArray(), a));
+        assertArrayEquals("junit".toCharArray(), a);
 
         input = new char[5];
         a = sb.getChars(input);
@@ -523,11 +523,11 @@ public class StrBuilderTest {
         sb.append("junit");
         char[] a = new char[5];
         sb.getChars(0, 5, a, 0);
-        assertTrue(Arrays.equals(new char[] {'j', 'u', 'n', 'i', 't'}, a));
+        assertArrayEquals(new char[]{'j', 'u', 'n', 'i', 't'}, a);
 
         final char[] b = new char[5];
         sb.getChars(0, 2, b, 3);
-        assertTrue(Arrays.equals(new char[] {0, 0, 0, 'j', 'u'}, b));
+        assertArrayEquals(new char[]{0, 0, 0, 'j', 'u'}, b);
 
         assertThrows(IndexOutOfBoundsException.class, () -> sb.getChars(-1, 0, b, 0));
         assertThrows(IndexOutOfBoundsException.class, () -> sb.getChars(0, -1, b, 0));

--- a/src/test/java/org/apache/commons/lang3/tuple/PairTest.java
+++ b/src/test/java/org/apache/commons/lang3/tuple/PairTest.java
@@ -17,7 +17,6 @@
 package org.apache.commons.lang3.tuple;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -58,7 +57,7 @@ public class PairTest {
 
         pair2.setValue("bar");
         assertNotEquals(pair, pair2);
-        assertFalse(pair.hashCode() == pair2.hashCode());
+        assertNotEquals(pair.hashCode(), pair2.hashCode());
     }
 
     @Test


### PR DESCRIPTION
Use JUnit features to clean up the assertions in the test so they are easier to read and maintain, and to produce better failure messages in case an assertion fails:

- `assertArraysEqual(x, y)` was used to replace `assertTrue(Arrays.equals(x, y))`
- `assertEquals(x, y)` was used to replace `assertTrue(x == y)`
- `assertNotEquals(x, y)` was used to replace `assertFalse(x == y)`
- Assertions in `FunctionsTest` were rewritten to use `assertThrows` instead of the boilerplate template of throwing an exception in a `try` block, `fail`ing after that statement to make sure the exception was thrown and asserting the properties of the exception in the `catch` block.

