### PR TITLE
Made String Reverse Method Faster

### DIFF
--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -7101,7 +7101,16 @@ public class StringUtils {
         if (str == null) {
             return null;
         }
-        return new StringBuilder(str).reverse().toString();
+
+        char[] chars = str.toCharArray();
+
+        for (int i = 0, j = chars.length - 1; i < j; i++, j--) {
+            char temp = chars[i];
+            chars[i] = chars[j];
+            chars[j] = temp;
+        }
+
+        return String.valueOf(chars);
     }
 
     /**

--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -7084,7 +7084,7 @@ public class StringUtils {
     // Reversing
     //-----------------------------------------------------------------------
     /**
-     * <p>Reverses a String as per {@link StringBuilder#reverse()}.</p>
+     * <p>Reverses a String</p>
      *
      * <p>A {@code null} String returns {@code null}.</p>
      *


### PR DESCRIPTION
Right now, StringUtils.reverse() is done the lazy way by initializing a new Stringbuilder, calling reverse, then converting back into a string. I filled out the reverse method by doing it manually.