### PR TITLE
Close/flush the `OutputStream` before calling `toByteArray()` on underlying `ByteArrayOutputStream`

### DIFF
--- a/src/test/java/org/apache/commons/lang3/tuple/ImmutablePairTest.java
+++ b/src/test/java/org/apache/commons/lang3/tuple/ImmutablePairTest.java
@@ -165,8 +165,9 @@ public class ImmutablePairTest {
     public void testSerialization() throws Exception {
         final ImmutablePair<Integer, String> origPair = ImmutablePair.of(0, "foo");
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        final ObjectOutputStream out = new ObjectOutputStream(baos);
-        out.writeObject(origPair);
+        try (ObjectOutputStream out = new ObjectOutputStream(baos)) {
+            out.writeObject(origPair);
+        }
         final ImmutablePair<Integer, String> deserializedPair = (ImmutablePair<Integer, String>) new ObjectInputStream(
                 new ByteArrayInputStream(baos.toByteArray())).readObject();
         assertEquals(origPair, deserializedPair);

--- a/src/test/java/org/apache/commons/lang3/tuple/ImmutableTripleTest.java
+++ b/src/test/java/org/apache/commons/lang3/tuple/ImmutableTripleTest.java
@@ -124,8 +124,9 @@ public class ImmutableTripleTest {
     public void testSerialization() throws Exception {
         final ImmutableTriple<Integer, String, Boolean> origTriple = ImmutableTriple.of(0, "foo", Boolean.TRUE);
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        final ObjectOutputStream out = new ObjectOutputStream(baos);
-        out.writeObject(origTriple);
+        try (ObjectOutputStream out = new ObjectOutputStream(baos)) {
+            out.writeObject(origTriple);
+        }
         final ImmutableTriple<Integer, String, Boolean> deserializedTriple = (ImmutableTriple<Integer, String, Boolean>) new ObjectInputStream(
                 new ByteArrayInputStream(baos.toByteArray())).readObject();
         assertEquals(origTriple, deserializedTriple);

--- a/src/test/java/org/apache/commons/lang3/tuple/MutablePairTest.java
+++ b/src/test/java/org/apache/commons/lang3/tuple/MutablePairTest.java
@@ -133,8 +133,9 @@ public class MutablePairTest {
     public void testSerialization() throws Exception {
         final MutablePair<Integer, String> origPair = MutablePair.of(0, "foo");
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        final ObjectOutputStream out = new ObjectOutputStream(baos);
-        out.writeObject(origPair);
+        try (ObjectOutputStream out = new ObjectOutputStream(baos)) {
+            out.writeObject(origPair);
+        }
         final MutablePair<Integer, String> deserializedPair = (MutablePair<Integer, String>) new ObjectInputStream(
                 new ByteArrayInputStream(baos.toByteArray())).readObject();
         assertEquals(origPair, deserializedPair);

--- a/src/test/java/org/apache/commons/lang3/tuple/MutableTripleTest.java
+++ b/src/test/java/org/apache/commons/lang3/tuple/MutableTripleTest.java
@@ -98,8 +98,9 @@ public class MutableTripleTest {
     public void testSerialization() throws Exception {
         final MutableTriple<Integer, String, Boolean> origTriple = MutableTriple.of(0, "foo", Boolean.TRUE);
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        final ObjectOutputStream out = new ObjectOutputStream(baos);
-        out.writeObject(origTriple);
+        try (ObjectOutputStream out = new ObjectOutputStream(baos)) {
+            out.writeObject(origTriple);
+        }
         final MutableTriple<Integer, String, Boolean> deserializedTriple = (MutableTriple<Integer, String, Boolean>) new ObjectInputStream(
                 new ByteArrayInputStream(baos.toByteArray())).readObject();
         assertEquals(origTriple, deserializedTriple);


### PR DESCRIPTION
This PR is related to: https://github.com/apache/commons-lang/pull/400 

I have pulled most recent changes from repository and used ```try-with-resources``` to correctly close resources. 