### PR TITLE
[LANG-1622] Corrected reference to right methods.

### DIFF
--- a/src/main/java/org/apache/commons/lang3/BooleanUtils.java
+++ b/src/main/java/org/apache/commons/lang3/BooleanUtils.java
@@ -417,10 +417,10 @@ public class BooleanUtils {
      *   BooleanUtils.toBoolean("yes")   = true
      *   BooleanUtils.toBoolean("false") = false
      *   BooleanUtils.toBoolean("x gti") = false
-     *   BooleanUtils.toBooleanObject("y") = true
-     *   BooleanUtils.toBooleanObject("n") = false
-     *   BooleanUtils.toBooleanObject("t") = true
-     *   BooleanUtils.toBooleanObject("f") = false
+     *   BooleanUtils.toBoolean("y") = true
+     *   BooleanUtils.toBoolean("n") = false
+     *   BooleanUtils.toBoolean("t") = true
+     *   BooleanUtils.toBoolean("f") = false
      * </pre>
      *
      * @param str  the String to check
@@ -548,9 +548,9 @@ public class BooleanUtils {
      * if unboxed to a {@code boolean}.</p>
      *
      * <pre>
-     *   BooleanUtils.toBoolean(Integer.valueOf(0))    = Boolean.FALSE
-     *   BooleanUtils.toBoolean(Integer.valueOf(1))    = Boolean.TRUE
-     *   BooleanUtils.toBoolean(Integer.valueOf(null)) = null
+     *   BooleanUtils.toBooleanObject(Integer.valueOf(0))    = Boolean.FALSE
+     *   BooleanUtils.toBooleanObject(Integer.valueOf(1))    = Boolean.TRUE
+     *   BooleanUtils.toBooleanObject(Integer.valueOf(null)) = null
      * </pre>
      *
      * @param value  the Integer to convert

--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -3791,8 +3791,8 @@ public class StringUtils {
      * StringUtils.isNumericSpace("  ")   = true
      * StringUtils.isNumericSpace("123")  = true
      * StringUtils.isNumericSpace("12 3") = true
-     * StringUtils.isNumeric("\u0967\u0968\u0969")  = true
-     * StringUtils.isNumeric("\u0967\u0968 \u0969")  = true
+     * StringUtils.isNumericSpace("\u0967\u0968\u0969")  = true
+     * StringUtils.isNumericSpace("\u0967\u0968 \u0969")  = true
      * StringUtils.isNumericSpace("ab2c") = false
      * StringUtils.isNumericSpace("12-3") = false
      * StringUtils.isNumericSpace("12.3") = false


### PR DESCRIPTION
Corrected:
StringUtils.isNumericSpace incorrectly refer to isNumeric
BooleanUtils.toBoolean incorrectly refer to toBooleanObject