### PR TITLE
[LANG-1524] : Added cycle detection check in toString for classes

### DIFF
--- a/src/main/java/org/apache/commons/lang3/reflect/TypeUtils.java
+++ b/src/main/java/org/apache/commons/lang3/reflect/TypeUtils.java
@@ -23,6 +23,7 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
 import java.lang.reflect.WildcardType;
+import java.lang.reflect.AnnotatedType;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -330,6 +331,10 @@ public class TypeUtils {
             return toString(cls.getComponentType()) + "[]";
         }
 
+        if(detectCycleWithEnclosingClass(cls)) {
+            throw new IllegalArgumentException("Cycle Detected while forming string for input class: " + cls.getName());
+        }
+
         final StringBuilder buf = new StringBuilder();
 
         if (cls.getEnclosingClass() != null) {
@@ -343,6 +348,32 @@ public class TypeUtils {
             buf.append('>');
         }
         return buf.toString();
+    }
+
+    /***
+     * Utility method which can be used to detect a cyclic reference in qualified name of a class. If a nested inner
+     * class is used as type parameter of parent class, that can lead to cyclic reference in name of parent class.
+     * If enclosing class of input class has same type parameter which extends the input class, then it forms a cycle.
+     *
+     * @param cls {@code Class} to format
+     * @return boolean
+     * @since 3.12
+     */
+    private static boolean detectCycleWithEnclosingClass(final Class<?> cls) {
+        boolean formsCycle = false;
+        if(cls.getEnclosingClass() != null) {
+            // current class -> temp$inner
+            // enclosing class-> temp
+            TypeVariable[] types = cls.getEnclosingClass().getTypeParameters();
+
+            for(int i = 0; i < types.length && !formsCycle; i++) {
+                AnnotatedType[] annotatedBounds = types[i].getAnnotatedBounds();
+                for(int j = 0; j < annotatedBounds.length && !formsCycle; j++) {
+                    formsCycle = (annotatedBounds[j].getType() == cls);
+                }
+            }
+        }
+        return formsCycle;
     }
 
     /**

--- a/src/test/java/org/apache/commons/lang3/reflect/TypeUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/reflect/TypeUtilsTest.java
@@ -60,9 +60,8 @@ class AAClass<T> {
     }
 }
 
-class ABClass<T extends ABClass.BBClass> {
-    public static class BBClass {
-
+class AAAAClass<T extends AAAAClass.BBBBClass> {
+    public static class BBBBClass {
     }
 }
 
@@ -959,6 +958,6 @@ public class TypeUtilsTest<B> {
 
     @Test
     public void testToStringLang1524() {
-        assertThrows(IllegalArgumentException.class, () -> TypeUtils.toString(ABClass.BBClass.class));
+        assertThrows(IllegalArgumentException.class, () -> TypeUtils.toString(AAAAClass.BBBBClass.class));
     }
 }

--- a/src/test/java/org/apache/commons/lang3/reflect/TypeUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/reflect/TypeUtilsTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.awt.Insets;
 import java.io.Serializable;
@@ -56,6 +57,12 @@ class AAAClass extends AAClass<String> {
 class AAClass<T> {
 
     public class BBClass<S> {
+    }
+}
+
+class ABClass<T extends ABClass.BBClass> {
+    public static class BBClass {
+
     }
 }
 
@@ -948,5 +955,10 @@ public class TypeUtilsTest<B> {
         assertTrue(TypeUtils.equals(t, TypeUtils.wrap(t).getType()));
 
         assertEquals(String.class, TypeUtils.wrap(String.class).getType());
+    }
+
+    @Test
+    public void testToStringLang1524() {
+        assertThrows(IllegalArgumentException.class, () -> TypeUtils.toString(ABClass.BBClass.class));
     }
 }


### PR DESCRIPTION
1. To String method earlier used to give stack overflow error in case of cyclic reference.
2. Added a cycle detection check before calling toString recursively on type parameters.