### PR TITLE
Add and use IllegalArgumentExceptions

### DIFF
--- a/src/main/java/org/apache/commons/lang3/ArrayUtils.java
+++ b/src/main/java/org/apache/commons/lang3/ArrayUtils.java
@@ -28,6 +28,7 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
+import org.apache.commons.lang3.exception.IllegalArgumentExceptions;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.commons.lang3.mutable.MutableInt;
 
@@ -267,15 +268,13 @@ public class ArrayUtils {
             } else if (object instanceof Object[]) {
                 final Object[] entry = (Object[]) object;
                 if (entry.length < 2) {
-                    throw new IllegalArgumentException("Array element " + i + ", '"
-                        + object
-                        + "', has a length less than 2");
+                    throw IllegalArgumentExceptions.format("Array element %,d, '%s', has a length less than 2", i,
+                            object);
                 }
                 map.put(entry[0], entry[1]);
             } else {
-                throw new IllegalArgumentException("Array element " + i + ", '"
-                        + object
-                        + "', is neither of type Map.Entry nor an Array");
+                throw IllegalArgumentExceptions
+                        .format("Array element %,d, '%s', is neither of type Map.Entry nor an Array", i, object);
             }
         }
         return map;
@@ -5098,8 +5097,8 @@ public class ArrayUtils {
              */
             final Class<?> type2 = array2.getClass().getComponentType();
             if (!type1.isAssignableFrom(type2)) {
-                throw new IllegalArgumentException("Cannot store " + type2.getName() + " in an array of "
-                        + type1.getName(), ase);
+                throw IllegalArgumentExceptions.format(ase, "Cannot store %s in an array of %s", type2.getName(),
+                        type1.getName(), ase);
             }
             throw ase; // No, so rethrow original
         }

--- a/src/main/java/org/apache/commons/lang3/CharUtils.java
+++ b/src/main/java/org/apache/commons/lang3/CharUtils.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.lang3;
 
+import org.apache.commons.lang3.exception.IllegalArgumentExceptions;
+
 /**
  * <p>Operations on char primitives and Character objects.</p>
  *
@@ -219,7 +221,7 @@ public class CharUtils {
      */
     public static int toIntValue(final char ch) {
         if (!isAsciiNumeric(ch)) {
-            throw new IllegalArgumentException("The character " + ch + " is not in the range '0' - '9'");
+            throw IllegalArgumentExceptions.format("The character %s is not in the range '0' - '9'", ch);
         }
         return ch - 48;
     }

--- a/src/main/java/org/apache/commons/lang3/Conversion.java
+++ b/src/main/java/org/apache/commons/lang3/Conversion.java
@@ -18,6 +18,8 @@ package org.apache.commons.lang3;
 
 import java.util.UUID;
 
