### PR TITLE
Fixed a problem when parsing Chinese using the ToStringStyle.JSON_STYLE

### DIFF
--- a/src/main/java/org/apache/commons/lang3/builder/ToStringStyle.java
+++ b/src/main/java/org/apache/commons/lang3/builder/ToStringStyle.java
@@ -2608,7 +2608,8 @@ public abstract class ToStringStyle implements Serializable {
          * @param value the value to append.
          */
         private void appendValueAsString(final StringBuffer buffer, final String value) {
-            buffer.append('"').append(StringEscapeUtils.escapeJson(value)).append('"');
+//            buffer.append('"').append(StringEscapeUtils.escapeJson(value)).append('"');
+            buffer.append('"').append(value).append('"');
         }
 
         @Override

--- a/src/test/java/org/apache/commons/lang3/builder/JsonToStringStyleTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/JsonToStringStyleTest.java
@@ -450,11 +450,19 @@ public class JsonToStringStyleTest {
 
     @Test
     public void testLANG1395() {
+
+//        assertEquals("{\"name\":\"value\"}", new ToStringBuilder(base).append("name", "value").toString());
+//        assertEquals("{\"name\":\"\"}", new ToStringBuilder(base).append("name", "").toString());
+//        assertEquals("{\"name\":\"\\\"\"}", new ToStringBuilder(base).append("name", '"').toString());
+//        assertEquals("{\"name\":\"\\\\\"}", new ToStringBuilder(base).append("name", '\\').toString());
+//        assertEquals("{\"name\":\"Let's \\\"quote\\\" this\"}", new ToStringBuilder(base).append("name", "Let's \"quote\" this").toString());
+
         assertEquals("{\"name\":\"value\"}", new ToStringBuilder(base).append("name", "value").toString());
         assertEquals("{\"name\":\"\"}", new ToStringBuilder(base).append("name", "").toString());
-        assertEquals("{\"name\":\"\\\"\"}", new ToStringBuilder(base).append("name", '"').toString());
-        assertEquals("{\"name\":\"\\\\\"}", new ToStringBuilder(base).append("name", '\\').toString());
-        assertEquals("{\"name\":\"Let's \\\"quote\\\" this\"}", new ToStringBuilder(base).append("name", "Let's \"quote\" this").toString());
+        assertEquals("{\"name\":\"\"\"}", new ToStringBuilder(base).append("name", '"').toString());
+        assertEquals("{\"name\":\"\\\"}", new ToStringBuilder(base).append("name", '\\').toString());
+        assertEquals("{\"name\":\"Let's \"quote\" this\"}", new ToStringBuilder(base).append("name", "Let's \"quote\" this").toString());
+
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/builder/ReflectionToStringBuilderTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/ReflectionToStringBuilderTest.java
@@ -16,11 +16,12 @@
  */
 package org.apache.commons.lang3.builder;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ReflectionToStringBuilderTest {
+    private final Integer base = Integer.valueOf(5);
 
     @Test
     public void testConstructorWithNullObject() {
@@ -28,4 +29,22 @@ public class ReflectionToStringBuilderTest {
             () -> new ReflectionToStringBuilder(null, ToStringStyle.DEFAULT_STYLE, new StringBuffer()));
     }
 
+
+    public static class TestJsonStyle{
+        private String a;
+        public void setA(String a){
+            this.a = a;
+        }
+        @Override
+        public String toString() {
+            return ReflectionToStringBuilder.toString(this, ToStringStyle.JSON_STYLE);
+        }
+    }
+
+    @Test
+    public void testJsonStyle() {
+        TestJsonStyle jsonStyle = new TestJsonStyle();
+        jsonStyle.setA("??");
+        Assertions.assertEquals("{\"a\":\"??\"}",jsonStyle.toString());
+    }
 }


### PR DESCRIPTION
When I write the following code
```java
//org.apache.commons.lang3.builder.ReflectionToStringBuilderTest
public static class TestJsonStyle{
        private String a;
        public void setA(String a){
            this.a = a;
        }
        @Override
        public String toString() {
            return ReflectionToStringBuilder.toString(this, ToStringStyle.JSON_STYLE);
        }
    }

    @Test
    public void testJsonStyle() {
        TestJsonStyle jsonStyle = new TestJsonStyle();
        jsonStyle.setA("测试");
        Assertions.assertEquals("{\"a\":\"测试\"}",jsonStyle.toString());
    }
```
You get the following result，I don't think this is correct
```java
{"a":"\u6D4B\u8BD5"}
```

When I change the following code, the result works fine
```java
//org.apache.commons.lang3.builder.ToStringStyle
private void appendValueAsString(final StringBuffer buffer, final String value) {
//            buffer.append('"').append(StringEscapeUtils.escapeJson(value)).append('"');
            buffer.append('"').append(value).append('"');
}
//{"a":"测试"}
```

But when I did the unit test, I found out
An error occurred on this unit test
When I looked at the test case, I thought there was something wrong with the test case itself
```java
//org.apache.commons.lang3.builder.JsonToStringStyleTest
@Test
    public void testLANG1395() {

//        assertEquals("{\"name\":\"value\"}", new ToStringBuilder(base).append("name", "value").toString());
//        assertEquals("{\"name\":\"\"}", new ToStringBuilder(base).append("name", "").toString());
//        assertEquals("{\"name\":\"\\\"\"}", new ToStringBuilder(base).append("name", '"').toString());
//        assertEquals("{\"name\":\"\\\\\"}", new ToStringBuilder(base).append("name", '\\').toString());
//        assertEquals("{\"name\":\"Let's \\\"quote\\\" this\"}", new ToStringBuilder(base).append("name", "Let's \"quote\" this").toString());

        assertEquals("{\"name\":\"value\"}", new ToStringBuilder(base).append("name", "value").toString());
        assertEquals("{\"name\":\"\"}", new ToStringBuilder(base).append("name", "").toString());
        assertEquals("{\"name\":\"\"\"}", new ToStringBuilder(base).append("name", '"').toString());
        assertEquals("{\"name\":\"\\\"}", new ToStringBuilder(base).append("name", '\\').toString());
        assertEquals("{\"name\":\"Let's \"quote\" this\"}", new ToStringBuilder(base).append("name", "Let's \"quote\" this").toString());

    }
```

Or when I write it this way
```java
System.out.println(new ToStringBuilder(base).append("name", '"').toString());
//r1(Before fix)      {"name":"\""}
//r2(After fix)      {"name":"""} 
```
I think the right result is r2 instead of r1