### PR TITLE
StringUtils.abbreviate handles empty abbrevMarker

### DIFF
--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -332,8 +332,15 @@ public class StringUtils {
      * @since 3.6
      */
     public static String abbreviate(final String str, final String abbrevMarker, int offset, final int maxWidth) {
-        if (isEmpty(str) || isEmpty(abbrevMarker)) {
+        if (isEmpty(str)) {
             return str;
+        }
+
+        if (abbrevMarker == null){
+            return str.substring(0,maxWidth + 1);
+        }
+        if (isEmpty(abbrevMarker)){
+            return str.substring(0, maxWidth);
         }
 
         final int abbrevMarkerLength = abbrevMarker.length();

--- a/src/test/java/org/apache/commons/lang3/StringUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringUtilsTest.java
@@ -306,7 +306,7 @@ public class StringUtilsTest {
         assertEquals("", StringUtils.abbreviate("", "...", 2));
         assertEquals("wai**", StringUtils.abbreviate("waiheke", "**", 5));
         assertEquals("And af,,,,", StringUtils.abbreviate("And after a long time, he finally met his son.", ",,,,", 10));
-
+        assertEquals("much too long", StringUtils.abbreviate("much too long text","",13));
         final String raspberry = "raspberry peach";
         assertEquals("raspberry pe..", StringUtils.abbreviate(raspberry, "..", 14));
         assertEquals("raspberry peach", StringUtils.abbreviate("raspberry peach", "---*---", 15));


### PR DESCRIPTION
StringUtils.abbreviate would not abbreviate properly when an empty
String was passed to abbrevMarker or abbrevMarker is null
Expected behaviour:
abbreviate("much too long text", "", 13).equals("much too long")
Actual behaviour:
abbreviate("much too long text", "", 13).equals("much too long text")

Behaves the same when abbrevMarker is null.

Added if statements to handle empty and null abbrevMarker
Passed all tests