### PR TITLE
[LANG-1608] Include junit-bom for dependency version alignment.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -513,13 +513,24 @@
     </contributor>
   </contributors>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>5.7.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <!-- Lang should depend on very little -->
   <dependencies>
     <!-- testing -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>5.7.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Alternatively, we can rollback to `org.junit.jupiter:junit-jupiter:5.6.2`.