### PR TITLE
LANG-1406: StringIndexOutOfBoundsException in StringUtils.replaceIgnoreCase

### DIFF
--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -5603,13 +5603,8 @@ public class StringUtils {
          if (isEmpty(text) || isEmpty(searchString) || replacement == null || max == 0) {
              return text;
          }
-         String searchText = text;
-         if (ignoreCase) {
-             searchText = text.toLowerCase();
-             searchString = searchString.toLowerCase();
-         }
          int start = 0;
-         int end = searchText.indexOf(searchString, start);
+         int end = ignoreCase ? indexOfIgnoreCase(text, searchString, start) : indexOf(text, searchString, start);
          if (end == INDEX_NOT_FOUND) {
              return text;
          }
@@ -5624,7 +5619,7 @@ public class StringUtils {
              if (--max == 0) {
                  break;
              }
-             end = searchText.indexOf(searchString, start);
+             end = ignoreCase ? indexOfIgnoreCase(text, searchString, start) : indexOf(text, searchString, start);
          }
          buf.append(text, start, text.length());
          return buf.toString();

--- a/src/test/java/org/apache/commons/lang3/StringUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringUtilsTest.java
@@ -2687,6 +2687,9 @@ public class StringUtilsTest {
 
         // StringUtils.removeIgnoreCase("queued", "zZ") = "queued"
         assertEquals("queued", StringUtils.removeIgnoreCase("queued", "zZ"));
+
+        // StringUtils.removeIgnoreCase("\u0130x", "x") = "\u0130"
+        assertEquals("\u0130", StringUtils.removeIgnoreCase("\u0130x", "x"));
     }
 
     @Test


### PR DESCRIPTION
Removes the conversion to lower case and uses instead StringUtils.indexOfIgnoreCase or StringUtils.indexOf