### PR TITLE
[LANG-1533] - RandomStringUtils.random() should not include \u0000 or control characters

### DIFF
--- a/src/main/java/org/apache/commons/lang3/RandomStringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/RandomStringUtils.java
@@ -404,6 +404,7 @@ public class RandomStringUtils {
                 case Character.UNASSIGNED:
                 case Character.PRIVATE_USE:
                 case Character.SURROGATE:
+                case Character.CONTROL:
                     count++;
                     continue;
                 }


### PR DESCRIPTION
Add Character.CONTROL 