+import org.apache.commons.lang3.exception.IllegalArgumentExceptions;
+
 
 /**
  * <p>
@@ -95,7 +97,7 @@ public class Conversion {
     public static int hexDigitToInt(final char hexDigit) {
         final int digit = Character.digit(hexDigit, 16);
         if (digit < 0) {
-            throw new IllegalArgumentException("Cannot interpret '" + hexDigit + "' as a hexadecimal digit");
+            throw IllegalArgumentExceptions.format("Cannot interpret '%s' as a hexadecimal digit", hexDigit);
         }
         return digit;
     }
@@ -153,7 +155,7 @@ public class Conversion {
         case 'F':
             return 0xF;
         default:
-            throw new IllegalArgumentException("Cannot interpret '" + hexDigit + "' as a hexadecimal digit");
+            throw IllegalArgumentExceptions.format("Cannot interpret '%s' as a hexadecimal digit", hexDigit);
         }
     }
 
@@ -211,7 +213,7 @@ public class Conversion {
         case 'F':
             return TTTT.clone();
         default:
-            throw new IllegalArgumentException("Cannot interpret '" + hexDigit + "' as a hexadecimal digit");
+            throw IllegalArgumentExceptions.format("Cannot interpret '%s' as a hexadecimal digit", hexDigit);
         }
     }
 
@@ -269,7 +271,7 @@ public class Conversion {
         case 'F':
             return TTTT.clone();
         default:
-            throw new IllegalArgumentException("Cannot interpret '" + hexDigit + "' as a hexadecimal digit");
+            throw IllegalArgumentExceptions.format("Cannot interpret '%s' as a hexadecimal digit", hexDigit);
         }
     }
 
@@ -372,10 +374,11 @@ public class Conversion {
      */
     public static char binaryToHexDigitMsb0_4bits(final boolean[] src, final int srcPos) {
         if (src.length > 8) {
-            throw new IllegalArgumentException("src.length>8: src.length=" + src.length);
+            throw IllegalArgumentExceptions.format("src.length>8: src.length=%,d");
         }
         if (src.length - srcPos < 4) {
-            throw new IllegalArgumentException("src.length-srcPos<4: src.length=" + src.length + ", srcPos=" + srcPos);
+            throw IllegalArgumentExceptions.format("src.length-srcPos<4: src.length=%,d, srcPos=%,d", src.length,
+                    srcPos);
         }
         if (src[srcPos + 3]) {
             if (src[srcPos + 2]) {

--- a/src/main/java/org/apache/commons/lang3/RandomStringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/RandomStringUtils.java
@@ -18,6 +18,8 @@ package org.apache.commons.lang3;
 
 import java.util.Random;
 
+import org.apache.commons.lang3.exception.IllegalArgumentExceptions;
+
 /**
  * <p>Operations for random {@code String}s.</p>
  * <p>Currently <em>private high surrogate</em> characters are ignored.
@@ -359,7 +361,7 @@ public class RandomStringUtils {
         if (count == 0) {
             return StringUtils.EMPTY;
         } else if (count < 0) {
-            throw new IllegalArgumentException("Requested random string length " + count + " is less than 0.");
+            throw IllegalArgumentExceptions.format("Requested random string length %,d is less than 0.", count);
         }
         if (chars != null && chars.length == 0) {
             throw new IllegalArgumentException("The chars array must not be empty");

--- a/src/main/java/org/apache/commons/lang3/Range.java
+++ b/src/main/java/org/apache/commons/lang3/Range.java
@@ -19,6 +19,8 @@ package org.apache.commons.lang3;
 import java.io.Serializable;
 import java.util.Comparator;
 
+import org.apache.commons.lang3.exception.IllegalArgumentExceptions;
+
 /**
  * <p>An immutable range of objects from a minimum to maximum point inclusive.</p>
  *
@@ -165,8 +167,8 @@ public final class Range<T> implements Serializable {
     @SuppressWarnings("unchecked")
     private Range(final T element1, final T element2, final Comparator<T> comp) {
         if (element1 == null || element2 == null) {
-            throw new IllegalArgumentException("Elements in a range must not be null: element1=" +
-                                               element1 + ", element2=" + element2);
+            throw IllegalArgumentExceptions.format("Elements in a range must not be null: element1=%s, element2=%s",
+                    element1, element2);
         }
         if (comp == null) {
             this.comparator = ComparableComparator.INSTANCE;
@@ -318,8 +320,8 @@ public final class Range<T> implements Serializable {
      */
     public Range<T> intersectionWith(final Range<T> other) {
         if (!this.isOverlappedBy(other)) {
-            throw new IllegalArgumentException(String.format(
-                "Cannot calculate intersection with non-overlapping range %s", other));
+            throw IllegalArgumentExceptions.format("Cannot calculate intersection with non-overlapping range %s",
+                    other);
         }
         if (this.equals(other)) {
             return this;

--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -27,6 +27,8 @@ import java.util.Locale;
 import java.util.Objects;
 import java.util.regex.Pattern;
 
+import org.apache.commons.lang3.exception.IllegalArgumentExceptions;
+
 /**
  * <p>Operations on {@link java.lang.String} that are
  * {@code null} safe.</p>
@@ -341,7 +343,7 @@ public class StringUtils {
         final int minAbbrevWidthOffset = abbrevMarkerLength + abbrevMarkerLength + 1;
 
         if (maxWidth < minAbbrevWidth) {
-            throw new IllegalArgumentException(String.format("Minimum abbreviation width is %d", minAbbrevWidth));
+            throw IllegalArgumentExceptions.format("Minimum abbreviation width is %d", minAbbrevWidth);
         }
         if (str.length() <= maxWidth) {
             return str;
@@ -356,7 +358,7 @@ public class StringUtils {
             return str.substring(0, maxWidth - abbrevMarkerLength) + abbrevMarker;
         }
         if (maxWidth < minAbbrevWidthOffset) {
-            throw new IllegalArgumentException(String.format("Minimum abbreviation width with offset is %d", minAbbrevWidthOffset));
+            throw IllegalArgumentExceptions.format("Minimum abbreviation width with offset is %d", minAbbrevWidthOffset);
         }
         if (offset + maxWidth - abbrevMarkerLength < str.length()) {
             return abbrevMarker + abbreviate(str.substring(offset), abbrevMarker, maxWidth - abbrevMarkerLength);
@@ -6654,10 +6656,8 @@ public class StringUtils {
 
         // make sure lengths are ok, these need to be equal
         if (searchLength != replacementLength) {
-            throw new IllegalArgumentException("Search and Replace array lengths don't match: "
-                + searchLength
-                + " vs "
-                + replacementLength);
+            throw IllegalArgumentExceptions.format("Search and Replace array lengths don't match: %s vs %s",
+                    searchLength, replacementLength);
         }
 
         // keep track of which still have matches

--- a/src/main/java/org/apache/commons/lang3/Validate.java
+++ b/src/main/java/org/apache/commons/lang3/Validate.java
@@ -21,6 +21,8 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.regex.Pattern;
 
+import org.apache.commons.lang3.exception.IllegalArgumentExceptions;
+
 /**
  * <p>This class assists in validating arguments. The validation methods are
  * based along the following principles:
@@ -106,7 +108,7 @@ public class Validate {
      */
     public static void isTrue(final boolean expression, final String message, final long value) {
         if (!expression) {
-            throw new IllegalArgumentException(String.format(message, Long.valueOf(value)));
+            throw IllegalArgumentExceptions.format(message, Long.valueOf(value));
         }
     }
 
@@ -131,7 +133,7 @@ public class Validate {
      */
     public static void isTrue(final boolean expression, final String message, final double value) {
         if (!expression) {
-            throw new IllegalArgumentException(String.format(message, Double.valueOf(value)));
+            throw IllegalArgumentExceptions.format(message, Double.valueOf(value));
         }
     }
 
@@ -155,7 +157,7 @@ public class Validate {
      */
     public static void isTrue(final boolean expression, final String message, final Object... values) {
         if (!expression) {
-            throw new IllegalArgumentException(String.format(message, values));
+            throw IllegalArgumentExceptions.format(message, values);
         }
     }
 
@@ -251,7 +253,7 @@ public class Validate {
             throw new NullPointerException(String.format(message, values));
         }
         if (array.length == 0) {
-            throw new IllegalArgumentException(String.format(message, values));
+            throw IllegalArgumentExceptions.format(message, values);
         }
         return array;
     }
@@ -300,7 +302,7 @@ public class Validate {
             throw new NullPointerException(String.format(message, values));
         }
         if (collection.isEmpty()) {
-            throw new IllegalArgumentException(String.format(message, values));
+            throw IllegalArgumentExceptions.format(message, values);
         }
         return collection;
     }
@@ -349,7 +351,7 @@ public class Validate {
             throw new NullPointerException(String.format(message, values));
         }
         if (map.isEmpty()) {
-            throw new IllegalArgumentException(String.format(message, values));
+            throw IllegalArgumentExceptions.format(message, values);
         }
         return map;
     }
@@ -398,7 +400,7 @@ public class Validate {
             throw new NullPointerException(String.format(message, values));
         }
         if (chars.length() == 0) {
-            throw new IllegalArgumentException(String.format(message, values));
+            throw IllegalArgumentExceptions.format(message, values);
         }
         return chars;
     }
@@ -451,7 +453,7 @@ public class Validate {
             throw new NullPointerException(String.format(message, values));
         }
         if (StringUtils.isBlank(chars)) {
-            throw new IllegalArgumentException(String.format(message, values));
+            throw IllegalArgumentExceptions.format(message, values);
         }
         return chars;
     }
@@ -510,7 +512,7 @@ public class Validate {
         for (int i = 0; i < array.length; i++) {
             if (array[i] == null) {
                 final Object[] values2 = ArrayUtils.add(values, Integer.valueOf(i));
-                throw new IllegalArgumentException(String.format(message, values2));
+                throw IllegalArgumentExceptions.format(message, values2);
             }
         }
         return array;
@@ -573,7 +575,7 @@ public class Validate {
         for (final Iterator<?> it = iterable.iterator(); it.hasNext(); i++) {
             if (it.next() == null) {
                 final Object[] values2 = ArrayUtils.addAll(values, Integer.valueOf(i));
-                throw new IllegalArgumentException(String.format(message, values2));
+                throw IllegalArgumentExceptions.format(message, values2);
             }
         }
         return iterable;
@@ -851,7 +853,7 @@ public class Validate {
     public static void matchesPattern(final CharSequence input, final String pattern) {
         // TODO when breaking BC, consider returning input
         if (!Pattern.matches(pattern, input)) {
-            throw new IllegalArgumentException(String.format(DEFAULT_MATCHES_PATTERN_EX, input, pattern));
+            throw IllegalArgumentExceptions.format(DEFAULT_MATCHES_PATTERN_EX, input, pattern);
         }
     }
 
@@ -875,7 +877,7 @@ public class Validate {
     public static void matchesPattern(final CharSequence input, final String pattern, final String message, final Object... values) {
         // TODO when breaking BC, consider returning input
         if (!Pattern.matches(pattern, input)) {
-            throw new IllegalArgumentException(String.format(message, values));
+            throw IllegalArgumentExceptions.format(message, values);
         }
     }
 
@@ -917,7 +919,7 @@ public class Validate {
      */
     public static void notNaN(final double value, final String message, final Object... values) {
         if (Double.isNaN(value)) {
-            throw new IllegalArgumentException(String.format(message, values));
+            throw IllegalArgumentExceptions.format(message, values);
         }
     }
 
@@ -958,7 +960,7 @@ public class Validate {
      */
     public static void finite(final double value, final String message, final Object... values) {
         if (Double.isNaN(value) || Double.isInfinite(value)) {
-            throw new IllegalArgumentException(String.format(message, values));
+            throw IllegalArgumentExceptions.format(message, values);
         }
     }
 
@@ -983,7 +985,7 @@ public class Validate {
     public static <T> void inclusiveBetween(final T start, final T end, final Comparable<T> value) {
         // TODO when breaking BC, consider returning value
         if (value.compareTo(start) < 0 || value.compareTo(end) > 0) {
-            throw new IllegalArgumentException(String.format(DEFAULT_INCLUSIVE_BETWEEN_EX_MESSAGE, value, start, end));
+            throw IllegalArgumentExceptions.format(DEFAULT_INCLUSIVE_BETWEEN_EX_MESSAGE, value, start, end);
         }
     }
 
@@ -1008,7 +1010,7 @@ public class Validate {
     public static <T> void inclusiveBetween(final T start, final T end, final Comparable<T> value, final String message, final Object... values) {
         // TODO when breaking BC, consider returning value
         if (value.compareTo(start) < 0 || value.compareTo(end) > 0) {
-            throw new IllegalArgumentException(String.format(message, values));
+            throw IllegalArgumentExceptions.format(message, values);
         }
     }
 
@@ -1029,7 +1031,7 @@ public class Validate {
     public static void inclusiveBetween(final long start, final long end, final long value) {
         // TODO when breaking BC, consider returning value
         if (value < start || value > end) {
-            throw new IllegalArgumentException(String.format(DEFAULT_INCLUSIVE_BETWEEN_EX_MESSAGE, value, start, end));
+            throw IllegalArgumentExceptions.format(DEFAULT_INCLUSIVE_BETWEEN_EX_MESSAGE, value, start, end);
         }
     }
 
@@ -1073,7 +1075,7 @@ public class Validate {
     public static void inclusiveBetween(final double start, final double end, final double value) {
         // TODO when breaking BC, consider returning value
         if (value < start || value > end) {
-            throw new IllegalArgumentException(String.format(DEFAULT_INCLUSIVE_BETWEEN_EX_MESSAGE, value, start, end));
+            throw IllegalArgumentExceptions.format(DEFAULT_INCLUSIVE_BETWEEN_EX_MESSAGE, value, start, end);
         }
     }
 
@@ -1121,7 +1123,7 @@ public class Validate {
     public static <T> void exclusiveBetween(final T start, final T end, final Comparable<T> value) {
         // TODO when breaking BC, consider returning value
         if (value.compareTo(start) <= 0 || value.compareTo(end) >= 0) {
-            throw new IllegalArgumentException(String.format(DEFAULT_EXCLUSIVE_BETWEEN_EX_MESSAGE, value, start, end));
+            throw IllegalArgumentExceptions.format(DEFAULT_EXCLUSIVE_BETWEEN_EX_MESSAGE, value, start, end);
         }
     }
 
@@ -1146,7 +1148,7 @@ public class Validate {
     public static <T> void exclusiveBetween(final T start, final T end, final Comparable<T> value, final String message, final Object... values) {
         // TODO when breaking BC, consider returning value
         if (value.compareTo(start) <= 0 || value.compareTo(end) >= 0) {
-            throw new IllegalArgumentException(String.format(message, values));
+            throw IllegalArgumentExceptions.format(message, values);
         }
     }
 
@@ -1167,7 +1169,7 @@ public class Validate {
     public static void exclusiveBetween(final long start, final long end, final long value) {
         // TODO when breaking BC, consider returning value
         if (value <= start || value >= end) {
-            throw new IllegalArgumentException(String.format(DEFAULT_EXCLUSIVE_BETWEEN_EX_MESSAGE, value, start, end));
+            throw IllegalArgumentExceptions.format(DEFAULT_EXCLUSIVE_BETWEEN_EX_MESSAGE, value, start, end);
         }
     }
 
@@ -1211,7 +1213,7 @@ public class Validate {
     public static void exclusiveBetween(final double start, final double end, final double value) {
         // TODO when breaking BC, consider returning value
         if (value <= start || value >= end) {
-            throw new IllegalArgumentException(String.format(DEFAULT_EXCLUSIVE_BETWEEN_EX_MESSAGE, value, start, end));
+            throw IllegalArgumentExceptions.format(DEFAULT_EXCLUSIVE_BETWEEN_EX_MESSAGE, value, start, end);
         }
     }
 
@@ -1260,8 +1262,8 @@ public class Validate {
     public static void isInstanceOf(final Class<?> type, final Object obj) {
         // TODO when breaking BC, consider returning obj
         if (!type.isInstance(obj)) {
-            throw new IllegalArgumentException(String.format(DEFAULT_IS_INSTANCE_OF_EX_MESSAGE, type.getName(),
-                    obj == null ? "null" : obj.getClass().getName()));
+            throw IllegalArgumentExceptions.format(DEFAULT_IS_INSTANCE_OF_EX_MESSAGE, type.getName(),
+                    obj == null ? "null" : obj.getClass().getName());
         }
     }
 
@@ -1285,7 +1287,7 @@ public class Validate {
     public static void isInstanceOf(final Class<?> type, final Object obj, final String message, final Object... values) {
         // TODO when breaking BC, consider returning obj
         if (!type.isInstance(obj)) {
-            throw new IllegalArgumentException(String.format(message, values));
+            throw IllegalArgumentExceptions.format(message, values);
         }
     }
 
@@ -1311,8 +1313,8 @@ public class Validate {
     public static void isAssignableFrom(final Class<?> superType, final Class<?> type) {
         // TODO when breaking BC, consider returning type
         if (!superType.isAssignableFrom(type)) {
-            throw new IllegalArgumentException(String.format(DEFAULT_IS_ASSIGNABLE_EX_MESSAGE, type == null ? "null" : type.getName(),
-                    superType.getName()));
+            throw IllegalArgumentExceptions.format(DEFAULT_IS_ASSIGNABLE_EX_MESSAGE,
+                    type == null ? "null" : type.getName(), superType.getName());
         }
     }
 
@@ -1336,7 +1338,7 @@ public class Validate {
     public static void isAssignableFrom(final Class<?> superType, final Class<?> type, final String message, final Object... values) {
         // TODO when breaking BC, consider returning type
         if (!superType.isAssignableFrom(type)) {
-            throw new IllegalArgumentException(String.format(message, values));
+            throw IllegalArgumentExceptions.format(message, values);
         }
     }
 }

--- a/src/main/java/org/apache/commons/lang3/event/EventUtils.java
+++ b/src/main/java/org/apache/commons/lang3/event/EventUtils.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.apache.commons.lang3.exception.IllegalArgumentExceptions;
 import org.apache.commons.lang3.reflect.MethodUtils;
 
 /**
@@ -48,13 +49,13 @@ public class EventUtils {
         try {
             MethodUtils.invokeMethod(eventSource, "add" + listenerType.getSimpleName(), listener);
         } catch (final NoSuchMethodException e) {
-            throw new IllegalArgumentException("Class " + eventSource.getClass().getName()
-                    + " does not have a public add" + listenerType.getSimpleName()
-                    + " method which takes a parameter of type " + listenerType.getName() + ".");
+            throw IllegalArgumentExceptions.format(
+                    "Class %s does not have a public add%s method which takes a parameter of type %s.",
+                    eventSource.getClass().getName(), listenerType.getSimpleName(), listenerType.getName());
         } catch (final IllegalAccessException e) {
-            throw new IllegalArgumentException("Class " + eventSource.getClass().getName()
-                    + " does not have an accessible add" + listenerType.getSimpleName ()
-                    + " method which takes a parameter of type " + listenerType.getName() + ".");
+            throw IllegalArgumentExceptions.format(
+                    "Class %s does not have an accessible add%s method which takes a parameter of type %s.",
+                    eventSource.getClass().getName(), listenerType.getSimpleName(), listenerType.getName());
         } catch (final InvocationTargetException e) {
             throw new RuntimeException("Unable to add listener.", e.getCause());
         }

--- a/src/main/java/org/apache/commons/lang3/exception/IllegalArgumentExceptions.java
+++ b/src/main/java/org/apache/commons/lang3/exception/IllegalArgumentExceptions.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+
+package org.apache.commons.lang3.exception;
+
+/**
+ * Shorthands creating {@link IllegalArgumentException} instances using formatted strings.
+ *
+ * <p>
+ * Originally from Apache Commons Text.
+ * </p>
+ * 
+ * @since 3.10
+ */
+public final class IllegalArgumentExceptions {
+
+    /**
+     * Creates an {@link IllegalArgumentException} with a message formated with {@link String#format(String,Object...)}.
+     *
+     * @param format See {@link String#format(String,Object...)}
+     * @param args See {@link String#format(String,Object...)}
+     * @return an {@link IllegalArgumentException} with a message formated with {@link String#format(String,Object...)}
+     */
+    public static IllegalArgumentException format(final String format, final Object... args) {
+        return new IllegalArgumentException(String.format(format, args));
+    }
+
+    /**
+     * Creates an {@link IllegalArgumentException} with a message formated with {@link String#format(String,Object...)}.
+     *
+     * @param t the throwable cause
+     * @param format See {@link String#format(String,Object...)}
+     * @param args See {@link String#format(String,Object...)}
+     * @return an {@link IllegalArgumentException} with a message formated with {@link String#format(String,Object...)}
+     */
+    public static IllegalArgumentException format(final Throwable t, final String format, final Object... args) {
+        return new IllegalArgumentException(String.format(format, args), t);
+    }
+
+    /**
+     * No need to build instances.
+     */
+    private IllegalArgumentExceptions() {
+        // empty
+    }
+}

--- a/src/main/java/org/apache/commons/lang3/text/ExtendedMessageFormat.java
+++ b/src/main/java/org/apache/commons/lang3/text/ExtendedMessageFormat.java
@@ -28,6 +28,7 @@ import java.util.Objects;
 
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.Validate;
+import org.apache.commons.lang3.exception.IllegalArgumentExceptions;
 
 /**
  * Extends <code>java.text.MessageFormat</code> to allow pluggable/additional formatting
@@ -184,8 +185,7 @@ public class ExtendedMessageFormat extends MessageFormat {
                 Validate.isTrue(foundFormats.size() == fmtCount);
                 Validate.isTrue(foundDescriptions.size() == fmtCount);
                 if (c[pos.getIndex()] != END_FE) {
-                    throw new IllegalArgumentException(
-                            "Unreadable format element at position " + start);
+                    throw IllegalArgumentExceptions.format("Unreadable format element at position %,d", start);
                 }
                 //$FALL-THROUGH$
             default:
@@ -351,9 +351,8 @@ public class ExtendedMessageFormat extends MessageFormat {
             result.append(c);
         }
         if (error) {
-            throw new IllegalArgumentException(
-                    "Invalid format argument index at position " + start + ": "
-                            + pattern.substring(start, pos.getIndex()));
+            throw IllegalArgumentExceptions.format("Invalid format argument index at position %,d: %s", start,
+                    pattern.substring(start, pos.getIndex()));
         }
         throw new IllegalArgumentException(
                 "Unterminated format element at position " + start);
@@ -389,8 +388,7 @@ public class ExtendedMessageFormat extends MessageFormat {
                 break;
             }
         }
-        throw new IllegalArgumentException(
-                "Unterminated format element at position " + start);
+        throw IllegalArgumentExceptions.format("Unterminated format element at position %,d", start);
     }
 
     /**
@@ -494,8 +492,7 @@ public class ExtendedMessageFormat extends MessageFormat {
             }
             next(pos);
         }
-        throw new IllegalArgumentException(
-                "Unterminated quoted string at position " + start);
+        throw IllegalArgumentExceptions.format("Unterminated quoted string at position %,d", start);
     }
 
     /**

--- a/src/main/java/org/apache/commons/lang3/time/DateUtils.java
+++ b/src/main/java/org/apache/commons/lang3/time/DateUtils.java
@@ -27,6 +27,7 @@ import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang3.Validate;
+import org.apache.commons.lang3.exception.IllegalArgumentExceptions;
 
 /**
  * <p>A suite of utilities surrounding the use of the
@@ -1095,7 +1096,7 @@ public class DateUtils {
                 val.set(aField[0], val.get(aField[0]) - offset);
             }
         }
-        throw new IllegalArgumentException("The field " + field + " is not supported");
+        throw IllegalArgumentExceptions.format("The field %s is not supported", field);
 
     }
 
@@ -1206,7 +1207,7 @@ public class DateUtils {
                 }
                 break;
             default:
-                throw new IllegalArgumentException("The range style " + rangeStyle + " is not valid.");
+                throw IllegalArgumentExceptions.format("The range style %s is not valid.", rangeStyle);
         }
         if (startCutoff < Calendar.SUNDAY) {
             startCutoff += 7;
@@ -1706,7 +1707,7 @@ public class DateUtils {
                 result += unit.convert(calendar.get(Calendar.MILLISECOND), TimeUnit.MILLISECONDS);
                 break;
             case Calendar.MILLISECOND: break; //never useful
-                default: throw new IllegalArgumentException("The fragment " + fragment + " is not supported");
+                default: throw IllegalArgumentExceptions.format("The fragment %s is not supported", fragment);
         }
         return result;
     }

--- a/src/main/java/org/apache/commons/lang3/time/FastDateParser.java
+++ b/src/main/java/org/apache/commons/lang3/time/FastDateParser.java
@@ -39,6 +39,8 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.commons.lang3.exception.IllegalArgumentExceptions;
+
 /**
  * <p>FastDateParser is a fast and thread-safe version of
  * {@link java.text.SimpleDateFormat}.</p>
@@ -557,7 +559,7 @@ public class FastDateParser implements DateParser, Serializable {
     private Strategy getStrategy(final char f, final int width, final Calendar definingCalendar) {
         switch(f) {
         default:
-            throw new IllegalArgumentException("Format '"+f+"' not supported");
+            throw IllegalArgumentExceptions.format("Format '%s' not supported", f);
         case 'D':
             return DAY_OF_YEAR_STRATEGY;
         case 'E':


### PR DESCRIPTION
Add and use `IllegalArgumentExceptions` to combine creating `IllegalArgumentException` instances with formatted messages using `String#format()`.