### PR TITLE
LANG-1530 another method like formatDurationWords with 

### DIFF
--- a/src/main/java/org/apache/commons/lang3/time/DurationFormatUtils.java
+++ b/src/main/java/org/apache/commons/lang3/time/DurationFormatUtils.java
@@ -17,10 +17,13 @@
 package org.apache.commons.lang3.time;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
+import java.util.List;
 import java.util.TimeZone;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
@@ -237,80 +240,31 @@ public class DurationFormatUtils {
             final boolean suppressLeadingZeroElements,
             final boolean suppressTrailingZeroElements) {
 
-        // This method is generally replaceable by the format method, but
-        // there are a series of tweaks and special cases that require
-        // trickery to replicate.
-        String msPartFormat = withMilliseconds ? "SSS" : StringUtils.EMPTY;
-        String format = "d' days 'H' hours 'm' minutes 's' seconds'" + msPartFormat;
-        String duration = formatDuration(durationMillis, format);
-        if (withMilliseconds) {
-            int splitIndex = duration.length() - 3;
-            String msPart = duration.substring(splitIndex);
-            duration = duration.substring(0, splitIndex) + StringUtils.SPACE + Integer.valueOf(msPart) + " milliseconds";
+        List<String> timeUnits = Arrays.asList("days", "hours", "minutes", "seconds", "milliseconds");
+        String duration = formatDuration(durationMillis, "d H m s SSS");
+        List<TimeUnitPart> timeUnitParts = new ArrayList<>();
+        List<String> timePartsValues = Arrays.asList(duration.split(StringUtils.SPACE));
+        int allowedElements = withMilliseconds ? timeUnits.size() : timeUnits.size() - 1;
+        for (int i = 0; i < allowedElements; i++) {
+            timeUnitParts.add(new TimeUnitPart(timeUnits.get(i), Integer.parseInt(timePartsValues.get(i))));
         }
 
         if (suppressLeadingZeroElements) {
-            // this is a temporary marker on the front. Like ^ in regexp.
-            duration = " " + duration;
-            String tmp = StringUtils.replaceOnce(duration, " 0 days", StringUtils.EMPTY);
-            if (tmp.length() != duration.length()) {
-                duration = tmp;
-                tmp = StringUtils.replaceOnce(duration, " 0 hours", StringUtils.EMPTY);
-                if (tmp.length() != duration.length()) {
-                    duration = tmp;
-                    tmp = StringUtils.replaceOnce(duration, " 0 minutes", StringUtils.EMPTY);
-                    duration = tmp;
-                    if (tmp.length() != duration.length()) {
-                        duration = StringUtils.replaceOnce(tmp, " 0 seconds", StringUtils.EMPTY);
-                    }
-                }
-            }
-            if (!duration.isEmpty()) {
-                // strip the space off again
-                duration = duration.substring(1);
+            TimeUnitPart timeUnitPart = timeUnitParts.get(0);
+            while (timeUnitPart.value == 0 && timeUnitParts.size() > 1) {
+                timeUnitParts.remove(0);
+                timeUnitPart = timeUnitParts.get(0);
             }
         }
-        if (suppressTrailingZeroElements) {
-            if (withMilliseconds) {
-                String tmp = StringUtils.replaceOnce(duration, " 0 milliseconds", StringUtils.EMPTY);
-                if (tmp.length() != duration.length()) {
-                    tmp = StringUtils.replaceOnce(duration, " 0 seconds", StringUtils.EMPTY);
-                    if (tmp.length() != duration.length()) {
-                        duration = tmp;
-                        tmp = StringUtils.replaceOnce(duration, " 0 minutes", StringUtils.EMPTY);
-                        if (tmp.length() != duration.length()) {
-                            duration = tmp;
-                            tmp = StringUtils.replaceOnce(duration, " 0 hours", StringUtils.EMPTY);
-                            if (tmp.length() != duration.length()) {
-                                duration = StringUtils.replaceOnce(tmp, " 0 days", StringUtils.EMPTY);
-                            }
-                        }
-                    }
-                }
-            } else {
-                String tmp = StringUtils.replaceOnce(duration, " 0 seconds", StringUtils.EMPTY);
-                if (tmp.length() != duration.length()) {
-                    duration = tmp;
-                    tmp = StringUtils.replaceOnce(duration, " 0 minutes", StringUtils.EMPTY);
-                    if (tmp.length() != duration.length()) {
-                        duration = tmp;
-                        tmp = StringUtils.replaceOnce(duration, " 0 hours", StringUtils.EMPTY);
-                        if (tmp.length() != duration.length()) {
-                            duration = StringUtils.replaceOnce(tmp, " 0 days", StringUtils.EMPTY);
-                        }
-                    }
-                }
-            }
 
+        if (suppressTrailingZeroElements) {
+            TimeUnitPart timeUnitPart = timeUnitParts.get(getLastIndex(timeUnitParts));
+            while (timeUnitPart.value == 0 && timeUnitParts.size() > 1) {
+                timeUnitParts.remove(getLastIndex(timeUnitParts));
+                timeUnitPart = timeUnitParts.get(getLastIndex(timeUnitParts));
+            }
         }
-        // handle plurals
-        duration = " " + duration;
-        duration = StringUtils.replaceOnce(duration, " 1 milliseconds", " 1 millisecond");
-        duration = StringUtils.replaceOnce(duration, " 1 seconds", " 1 second");
-        duration = StringUtils.replaceOnce(duration, " 1 minutes", " 1 minute");
-        duration = StringUtils.replaceOnce(duration, " 1 hours", " 1 hour");
-        duration = StringUtils.replaceOnce(duration, " 1 days", " 1 day");
-        return duration.trim();
+        return handlePlurals(timeUnitParts, timeUnits);
     }
 
     //-----------------------------------------------------------------------
@@ -554,6 +508,34 @@ public class DurationFormatUtils {
             }
         }
         return buffer.toString();
+    }
+
+    private static int getLastIndex(List<?> list) {
+        return list.size() - 1;
+    }
+
+    private static class TimeUnitPart {
+        private String timeUnit;
+        private int value;
+
+        public TimeUnitPart(String timeUnit, int value) {
+            this.timeUnit = timeUnit;
+            this.value = value;
+        }
+    }
+
+    private static String handlePlurals(List<TimeUnitPart> timeUnitParts, List<String> timeUnits) {
+        String duration = StringUtils.SPACE + timeUnitParts.stream()
+                                                           .map(part -> part.value + StringUtils.SPACE + part.timeUnit)
+                                                           .collect(Collectors.joining(StringUtils.SPACE));
+        for (String timeUnit : timeUnits) {
+            duration = makePlural(duration, timeUnit);
+        }
+        return duration.trim();
+    }
+
+    private static String makePlural(String duration, String timeUnit) {
+        return StringUtils.replaceOnce(duration, " 1 " + timeUnit, " 1 " + timeUnit.substring(0, timeUnit.length() - 1));
     }
 
     /**

--- a/src/test/java/org/apache/commons/lang3/time/DurationFormatUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/DurationFormatUtilsTest.java
@@ -27,6 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
+import java.time.Duration;
 import java.util.Calendar;
 import java.util.TimeZone;
 
@@ -578,6 +579,62 @@ public class DurationFormatUtilsTest {
     @Test
     public void testLANG981() { // unmatched quote char in lexx
         assertThrows(IllegalArgumentException.class, () -> DurationFormatUtils.lexx("'yMdHms''S"));
+    }
+
+    @Test
+    public void formatDurationWordsRemovedLeadingAndTrailingZeros() {
+        String formattedDuration = DurationFormatUtils.formatDurationWords(Duration.ofHours(1)
+                                                                                   .plusMinutes(3)
+                                                                                   .plusMillis(157)
+                                                                                   .toMillis(),
+                                                                           true,
+                                                                           true);
+        assertEquals("1 hour 3 minutes", formattedDuration);
+    }
+
+    @Test
+    public void formatWordsWithMsRemovedLeadingZeros() {
+        String formattedDuration = DurationFormatUtils.formatDurationWordsWithMs(Duration.ofHours(1)
+                                                                     .plusMinutes(33)
+                                                                     .plusSeconds(12)
+                                                                     .plusMillis(157)
+                                                                     .toMillis());
+        assertEquals("1 hour 33 minutes 12 seconds 157 milliseconds", formattedDuration);
+
+        formattedDuration = DurationFormatUtils.formatDurationWordsWithMs(Duration.ofHours(1)
+                                                                                         .plusMinutes(33)
+                                                                                         .toMillis());
+        assertEquals("1 hour 33 minutes 0 seconds 0 milliseconds", formattedDuration);
+    }
+
+
+    @Test
+    public void formatWordsWithMsWithoutRemovedLeadingAndTrailingZeros() {
+        String formattedDuration = DurationFormatUtils.formatDurationWordsWithMs(Duration.ofHours(1)
+                                                                     .plusMinutes(33)
+                                                                     .plusSeconds(12)
+                                                                     .plusMillis(157)
+                                                                     .toMillis(),
+                                                             false,
+                                                             false);
+        assertEquals("0 days 1 hour 33 minutes 12 seconds 157 milliseconds", formattedDuration);
+
+        formattedDuration = DurationFormatUtils.formatDurationWordsWithMs(Duration.ofHours(1)
+                                                                                         .plusMinutes(33)
+                                                                                         .plusSeconds(12)
+                                                                                         .toMillis(),
+                                                                                 false,
+                                                                                 false);
+        assertEquals("0 days 1 hour 33 minutes 12 seconds 0 milliseconds", formattedDuration);
+
+        formattedDuration = DurationFormatUtils.formatDurationWordsWithMs(Duration.ofHours(1)
+                                                                                         .plusMinutes(33)
+                                                                                         .plusSeconds(12)
+                                                                                         .plusMillis(1)
+                                                                                         .toMillis(),
+                                                                                 false,
+                                                                                 false);
+        assertEquals("0 days 1 hour 33 minutes 12 seconds 1 millisecond", formattedDuration);
     }
 
     private static final int FOUR_YEARS = 365 * 3 + 366;

--- a/src/test/java/org/apache/commons/lang3/time/DurationFormatUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/DurationFormatUtilsTest.java
@@ -28,7 +28,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.Calendar;
+import java.util.List;
 import java.util.TimeZone;
 
 import org.junit.jupiter.api.Test;
@@ -583,71 +585,90 @@ public class DurationFormatUtilsTest {
 
     @Test
     public void formatDurationWordsRemovedLeadingAndTrailingZeros() {
-        String formattedDuration = DurationFormatUtils.formatDurationWords(Duration.ofHours(1)
-                                                                                   .plusMinutes(3)
-                                                                                   .plusMillis(157)
-                                                                                   .toMillis(),
-                                                                           true,
-                                                                           true);
-        assertEquals("1 hour 3 minutes", formattedDuration);
+        List<DurationFormatTestCase> testCases = Arrays.asList(
+                new DurationFormatTestCase("1 hour 3 minutes",
+                                           Duration.ofHours(1).plusMinutes(3).plusMillis(157)),
+                new DurationFormatTestCase("1 minute",
+                                           Duration.ofMinutes(1)),
+                new DurationFormatTestCase("0 seconds",
+                                           Duration.ZERO));
+
+        testCases.forEach(testCase-> {
+            String formattedDuration = DurationFormatUtils.formatDurationWords(testCase.duration.toMillis(),
+                                                                               true,
+                                                                               true);
+            assertEquals(testCase.expectedFormat, formattedDuration);
+        });
     }
 
     @Test
     public void formatWordsWithMsRemovedLeadingZeros() {
-        String formattedDuration = DurationFormatUtils.formatDurationWordsWithMs(Duration.ofHours(1)
-                                                                     .plusMinutes(33)
-                                                                     .plusSeconds(12)
-                                                                     .plusMillis(157)
-                                                                     .toMillis());
-        assertEquals("1 hour 33 minutes 12 seconds 157 milliseconds", formattedDuration);
+        List<DurationFormatTestCase> testCases = Arrays.asList(
+                new DurationFormatTestCase("1 hour 33 minutes 12 seconds 157 milliseconds",
+                                           Duration.ofHours(1).plusMinutes(33).plusSeconds(12).plusMillis(157)),
+                new DurationFormatTestCase("1 hour 33 minutes 0 seconds 0 milliseconds",
+                                           Duration.ofHours(1).plusMinutes(33)),
+                new DurationFormatTestCase("0 milliseconds",
+                                           Duration.ZERO),
+                new DurationFormatTestCase("1 day 0 hours 0 minutes 0 seconds 0 milliseconds",
+                                           Duration.ofDays(1)));
 
-        formattedDuration = DurationFormatUtils.formatDurationWordsWithMs(Duration.ofHours(1)
-                                                                                         .plusMinutes(33)
-                                                                                         .toMillis());
-        assertEquals("1 hour 33 minutes 0 seconds 0 milliseconds", formattedDuration);
+        testCases.forEach(testCase-> {
+            String formattedDuration = DurationFormatUtils.formatDurationWordsWithMs(testCase.duration.toMillis());
+            assertEquals(testCase.expectedFormat, formattedDuration);
+        });
+    }
+
+    @Test
+    public void formatWordsWithMsRemovedLeadingAndTrailingZeros() {
+        List<DurationFormatTestCase> testCases = Arrays.asList(
+                new DurationFormatTestCase("1 hour 33 minutes 12 seconds 157 milliseconds",
+                                           Duration.ofHours(1).plusMinutes(33).plusSeconds(12).plusMillis(157)),
+                new DurationFormatTestCase("0 milliseconds",
+                                           Duration.ZERO),
+                new DurationFormatTestCase("1 hour 33 minutes",
+                                           Duration.ofHours(1).plusMinutes(33)));
+
+        testCases.forEach(testCase-> {
+            String formattedDuration = DurationFormatUtils.formatDurationWordsWithMs(testCase.duration.toMillis(),
+                                                                                     true,
+                                                                                     true);
+            assertEquals(testCase.expectedFormat, formattedDuration);
+        });
     }
 
 
     @Test
     public void formatWordsWithMsWithoutRemovedLeadingAndTrailingZeros() {
-        String formattedDuration = DurationFormatUtils.formatDurationWordsWithMs(Duration.ofHours(1)
-                                                                     .plusMinutes(33)
-                                                                     .plusSeconds(12)
-                                                                     .plusMillis(157)
-                                                                     .toMillis(),
-                                                             false,
-                                                             false);
-        assertEquals("0 days 1 hour 33 minutes 12 seconds 157 milliseconds", formattedDuration);
+        List<DurationFormatTestCase> testCases = Arrays.asList(
+                new DurationFormatTestCase("0 days 1 hour 33 minutes 12 seconds 157 milliseconds",
+                                           Duration.ofHours(1).plusMinutes(33).plusSeconds(12).plusMillis(157)),
+                new DurationFormatTestCase("0 days 1 hour 33 minutes 12 seconds 0 milliseconds",
+                                           Duration.ofHours(1).plusMinutes(33).plusSeconds(12)),
+                new DurationFormatTestCase("0 days 1 hour 33 minutes 12 seconds 1 millisecond",
+                                           Duration.ofHours(1).plusMinutes(33).plusSeconds(12).plusMillis(1)));
 
-        formattedDuration = DurationFormatUtils.formatDurationWordsWithMs(Duration.ofHours(1)
-                                                                                         .plusMinutes(33)
-                                                                                         .plusSeconds(12)
-                                                                                         .toMillis(),
-                                                                                 false,
-                                                                                 false);
-        assertEquals("0 days 1 hour 33 minutes 12 seconds 0 milliseconds", formattedDuration);
+        testCases.forEach(testCase-> {
+            String formattedDuration = DurationFormatUtils.formatDurationWordsWithMs(testCase.duration.toMillis(),
+                                                                                     false,
+                                                                                     false);
+            assertEquals(testCase.expectedFormat, formattedDuration);
+        });
+    }
 
-        formattedDuration = DurationFormatUtils.formatDurationWordsWithMs(Duration.ofHours(1)
-                                                                                         .plusMinutes(33)
-                                                                                         .plusSeconds(12)
-                                                                                         .plusMillis(1)
-                                                                                         .toMillis(),
-                                                                                 false,
-                                                                                 false);
-        assertEquals("0 days 1 hour 33 minutes 12 seconds 1 millisecond", formattedDuration);
+    @Test
+    public void formatZeroMillisecondsNotRemoveLeadingButRemoveTrailing() {
+        String formattedDuration = DurationFormatUtils.formatDurationWordsWithMs(0, false, true);
+        assertEquals("0 days", formattedDuration);
+    }
+
+    @Test
+    public void formatZeroMillisecondsWithoutMillisNotRemoveLeadingZeroButRemoveTrailing() {
+        String formattedDuration = DurationFormatUtils.formatDurationWords(0, false, true);
+        assertEquals("0 days", formattedDuration);
     }
 
     private static final int FOUR_YEARS = 365 * 3 + 366;
-
-    // Takes a minute to run, so generally turned off
-//    public void testBrutally() {
-//        Calendar c = Calendar.getInstance();
-//        c.set(2004, 0, 1, 0, 0, 0);
-//        for (int i=0; i < FOUR_YEARS; i++) {
-//            bruteForce(c.get(Calendar.YEAR), c.get(Calendar.MONTH), c.get(Calendar.DAY_OF_MONTH), "d", Calendar.DAY_OF_MONTH );
-//            c.add(Calendar.DAY_OF_MONTH, 1);
-//        }
-//    }
 
     private void bruteForce(final int year, final int month, final int day, final String format, final int calendarType) {
         final String msg = year + "-" + month + "-" + day + " to ";
@@ -685,4 +706,13 @@ public class DurationFormatUtilsTest {
         }
     }
 
+    private static class DurationFormatTestCase {
+        private String expectedFormat;
+        private Duration duration;
+
+        public DurationFormatTestCase(String expectedFormat, Duration duration) {
+            this.expectedFormat = expectedFormat;
+            this.duration = duration;
+        }
+    }
 }


### PR DESCRIPTION
added new method 'formatDurationWordsWithMs' for format duration: 
0 days 0 hours 0 minutes 0 seconds 0 milliseconds
still exists old method 'formatDurationWords' which format as below:
0 days 0 hours 0 minutes 0 seconds
 