### PR TITLE
LANG-1628: Javadoc correction for RandomStringUtils.random()

### DIFF
--- a/src/main/java/org/apache/commons/lang3/RandomStringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/RandomStringUtils.java
@@ -345,8 +345,10 @@ public class RandomStringUtils {
      * @param count  the length of random string to create
      * @param start  the position in set of chars to start at (inclusive)
      * @param end  the position in set of chars to end before (exclusive)
-     * @param letters  only allow letters?
-     * @param numbers  only allow numbers?
+     * @param letters  if {@code true}, generated string may include
+     *  alphabetic characters
+     * @param numbers  if {@code true}, generated string may include
+     *  numeric characters
      * @param chars  the set of chars to choose randoms from, must not be empty.
      *  If {@code null}, then it will use the set of all chars.
      * @param random  a source of randomness.

--- a/src/main/java/org/apache/commons/lang3/RandomStringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/RandomStringUtils.java
@@ -309,8 +309,10 @@ public class RandomStringUtils {
      * @param count  the length of random string to create
      * @param start  the position in set of chars to start at
      * @param end  the position in set of chars to end before
-     * @param letters  only allow letters?
-     * @param numbers  only allow numbers?
+     * @param letters  if {@code true}, generated string may include
+     *  alphabetic characters
+     * @param numbers  if {@code true}, generated string may include
+     *  numeric characters
      * @param chars  the set of chars to choose randoms from.
      *  If {@code null}, then it will use the set of all chars.
      * @return the random string


### PR DESCRIPTION
Javadoc correction for RandomStringUtils.random() letters and numbers parameters to make it consistent with other overloaded random()  method Javadoc for the same parameters.