### PR TITLE
Optimize string split methods: 1. Use ThreadLocal to make reuse of th…

### DIFF
--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -19,7 +19,12 @@ package org.apache.commons.lang3;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
 import java.text.Normalizer;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
 import java.util.regex.Pattern;
 
 /**

--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -7981,12 +7981,16 @@ public class StringUtils {
         }
     };
 
-    // Private class act as a buffer while splitting.
-    // "SplitBufferThreadLocalHelper" is constructed as a thread local variable so it is
-    // thread safe. The "splitBuffer" field acts as a buffer to hold the temporary
-    // representation of string split segments. It is shared by all
-    // calls to splitByCharacterType() or splitByWholeSeparatorWorker()
-    // or splitWorker(String) or splitWorker(char) and its variants in that particular thread.
+
+
+    /**
+     * Private class act as a buffer while splitting.
+     * "SplitBufferThreadLocalHelper" is constructed as a thread local variable so it is
+     * thread safe. The "splitBuffer" field acts as a buffer to hold the temporary
+     * representation of string split segments. It is shared by all
+     * calls to {@link #splitByCharacterType(String, boolean)} or {@link #splitByWholeSeparatorWorker(String, String, int, boolean)}
+     * or {@link #splitWorker(String, char, boolean)} or {@link #split(String, String, int)} and its variants in that particular thread.
+     */
     private static final class SplitBufferThreadLocalHelper {
 
         private final SplitBuffer splitBuffer = new SplitBuffer();
@@ -7997,7 +8001,18 @@ public class StringUtils {
         }
     }
 
