### PR TITLE
[LANG-1523] Avoid unnecessary allocation in StringUtils.wrapIfMissing

### DIFF
--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -9417,6 +9417,9 @@ public class StringUtils {
         if (isEmpty(str) || wrapWith == CharUtils.NUL) {
             return str;
         }
+        if(str.charAt(0) == wrapWith && str.charAt(str.length()-1) == wrapWith){
+            return str;
+        }
         final StringBuilder builder = new StringBuilder(str.length() + 2);
         if (str.charAt(0) != wrapWith) {
             builder.append(wrapWith);

--- a/src/test/java/org/apache/commons/lang3/StringUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringUtilsTest.java
@@ -3176,6 +3176,7 @@ public class StringUtilsTest {
         assertEquals("/x/y/z/", StringUtils.wrapIfMissing("/x/y/z", '/'));
         assertEquals("/x/y/z/", StringUtils.wrapIfMissing("x/y/z/", '/'));
         assertEquals("/", StringUtils.wrapIfMissing("/", '/'));
+        assertEquals("xabx", StringUtils.wrapIfMissing("xabx", 'x'));
     }
 
     @Test


### PR DESCRIPTION
It seems like the String Builder is being created after checking if the str or the wrapper is null. What we can do is check if the str is already wrapped, if so then just return the str. This would avoid the String Builder being created.