### PR TITLE
Fix checkstyle violations (tabs, missing spaces after commas, missing javadocs)

### DIFF
--- a/src/main/java/org/apache/commons/lang3/Functions.java
+++ b/src/main/java/org/apache/commons/lang3/Functions.java
@@ -144,119 +144,159 @@ public class Functions {
 
     /**
      * Converts the given {@link FailableRunnable} into a standard {@link Runnable}.
+     *
+     * @param pRunnable a {@code FailableRunnable}
+     * @return a standard {@code Runnable}
      */
     public static Runnable asRunnable(FailableRunnable<?> pRunnable) {
-    	return () -> {
-    		try {
-    			pRunnable.run();
-    		} catch (Throwable t) {
-    			throw rethrow(t);
-    		}
-    	};
+        return () -> {
+            try {
+                pRunnable.run();
+            } catch (Throwable t) {
+                throw rethrow(t);
+            }
+        };
     }
 
     /**
      * Converts the given {@link FailableConsumer} into a standard {@link Consumer}.
+     *
+     * @param <I> the type used by the consumers
+     * @param pConsumer a {@code FailableConsumer}
+     * @return a standard {@code Consumer}
      */
-    public static <I> Consumer<I> asConsumer(FailableConsumer<I,?> pConsumer) {
-    	return (pInput) -> {
-    		try {
-    			pConsumer.accept(pInput);
-    		} catch (Throwable t) {
-    			throw rethrow(t);
-    		}
-    	};
+    public static <I> Consumer<I> asConsumer(FailableConsumer<I, ?> pConsumer) {
+        return (pInput) -> {
+            try {
+                pConsumer.accept(pInput);
+            } catch (Throwable t) {
+                throw rethrow(t);
+            }
+        };
     }
 
     /**
      * Converts the given {@link FailableCallable} into a standard {@link Callable}.
+     *
+     * @param <O> the type used by the callables
+     * @param pCallable a {@code FailableCallable}
+     * @return a standard {@code Callable}
      */
-    public static <O> Callable<O> asCallable(FailableCallable<O,?> pCallable) {
-    	return () -> {
-    		try {
-    			return pCallable.call();
-    		} catch (Throwable t) {
-    			throw rethrow(t);
-    		}
-    	};
+    public static <O> Callable<O> asCallable(FailableCallable<O, ?> pCallable) {
+        return () -> {
+            try {
+                return pCallable.call();
+            } catch (Throwable t) {
+                throw rethrow(t);
+            }
+        };
     }
 
     /**
      * Converts the given {@link FailableBiConsumer} into a standard {@link BiConsumer}.
+     *
+     * @param <I1> the type of the first argument of the consumers
+     * @param <I2> the type of the second argument of the consumers
+     * @param pConsumer a failable {@code BiConsumer}
+     * @return a standard {@code BiConsumer}
      */
-    public static <I1,I2> BiConsumer<I1,I2> asBiConsumer(FailableBiConsumer<I1,I2,?> pConsumer) {
-    	return (pInput1, pInput2) -> {
-    		try {
-    			pConsumer.accept(pInput1, pInput2);
-    		} catch (Throwable t) {
-    			throw rethrow(t);
-    		}
-    	};
+    public static <I1, I2> BiConsumer<I1, I2> asBiConsumer(FailableBiConsumer<I1, I2, ?> pConsumer) {
+        return (pInput1, pInput2) -> {
+            try {
+                pConsumer.accept(pInput1, pInput2);
+            } catch (Throwable t) {
+                throw rethrow(t);
+            }
+        };
     }
 
     /**
      * Converts the given {@link FailableFunction} into a standard {@link Function}.
+     *
+     * @param <I> the type of the input of the functions
+     * @param <O> the type of the output of the functions
+     * @param pFunction a {code FailableFunction}
+     * @return a standard {@code Function}
      */
-    public static <I,O> Function<I,O> asFunction(FailableFunction<I,O,?> pFunction) {
-    	return (pInput) -> {
-    		try {
-    			return pFunction.apply(pInput);
-    		} catch (Throwable t) {
-    			throw rethrow(t);
-    		}
-    	};
+    public static <I, O> Function<I, O> asFunction(FailableFunction<I, O, ?> pFunction) {
+        return (pInput) -> {
+            try {
+                return pFunction.apply(pInput);
+            } catch (Throwable t) {
+                throw rethrow(t);
+            }
+        };
     }
 
     /**
      * Converts the given {@link FailableBiFunction} into a standard {@link BiFunction}.
+     *
+     * @param <I1> the type of the first argument of the input of the functions
+     * @param <I2> the type of the second argument of the input of the functions
+     * @param <O> the type of the output of the functions
+     * @param pFunction a {@code FailableBiFunction}
+     * @return a standard {@code BiFunction}
      */
-    public static <I1,I2,O> BiFunction<I1,I2,O> asBiFunction(FailableBiFunction<I1,I2,O,?> pFunction) {
-    	return (pInput1, pInput2) -> {
-    		try {
-    			return pFunction.apply(pInput1, pInput2);
-    		} catch (Throwable t) {
-    			throw rethrow(t);
-    		}
-    	};
+    public static <I1, I2, O> BiFunction<I1, I2, O> asBiFunction(FailableBiFunction<I1, I2, O, ?> pFunction) {
+        return (pInput1, pInput2) -> {
+            try {
+                return pFunction.apply(pInput1, pInput2);
+            } catch (Throwable t) {
+                throw rethrow(t);
+            }
+        };
     }
 
     /**
      * Converts the given {@link FailablePredicate} into a standard {@link Predicate}.
+     *
+     * @param <I> the type used by the predicates
+     * @param pPredicate a {@code FailablePredicate}
+     * @return a standard {@code Predicate}
      */
-    public static <I> Predicate<I> asPredicate(FailablePredicate<I,?> pPredicate) {
-    	return (pInput) -> {
-    		try {
-    			return pPredicate.test(pInput);
-    		} catch (Throwable t) {
-    			throw rethrow(t);
-    		}
-    	};
+    public static <I> Predicate<I> asPredicate(FailablePredicate<I, ?> pPredicate) {
+        return (pInput) -> {
+            try {
+                return pPredicate.test(pInput);
+            } catch (Throwable t) {
+                throw rethrow(t);
+            }
+        };
     }
 
     /**
      * Converts the given {@link FailableBiPredicate} into a standard {@link BiPredicate}.
+     *
+     * @param <I1> the type of the first argument used by the predicates
+     * @param <I2> the type of the second argument used by the predicates
+     * @param pPredicate a {@code FailableBiPredicate}
+     * @return a standard {@code BiPredicate}
      */
-    public static <I1,I2> BiPredicate<I1,I2> asBiPredicate(FailableBiPredicate<I1,I2,?> pPredicate) {
-    	return (pInput1, pInput2) -> {
-    		try {
-    			return pPredicate.test(pInput1, pInput2);
-    		} catch (Throwable t) {
-    			throw rethrow(t);
-    		}
-    	};
+    public static <I1, I2> BiPredicate<I1, I2> asBiPredicate(FailableBiPredicate<I1, I2, ?> pPredicate) {
+        return (pInput1, pInput2) -> {
+            try {
+                return pPredicate.test(pInput1, pInput2);
+            } catch (Throwable t) {
+                throw rethrow(t);
+            }
+        };
     }
 
     /**
      * Converts the given {@link FailableSupplier} into a standard {@link Supplier}.
+     *
+     * @param <O> the type supplied by the suppliers
+     * @param pSupplier a {@code FailableSupplier}
+     * @return a standard {@code Supplier}
      */
-    public static <O> Supplier<O> asSupplier(FailableSupplier<O,?> pSupplier) {
-    	return () -> {
-    		try {
-    			return pSupplier.get();
-    		} catch (Throwable t) {
-    			throw rethrow(t);
-    		}
-    	};
+    public static <O> Supplier<O> asSupplier(FailableSupplier<O, ?> pSupplier) {
+        return () -> {
+            try {
+                return pSupplier.get();
+            } catch (Throwable t) {
+                throw rethrow(t);
+            }
+        };
     }
 
     /**
@@ -396,12 +436,12 @@ public class Functions {
      * @param <T> The type of checked exception, which the supplier can throw.
      * @return The object, which has been created by the supplier
      */
-    public static <O,T extends Throwable> O get(FailableSupplier<O,T> pSupplier) {
-    	try {
-    		return pSupplier.get();
-    	} catch (Throwable t) {
-    		throw rethrow(t);
-    	}
+    public static <O, T extends Throwable> O get(FailableSupplier<O, T> pSupplier) {
+        try {
+            return pSupplier.get();
+        } catch (Throwable t) {
+            throw rethrow(t);
+        }
     }
 
 

--- a/src/test/java/org/apache/commons/lang3/FunctionsTest.java
+++ b/src/test/java/org/apache/commons/lang3/FunctionsTest.java
@@ -39,7 +39,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
 class FunctionsTest {
     public static class SomeException extends Exception {
@@ -168,7 +167,9 @@ class FunctionsTest {
     @Test
     void testAsCallable() {
         FailureOnOddInvocations.invocation = 0;
-        final FailableCallable<FailureOnOddInvocations,SomeException> failableCallable = () -> { return new FailureOnOddInvocations(); };
+        final FailableCallable<FailureOnOddInvocations, SomeException> failableCallable = () -> {
+            return new FailureOnOddInvocations();
+        };
         final Callable<FailureOnOddInvocations> callable = Functions.asCallable(failableCallable);
         UndeclaredThrowableException e = assertThrows(UndeclaredThrowableException.class, () ->  callable.call());
         final Throwable cause = e.getCause();
@@ -177,9 +178,9 @@ class FunctionsTest {
         assertEquals("Odd Invocation: 1", cause.getMessage());
         final FailureOnOddInvocations instance;
         try {
-        	instance = callable.call();
+            instance = callable.call();
         } catch (Exception ex) {
-        	throw Functions.rethrow(ex);
+            throw Functions.rethrow(ex);
         }
         assertNotNull(instance);
     }
@@ -211,7 +212,7 @@ class FunctionsTest {
     void testAsConsumer() {
         final IllegalStateException ise = new IllegalStateException();
         final Testable testable = new Testable(ise);
-        final Consumer<Testable> consumer = Functions.asConsumer((t) -> t.test()); 
+        final Consumer<Testable> consumer = Functions.asConsumer((t) -> t.test());
         Throwable e = assertThrows(IllegalStateException.class, () -> consumer.accept(testable));
         assertSame(ise, e);
 
@@ -257,7 +258,9 @@ class FunctionsTest {
     void testAsBiConsumer() {
         final IllegalStateException ise = new IllegalStateException();
         final Testable testable = new Testable(null);
-        final FailableBiConsumer<Testable, Throwable, Throwable> failableBiConsumer = (t, th) -> { t.setThrowable(th); t.test(); }; 
+        final FailableBiConsumer<Testable, Throwable, Throwable> failableBiConsumer = (t, th) -> {
+            t.setThrowable(th); t.test();
+        };
         final BiConsumer<Testable, Throwable> consumer = Functions.asBiConsumer(failableBiConsumer);
         Throwable e = assertThrows(IllegalStateException.class, () -> consumer.accept(testable, ise));
         assertSame(ise, e);
@@ -305,11 +308,11 @@ class FunctionsTest {
     public void testAsFunction() {
         final IllegalStateException ise = new IllegalStateException();
         final Testable testable = new Testable(ise);
-        final FailableFunction<Throwable,Integer,Throwable> failableFunction = (th) -> {
-        	testable.setThrowable(th);
-        	return Integer.valueOf(testable.testInt());
+        final FailableFunction<Throwable, Integer, Throwable> failableFunction = (th) -> {
+            testable.setThrowable(th);
+            return Integer.valueOf(testable.testInt());
         };
-        final Function<Throwable,Integer> function = Functions.asFunction(failableFunction);
+        final Function<Throwable, Integer> function = Functions.asFunction(failableFunction);
         Throwable e = assertThrows(IllegalStateException.class, () -> function.apply(ise));
         assertSame(ise, e);
 
@@ -354,11 +357,11 @@ class FunctionsTest {
     public void testAsBiFunction() {
         final IllegalStateException ise = new IllegalStateException();
         final Testable testable = new Testable(ise);
-        final FailableBiFunction<Testable,Throwable,Integer,Throwable> failableBiFunction = (t, th) -> {
-        	t.setThrowable(th);
-        	return Integer.valueOf(t.testInt());
+        final FailableBiFunction<Testable, Throwable, Integer, Throwable> failableBiFunction = (t, th) -> {
+            t.setThrowable(th);
+            return Integer.valueOf(t.testInt());
         };
-        final BiFunction<Testable,Throwable,Integer> biFunction = Functions.asBiFunction(failableBiFunction);
+        final BiFunction<Testable, Throwable, Integer> biFunction = Functions.asBiFunction(failableBiFunction);
         Throwable e = assertThrows(IllegalStateException.class, () -> biFunction.apply(testable, ise));
         assertSame(ise, e);
 
@@ -392,7 +395,9 @@ class FunctionsTest {
     @Test
     public void testAsSupplier() {
         FailureOnOddInvocations.invocation = 0;
-        final FailableSupplier<FailureOnOddInvocations,Throwable> failableSupplier = () -> { return new FailureOnOddInvocations(); };
+        final FailableSupplier<FailureOnOddInvocations, Throwable> failableSupplier = () -> {
+            return new FailureOnOddInvocations();
+        };
         final Supplier<FailureOnOddInvocations> supplier = Functions.asSupplier(failableSupplier);
         UndeclaredThrowableException e = assertThrows(UndeclaredThrowableException.class, () ->  supplier.get());
         final Throwable cause = e.getCause();


### PR DESCRIPTION
I think some changes slipped with some recent change. Reviewing PR of contributors, it was quite hard to distinguish what was failing due to the contributor's PR.

If Travis is happy with this change, will merge it as I think this is a small change (formatting, adding javadocs, commas, replacing tab characters, etc).

Cheers
Bruno