### PR TITLE
Add GenericArrayType support to TypeUtils.containsTypeVariables

### DIFF
--- a/src/main/java/org/apache/commons/lang3/reflect/TypeUtils.java
+++ b/src/main/java/org/apache/commons/lang3/reflect/TypeUtils.java
@@ -1447,6 +1447,10 @@ public class TypeUtils {
             return containsTypeVariables(getImplicitLowerBounds(wild)[0])
                 || containsTypeVariables(getImplicitUpperBounds(wild)[0]);
         }
+        if (type instanceof GenericArrayType) {
+            final GenericArrayType arrayType = (GenericArrayType) type;
+            return containsTypeVariables(arrayType.getGenericComponentType());
+        }
         return false;
     }
 

--- a/src/test/java/org/apache/commons/lang3/reflect/TypeUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/reflect/TypeUtilsTest.java
@@ -38,6 +38,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.TreeSet;
 
 import org.apache.commons.lang3.reflect.testbed.Foo;
@@ -801,6 +802,49 @@ public class TypeUtilsTest<B> {
     public void testLANG1348() throws Exception {
         final Method method = Enum.class.getMethod("valueOf", Class.class, String.class);
         assertEquals("T extends java.lang.Enum<T>", TypeUtils.toString(method.getGenericReturnType()));
+    }
+
+    @Test
+    public void testContainsTypeVariables() throws Exception {
+        abstract class Test1<G> {
+            public abstract Object m0();
+            public abstract String[] m1();
+            public abstract <E> E[] m2();
+            public abstract <E> List<? extends E> m3();
+            public abstract <E extends Enum<E>> List<? extends Enum<E>> m4();
+            public abstract List<? extends Enum<?>> m5();
+            public abstract List<? super Enum<?>> m6();
+            public abstract List<?> m7();
+            public abstract Map<? extends Enum<?>, ? super Enum<?>> m8();
+            public abstract <K, V> Map<? extends K, ? super V[]> m9();
+            public abstract <K, V> Map<? extends K, V[]> m10();
+            public abstract <K, V> Map<? extends K, List<V[]>> m11();
+            public abstract List m12();
+            public abstract Map m13();
+            public abstract Properties m14();
+            public abstract G m15();
+            public abstract List<G> m16();
+            public abstract Enum m17();
+        }
+
+        assertFalse(TypeUtils.containsTypeVariables(Test1.class.getMethod("m0").getGenericReturnType()));
+        assertFalse(TypeUtils.containsTypeVariables(Test1.class.getMethod("m1").getGenericReturnType()));
+        assertTrue(TypeUtils.containsTypeVariables(Test1.class.getMethod("m2").getGenericReturnType()));
+        assertTrue(TypeUtils.containsTypeVariables(Test1.class.getMethod("m3").getGenericReturnType()));
+        assertTrue(TypeUtils.containsTypeVariables(Test1.class.getMethod("m4").getGenericReturnType()));
+        assertFalse(TypeUtils.containsTypeVariables(Test1.class.getMethod("m5").getGenericReturnType()));
+        assertFalse(TypeUtils.containsTypeVariables(Test1.class.getMethod("m6").getGenericReturnType()));
+        assertFalse(TypeUtils.containsTypeVariables(Test1.class.getMethod("m7").getGenericReturnType()));
+        assertFalse(TypeUtils.containsTypeVariables(Test1.class.getMethod("m8").getGenericReturnType()));
+        assertTrue(TypeUtils.containsTypeVariables(Test1.class.getMethod("m9").getGenericReturnType()));
+        assertTrue(TypeUtils.containsTypeVariables(Test1.class.getMethod("m10").getGenericReturnType()));
+        assertTrue(TypeUtils.containsTypeVariables(Test1.class.getMethod("m11").getGenericReturnType()));
+        assertTrue(TypeUtils.containsTypeVariables(Test1.class.getMethod("m12").getGenericReturnType()));
+        assertTrue(TypeUtils.containsTypeVariables(Test1.class.getMethod("m13").getGenericReturnType()));
+        assertFalse(TypeUtils.containsTypeVariables(Test1.class.getMethod("m14").getGenericReturnType()));
+        assertTrue(TypeUtils.containsTypeVariables(Test1.class.getMethod("m15").getGenericReturnType()));
+        assertTrue(TypeUtils.containsTypeVariables(Test1.class.getMethod("m16").getGenericReturnType()));
+        assertTrue(TypeUtils.containsTypeVariables(Test1.class.getMethod("m17").getGenericReturnType()));
     }
 
     public Iterable<? extends Map<Integer, ? extends Collection<?>>> iterable;


### PR DESCRIPTION
Currently, org.apache.commons.lang3.reflect.TypeUtils#containsTypeVariables doesn't contain a special case for GenericArrayType like E[], so if the passed argument is a GenericArrayType instance containing type variables, this method will return false.