### PR TITLE
[LANG-1489] Add null-safe APIs as StringUtils.toRoot[Lower|Upper]Case(String)

### DIFF
--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -8891,6 +8891,28 @@ public class StringUtils {
     }
 
     /**
+     * Converts the given source String as a lower-case using the {@link Locale#ROOT} locale in a null-safe manner.
+     *
+     * @param source A source String or null.
+     * @return the given source String as a lower-case using the {@link Locale#ROOT} locale or null.
+     * @since 3.10
+     */
+    public static String toRootLowerCase(final String source) {
+        return source == null ? null : source.toLowerCase(Locale.ROOT);
+    }
+
+    /**
+     * Converts the given source String as a upper-case using the {@link Locale#ROOT} locale in a null-safe manner.
+     *
+     * @param source A source String or null.
+     * @return the given source String as a upper-case using the {@link Locale#ROOT} locale or null.
+     * @since 3.10
+     */
+    public static String toRootUpperCase(final String source) {
+        return source == null ? null : source.toUpperCase(Locale.ROOT);
+    }
+
+    /**
      * Converts a <code>byte[]</code> to a String using the specified character encoding.
      *
      * @param bytes

--- a/src/test/java/org/apache/commons/lang3/StringUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringUtilsTest.java
@@ -19,6 +19,7 @@ package org.apache.commons.lang3;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -3191,5 +3192,45 @@ public class StringUtilsTest {
         assertEquals("/", StringUtils.wrapIfMissing("/", "/"));
         assertEquals("ab/ab", StringUtils.wrapIfMissing("/", "ab"));
         assertEquals("ab/ab", StringUtils.wrapIfMissing("ab/ab", "ab"));
+    }
+
+    @Test
+    public void testToRootLowerCase() {
+        assertEquals(null, StringUtils.toRootLowerCase(null));
+        assertEquals("a", StringUtils.toRootLowerCase("A"));
+        assertEquals("a", StringUtils.toRootLowerCase("a"));
+        final Locale TURKISH = Locale.forLanguageTag("tr");
+        // Sanity checks:
+        assertNotEquals("title", "TITLE".toLowerCase(TURKISH));
+        assertEquals("title", "TITLE".toLowerCase(Locale.ROOT));
+        assertEquals("title", StringUtils.toRootLowerCase("TITLE"));
+        // Make sure we are not using the default Locale:
+        Locale defaultLocales = Locale.getDefault();
+        try {
+            Locale.setDefault(TURKISH);
+            assertEquals("title", StringUtils.toRootLowerCase("TITLE"));
+        } finally {
+            Locale.setDefault(defaultLocales);
+        }
+    }
+
+    @Test
+    public void testToRootUpperCase() {
+        assertEquals(null, StringUtils.toRootUpperCase(null));
+        assertEquals("A", StringUtils.toRootUpperCase("a"));
+        assertEquals("A", StringUtils.toRootUpperCase("A"));
+        final Locale TURKISH = Locale.forLanguageTag("tr");
+        // Sanity checks:
+        assertNotEquals("TITLE", "title".toUpperCase(TURKISH));
+        assertEquals("TITLE", "title".toUpperCase(Locale.ROOT));
+        assertEquals("TITLE", StringUtils.toRootUpperCase("title"));
+        // Make sure we are not using the default Locale:
+        Locale defaultLocales = Locale.getDefault();
+        try {
+            Locale.setDefault(TURKISH);
+            assertEquals("TITLE", StringUtils.toRootUpperCase("title"));
+        } finally {
+            Locale.setDefault(defaultLocales);
+        }
     }
 }


### PR DESCRIPTION
[LANG-1489] Add null-safe APIs as StringUtils.toRootLowerCase(String) and StringUtils.toRootUpperCase(String)

https://issues.apache.org/jira/browse/LANG-1489
