### PR TITLE
LANG-1484: Allow decimal point at the end of the String

### DIFF
--- a/src/main/java/org/apache/commons/lang3/math/NumberUtils.java
+++ b/src/main/java/org/apache/commons/lang3/math/NumberUtils.java
@@ -1729,9 +1729,6 @@ public class NumberUtils {
         if (StringUtils.isEmpty(str)) {
             return false;
         }
-        if (str.charAt(str.length() - 1) == '.') {
-            return false;
-        }
         if (str.charAt(0) == '-') {
             if (str.length() == 1) {
                 return false;

--- a/src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java
@@ -1454,7 +1454,7 @@ public class NumberUtilsTest {
         assertFalse( NumberUtils.isParsable("pendro") );
         assertFalse( NumberUtils.isParsable("64, 2") );
         assertFalse( NumberUtils.isParsable("64.2.2") );
-        assertFalse( NumberUtils.isParsable("64.") );
+        assertTrue( NumberUtils.isParsable("64.") );
         assertFalse( NumberUtils.isParsable("64L") );
         assertFalse( NumberUtils.isParsable("-") );
         assertFalse( NumberUtils.isParsable("--2") );


### PR DESCRIPTION
LANG-1484: Allow decimal point at the end of the String because Double.parseDouble, Float.parseFloat allow this.

https://issues.apache.org/jira/projects/LANG/issues/LANG-1484

IMO, we can allow decimal at end of String. Please suggest.