### PR TITLE
LANG-1513 ObjectUtils: Get first non-null supplier value

### DIFF
--- a/src/main/java/org/apache/commons/lang3/ObjectUtils.java
+++ b/src/main/java/org/apache/commons/lang3/ObjectUtils.java
@@ -210,6 +210,45 @@ public class ObjectUtils {
     }
 
     /**
+     * <p>Executes the given suppliers in order and returns the first return
+     * value where a value other than {@code null} is returned.
+     * Once a non-{@code null} value is obtained, all following suppliers are
+     * not executed anymore.
+     * If all the return values are {@code null} or no suppliers are provided
+     * then {@code null} is returned.</p>
+     *
+     * <pre>
+     * ObjectUtils.firstNonNullLazy(null, () -&gt; null) = null
+     * ObjectUtils.firstNonNullLazy(() -&gt; null, () -&gt; "") = ""
+     * ObjectUtils.firstNonNullLazy(() -&gt; "", () -&gt; throw new IllegalStateException()) = ""
+     * ObjectUtils.firstNonNullLazy(() -&gt; null, () -&gt; "zz) = "zz"
+     * ObjectUtils.firstNonNullLazy() = null
+     * </pre>
+     *
+     * @param <T> the type of the return values
+     * @param suppliers  the suppliers returning the values to test.
+     *                   {@code null} values are ignored.
+     *                   Suppliers may return {@code null} or a value of type @{code T}
+     * @return the first return value from {@code suppliers} which is not {@code null},
+     *  or {@code null} if there are no non-null values
+     * @since 3.10
+     */
+    @SafeVarargs
+    public static <T> T firstNonNullLazy(final Supplier<T>... suppliers) {
+        if (suppliers != null) {
+            for (final Supplier<T> val : suppliers) {
+                if (val != null) {
+                    T value = val.get();
+                    if (value != null) {
+                        return value;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
      * <p>
      * Returns the given {@code object} is it is non-null, otherwise returns the Supplier's {@link Supplier#get()}
      * value.

--- a/src/test/java/org/apache/commons/lang3/ObjectUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/ObjectUtilsTest.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.lang.reflect.Constructor;
@@ -147,6 +148,28 @@ public class ObjectUtilsTest {
 
         assertNull(ObjectUtils.firstNonNull((Object) null));
         assertNull(ObjectUtils.firstNonNull((Object[]) null));
+    }
+
+    @Test
+    public void testFirstNonNullLazy() {
+        // first non null
+        assertEquals("", ObjectUtils.firstNonNullLazy(() -> null, () -> ""));
+        // first encountered value is used
+        assertEquals("1", ObjectUtils.firstNonNullLazy(() -> null, () -> "1", () -> "2", () -> null));
+        assertEquals("123", ObjectUtils.firstNonNullLazy(() -> "123", () -> null, () -> "456"));
+        // don't evaluate suppliers after first value is found
+        assertEquals("123", ObjectUtils.firstNonNullLazy(() -> null, () -> "123", () -> fail("Supplier after first non-null value should not be evaluated")));
+        // supplier returning null and null supplier both result in null
+        assertNull(ObjectUtils.firstNonNullLazy(null, () -> null));
+        // Explicitly pass in an empty array of Object type to ensure compiler doesn't complain of unchecked generic array creation
+        assertNull(ObjectUtils.firstNonNullLazy());
+        // supplier is null
+        assertNull(ObjectUtils.firstNonNullLazy((Supplier<Object>) null));
+        // varargs array itself is null
+        assertNull(ObjectUtils.firstNonNullLazy((Supplier<Object>[]) null));
+        // test different types
+        assertEquals(1, ObjectUtils.firstNonNullLazy(() -> null, () -> 1));
+        assertEquals(Boolean.TRUE, ObjectUtils.firstNonNullLazy(() -> null, () -> Boolean.TRUE));
     }
 
     /**


### PR DESCRIPTION
Lazy evaluation variant of firstNonNull to allow using it for expensive operations.
When the first value of different options is required, but they're expensive to calculate.

I tried to match the code and test style present.