### PR TITLE
Speed up Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,8 @@ matrix:
   allow_failures:
     - jdk: openjdk-ea
 
+install: skip
+
 script:
   - mvn
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,10 @@
 # limitations under the License.
 
 language: java
+
+cache:
+  directories:
+    - $HOME/.m2/repository
 jdk:
   - openjdk8
   - openjdk11

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,4 @@ matrix:
 install: skip
 
 script:
-  - mvn
-
-after_success:
-  - mvn clean test jacoco:report coveralls:report -Ptravis-jacoco javadoc:javadoc -Ddoclint=all
+  - mvn clean verify apache-rat:check checkstyle:check japicmp:cmp spotbugs:check jacoco:report coveralls:report -Ptravis-jacoco javadoc:javadoc -Ddoclint=all


### PR DESCRIPTION
I saw that the Travis builds are taking over 10min, much more than what I saw locally. I made some modifications to the Travis file to improve that:

- I've activated caching of `.m2/repository`, so the dependencies don't have to be redownloaded every time
- I've removed the unnecessary `mvn install -DskipTest` which Travis does by default
- I've combined the two build steps into one - The only behavioral change here is that there is no longer a test without jacoco instrumentation. If you're concerned about that and are okay with spending double the time on testing (once with and once without jacoco), I can revert that commit.