### PR TITLE
LANG-1485 : Add getters for lhs and rhs objects in DiffResult

### DIFF
--- a/src/main/java/org/apache/commons/lang3/builder/DiffResult.java
+++ b/src/main/java/org/apache/commons/lang3/builder/DiffResult.java
@@ -89,6 +89,22 @@ public class DiffResult implements Iterable<Diff<?>> {
     }
 
     /**
+     * <p>Return the object the right object has been compared to</p>
+     * @return the left object of the diff
+     */
+    public Object getLhs() {
+        return this.lhs;
+    }
+
+    /**
+     * <p>Return the object the left object has been compared to</p>
+     * @return the right object of the diff
+     */
+    public Object getRhs() {
+        return this.rhs;
+    }
+
+    /**
      * <p>
      * Returns an unmodifiable list of {@code Diff}s. The list may be empty if
      * there were no differences between the objects.

--- a/src/main/java/org/apache/commons/lang3/builder/DiffResult.java
+++ b/src/main/java/org/apache/commons/lang3/builder/DiffResult.java
@@ -89,18 +89,20 @@ public class DiffResult implements Iterable<Diff<?>> {
     }
 
     /**
-     * <p>Return the object the right object has been compared to</p>
+     * <p>Gets the object the right object has been compared to.</p>
+     * @since 3.10
      * @return the left object of the diff
      */
-    public Object getLhs() {
+    public Object getLeft() {
         return this.lhs;
     }
 
     /**
-     * <p>Return the object the left object has been compared to</p>
+     * <p>Gets the object the left object has been compared to.</p>
+     * @ 3.10
      * @return the right object of the diff
      */
-    public Object getRhs() {
+    public Object getRight() {
         return this.rhs;
     }
 

--- a/src/main/java/org/apache/commons/lang3/builder/DiffResult.java
+++ b/src/main/java/org/apache/commons/lang3/builder/DiffResult.java
@@ -89,18 +89,20 @@ public class DiffResult implements Iterable<Diff<?>> {
     }
 
     /**
-     * <p>Gets the object the right object has been compared to.</p>
-     * @since 3.10
+     * <p>Returns the object the right object has been compared to.</p>
+     *
      * @return the left object of the diff
+     * @since 3.10
      */
     public Object getLeft() {
         return this.lhs;
     }
 
     /**
-     * <p>Gets the object the left object has been compared to.</p>
-     * @ 3.10
+     * <p>Returns the object the left object has been compared to.</p>
+     *
      * @return the right object of the diff
+     * @since 3.10
      */
     public Object getRight() {
         return this.rhs;

--- a/src/test/java/org/apache/commons/lang3/builder/DiffResultTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/DiffResultTest.java
@@ -146,4 +146,16 @@ public class DiffResultTest {
                 SHORT_STYLE).build();
         assertEquals(DiffResult.OBJECTS_SAME_STRING, diffResult.toString());
     }
+
+    @Test
+    public void testGetLhs() {
+        final SimpleClass lhs = new SimpleClass(true);
+        final SimpleClass rhs = new SimpleClass(false);
+
+        final List<Diff<?>> diffs = lhs.diff(rhs).getDiffs();
+        final DiffResult diffResult = new DiffResult(lhs, rhs, diffs, SHORT_STYLE);
+
+        assertEquals(lhs, diffResult.getLhs());
+        assertEquals(rhs, diffResult.getRhs());
+    }
 }

--- a/src/test/java/org/apache/commons/lang3/builder/DiffResultTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/DiffResultTest.java
@@ -148,14 +148,14 @@ public class DiffResultTest {
     }
 
     @Test
-    public void testGetLhs() {
-        final SimpleClass lhs = new SimpleClass(true);
-        final SimpleClass rhs = new SimpleClass(false);
+    public void testLeftAndRightGetters() {
+        final SimpleClass left = new SimpleClass(true);
+        final SimpleClass right = new SimpleClass(false);
 
-        final List<Diff<?>> diffs = lhs.diff(rhs).getDiffs();
-        final DiffResult diffResult = new DiffResult(lhs, rhs, diffs, SHORT_STYLE);
+        final List<Diff<?>> diffs = left.diff(right).getDiffs();
+        final DiffResult diffResult = new DiffResult(left, right, diffs, SHORT_STYLE);
 
-        assertEquals(lhs, diffResult.getLhs());
-        assertEquals(rhs, diffResult.getRhs());
+        assertEquals(left, diffResult.getLeft());
+        assertEquals(right, diffResult.getRight());
     }
 }


### PR DESCRIPTION
As explained in the [JIRA ticket](https://issues.apache.org/jira/browse/LANG-1485) I add a getter for the `lhs` and `rhs` objects of the `DiffResult`
Tests included 