### PR TITLE
[LANG-1622] Javadoc of BooleanUtils incorrectly refers to another method

### DIFF
--- a/src/main/java/org/apache/commons/lang3/BooleanUtils.java
+++ b/src/main/java/org/apache/commons/lang3/BooleanUtils.java
@@ -548,9 +548,9 @@ public class BooleanUtils {
      * if unboxed to a {@code boolean}.</p>
      *
      * <pre>
-     *   BooleanUtils.toBoolean(Integer.valueOf(0))    = Boolean.FALSE
-     *   BooleanUtils.toBoolean(Integer.valueOf(1))    = Boolean.TRUE
-     *   BooleanUtils.toBoolean(Integer.valueOf(null)) = null
+     *   BooleanUtils.toBooleanObject(Integer.valueOf(0))    = Boolean.FALSE
+     *   BooleanUtils.toBooleanObject(Integer.valueOf(1))    = Boolean.TRUE
+     *   BooleanUtils.toBooleanObject(Integer.valueOf(null)) = null
      * </pre>
      *
      * @param value  the Integer to convert


### PR DESCRIPTION
One more function is referred incorrectly in BooleanUtils i.e. toBooleanObject(final Integer value).