### PR TITLE
[LANG-1524] : Added cycle detection check in toString for classes

### DIFF
--- a/src/test/java/org/apache/commons/lang3/reflect/TypeUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/reflect/TypeUtilsTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.awt.Insets;
 import java.io.Serializable;
@@ -47,6 +48,13 @@ import org.apache.commons.lang3.reflect.testbed.GenericTypeHolder;
 import org.apache.commons.lang3.reflect.testbed.StringParameterizedChild;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+
+class AAAAClass<T extends AAAAClass.BBBBClass.CCCClass> {
+    public static class BBBBClass {
+        public static class CCCClass {
+        }
+    }
+}
 
 class AAAClass extends AAClass<String> {
     public class BBBClass extends BBClass<String> {
@@ -948,5 +956,12 @@ public class TypeUtilsTest<B> {
         assertTrue(TypeUtils.equals(t, TypeUtils.wrap(t).getType()));
 
         assertEquals(String.class, TypeUtils.wrap(String.class).getType());
+    }
+
+    @Test
+    public void testLand1524() {
+        assertThrows(IllegalArgumentException.class, () -> TypeUtils.toString(AAAAClass.BBBBClass.CCCClass.class));
+        assertThrows(IllegalArgumentException.class, () -> TypeUtils.toString(AAAAClass.BBBBClass.class));
+        assertThrows(IllegalArgumentException.class, () -> TypeUtils.toString(AAAAClass.class));
     }
 }

--- a/src/test/java/org/apache/commons/lang3/reflect/TypeUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/reflect/TypeUtilsTest.java
@@ -959,7 +959,7 @@ public class TypeUtilsTest<B> {
     }
 
     @Test
-    public void testLand1524() {
+    public void testLang1524() {
         assertThrows(IllegalArgumentException.class, () -> TypeUtils.toString(AAAAClass.BBBBClass.CCCClass.class));
         assertThrows(IllegalArgumentException.class, () -> TypeUtils.toString(AAAAClass.BBBBClass.class));
         assertThrows(IllegalArgumentException.class, () -> TypeUtils.toString(AAAAClass.class));


### PR DESCRIPTION
1. To String method earlier used to give stack overflow error in case of cyclic reference.
2. Added a cycle detection check before calling toString recursively on type parameters.
https://issues.apache.org/jira/browse/LANG-1524