-    //buffer class
+    /**
+     * A buffer class to hold split segments,
+     * this class is hold by the {@link ThreadLocal} so it is thread-safe.<br>
+     * While splitting, the segments will be add to the tail of the array with
+     * {@link SplitBuffer#add(String)} method(If the capacity of the array is not enough, it will enable auto-expanding).<br>
+     * {@link SplitBuffer#toArray()} method will copy current segments to a single String array.<br>
+     * {@link SplitBuffer#reset()} method will set the length of the array to 0, however, the "elementData" array will be reused next time.<br>
+     * This class is designed to replace previous {@link ArrayList}, in previous version, an ArrayList
+     * is created every time the split method is called, It means array allocation every time,if the segments
+     * is large, it may also contains several resizing desiged by ArrayList.<br>
+     * The mainly purpose of this class is to improve performance.
+     */
     private static final class SplitBuffer {
 
         /**
@@ -8073,7 +8088,7 @@ public class StringUtils {
          * the given minimum capacity is greater than MAX_ARRAY_SIZE.
          *
          * @param minCapacity the desired minimum capacity
-         * @throws OutOfMemoryError if minCapacity is less than zero
+         * @throws RuntimeException if minCapacity is less than zero
          */
         private int newCapacity(int minCapacity) {
             // overflow-conscious code
@@ -8084,7 +8099,7 @@ public class StringUtils {
                     return Math.max(DEFAULT_CAPACITY, minCapacity);
                 }
                 if (minCapacity < 0) { // overflow
-                    throw new OutOfMemoryError();
+                    throw new RuntimeException("capacity overflow!");
                 }
                 return minCapacity;
             }

--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -8010,7 +8010,7 @@ public class StringUtils {
      * {@link SplitBuffer#reset()} method will set the length of the array to 0, however, the "elementData" array will be reused next time.<br>
      * This class is designed to replace previous {@link ArrayList}, in previous version, an ArrayList
      * is created every time the split method is called, It means array allocation every time,if the segments
-     * is large, it may also contains several resizing desiged by ArrayList.<br>
+     * is large, it may also contains several resizing designed by ArrayList.<br>
      * The mainly purpose of this class is to improve performance.
      */
     private static final class SplitBuffer {
@@ -8040,7 +8040,7 @@ public class StringUtils {
 
         private static int hugeCapacity(int minCapacity) {
             if (minCapacity < 0) {// overflow
-                throw new OutOfMemoryError();
+                throw new RuntimeException("capacity overflow!");
             }
             return (minCapacity > MAX_ARRAY_SIZE)
                     ? Integer.MAX_VALUE

--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -8025,8 +8025,9 @@ public class StringUtils {
         private int size;
 
         private static int hugeCapacity(int minCapacity) {
-            if (minCapacity < 0) // overflow
+            if (minCapacity < 0) { // overflow
                 throw new OutOfMemoryError();
+            }
             return (minCapacity > MAX_ARRAY_SIZE)
                     ? Integer.MAX_VALUE
                     : MAX_ARRAY_SIZE;
@@ -8055,8 +8056,9 @@ public class StringUtils {
          * which helps when add(E) is called in a C1-compiled loop.
          */
         private void add(String e, Object[] elementData, int s) {
-            if (s == elementData.length)
+            if (s == elementData.length) {
                 elementData = grow(size + 1);
+            }
             elementData[s] = e;
             size = s + 1;
         }
@@ -8087,10 +8089,12 @@ public class StringUtils {
             int oldCapacity = elementData.length;
             int newCapacity = oldCapacity + (oldCapacity >> 1);
             if (newCapacity - minCapacity <= 0) {
-                if (elementData == DEFAULTCAPACITY_EMPTY_ELEMENTDATA)
+                if (elementData == DEFAULTCAPACITY_EMPTY_ELEMENTDATA) {
                     return Math.max(DEFAULT_CAPACITY, minCapacity);
-                if (minCapacity < 0) // overflow
+                }
+                if (minCapacity < 0) {// overflow
                     throw new OutOfMemoryError();
+                }
                 return minCapacity;
             }
             return (newCapacity - MAX_ARRAY_SIZE <= 0)

--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -7984,7 +7984,7 @@ public class StringUtils {
 
     // Private class act as a buffer while splitting.
     // "SplitBufferThreadLocalHelper" is constructed as a thread local variable so it is
-    // thread safe. The "list" field acts as a buffer to hold the temporary
+    // thread safe. The "splitBuffer" field acts as a buffer to hold the temporary
     // representation of string split segments. It is shared by all
     // calls to splitByCharacterType() or splitByWholeSeparatorWorker()
     // or splitWorker(String) or splitWorker(char) and its variants in that particular thread.

--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -19,7 +19,6 @@ package org.apache.commons.lang3;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
 import java.text.Normalizer;
-import java.util.AbstractList;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;

--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -7981,6 +7981,12 @@ public class StringUtils {
         }
     };
 
+    // Private class act as a buffer while splitting.
+    // "SplitBufferThreadLocalHelper" is constructed as a thread local variable so it is
+    // thread safe. The "list" field acts as a buffer to hold the temporary
+    // representation of string split segments. It is shared by all
+    // calls to splitByCharacterType() or splitByWholeSeparatorWorker()
+    // or splitWorker(String) or splitWorker(char) and its variants in that particular thread.
     private static final class SplitBufferThreadLocalHelper {
 
         private final ArrayList<String> list = new ArrayList<>();

--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -19,12 +19,7 @@ package org.apache.commons.lang3;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
 import java.text.Normalizer;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Locale;
-import java.util.Objects;
+import java.util.*;
 import java.util.regex.Pattern;
 
 /**
@@ -7434,7 +7429,7 @@ public class StringUtils {
             return ArrayUtils.EMPTY_STRING_ARRAY;
         }
         final char[] c = str.toCharArray();
-        final List<String> list = new ArrayList<>();
+        final List<String> list = SPLIT_BUFFER_THREAD_LOCAL.get().getList();
         int tokenStart = 0;
         int currentType = Character.getType(c[tokenStart]);
         for (int pos = tokenStart + 1; pos < c.length; pos++) {
@@ -7455,7 +7450,7 @@ public class StringUtils {
             currentType = type;
         }
         list.add(new String(c, tokenStart, c.length - tokenStart));
-        return list.toArray(new String[list.size()]);
+        return list.toArray(new String[0]);
     }
 
     /**
@@ -7639,7 +7634,7 @@ public class StringUtils {
 
         final int separatorLength = separator.length();
 
-        final ArrayList<String> substrings = new ArrayList<>();
+        final ArrayList<String> substrings = SPLIT_BUFFER_THREAD_LOCAL.get().getList();
         int numberOfSubstrings = 0;
         int beg = 0;
         int end = 0;
@@ -7683,7 +7678,7 @@ public class StringUtils {
             }
         }
 
-        return substrings.toArray(new String[substrings.size()]);
+        return substrings.toArray(new String[0]);
     }
 
     // -----------------------------------------------------------------------
@@ -7850,7 +7845,7 @@ public class StringUtils {
         if (len == 0) {
             return ArrayUtils.EMPTY_STRING_ARRAY;
         }
-        final List<String> list = new ArrayList<>();
+        final List<String> list = SPLIT_BUFFER_THREAD_LOCAL.get().getList();
         int i = 0, start = 0;
         boolean match = false;
         boolean lastMatch = false;
@@ -7871,7 +7866,7 @@ public class StringUtils {
         if (match || preserveAllTokens && lastMatch) {
             list.add(str.substring(start, i));
         }
-        return list.toArray(new String[list.size()]);
+        return list.toArray(new String[0]);
     }
 
     /**
@@ -7900,7 +7895,7 @@ public class StringUtils {
         if (len == 0) {
             return ArrayUtils.EMPTY_STRING_ARRAY;
         }
-        final List<String> list = new ArrayList<>();
+        final List<String> list = SPLIT_BUFFER_THREAD_LOCAL.get().getList();
         int sizePlus1 = 1;
         int i = 0, start = 0;
         boolean match = false;
@@ -7970,7 +7965,25 @@ public class StringUtils {
         if (match || preserveAllTokens && lastMatch) {
             list.add(str.substring(start, i));
         }
-        return list.toArray(new String[list.size()]);
+        return list.toArray(new String[0]);
+    }
+
+    private static final ThreadLocal<SplitBufferThreadLocalHelper> SPLIT_BUFFER_THREAD_LOCAL
+            = new ThreadLocal<SplitBufferThreadLocalHelper>() {
+        @Override
+        protected SplitBufferThreadLocalHelper initialValue() {
+            return new SplitBufferThreadLocalHelper();
+        }
+    };
+
+    private static final class SplitBufferThreadLocalHelper {
+
+        private final ArrayList<String> list = new ArrayList<>();
+
+        ArrayList<String> getList() {
+            list.clear();
+            return list;
+        }
     }
 
     /**


### PR DESCRIPTION
####Optimize string split methods:

-  In current impl of split methods, a string array list is created every time the method called, this should increase gc burden， also, if a string contains too many segments, it should contains several array resizing during the method call. Use ThreadLocal to make reuse of ArrayList and avoid resizing, this trick can also be found on JDK: see java.math.BigDecimal#toString();

```

// Private class to build a string representation for BigDecimal object.
    // "StringBuilderHelper" is constructed as a thread local variable so it is
    // thread safe. The StringBuilder field acts as a buffer to hold the temporary
    // representation of BigDecimal. The cmpCharArray holds all the characters for
    // the compact representation of BigDecimal (except for '-' sign' if it is
    // negative) if its intCompact field is not INFLATED. It is shared by all
    // calls to toString() and its variants in that particular thread.
    static class StringBuilderHelper {
        final StringBuilder sb;    // Placeholder for BigDecimal string
        final char[] cmpCharArray; // character array to place the intCompact

        StringBuilderHelper() {
            sb = new StringBuilder();
            // All non negative longs can be made to fit into 19 character array.
            cmpCharArray = new char[19];
        }

        // Accessors.
        StringBuilder getStringBuilder() {
            sb.setLength(0);
            return sb;
        }
       ...

```

-  From JetBrains Intellij Idea inspection:

> There are two styles to convert a collection to an array: either using a pre-sized array (like c.toArray(new String[c.size()])) or using an empty array (like c.toArray(new String[0]).
> 
> In older Java versions using pre-sized array was recommended, as the reflection call which is necessary to create an array of proper size was quite slow. However since late updates of OpenJDK 6 this call was intrinsified, making the performance of the empty array version the same and sometimes even better, compared to the pre-sized version. Also passing pre-sized array is dangerous for a concurrent or synchronized collection as a data race is possible between the size and toArray call which may result in extra nulls at the end of the array, if the collection was concurrently shrunk during the operation.
> 
> This inspection allows to follow the uniform style: either using an empty array (which is recommended in modern Java) or using a pre-sized array (which might be faster in older Java versions or non-HotSpot based JVMs).

See more:[https://shipilev.net/blog/2016/arrays-wisdom-ancients/](https://shipilev.net/blog/2016/arrays-wisdom-ancients/)