### PR TITLE
[LANG-1612] testGetAllFields and testGetFieldsWithAnnotation sometimes fail

### DIFF
--- a/src/test/java/org/apache/commons/lang3/reflect/FieldUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/reflect/FieldUtilsTest.java
@@ -168,7 +168,10 @@ public class FieldUtilsTest {
         final Field[] fieldsNumber = Number.class.getDeclaredFields();
         assertArrayEquals(fieldsNumber, FieldUtils.getAllFields(Number.class));
         final Field[] fieldsInteger = Integer.class.getDeclaredFields();
-        assertArrayEquals(ArrayUtils.addAll(fieldsInteger, fieldsNumber), FieldUtils.getAllFields(Integer.class));
+        final List<Field> fieldsIntegerAndNumber = Arrays.asList(ArrayUtils.addAll(fieldsInteger, fieldsNumber));
+        final List<Field> allFieldsInteger = Arrays.asList(FieldUtils.getAllFields(Integer.class));
+        assertTrue(fieldsIntegerAndNumber.size() == allFieldsInteger.size() &&
+                fieldsIntegerAndNumber.containsAll(allFieldsInteger) && allFieldsInteger.containsAll(fieldsIntegerAndNumber));
         final Field[] allFields = FieldUtils.getAllFields(PublicChild.class);
         // Under Jacoco,0.8.1 and Java 10, the field count is 7.
         int expected = 5;

--- a/src/test/java/org/apache/commons/lang3/reflect/FieldUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/reflect/FieldUtilsTest.java
@@ -207,11 +207,11 @@ public class FieldUtilsTest {
     @Test
     public void testGetFieldsWithAnnotation() throws NoSuchFieldException {
         assertArrayEquals(new Field[0], FieldUtils.getFieldsWithAnnotation(Object.class, Annotated.class));
-        final Field[] annotatedFields = new Field[]{
-                FieldUtilsTest.class.getDeclaredField("publicChild"),
-                FieldUtilsTest.class.getDeclaredField("privatelyShadowedChild")
-        };
-        assertArrayEquals(annotatedFields, FieldUtils.getFieldsWithAnnotation(FieldUtilsTest.class, Annotated.class));
+        final List<Field> fieldsWithAnnotation = Arrays.asList(FieldUtils.getFieldsWithAnnotation(FieldUtilsTest.class, Annotated.class));
+        assertTrue(fieldsWithAnnotation.size() == 2 &&
+                fieldsWithAnnotation.contains(FieldUtilsTest.class.getDeclaredField("publicChild")) &&
+                fieldsWithAnnotation.contains(FieldUtilsTest.class.getDeclaredField("privatelyShadowedChild"))
+        );
     }
 
     @Test


### PR DESCRIPTION
Issue link: https://issues.apache.org/jira/browse/LANG-1612

Don't use `assertArrayEquals()` because it would fail when the array returned by `FieldUtils.getAllFields(...)` is not ordered in the way the test assumes in `annotatedFields` and `ArrayUtils.addAll(fieldsInteger, fieldsNumber)`. 

Instead, do order-independent assertions on: 1) the size of the returned array, 2) the element it contains. 