### PR TITLE
(doc): Document public RandomStringUtils exploit

### DIFF
--- a/src/main/java/org/apache/commons/lang3/RandomStringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/RandomStringUtils.java
@@ -37,7 +37,7 @@ import java.util.Random;
  * class relies, are <b>not cryptographically secure</b>.
  * Do not use this classes' default implementation of {@link Random} in security sensitive locations,
  * for example password reset key generation, as all future values can be computed as proven by
- * <a href="https://medium.com/@alex91ar/the-java-soothsayer-a-practical-application-for-insecure-randomness-c67b0cd148cd">
+ * <a href="https://medium.com/@alex91ar/the-java-soothsayer-a-practical-application-for-insecure-randomness-c67b0cd148cd?source=friends_link&sk=3db1c41cc81a58f70ed05a7315191385">
  * this proof of concept.</a></p>
  *
  * <p>Please note that the Apache Commons project provides a component

--- a/src/main/java/org/apache/commons/lang3/RandomStringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/RandomStringUtils.java
@@ -34,7 +34,11 @@ import java.util.Random;
  * RandomStringGenerator</a> instead.</p>
  *
  * <p>Caveat: Instances of {@link Random}, upon which the implementation of this
- * class relies, are not cryptographically secure.</p>
+ * class relies, are <b>not cryptographically secure</b>.
+ * Do not use this classes' default implementation of {@link Random} in security sensitive locations,
+ * for example password reset key generation, as all future values can be computed as proven by
+ * <a href="https://medium.com/@alex91ar/the-java-soothsayer-a-practical-application-for-insecure-randomness-c67b0cd148cd">
+ * this proof of concept.</a></p>
  *
  * <p>Please note that the Apache Commons project provides a component
  * dedicated to pseudo-random number generation, namely


### PR DESCRIPTION
Document the public exploit that exists for `RandomStringUtils`.

This documentation update stems from my finding this vulnerability in the very popular code generator JHipster.

https://nvd.nist.gov/vuln/detail/CVE-2019-16303