### PR TITLE
LANG-1610: Fix StringUtils.unwrap throws StringIndexOutOfBoundsException

### DIFF
--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -9371,7 +9371,7 @@ public class StringUtils {
      * @since 3.6
      */
     public static String unwrap(final String str, final String wrapToken) {
-        if (isEmpty(str) || isEmpty(wrapToken) || str.length() == 1) {
+        if (isEmpty(str) || isEmpty(wrapToken) || str.length() < 2 * wrapToken.length()) {
             return str;
         }
 

--- a/src/test/java/org/apache/commons/lang3/StringUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringUtilsTest.java
@@ -3174,6 +3174,7 @@ public class StringUtilsTest {
         assertEquals("abc", StringUtils.unwrap("abc", null));
         assertEquals("abc", StringUtils.unwrap("abc", ""));
         assertEquals("a", StringUtils.unwrap("a", "a"));
+        assertEquals("ababa", StringUtils.unwrap("ababa", "aba"));
         assertEquals("", StringUtils.unwrap("aa", "a"));
         assertEquals("abc", StringUtils.unwrap("\'abc\'", "\'"));
         assertEquals("abc", StringUtils.unwrap("\"abc\"", "\""));


### PR DESCRIPTION
When wrapToken.length() * 2 is larger than str.length(), and str starts with and ends with wrapToken, the function calls str.substring(beginIndex, endIndex) with beginIndex larger than endIndex, which throws a StringIndexOutOfBoundsException.

It should return the original string since it is not quoted properly with the wrapToken according to documentation.