### PR TITLE
Improve reproducibility of generated JARs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -785,6 +785,11 @@
             <version>5.1.1</version>
           </dependency>
         </dependencies>
+        <configuration>
+          <instructions>
+            <_removeheaders>Bnd-LastModified,Include-Resource</_removeheaders>
+          </instructions>
+        </configuration>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
[maven-bundle-plugin](https://felix.apache.org/documentation/subprojects/apache-felix-maven-bundle-plugin-bnd.html) adds a couple of extra manifest headers like `Bnd-LastModified` recording information about the build. This makes it harder to reproduce the JAR bit by bit on a different machine. The documented way to remove these is the `-noextraheaders: true` instruction, see the [bnd-maven-plugin README](https://github.com/bndtools/bnd/blob/cc61fa32da6b779a9607d02b78c2052015493eb6/maven/bnd-maven-plugin/README.md#reproducible-builds) and the [Apache Maven guide to reproducible builds](https://maven.apache.org/guides/mini/guide-reproducible-builds.html).

Even after applying this instruction, the ordering of the `Include-Resource` header appears to be file system dependent. Remove this header as well to allow for reproducible builds.