### PR TITLE
[LANG-1514] make test more stable by wrapping assertions in hashset

### DIFF
--- a/src/test/java/org/apache/commons/lang3/reflect/FieldUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/reflect/FieldUtilsTest.java
@@ -36,6 +36,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -188,7 +189,7 @@ public class FieldUtilsTest {
         final List<Field> fieldsInteger = Arrays.asList(Integer.class.getDeclaredFields());
         final List<Field> allFieldsInteger = new ArrayList<>(fieldsInteger);
         allFieldsInteger.addAll(fieldsNumber);
-        assertEquals(allFieldsInteger, FieldUtils.getAllFieldsList(Integer.class));
+        assertEquals(new HashSet(allFieldsInteger), new HashSet(FieldUtils.getAllFieldsList(Integer.class)));
         final List<Field> allFields = FieldUtils.getAllFieldsList(PublicChild.class);
         // Under Jacoco,0.8.1 and Java 10, the field count is 7.
         int expected = 5;


### PR DESCRIPTION
This fixes [LANG-1514](https://issues.apache.org/jira/projects/LANG/issues/LANG-1514?filter=allissues)

This PR proposes to replace the expected and actual values of the assertions in the tests by wrapping each value into a HashSet and then checking if the two sets are equal, thus ignoring the order of elements in the collections.