### PR TITLE
LANG-1460: (doc) (trivial) correct release year for v3.9 in release-history.xml

### DIFF
--- a/src/site/xdoc/release-history.xml
+++ b/src/site/xdoc/release-history.xml
@@ -32,7 +32,7 @@ limitations under the License.
           <th>Version</th><th>Release date</th><th>Required Java Version</th><th>Javadoc</th><th>Release notes</th>
         </tr>
         <tr>
-          <td>3.9</td><td>2018-04-09</td><td>8</td><td><a href="javadocs/api-3.9/">api-3.9</a></td><td><a href="release-notes/RELEASE-NOTES-3.9.txt">release notes for 3.9</a></td>
+          <td>3.9</td><td>2019-04-09</td><td>8</td><td><a href="javadocs/api-3.9/">api-3.9</a></td><td><a href="release-notes/RELEASE-NOTES-3.9.txt">release notes for 3.9</a></td>
         </tr>
         <tr>
           <td>3.8.1</td><td>2018-09-19</td><td>7</td><td><a href="javadocs/api-3.8.1/">api-3.8.1</a></td><td><a href="release-notes/RELEASE-NOTES-3.8.1.txt">release notes for 3.8.1</a></td>


### PR DESCRIPTION
For v3.9, it had 2018-04-09, which should be 2019-04-09.

_(I missed the note about not requiring a JIRA ticket for such trivial changes.)_