### PR TITLE
[LANG-1596] ArrayUtils.toPrimitive(Object) does not support boolean and other types

### DIFF
--- a/src/main/java/org/apache/commons/lang3/ArrayUtils.java
+++ b/src/main/java/org/apache/commons/lang3/ArrayUtils.java
@@ -9478,6 +9478,15 @@ public static int indexOf(final int[] array, final int valueToFind) {
         }
         final Class<?> ct = array.getClass().getComponentType();
         final Class<?> pt = ClassUtils.wrapperToPrimitive(ct);
+        if (Boolean.TYPE.equals(pt)) {
+            return toPrimitive((Boolean[]) array);
+        }
+        if (Character.TYPE.equals(pt)) {
+            return toPrimitive((Character[]) array);
+        }
+        if (Byte.TYPE.equals(pt)) {
+            return toPrimitive((Byte[]) array);
+        }
         if (Integer.TYPE.equals(pt)) {
             return toPrimitive((Integer[]) array);
         }

--- a/src/test/java/org/apache/commons/lang3/ArrayUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/ArrayUtilsTest.java
@@ -341,11 +341,27 @@ public class ArrayUtilsTest {
     @Test
     public void testCreatePrimitiveArray() {
         assertNull(ArrayUtils.toPrimitive((Object[]) null));
+        assertArrayEquals(new boolean[]{true}, ArrayUtils.toPrimitive(new Boolean[]{true}));
+        assertArrayEquals(new char[]{'a'}, ArrayUtils.toPrimitive(new Character[]{'a'}));
+        assertArrayEquals(new byte[]{1}, ArrayUtils.toPrimitive(new Byte[]{1}));
         assertArrayEquals(new int[]{}, ArrayUtils.toPrimitive(new Integer[]{}));
         assertArrayEquals(new short[]{2}, ArrayUtils.toPrimitive(new Short[]{2}));
         assertArrayEquals(new long[]{2, 3}, ArrayUtils.toPrimitive(new Long[]{2L, 3L}));
         assertArrayEquals(new float[]{3.14f}, ArrayUtils.toPrimitive(new Float[]{3.14f}), 0.1f);
         assertArrayEquals(new double[]{2.718}, ArrayUtils.toPrimitive(new Double[]{2.718}), 0.1);
+    }
+
+    @Test
+    public void testCreatePrimitiveArrayViaObjectArray() {
+        assertNull(ArrayUtils.toPrimitive((Object) null));
+        assertArrayEquals(new boolean[]{true}, (boolean[]) ArrayUtils.toPrimitive((Object) new Boolean[]{true}));
+        assertArrayEquals(new char[]{'a'}, (char[]) ArrayUtils.toPrimitive((Object) new Character[]{'a'}));
+        assertArrayEquals(new byte[]{1}, (byte[]) ArrayUtils.toPrimitive((Object) new Byte[]{1}));
+        assertArrayEquals(new int[]{}, (int[]) ArrayUtils.toPrimitive((Object) new Integer[]{}));
+        assertArrayEquals(new short[]{2}, (short[]) ArrayUtils.toPrimitive((Object) new Short[]{2}));
+        assertArrayEquals(new long[]{2, 3}, (long[]) ArrayUtils.toPrimitive((Object) new Long[]{2L, 3L}));
+        assertArrayEquals(new float[]{3.14f}, (float[]) ArrayUtils.toPrimitive((Object) new Float[]{3.14f}), 0.1f);
+        assertArrayEquals(new double[]{2.718}, (double[]) ArrayUtils.toPrimitive((Object) new Double[]{2.718}), 0.1);
     }
 
     /**


### PR DESCRIPTION
- Add support for the missing types to toPrimitive(Object)
- Added tests for toPrimitive methods which did not have test coverage yet
- Added explicit test for the toPrimitive(Object) method for all primitive types