### PR TITLE
LANG-1435: Implemented defaultIfNull method that uses a supplier for default value

### DIFF
--- a/src/main/java/org/apache/commons/lang3/ObjectUtils.java
+++ b/src/main/java/org/apache/commons/lang3/ObjectUtils.java
@@ -180,11 +180,11 @@ public class ObjectUtils {
      *  <p>Returns a default value if the object passed is {@code null}.</p>
      *
      * <pre>
-     * ObjectUtils.defaultIfNull(null, () -> null) = null
-     * ObjectUtils.defaultIfNull(null, () -> "")   = ""
-     * ObjectUtils.defaultIfNull(null, () -> "zz") = "zz"
-     * ObjectUtils.defaultIfNull("abc", *)         = "abc"
-     * ObjectUtils.defaultIfNull(Boolean.TRUE, *)  = Boolean.TRUE
+     * {@code ObjectUtils.getDefaultIfNull(null, () -> null)} = null
+     * {@code ObjectUtils.getDefaultIfNull(null, () -> "")  } = ""
+     * {@code ObjectUtils.getDefaultIfNull(null, () -> "zz")} = "zz"
+     * {@code ObjectUtils.getDefaultIfNull("abc", *)        } = "abc"
+     * {@code ObjectUtils.getDefaultIfNull(Boolean.TRUE, *) } = Boolean.TRUE
      * </pre>
      *
      * @param object  the {@code Object} to test, may be {@code null}

--- a/src/main/java/org/apache/commons/lang3/ObjectUtils.java
+++ b/src/main/java/org/apache/commons/lang3/ObjectUtils.java
@@ -193,7 +193,7 @@ public class ObjectUtils {
      * @param <T>  the type of the object
      * @return {@code object} if it is not {@code null}, value returned by defaultValueSupplier otherwise
      */
-    public static <T> T defaultIfNull(final T object, final Supplier<T> defaultValueSupplier) {
+    public static <T> T getDefaultIfNull(final T object, final Supplier<T> defaultValueSupplier) {
         return object != null ? object : defaultValueSupplier.get();
     }
 

--- a/src/main/java/org/apache/commons/lang3/ObjectUtils.java
+++ b/src/main/java/org/apache/commons/lang3/ObjectUtils.java
@@ -27,6 +27,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeSet;
+import java.util.function.Supplier;
 
 import org.apache.commons.lang3.exception.CloneFailedException;
 import org.apache.commons.lang3.mutable.MutableInt;
@@ -173,6 +174,27 @@ public class ObjectUtils {
      */
     public static <T> T defaultIfNull(final T object, final T defaultValue) {
         return object != null ? object : defaultValue;
+    }
+
+    /**
+     *  <p>Returns a default value if the object passed is {@code null}.</p>
+     *
+     * <pre>
+     * ObjectUtils.defaultIfNull(null, () -> null) = null
+     * ObjectUtils.defaultIfNull(null, () -> "")   = ""
+     * ObjectUtils.defaultIfNull(null, () -> "zz") = "zz"
+     * ObjectUtils.defaultIfNull("abc", *)         = "abc"
+     * ObjectUtils.defaultIfNull(Boolean.TRUE, *)  = Boolean.TRUE
+     * </pre>
+     *
+     * @param object  the {@code Object} to test, may be {@code null}
+     * @param defaultValueSupplier  a supplier that gives the default value to return, may not be {@code null},
+     *                              but may result in a {@code null} value
+     * @param <T>  the type of the object
+     * @return {@code object} if it is not {@code null}, value returned by defaultValueSupplier otherwise
+     */
+    public static <T> T defaultIfNull(final T object, final Supplier<T> defaultValueSupplier) {
+        return object != null ? object : defaultValueSupplier.get();
     }
 
     /**

--- a/src/test/java/org/apache/commons/lang3/ObjectUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/ObjectUtilsTest.java
@@ -45,6 +45,7 @@ import org.apache.commons.lang3.exception.CloneFailedException;
 import org.apache.commons.lang3.mutable.MutableObject;
 import org.apache.commons.lang3.text.StrBuilder;
 import org.junit.jupiter.api.Test;
+import org.opentest4j.AssertionFailedError;
 
 /**
  * Unit tests {@link org.apache.commons.lang3.ObjectUtils}.
@@ -114,6 +115,17 @@ public class ObjectUtilsTest {
         final Object dflt = BAR;
         assertSame(dflt, ObjectUtils.defaultIfNull(null, dflt), "dflt was not returned when o was null");
         assertSame(o, ObjectUtils.defaultIfNull(o, dflt), "dflt was returned when o was not null");
+    }
+
+    @Test
+    public void testDefaultIfNull() {
+        final Object o = FOO;
+        final Object dflt = BAR;
+        assertSame(o, ObjectUtils.defaultIfNull(o, () -> null));
+        assertSame(o, ObjectUtils.defaultIfNull(o, () -> { throw new AssertionFailedError("This supplier should have never been executed"); }));
+        assertSame(Boolean.TRUE, ObjectUtils.defaultIfNull(Boolean.TRUE, () -> { throw new AssertionFailedError("This supplier should have never been executed"); }));
+        assertNull(ObjectUtils.defaultIfNull(null, () -> null));
+        assertSame(dflt, ObjectUtils.defaultIfNull(null, () -> dflt));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/ObjectUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/ObjectUtilsTest.java
@@ -110,7 +110,7 @@ public class ObjectUtilsTest {
 
     //-----------------------------------------------------------------------
     @Test
-    public void testIsNull() {
+    public void testDefaultIfNull() {
         final Object o = FOO;
         final Object dflt = BAR;
         assertSame(dflt, ObjectUtils.defaultIfNull(null, dflt), "dflt was not returned when o was null");
@@ -118,7 +118,7 @@ public class ObjectUtilsTest {
     }
 
     @Test
-    public void testDefaultIfNull() {
+    public void testGetDefaultIfNull() {
         final Object o = FOO;
         final Object dflt = BAR;
         assertSame(o, ObjectUtils.getDefaultIfNull(o, () -> null));

--- a/src/test/java/org/apache/commons/lang3/ObjectUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/ObjectUtilsTest.java
@@ -121,11 +121,15 @@ public class ObjectUtilsTest {
     public void testDefaultIfNull() {
         final Object o = FOO;
         final Object dflt = BAR;
-        assertSame(o, ObjectUtils.defaultIfNull(o, () -> null));
-        assertSame(o, ObjectUtils.defaultIfNull(o, () -> { throw new AssertionFailedError("This supplier should have never been executed"); }));
-        assertSame(Boolean.TRUE, ObjectUtils.defaultIfNull(Boolean.TRUE, () -> { throw new AssertionFailedError("This supplier should have never been executed"); }));
-        assertNull(ObjectUtils.defaultIfNull(null, () -> null));
-        assertSame(dflt, ObjectUtils.defaultIfNull(null, () -> dflt));
+        assertSame(o, ObjectUtils.getDefaultIfNull(o, () -> null));
+        assertSame(o, ObjectUtils.getDefaultIfNull(o, () -> {
+            throw new AssertionFailedError("This supplier should have never been executed");
+        }));
+        assertSame(Boolean.TRUE, ObjectUtils.getDefaultIfNull(Boolean.TRUE, () -> {
+            throw new AssertionFailedError("This supplier should have never been executed");
+        }));
+        assertNull(ObjectUtils.getDefaultIfNull(null, () -> null));
+        assertSame(dflt, ObjectUtils.getDefaultIfNull(null, () -> dflt));
     }
 
     @Test


### PR DESCRIPTION
From JIRA ticket: 

> Currently, if the default value in defaultIfNull is computationally slow (for example, it requires a database call, or complex calculations), it's not worth using the util method. This feature is to implement a method that would only perform this computationally slow action if the object value is actually null. This can be done using a Supplier.

> In short, you'd call ObjectUtils.getDefaultIfNull(someNullableValue, DbUtil::doGet) instead of ObjectUtils.defaultIfNull(someNullableValue, DbUtil.doGet())