### PR TITLE
[LANG-1475] Fix unwrap StringIndexOutOfBoundsException

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -54,6 +54,7 @@ The <action> type attribute can be add,update,fix,remove.
     <action issue="LANG-1467" type="add" dev="ggregory">Add zero arg constructor for org.apache.commons.lang3.NotImplementedException.</action>
     <action issue="LANG-1470" type="add" dev="ggregory">Add ArrayUtils.addFirst() methods.</action>
     <action issue="LANG-1437" type="update" dev="ggregory" due-to="Andrei Troie">Remove redundant if statements in join methods #411.</action>
+    <action issue="LANG-1475" type="fix" dev="stzx">StringUtils.unwrap incorrect throw StringIndexOutOfBoundsException.</action>
   </release>
 
   <release version="3.9" date="2019-04-09" description="New features and bug fixes. Requires Java 8, supports Java 9, 10, 11">

--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -9159,8 +9159,10 @@ public class StringUtils {
      * StringUtils.unwrap(null, null)         = null
      * StringUtils.unwrap(null, '\0')         = null
      * StringUtils.unwrap(null, '1')          = null
+     * StringUtils.unwrap("a", 'a')           = "a"
+     * StringUtils.unwrap("aa", 'a')           = ""
      * StringUtils.unwrap("\'abc\'", '\'')    = "abc"
-     * StringUtils.unwrap("AABabcBAA", 'A')  = "ABabcBA"
+     * StringUtils.unwrap("AABabcBAA", 'A')   = "ABabcBA"
      * StringUtils.unwrap("A", '#')           = "A"
      * StringUtils.unwrap("#A", '#')          = "#A"
      * StringUtils.unwrap("A#", '#')          = "A#"
@@ -9175,16 +9177,15 @@ public class StringUtils {
      * @since 3.6
      */
     public static String unwrap(final String str, final char wrapChar) {
-        if (isEmpty(str) || wrapChar == CharUtils.NUL) {
+        if (isEmpty(str) || wrapChar == CharUtils.NUL || str.length() == 1) {
             return str;
         }
 
         if (str.charAt(0) == wrapChar && str.charAt(str.length() - 1) == wrapChar) {
             final int startIndex = 0;
             final int endIndex = str.length() - 1;
-            if (endIndex != -1) {
-                return str.substring(startIndex + 1, endIndex);
-            }
+
+            return str.substring(startIndex + 1, endIndex);
         }
 
         return str;
@@ -9199,6 +9200,8 @@ public class StringUtils {
      * StringUtils.unwrap(null, null)         = null
      * StringUtils.unwrap(null, "")           = null
      * StringUtils.unwrap(null, "1")          = null
+     * StringUtils.unwrap("a", "a")           = "a"
+     * StringUtils.unwrap("aa", "a")          = ""
      * StringUtils.unwrap("\'abc\'", "\'")    = "abc"
      * StringUtils.unwrap("\"abc\"", "\"")    = "abc"
      * StringUtils.unwrap("AABabcBAA", "AA")  = "BabcB"
@@ -9216,7 +9219,7 @@ public class StringUtils {
      * @since 3.6
      */
     public static String unwrap(final String str, final String wrapToken) {
-        if (isEmpty(str) || isEmpty(wrapToken)) {
+        if (isEmpty(str) || isEmpty(wrapToken) || str.length() == 1) {
             return str;
         }
 
@@ -9224,6 +9227,7 @@ public class StringUtils {
             final int startIndex = str.indexOf(wrapToken);
             final int endIndex = str.lastIndexOf(wrapToken);
             final int wrapLength = wrapToken.length();
+
             if (startIndex != -1 && endIndex != -1) {
                 return str.substring(startIndex + wrapLength, endIndex);
             }

--- a/src/test/java/org/apache/commons/lang3/StringUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringUtilsTest.java
@@ -3073,6 +3073,8 @@ public class StringUtilsTest {
         assertNull(StringUtils.unwrap(null, '1'));
 
         assertEquals("abc", StringUtils.unwrap("abc", null));
+        assertEquals("a", StringUtils.unwrap("a", "a"));
+        assertEquals("", StringUtils.unwrap("aa", "a"));
         assertEquals("abc", StringUtils.unwrap("\'abc\'", '\''));
         assertEquals("abc", StringUtils.unwrap("AabcA", 'A'));
         assertEquals("AabcA", StringUtils.unwrap("AAabcAA", 'A'));
@@ -3090,6 +3092,8 @@ public class StringUtilsTest {
 
         assertEquals("abc", StringUtils.unwrap("abc", null));
         assertEquals("abc", StringUtils.unwrap("abc", ""));
+        assertEquals("a", StringUtils.unwrap("a", "a"));
+        assertEquals("", StringUtils.unwrap("aa", "a"));
         assertEquals("abc", StringUtils.unwrap("\'abc\'", "\'"));
         assertEquals("abc", StringUtils.unwrap("\"abc\"", "\""));
         assertEquals("abc\"xyz", StringUtils.unwrap("\"abc\"xyz\"", "\""));


### PR DESCRIPTION
When the string length is shorter than two, it should be returned directly without operation.