### PR TITLE
Lang 1456 either

### DIFF
--- a/src/main/java/org/apache/commons/lang3/tuple/Either.java
+++ b/src/main/java/org/apache/commons/lang3/tuple/Either.java
@@ -1,0 +1,444 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.lang3.tuple;
+
+import java.io.Serializable;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+/**
+ * <p>
+ * The {@code Either} data type stores one of two possible values. It is a
+ * discriminated union of size two. It is like an Optional, but with an
+ * alternative value instead of emptiness.
+ * </p>
+ *
+ * <p>
+ * The two alternatives are referred to as left and right. An object of type
+ * {@code Either} holds either a left or a right value. These values may have
+ * different types.
+ * </p>
+ *
+ * @param <L> the type stored in the left alternative
+ * @param <R> the type stored in the right alternative
+ */
+public abstract class Either<L, R> implements Serializable {
+
+    /**
+     * Serialization version.
+     */
+    private static final long serialVersionUID = 5569490827534264777L;
+
+    /**
+     * <p>
+     * Reduces both alternatives to the same type, using a transformation for
+     * either side.
+     * </p>
+     * <p>
+     * Applies transformation on the left or the right alternative and gets the
+     * result.
+     * </p>
+     *
+     * @param <E> The type to reduce to, both functions turn a value of their
+     *            respective sides type into this return type
+     * @param left the function to call in the left alternative
+     * @param right the function to call in the right alternative
+     * @return the result of the transformation
+     */
+    public abstract <E> E reduce(Function<? super L, ? extends E> left,
+            Function<? super R, ? extends E> right);
+
+    /**
+     * <p>
+     * Applies transformation on the left or the right alternative, stores the
+     * result in a new {@code Either} object and returns the new {@code Either}
+     * object.
+     * </p>
+     *
+     * <p>
+     * When called on a left alternative, the result will also be a left
+     * alternative. When called on a right alternative, the result will also be
+     * a right alternative.
+     * </p>
+     *
+     * @param <E> The type of the left alternative of the result
+     * @param <F> The type of the right alternative of the result
+     * @param left the function to call in the left alternative
+     * @param right the function to call in the right alternative
+     * @return a new Either object with a transformed left or right value.
+     */
+    public abstract <E, F> Either<E, F> map(
+            Function<? super L, ? extends E> left,
+            Function<? super R, ? extends F> right);
+
+    /**
+     * <p>
+     * Consumes the Either by calling one of two consumers, depending on which
+     * alternative this Either object represents.
+     * </p>
+     *
+     * <p>
+     * Terminal operation, in {@code Stream} jargon
+     * </p>
+     *
+     * @param left the consumer of the left alternative
+     * @param right the consumer of the right alternative
+     */
+    public abstract void ifLeftOrElse(Consumer<? super L> left,
+            Consumer<? super R> right);
+
+    /**
+     * <p>
+     * Convenience method when working with streams.
+     * </p>
+     *
+     * <p>
+     * {@code Stream.of(Either.left(1), Either.right(false)).flatMap(Either::streamLeft)}
+     * will result in a {@code Stream<Integer>} containing a single integer of
+     * value one.
+     * </p>
+     *
+     * <p>
+     * Modeled after {@code Optional.stream()}
+     * </p>
+     *
+     * @return a {@code Stream} of the left leftValue, or an empty
+     *         {@code Stream} if this {@code Either} object represents the right
+     *         alternative
+     */
+    public abstract Stream<L> streamLeft();
+
+    /**
+     * <p>
+     * Convenience method when working with streams.
+     * </p>
+     *
+     * <p>
+     * {@code Stream.of(Either.left(1), Either.right(false)).flatMap(Either::streamRight)}
+     * will result in a {@code Stream<Boolean>} containing a single boolean of
+     * value false.
+     * </p>
+     *
+     * <p>
+     * Modeled after {@code Optional.stream()}
+     * </p>
+     *
+     * @return a Stream of the right leftValue, or an empty {@code Stream} if
+     *         this {@code Either} object represents the left alternative
+     */
+    public abstract Stream<R> streamRight();
+
+    /**
+     * <p>
+     * Gets the left value wrapped in an {@code Optional} when called on a left
+     * alternative, returns empty otherwise.
+     * </p>
+     *
+     * @return the left leftValue wrapped in an Optional if this object
+     *         represents the left alternative, empty otherwise
+     */
+    public abstract Optional<L> getLeft();
+
+    /**
+     * <p>
+     * Gets the right value wrapped in an {@code Optional} when called on a
+     * right alternative, returns empty otherwise.
+     * </p>
+     *
+     * @return the right value wrapped in an Optional if this object represents
+     *         the left alternative, empty otherwise
+     */
+    public abstract Optional<R> getRight();
+
+    /**
+     * <p>
+     * Gets a new Either object with the sides switched.
+     * </p>
+     *
+     * <p>
+     * Left will become right and vice versa.
+     * </p>
+     *
+     * @return a new either object, that is inverted or swapped
+     */
+    public abstract Either<R, L> swap();
+
+    /**
+     * Creates an {@code Either} object that represent the left alternative.
+     *
+     * @param <L> The type of the left alternative of the result
+     * @param <R> The type of the right alternative of the result
+     * @param value the leftValue to store in the left alternative
+     * @return a new Either object representing the left alternative
+     */
+    public static <L, R> Either<L, R> left(L value) {
+        return new Left<>(value);
+    }
+
+    /**
+     * Creates an {@code Either} object that represent the right alternative.
+     *
+     * @param <L> The type of the left alternative of the result
+     * @param <R> The type of the right alternative of the result
+     * @param value the leftValue to store in the right alternative
+     * @return a new {@code Either} object representing the right alternative
+     */
+    public static <L, R> Either<L, R> right(final R value) {
+        return new Right<>(value);
+    }
+
+    /**
+     * <p>
+     * Create an {@code Either} from an {@code Optional} and a default value for
+     * the right side.
+     * </p>
+     *
+     * @param <L> The type of the left alternative of the result
+     * @param <R> The type of the right alternative of the result
+     * @param optional the value held by the left side, if present
+     * @param alternative the value held by the right side, if optional is not
+     *            present
+     * @return a new {@code Either} based on an optional and an alternative.
+     */
+    public static <L, R> Either<L, R> leftIfPresentOrElse(
+            final Optional<? extends L> optional, final R alternative) {
+        return optional.map(Either::<L, R>left)
+                .orElseGet(() -> new Right<>(alternative));
+    }
+
+    /**
+     * <p>
+     * Create an {@code Either} from an {@code Optional} and a default value for
+     * the right side.
+     * </p>
+     *
+     * @param <L> The type of the left alternative of the result
+     * @param <R> The type of the right alternative of the result
+     * @param optional the value held by the right side, if present
+     * @param alternative the value held by the left side, if optional is not
+     *            present
+     * @return a new {@code Either} based on an optional and an alternative.
+     */
+    public static <L, R> Either<L, R> rightIfPresentOrElse(//
+            final Optional<? extends R> optional, //
+            final L alternative) {
+        return optional.map(Either::<L, R>right)
+                .orElseGet(() -> new Left<>(alternative));
+    }
+
+    /**
+     * <p>
+     * Left alternative, the stored value is of type L.
+     * </p>
+     *
+     * @param <L> the type stored in the left alternative
+     * @param <R> the type stored in the right alternative
+     */
+    private static final class Left<L, R> extends Either<L, R> {
+
+        /**
+         * Serialization version.
+         */
+        private static final long serialVersionUID = -3735547322443371991L;
+        /**
+         * Stored leftValue of the left alternative.
+         */
+        private final L leftValue;
+
+        /**
+         * <p>
+         * Creates a right alternative. Implementing the left side of the @{code
+         * Either}, the side that holds a value of type {@code L}.
+         * </p>
+         *
+         * @param value the object stored by this left alternative.
+         */
+        Left(final L value) {
+            leftValue = value;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public <E> E reduce(final Function<? super L, ? extends E> left, //
+                final Function<? super R, ? extends E> right) {
+            return left.apply(leftValue);
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public <E, F> Either<E, F> map(
+                final Function<? super L, ? extends E> left, //
+                final Function<? super R, ? extends F> right) {
+            return Either.<E, F>left(left.apply(leftValue));
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public void ifLeftOrElse(final Consumer<? super L> left,
+                final Consumer<? super R> right) {
+            left.accept(leftValue);
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public Optional<L> getLeft() {
+            return Optional.of(leftValue);
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public Optional<R> getRight() {
+            return Optional.empty();
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public Either<R, L> swap() {
+            return new Right<>(leftValue);
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public Stream<L> streamLeft() {
+            return Stream.of(leftValue);
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public Stream<R> streamRight() {
+            return Stream.empty();
+        }
+    }
+
+    /**
+     * <p>
+     * Right alternative, the stored value is of type {@code R}.
+     * </p>
+     *
+     * @param <L> the type stored in the left alternative
+     * @param <R> the type stored in the right alternative
+     */
+    private static final class Right<L, R> extends Either<L, R> {
+
+        /**
+         * Serialization version.
+         */
+        private static final long serialVersionUID = -8702051397862504245L;
+        /**
+         * Stored leftValue of the right alternative.
+         */
+        private final R rightValue;
+
+        /**
+         * <p>
+         * Creates a right alternative. Implementing the right side of
+         * the @{code Either}, the side that holds a value of type {@code R}.
+         * </p>
+         *
+         * @param value the object stored by this right alternative.
+         */
+        Right(final R value) {
+            rightValue = value;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public <E> E reduce(final Function<? super L, ? extends E> left,
+                final Function<? super R, ? extends E> right) {
+            return right.apply(rightValue);
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public <E, F> Either<E, F> map(
+                final Function<? super L, ? extends E> left,
+                final Function<? super R, ? extends F> right) {
+            return Either.<E, F>right(right.apply(rightValue));
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public void ifLeftOrElse(final Consumer<? super L> left,
+                final Consumer<? super R> right) {
+            right.accept(rightValue);
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public Optional<R> getRight() {
+            return Optional.of(rightValue);
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public Optional<L> getLeft() {
+            return Optional.empty();
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public Either<R, L> swap() {
+            return new Left<>(rightValue);
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public Stream<L> streamLeft() {
+            return Stream.empty();
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public Stream<R> streamRight() {
+            return Stream.of(rightValue);
+        }
+    }
+}

--- a/src/test/java/org/apache/commons/lang3/tuple/EitherTest.java
+++ b/src/test/java/org/apache/commons/lang3/tuple/EitherTest.java
@@ -1,0 +1,309 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.lang3.tuple;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * <p>
+ * White box unit testing of Either.
+ * </p>
+ */
+public class EitherTest {
+
+    /**
+     * <p>
+     * Gets a function to add something.
+     * </p>
+     *
+     * @param i the value to add to the parameter of the function
+     * @return a function which adds i to its parameter
+     */
+    public static Function<Integer, Integer> add(final int i) {
+        return t -> t + i;
+    }
+
+    @Test
+    public void testReduce() {
+        // Given a left alternative with value one, and a right alternative of
+        // value
+        // two.
+        final Either<Integer, Integer> left = Either.left(1);
+        final Either<Integer, Integer> right = Either.right(2);
+
+        // When we reduce by calling add one on the left size and add two on the
+        // right
+        final int resultLeft = left.reduce(add(1), add(2));
+        final int resultRight = right.reduce(add(1), add(2));
+
+        // Then we expect
+        assertEquals(2, resultLeft);
+        assertEquals(4, resultRight);
+    }
+
+    /**
+     * <p>
+     * Gets a function which returns a constant value regardless of its
+     * parameter.
+     * </p>
+     *
+     * @param <E> the type of the argument the function ignores
+     * @param <F> the type of the constant the function returns
+     * @param x the constant to be returned by the function
+     * @return the function to return x
+     */
+    public static <E, F> Function<E, F> always(final F x) {
+        return t -> x;
+    }
+
+    /**
+     * <p>
+     * Gets an identity function.
+     * </p>
+     *
+     * @param <E> the type of the parameter and result of the identity function
+     * @return identity function
+     */
+    public static <E> Function<E, E> id() {
+        return t -> t;
+    }
+
+    @Test
+    public void testReduceHeterogeneous() {
+        // Given a left alternative with value one, and a right alternative of
+        // value
+        // two.
+        final Either<Integer, Boolean> left = Either.left(1);
+        final Either<Integer, Boolean> right = Either.right(false);
+
+        // When we reduce by calling add one on the left size and add two on the
+        // right
+        final boolean resultLeft =
+                left.reduce(always(true), EitherTest.<Boolean>id());
+        final boolean resultRight =
+                right.reduce(always(true), EitherTest.<Boolean>id());
+
+        // Then we expect
+        assertEquals(true, resultLeft);
+        assertEquals(false, resultRight);
+    }
+
+    @Test
+    public void testMap() {
+        // Given a left alternative with value one, and a right alternative of
+        // value
+        // false.
+        final Either<Integer, Boolean> left = Either.left(1);
+        final Either<Integer, Boolean> right = Either.right(false);
+
+        // When we call map with
+        final Either<Integer, Boolean> leftResult =
+                left.map(always(2), always(true));
+        final Either<Integer, Boolean> rightResult =
+                right.map(always(2), always(true));
+
+        // Then we expect
+        assertEquals(2, (int) leftResult.getLeft().get());
+        assertEquals(Optional.empty(), leftResult.getRight());
+
+        assertEquals(true, (boolean) rightResult.getRight().get());
+        assertEquals(Optional.empty(), rightResult.getLeft());
+    }
+
+    /**
+     * @param <E> the type to consume and check.
+     * @param log to log the execution.
+     * @param check value to assert equals with the argument of accept.
+     * @return a consumer to log its execution and check its parameter.
+     */
+    private static <E> Consumer<E> logAndCheckConsumer(final AtomicBoolean log,
+            final E check) {
+        return t -> {
+            assertEquals(t, check);
+            log.set(true);
+        };
+    }
+
+    @Test
+    public void testIfLeftOrElse() {
+        // Given a left alternative with value one, and a right alternative of
+        // value
+        // false.
+        final Either<Integer, Boolean> left = Either.left(1);
+        final Either<Integer, Boolean> right = Either.right(false);
+
+        // Given four atomic booleans to log execution
+        final AtomicBoolean leftExecutedLeft = new AtomicBoolean(false);
+        final AtomicBoolean leftExecutedRight = new AtomicBoolean(false);
+        final AtomicBoolean rightExecutedLeft = new AtomicBoolean(false);
+        final AtomicBoolean rightExecutedRight = new AtomicBoolean(false);
+
+        // Given a function to log its execution to a boolean and assert equals
+        // on its argument.
+        // see definition of logAndCheckConsumer
+
+        // When we call ifLeftOrElse using a consumer which asserts equality of
+        // reference value and
+        // logs its execution to an atomic boolean.
+        left.ifLeftOrElse(logAndCheckConsumer(leftExecutedLeft, 1),
+                logAndCheckConsumer(leftExecutedRight, null));
+        right.ifLeftOrElse(logAndCheckConsumer(rightExecutedLeft, null),
+                logAndCheckConsumer(rightExecutedRight, false));
+
+        // Then we expect
+        assertEquals(true, leftExecutedLeft.get());
+        assertEquals(false, leftExecutedRight.get());
+        assertEquals(false, rightExecutedLeft.get());
+        assertEquals(true, rightExecutedRight.get());
+    }
+
+    @Test
+    public void testGettersAndSwap() {
+        // Given a left alternative with value one, and a right alternative of
+        // value
+        // two.
+        final Either<Integer, Integer> left = Either.left(1);
+        final Either<Integer, Integer> right = Either.right(2);
+
+        // Given their swapped values
+        final Either<Integer, Integer> swappedLeft = left.swap();
+        final Either<Integer, Integer> swappedRight = right.swap();
+
+        // Then we expect
+        assertEquals(1, (int) left.getLeft().get());
+        assertEquals(Optional.empty(), left.getRight());
+
+        assertEquals(2, (int) right.getRight().get());
+        assertEquals(Optional.empty(), right.getLeft());
+
+        assertEquals(1, (int) swappedLeft.getRight().get());
+        assertEquals(Optional.empty(), swappedLeft.getLeft());
+
+        assertEquals(2, (int) swappedRight.getLeft().get());
+        assertEquals(Optional.empty(), swappedRight.getRight());
+    }
+
+    @Test
+    public void testStream() {
+        final Either<Integer, Boolean> left = Either.left(1);
+        final Either<Integer, Boolean> right = Either.right(false);
+
+        // Then
+        final List<Integer> streamedLeft =
+                left.streamLeft().collect(Collectors.<Integer>toList());
+        assertEquals(1, streamedLeft.size());
+        assertEquals(1, (int) streamedLeft.get(0));
+        assertEquals(0, left.streamRight().collect(Collectors.toList()).size());
+
+        final List<Boolean> streamedRight =
+                right.streamRight().collect(Collectors.<Boolean>toList());
+        assertEquals(1, streamedRight.size());
+        assertEquals(false, (boolean) streamedRight.get(0));
+        assertEquals(0, right.streamLeft().collect(Collectors.toList()).size());
+    }
+
+    @Test
+    public void testLeftIfPresentOrElse() {
+        // Given a left and a right made using an optional value for the left
+        // side and a default value
+        // for the right side.
+        final Optional<Integer> leftOptionalValue = Optional.of(1);
+        final Either<Integer, Boolean> left =
+                Either.leftIfPresentOrElse(leftOptionalValue, false);
+        final Either<Integer, Boolean> right;
+        right = Either.leftIfPresentOrElse(Optional.<Integer>empty(), false);
+
+        // Then we expect
+        assertEquals(1, (int) left.getLeft().get());
+        assertEquals(Optional.empty(), left.getRight());
+
+        assertEquals(Optional.empty(), right.getLeft());
+        assertEquals(false, (boolean) right.getRight().get());
+    }
+
+    @Test
+    public void testRightIfPresentOrElse() {
+        // Given a left and a right made using an optional value for the left
+        // side and a default value
+        // for the right side.
+        final Optional<Boolean> rightOptionalValue = Optional.of(false);
+        final Either<Integer, Boolean> left;
+        left = Either.rightIfPresentOrElse(Optional.<Boolean>empty(), 1);
+        final Either<Integer, Boolean> right;
+        right = Either.rightIfPresentOrElse(rightOptionalValue, 1);
+
+        // Then we expect
+        assertEquals(1, (int) left.getLeft().get());
+        assertEquals(Optional.empty(), left.getRight());
+
+        assertEquals(Optional.empty(), right.getLeft());
+        assertEquals(false, (boolean) right.getRight().get());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testSerialization() throws IOException, ClassNotFoundException {
+        // Given a left alternative with value one, and a right alternative of
+        // value
+        // false.
+        final Either<Integer, Boolean> left = Either.left(1);
+        final Either<Integer, Boolean> right = Either.right(false);
+
+        // Given output streams
+        final ByteArrayOutputStream baosLeft = new ByteArrayOutputStream();
+        final ByteArrayOutputStream baosRight = new ByteArrayOutputStream();
+        final ObjectOutputStream outLeft = new ObjectOutputStream(baosLeft);
+        final ObjectOutputStream outRight = new ObjectOutputStream(baosRight);
+
+        // When we serialize
+        outLeft.writeObject(left);
+        outRight.writeObject(right);
+
+        // And deserialize
+        final Either<Integer, Boolean> deserializedLeft;
+        deserializedLeft = (Either<Integer,
+                Boolean>) new ObjectInputStream(
+                        new ByteArrayInputStream(baosLeft.toByteArray()))
+                                .readObject();
+        final Either<Integer, Boolean> deserializedRight;
+        deserializedRight = (Either<Integer,
+                Boolean>) new ObjectInputStream(
+                        new ByteArrayInputStream(baosRight.toByteArray()))
+                                .readObject();
+
+        // Then we expect the deserialized object to behave as the original.
+        assertEquals(1, (int) deserializedLeft.getLeft().get());
+        assertEquals(Optional.empty(), deserializedLeft.getRight());
+
+        assertEquals(false, (boolean) deserializedRight.getRight().get());
+        assertEquals(Optional.empty(), deserializedRight.getLeft());
+    }
+}


### PR DESCRIPTION
Stores a single value, either of type `L`, or of type `R`. Fits in between `Stream` and `Optional` in terms of applying transformations conditionally (and safely).
An `Either` implementation is available in the standard library of both haskell and scala.

[https://issues.apache.org/jira/browse/LANG-1456](https://issues.apache.org/jira/browse/LANG-1456)