### PR TITLE
NumberUtilsTest - incorrect types in min/max tests

### DIFF
--- a/src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java
@@ -696,11 +696,11 @@ public class NumberUtilsTest {
 
     @Test
     public void testMinLong() {
-        assertEquals(5, NumberUtils.min(5), "min(long[]) failed for array length 1");
-        assertEquals(6, NumberUtils.min(6, 9), "min(long[]) failed for array length 2");
+        assertEquals(5L, NumberUtils.min(5L), "min(long[]) failed for array length 1");
+        assertEquals(6L, NumberUtils.min(6L, 9L), "min(long[]) failed for array length 2");
 
-        assertEquals(-10, NumberUtils.min(-10, -5, 0, 5, 10));
-        assertEquals(-10, NumberUtils.min(-5, 0, -10, 5, 10));
+        assertEquals(-10L, NumberUtils.min(-10L, -5L, 0L, 5L, 10L));
+        assertEquals(-10L, NumberUtils.min(-5L, 0L, -10L, 5L, 10L));
     }
 
     @Test
@@ -734,11 +734,11 @@ public class NumberUtilsTest {
 
     @Test
     public void testMinShort() {
-        assertEquals(5, NumberUtils.min(5), "min(short[]) failed for array length 1");
-        assertEquals(6, NumberUtils.min(6, 9), "min(short[]) failed for array length 2");
+        assertEquals((short)5, NumberUtils.min((short)5), "min(short[]) failed for array length 1");
+        assertEquals((short)6, NumberUtils.min((short)6, (short)9), "min(short[]) failed for array length 2");
 
-        assertEquals(-10, NumberUtils.min(-10, -5, 0, 5, 10));
-        assertEquals(-10, NumberUtils.min(-5, 0, -10, 5, 10));
+        assertEquals((short)-10, NumberUtils.min((short)-10, (short)-5, (short)0, (short)5, (short)10));
+        assertEquals((short)-10, NumberUtils.min((short)-5, (short)0, (short)-10, (short)5, (short)10));
     }
 
     @Test
@@ -753,11 +753,11 @@ public class NumberUtilsTest {
 
     @Test
     public void testMinByte() {
-        assertEquals(5, NumberUtils.min(5), "min(byte[]) failed for array length 1");
-        assertEquals(6, NumberUtils.min(6, 9), "min(byte[]) failed for array length 2");
+        assertEquals((byte)5, NumberUtils.min((byte)5), "min(byte[]) failed for array length 1");
+        assertEquals((byte)6, NumberUtils.min((byte)6, (byte)9), "min(byte[]) failed for array length 2");
 
-        assertEquals(-10, NumberUtils.min(-10, -5, 0, 5, 10));
-        assertEquals(-10, NumberUtils.min(-5, 0, -10, 5, 10));
+        assertEquals((byte)-10, NumberUtils.min((byte)-10, (byte)-5, (byte)0, (byte)5, (byte)10));
+        assertEquals((byte)-10, NumberUtils.min((byte)-5, (byte)0, (byte)-10, (byte)5, (byte)10));
     }
 
     @Test
@@ -810,11 +810,11 @@ public class NumberUtilsTest {
 
     @Test
     public void testMaxLong() {
-        assertEquals(5, NumberUtils.max(5), "max(long[]) failed for array length 1");
-        assertEquals(9, NumberUtils.max(6, 9), "max(long[]) failed for array length 2");
-        assertEquals(10, NumberUtils.max(-10, -5, 0, 5, 10), "max(long[]) failed for array length 5");
-        assertEquals(10, NumberUtils.max(-10, -5, 0, 5, 10));
-        assertEquals(10, NumberUtils.max(-5, 0, 10, 5, -10));
+        assertEquals(5L, NumberUtils.max(5L), "max(long[]) failed for array length 1");
+        assertEquals(9L, NumberUtils.max(6L, 9L), "max(long[]) failed for array length 2");
+        assertEquals(10L, NumberUtils.max(-10L, -5L, 0L, 5L, 10L), "max(long[]) failed for array length 5");
+        assertEquals(10L, NumberUtils.max(-10L, -5L, 0L, 5L, 10L));
+        assertEquals(10L, NumberUtils.max(-5L, 0L, 10L, 5L, -10L));
     }
 
     @Test
@@ -848,11 +848,11 @@ public class NumberUtilsTest {
 
     @Test
     public void testMaxShort() {
-        assertEquals(5, NumberUtils.max(5), "max(short[]) failed for array length 1");
-        assertEquals(9, NumberUtils.max(6, 9), "max(short[]) failed for array length 2");
-        assertEquals(10, NumberUtils.max(-10, -5, 0, 5, 10), "max(short[]) failed for array length 5");
-        assertEquals(10, NumberUtils.max(-10, -5, 0, 5, 10));
-        assertEquals(10, NumberUtils.max(-5, 0, 10, 5, -10));
+        assertEquals((short)5, NumberUtils.max((short)5), "max(short[]) failed for array length 1");
+        assertEquals((short)9, NumberUtils.max((short)6, (short)9), "max(short[]) failed for array length 2");
+        assertEquals((short)10, NumberUtils.max((short)-10, (short)-5, (short)0, (short)5, (short)10), "max(short[]) failed for array length 5");
+        assertEquals((short)10, NumberUtils.max((short)-10, (short)-5,(short) 0,(short) 5, (short)10));
+        assertEquals((short)10, NumberUtils.max((short)-5,(short) 0,(short) 10, (short)5,(short) -10));
     }
 
     @Test
@@ -867,11 +867,11 @@ public class NumberUtilsTest {
 
     @Test
     public void testMaxByte() {
-        assertEquals(5, NumberUtils.max(5), "max(byte[]) failed for array length 1");
-        assertEquals(9, NumberUtils.max(6, 9), "max(byte[]) failed for array length 2");
-        assertEquals(10, NumberUtils.max(-10, -5, 0, 5, 10), "max(byte[]) failed for array length 5");
-        assertEquals(10, NumberUtils.max(-10, -5, 0, 5, 10));
-        assertEquals(10, NumberUtils.max(-5, 0, 10, 5, -10));
+        assertEquals((byte)5, NumberUtils.max((byte)5), "max(byte[]) failed for array length 1");
+        assertEquals((byte)9, NumberUtils.max((byte)6, (byte)9), "max(byte[]) failed for array length 2");
+        assertEquals((byte)10, NumberUtils.max((byte)-10, (byte)-5, (byte)0, (byte)5, (byte)10), "max(byte[]) failed for array length 5");
+        assertEquals((byte)10, NumberUtils.max((byte)-10, (byte)-5, (byte)0, (byte)5, (byte)10));
+        assertEquals((byte)10, NumberUtils.max((byte)-5, (byte)0, (byte)10, (byte)5, (byte)-10));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java
@@ -16,7 +16,12 @@
  */
 package org.apache.commons.lang3.math;
 
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
@@ -24,7 +29,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.RoundingMode;
 
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests {@link org.apache.commons.lang3.math.NumberUtils}.

--- a/src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java
@@ -16,12 +16,7 @@
  */
 package org.apache.commons.lang3.math;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
@@ -29,7 +24,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.RoundingMode;
 
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Unit tests {@link org.apache.commons.lang3.math.NumberUtils}.
@@ -734,11 +729,11 @@ public class NumberUtilsTest {
 
     @Test
     public void testMinShort() {
-        assertEquals((short)5, NumberUtils.min((short)5), "min(short[]) failed for array length 1");
-        assertEquals((short)6, NumberUtils.min((short)6, (short)9), "min(short[]) failed for array length 2");
+        assertEquals((short) 5, NumberUtils.min((short) 5), "min(short[]) failed for array length 1");
+        assertEquals((short) 6, NumberUtils.min((short) 6, (short) 9), "min(short[]) failed for array length 2");
 
-        assertEquals((short)-10, NumberUtils.min((short)-10, (short)-5, (short)0, (short)5, (short)10));
-        assertEquals((short)-10, NumberUtils.min((short)-5, (short)0, (short)-10, (short)5, (short)10));
+        assertEquals((short) -10, NumberUtils.min((short) -10, (short) -5, (short) 0, (short) 5, (short) 10));
+        assertEquals((short) -10, NumberUtils.min((short) -5, (short) 0, (short) -10, (short) 5, (short) 10));
     }
 
     @Test
@@ -753,11 +748,11 @@ public class NumberUtilsTest {
 
     @Test
     public void testMinByte() {
-        assertEquals((byte)5, NumberUtils.min((byte)5), "min(byte[]) failed for array length 1");
-        assertEquals((byte)6, NumberUtils.min((byte)6, (byte)9), "min(byte[]) failed for array length 2");
+        assertEquals((byte) 5, NumberUtils.min((byte) 5), "min(byte[]) failed for array length 1");
+        assertEquals((byte) 6, NumberUtils.min((byte) 6, (byte) 9), "min(byte[]) failed for array length 2");
 
-        assertEquals((byte)-10, NumberUtils.min((byte)-10, (byte)-5, (byte)0, (byte)5, (byte)10));
-        assertEquals((byte)-10, NumberUtils.min((byte)-5, (byte)0, (byte)-10, (byte)5, (byte)10));
+        assertEquals((byte) -10, NumberUtils.min((byte) -10, (byte) -5, (byte) 0, (byte) 5, (byte) 10));
+        assertEquals((byte) -10, NumberUtils.min((byte) -5, (byte) 0, (byte) -10, (byte) 5, (byte) 10));
     }
 
     @Test
@@ -848,11 +843,11 @@ public class NumberUtilsTest {
 
     @Test
     public void testMaxShort() {
-        assertEquals((short)5, NumberUtils.max((short)5), "max(short[]) failed for array length 1");
-        assertEquals((short)9, NumberUtils.max((short)6, (short)9), "max(short[]) failed for array length 2");
-        assertEquals((short)10, NumberUtils.max((short)-10, (short)-5, (short)0, (short)5, (short)10), "max(short[]) failed for array length 5");
-        assertEquals((short)10, NumberUtils.max((short)-10, (short)-5,(short) 0,(short) 5, (short)10));
-        assertEquals((short)10, NumberUtils.max((short)-5,(short) 0,(short) 10, (short)5,(short) -10));
+        assertEquals((short) 5, NumberUtils.max((short) 5), "max(short[]) failed for array length 1");
+        assertEquals((short) 9, NumberUtils.max((short) 6, (short) 9), "max(short[]) failed for array length 2");
+        assertEquals((short) 10, NumberUtils.max((short) -10, (short) -5, (short) 0, (short) 5, (short) 10), "max(short[]) failed for array length 5");
+        assertEquals((short) 10, NumberUtils.max((short) -10, (short) -5, (short) 0, (short) 5, (short) 10));
+        assertEquals((short) 10, NumberUtils.max((short) -5, (short) 0, (short) 10, (short) 5, (short) -10));
     }
 
     @Test
@@ -867,11 +862,11 @@ public class NumberUtilsTest {
 
     @Test
     public void testMaxByte() {
-        assertEquals((byte)5, NumberUtils.max((byte)5), "max(byte[]) failed for array length 1");
-        assertEquals((byte)9, NumberUtils.max((byte)6, (byte)9), "max(byte[]) failed for array length 2");
-        assertEquals((byte)10, NumberUtils.max((byte)-10, (byte)-5, (byte)0, (byte)5, (byte)10), "max(byte[]) failed for array length 5");
-        assertEquals((byte)10, NumberUtils.max((byte)-10, (byte)-5, (byte)0, (byte)5, (byte)10));
-        assertEquals((byte)10, NumberUtils.max((byte)-5, (byte)0, (byte)10, (byte)5, (byte)-10));
+        assertEquals((byte) 5, NumberUtils.max((byte) 5), "max(byte[]) failed for array length 1");
+        assertEquals((byte) 9, NumberUtils.max((byte) 6, (byte) 9), "max(byte[]) failed for array length 2");
+        assertEquals((byte) 10, NumberUtils.max((byte) -10, (byte) -5, (byte) 0, (byte) 5, (byte) 10), "max(byte[]) failed for array length 5");
+        assertEquals((byte) 10, NumberUtils.max((byte) -10, (byte) -5, (byte) 0, (byte) 5, (byte) 10));
+        assertEquals((byte) 10, NumberUtils.max((byte) -5, (byte) 0, (byte) 10, (byte) 5, (byte) -10));
     }
 
     @Test


### PR DESCRIPTION
Some of the tests related to finding min and max values does not have types declared. As a result min/max of value ```int``` methods are being tested multiple times without invoking target methods ```byte```, ```long``` etc.
I fixed types and added casting where required.