### PR TITLE
Code refactor to simplify Functions and new tests

### DIFF
--- a/src/main/java/org/apache/commons/lang3/Functions.java
+++ b/src/main/java/org/apache/commons/lang3/Functions.java
@@ -217,7 +217,7 @@ public class Functions {
      * @return a standard {@code BiFunction}
      */
     public static <I1, I2, O> BiFunction<I1, I2, O> asBiFunction(FailableBiFunction<I1, I2, O, ?> pFunction) {
-        return (pInput1, pInput2) -> apply(pFunction,pInput1,pInput2);
+        return (pInput1, pInput2) -> apply(pFunction, pInput1, pInput2);
     }
 
     /**
@@ -228,7 +228,7 @@ public class Functions {
      * @return a standard {@code Predicate}
      */
     public static <I> Predicate<I> asPredicate(FailablePredicate<I, ?> pPredicate) {
-        return (pInput) -> test(pPredicate,pInput);
+        return (pInput) -> test(pPredicate, pInput);
     }
 
     /**
@@ -240,7 +240,7 @@ public class Functions {
      * @return a standard {@code BiPredicate}
      */
     public static <I1, I2> BiPredicate<I1, I2> asBiPredicate(FailableBiPredicate<I1, I2, ?> pPredicate) {
-        return (pInput1, pInput2) -> test(pPredicate,pInput1,pInput2);
+        return (pInput1, pInput2) -> test(pPredicate, pInput1, pInput2);
     }
 
     /**

--- a/src/main/java/org/apache/commons/lang3/Functions.java
+++ b/src/main/java/org/apache/commons/lang3/Functions.java
@@ -158,13 +158,7 @@ public class Functions {
      * @return a standard {@code Runnable}
      */
     public static Runnable asRunnable(FailableRunnable<?> pRunnable) {
-        return () -> {
-            try {
-                pRunnable.run();
-            } catch (Throwable t) {
-                throw rethrow(t);
-            }
-        };
+        return () -> run(pRunnable);
     }
 
     /**
@@ -175,13 +169,7 @@ public class Functions {
      * @return a standard {@code Consumer}
      */
     public static <I> Consumer<I> asConsumer(FailableConsumer<I, ?> pConsumer) {
-        return (pInput) -> {
-            try {
-                pConsumer.accept(pInput);
-            } catch (Throwable t) {
-                throw rethrow(t);
-            }
-        };
+        return (pInput) -> accept(pConsumer, pInput);
     }
 
     /**
@@ -192,13 +180,7 @@ public class Functions {
      * @return a standard {@code Callable}
      */
     public static <O> Callable<O> asCallable(FailableCallable<O, ?> pCallable) {
-        return () -> {
-            try {
-                return pCallable.call();
-            } catch (Throwable t) {
-                throw rethrow(t);
-            }
-        };
+        return () -> call(pCallable);
     }
 
     /**
@@ -210,13 +192,7 @@ public class Functions {
      * @return a standard {@code BiConsumer}
      */
     public static <I1, I2> BiConsumer<I1, I2> asBiConsumer(FailableBiConsumer<I1, I2, ?> pConsumer) {
-        return (pInput1, pInput2) -> {
-            try {
-                pConsumer.accept(pInput1, pInput2);
-            } catch (Throwable t) {
-                throw rethrow(t);
-            }
-        };
+        return (pInput1, pInput2) -> accept(pConsumer, pInput1, pInput2);
     }
 
     /**
@@ -228,13 +204,7 @@ public class Functions {
      * @return a standard {@code Function}
      */
     public static <I, O> Function<I, O> asFunction(FailableFunction<I, O, ?> pFunction) {
-        return (pInput) -> {
-            try {
-                return pFunction.apply(pInput);
-            } catch (Throwable t) {
-                throw rethrow(t);
-            }
-        };
+        return (pInput) -> apply(pFunction, pInput);
     }
 
     /**
@@ -247,13 +217,7 @@ public class Functions {
      * @return a standard {@code BiFunction}
      */
     public static <I1, I2, O> BiFunction<I1, I2, O> asBiFunction(FailableBiFunction<I1, I2, O, ?> pFunction) {
-        return (pInput1, pInput2) -> {
-            try {
-                return pFunction.apply(pInput1, pInput2);
-            } catch (Throwable t) {
-                throw rethrow(t);
-            }
-        };
+        return (pInput1, pInput2) -> apply(pFunction,pInput1,pInput2);
     }
 
     /**
@@ -264,13 +228,7 @@ public class Functions {
      * @return a standard {@code Predicate}
      */
     public static <I> Predicate<I> asPredicate(FailablePredicate<I, ?> pPredicate) {
-        return (pInput) -> {
-            try {
-                return pPredicate.test(pInput);
-            } catch (Throwable t) {
-                throw rethrow(t);
-            }
-        };
+        return (pInput) -> test(pPredicate,pInput);
     }
 
     /**
@@ -282,13 +240,7 @@ public class Functions {
      * @return a standard {@code BiPredicate}
      */
     public static <I1, I2> BiPredicate<I1, I2> asBiPredicate(FailableBiPredicate<I1, I2, ?> pPredicate) {
-        return (pInput1, pInput2) -> {
-            try {
-                return pPredicate.test(pInput1, pInput2);
-            } catch (Throwable t) {
-                throw rethrow(t);
-            }
-        };
+        return (pInput1, pInput2) -> test(pPredicate,pInput1,pInput2);
     }
 
     /**
@@ -299,13 +251,7 @@ public class Functions {
      * @return a standard {@code Supplier}
      */
     public static <O> Supplier<O> asSupplier(FailableSupplier<O, ?> pSupplier) {
-        return () -> {
-            try {
-                return pSupplier.get();
-            } catch (Throwable t) {
-                throw rethrow(t);
-            }
-        };
+        return () -> get(pSupplier);
     }
 
     /**

--- a/src/test/java/org/apache/commons/lang3/FunctionsTest.java
+++ b/src/test/java/org/apache/commons/lang3/FunctionsTest.java
@@ -404,6 +404,7 @@ class FunctionsTest {
     }
 
     @Test
+    @DisplayName("Test that asPredicate(FailablePredicate) is converted to -> Predicate ")
     public void testAsPredicate() {
         FailureOnOddInvocations.invocation = 0;
         final Functions.FailablePredicate<Object, Throwable> failablePredicate = (t) -> FailureOnOddInvocations.failingBool();
@@ -418,6 +419,7 @@ class FunctionsTest {
     }
 
     @Test
+    @DisplayName("Test that asPredicate(FailableBiPredicate) is converted to -> BiPredicate ")
     public void testAsBiPredicate() {
         FailureOnOddInvocations.invocation = 0;
         final Functions.FailableBiPredicate<Object, Object, Throwable> failableBiPredicate = (t1, t2) -> FailureOnOddInvocations.failingBool();

--- a/src/test/java/org/apache/commons/lang3/FunctionsTest.java
+++ b/src/test/java/org/apache/commons/lang3/FunctionsTest.java
@@ -99,18 +99,18 @@ class FunctionsTest {
     public static class FailureOnOddInvocations {
         private static int invocation;
 
-        static boolean failingBool() throws SomeException {
+        private static void throwOnOdd() throws SomeException {
             final int i = ++invocation;
             if (i % 2 == 1) {
                 throw new SomeException("Odd Invocation: " + i);
             }
+        }
+        static boolean failingBool() throws SomeException {
+            throwOnOdd();
             return true;
         }
         FailureOnOddInvocations() throws SomeException {
-            final int i = ++invocation;
-            if (i % 2 == 1) {
-                throw new SomeException("Odd Invocation: " + i);
-            }
+            throwOnOdd();
         }
     }
 


### PR DESCRIPTION
The Functions class implemented the `asXXX` methods in a "copy-paste" way instead of using the already implemented static methods of the same class.

Also the tests for the methods `asPredicate` and `asBiPredicate` were missing.