### PR TITLE
Correct markup in Javadoc for unbalanced braces

### DIFF
--- a/src/main/java/org/apache/commons/lang3/text/ExtendedMessageFormat.java
+++ b/src/main/java/org/apache/commons/lang3/text/ExtendedMessageFormat.java
@@ -38,8 +38,8 @@ import org.apache.commons.lang3.Validate;
  * and the formats supported by {@code java.text.MessageFormat} can be overridden
  * at the format and/or format style level (see MessageFormat).  A "format element"
  * embedded in the message pattern is specified (<b>()?</b> signifies optionality):<br>
- * {@code {}<i>argument-number</i><b>(</b>{@code ,}<i>format-name</i><b>
- * (</b>{@code ,}<i>format-style</i><b>)?)?</b>{@code }}
+ * <code>{</code><i>argument-number</i><b>(</b>{@code ,}<i>format-name</i><b>
+ * (</b>{@code ,}<i>format-style</i><b>)?)?</b><code>}</code>
  *
  * <p>
  * <i>format-name</i> and <i>format-style</i> values are trimmed of surrounding whitespace


### PR DESCRIPTION
Use `<code>{</code>` instead of `{@code {}`, as the latter one is
invalid. It works in the current javadoc, as it is accompanied
with the equally invalid closing statement `{@code }}`, which
balances the used braces in the `{@code ...}` fragments and combines
the first invalid statement with the last one.