### PR TITLE
 Added 1 and 0 in toBooleanObject(final String str) 

### DIFF
--- a/src/main/java/org/apache/commons/lang3/BooleanUtils.java
+++ b/src/main/java/org/apache/commons/lang3/BooleanUtils.java
@@ -581,11 +581,13 @@ public class BooleanUtils {
             case 1: {
                 final char ch0 = str.charAt(0);
                 if (ch0 == 'y' || ch0 == 'Y' ||
-                    ch0 == 't' || ch0 == 'T') {
+                    ch0 == 't' || ch0 == 'T' ||
+                    ch0 == '1') {
                     return Boolean.TRUE;
                 }
                 if (ch0 == 'n' || ch0 == 'N' ||
-                    ch0 == 'f' || ch0 == 'F') {
+                    ch0 == 'f' || ch0 == 'F' ||
+                    ch0 == '0') {
                     return Boolean.FALSE;
                 }
                 break;

--- a/src/main/java/org/apache/commons/lang3/BooleanUtils.java
+++ b/src/main/java/org/apache/commons/lang3/BooleanUtils.java
@@ -532,10 +532,10 @@ public class BooleanUtils {
     /**
      * <p>Converts a String to a Boolean.</p>
      *
-     * <p>{@code 'true'}, {@code 'on'}, {@code 'y'}, {@code 't'} or {@code 'yes'}
-     * (case insensitive) will return {@code true}.
-     * {@code 'false'}, {@code 'off'}, {@code 'n'}, {@code 'f'} or {@code 'no'}
-     * (case insensitive) will return {@code false}.
+     * <p>{@code 'true'}, {@code 'on'}, {@code 'y'}, {@code 't'}, {@code 'yes'}
+     * or {@code '1'} (case insensitive) will return {@code true}.
+     * {@code 'false'}, {@code 'off'}, {@code 'n'}, {@code 'f'}, {@code 'no'}
+     * or {@code '0'} (case insensitive) will return {@code false}.
      * Otherwise, {@code null} is returned.</p>
      *
      * <p>NOTE: This method may return {@code null} and may throw a {@code NullPointerException}
@@ -556,6 +556,8 @@ public class BooleanUtils {
      *   BooleanUtils.toBooleanObject("oFf")   = Boolean.FALSE
      *   BooleanUtils.toBooleanObject("yes")   = Boolean.TRUE
      *   BooleanUtils.toBooleanObject("Y")     = Boolean.TRUE // i.e. Y[ES]
+     *   BooleanUtils.toBooleanObject("1")     = Boolean.TRUE
+     *   BooleanUtils.toBooleanObject("0")     = Boolean.FALSE
      *   BooleanUtils.toBooleanObject("blue")  = null
      *   BooleanUtils.toBooleanObject("true ") = null // trailing space (too long)
      *   BooleanUtils.toBooleanObject("ono")   = null // does not match on or no

--- a/src/test/java/org/apache/commons/lang3/BooleanUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/BooleanUtilsTest.java
@@ -280,10 +280,12 @@ public class BooleanUtilsTest {
         assertEquals(Boolean.TRUE, BooleanUtils.toBooleanObject("Y"));
         assertEquals(Boolean.TRUE, BooleanUtils.toBooleanObject("t")); // true
         assertEquals(Boolean.TRUE, BooleanUtils.toBooleanObject("T"));
+        assertEquals(Boolean.TRUE, BooleanUtils.toBooleanObject("1"));
         assertEquals(Boolean.FALSE, BooleanUtils.toBooleanObject("f")); // false
         assertEquals(Boolean.FALSE, BooleanUtils.toBooleanObject("F"));
         assertEquals(Boolean.FALSE, BooleanUtils.toBooleanObject("n")); // No
         assertEquals(Boolean.FALSE, BooleanUtils.toBooleanObject("N"));
+        assertEquals(Boolean.FALSE, BooleanUtils.toBooleanObject("0"));
         assertNull(BooleanUtils.toBooleanObject("z"));
 
         assertNull(BooleanUtils.toBooleanObject("ab"));
@@ -353,7 +355,9 @@ public class BooleanUtilsTest {
         assertTrue(BooleanUtils.toBoolean("YeS"));
         assertTrue(BooleanUtils.toBoolean("YEs"));
         assertTrue(BooleanUtils.toBoolean("YES"));
+        assertTrue(BooleanUtils.toBoolean("1"));
         assertFalse(BooleanUtils.toBoolean("yes?"));
+        assertFalse(BooleanUtils.toBoolean("0"));
         assertFalse(BooleanUtils.toBoolean("tru"));
 
         assertFalse(BooleanUtils.toBoolean("no"));


### PR DESCRIPTION
I stubmled over this during the week and am wondering why 1 and 0 are not a default true and false representation. So I created this PR. I'm not strongly opnionated about it. So if there is a good reason for 1 and 0 not beeing a good case here, feel free to close it.

I think, parsing the string to an int before calling toBoolean is unnecessary. And it should be common enough that you shouldn't have to call: toBooleanObject(final String str, final String trueString, final String falseString, final String nullString)