### PR TITLE
[LANG-1544] MethodUtils.invokeMethod NullPointerException in case of null in args list

### DIFF
--- a/src/main/java/org/apache/commons/lang3/reflect/MethodUtils.java
+++ b/src/main/java/org/apache/commons/lang3/reflect/MethodUtils.java
@@ -30,13 +30,16 @@ import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.ClassUtils;
 import org.apache.commons.lang3.ClassUtils.Interfaces;
 import org.apache.commons.lang3.Validate;
+
+import static java.util.stream.Collectors.toList;
 
 /**
  * <p>Utility reflection methods focused on {@link Method}s, originally from Commons BeanUtils.
@@ -742,35 +745,51 @@ public class MethodUtils {
         Validate.notNull(cls, "cls");
         Validate.notEmpty(methodName, "methodName");
 
-        // Address methods in superclasses
-        Method[] methodArray = cls.getDeclaredMethods();
-        final List<Class<?>> superclassList = ClassUtils.getAllSuperclasses(cls);
-        for (final Class<?> klass : superclassList) {
-            methodArray = ArrayUtils.addAll(methodArray, klass.getDeclaredMethods());
-        }
+        final List<Method> methods = Arrays.stream(cls.getDeclaredMethods())
+                .filter(method -> method.getName().equals(methodName))
+                .collect(toList());
 
-        Method inexactMatch = null;
-        for (final Method method : methodArray) {
-            if (methodName.equals(method.getName()) &&
-                    Objects.deepEquals(parameterTypes, method.getParameterTypes())) {
+        ClassUtils.getAllSuperclasses(cls).stream()
+                .map(Class::getDeclaredMethods)
+                .flatMap(Arrays::stream)
+                .filter(method -> method.getName().equals(methodName))
+                .forEach(methods::add);
+
+        for (Method method : methods) {
+            if (Arrays.deepEquals(method.getParameterTypes(), parameterTypes)) {
                 return method;
-            } else if (methodName.equals(method.getName()) &&
-                    ClassUtils.isAssignable(parameterTypes, method.getParameterTypes(), true)) {
-                if ((inexactMatch == null) || (distance(parameterTypes, method.getParameterTypes())
-                        < distance(parameterTypes, inexactMatch.getParameterTypes()))) {
-                    inexactMatch = method;
-                }
             }
-
         }
-        return inexactMatch;
+
+        final TreeMap<Double, List<Method>> candidates = new TreeMap<>();
+
+        methods.stream()
+                .filter(method -> ClassUtils.isAssignable(parameterTypes, method.getParameterTypes(), true))
+                .forEach(method -> {
+                    final double distance = distance(parameterTypes, method.getParameterTypes());
+                    List<Method> methods1 = candidates.computeIfAbsent(distance, k -> new ArrayList<>());
+                    methods1.add(method);
+                });
+
+        if (candidates.isEmpty()) {
+            return null;
+        }
+
+        final List<Method> bestCandidates = candidates.values().iterator().next();
+        if (bestCandidates.size() == 1) {
+            return bestCandidates.get(0);
+        }
+
+        final String target = methodName + Arrays.stream(parameterTypes).map(String::valueOf).collect(Collectors.joining(",", "(", ")"));
+        final String strCandidates = bestCandidates.stream().map(Method::toString).collect(Collectors.joining("\n  "));
+        throw new IllegalStateException("Found multiple candidates for method " + target + " on class " + cls + ":\n  " + strCandidates);
     }
 
     /**
      * <p>Returns the aggregate number of inheritance hops between assignable argument class types.  Returns -1
      * if the arguments aren't assignable.  Fills a specific purpose for getMatchingMethod and is not generalized.</p>
-     * @param classArray
-     * @param toClassArray
+     * @param classArray the Class array to calculate the distance from.
+     * @param toClassArray the Class array to calculate the distance to.
      * @return the aggregate number of inheritance hops between assignable argument class types.
      */
     private static int distance(final Class<?>[] classArray, final Class<?>[] toClassArray) {
@@ -781,10 +800,12 @@ public class MethodUtils {
         }
         for (int offset = 0; offset < classArray.length; offset++) {
             // Note InheritanceUtils.distance() uses different scoring system.
-            if (classArray[offset].equals(toClassArray[offset])) {
+            final Class<?> aClass = classArray[offset];
+            final Class<?> toClass = toClassArray[offset];
+            if (aClass == null || aClass.equals(toClass)) {
                 continue;
-            } else if (ClassUtils.isAssignable(classArray[offset], toClassArray[offset], true)
-                    && !ClassUtils.isAssignable(classArray[offset], toClassArray[offset], false)) {
+            } else if (ClassUtils.isAssignable(aClass, toClass, true)
+                    && !ClassUtils.isAssignable(aClass, toClass, false)) {
                 answer++;
             } else {
                 answer = answer + 2;

--- a/src/test/java/org/apache/commons/lang3/reflect/MethodUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/reflect/MethodUtilsTest.java
@@ -29,6 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.awt.*;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.util.Arrays;
@@ -1017,5 +1018,84 @@ public class MethodUtilsTest {
         assertEquals(2, distanceMethod.invoke(null, new Class[]{Integer.class}, new Class[]{Object.class}));
 
         distanceMethod.setAccessible(false);
+    }
+
+    @Test
+    public void testGetMatchingMethod() throws NoSuchMethodException {
+        assertEquals(MethodUtils.getMatchingMethod(GetMatchingMethodClass.class, "testMethod"),
+                GetMatchingMethodClass.class.getMethod("testMethod"));
+
+        assertEquals(MethodUtils.getMatchingMethod(GetMatchingMethodClass.class, "testMethod", Long.TYPE),
+                GetMatchingMethodClass.class.getMethod("testMethod", Long.TYPE));
+
+        assertEquals(MethodUtils.getMatchingMethod(GetMatchingMethodClass.class, "testMethod", Long.class),
+                GetMatchingMethodClass.class.getMethod("testMethod", Long.class));
+
+        assertEquals(MethodUtils.getMatchingMethod(GetMatchingMethodClass.class, "testMethod", (Class<?>) null),
+                GetMatchingMethodClass.class.getMethod("testMethod", Long.class));
+
+        assertThrows(IllegalStateException.class,
+                () -> MethodUtils.getMatchingMethod(GetMatchingMethodClass.class, "testMethod2", (Class<?>) null));
+
+        assertEquals(MethodUtils.getMatchingMethod(GetMatchingMethodClass.class, "testMethod3", Long.TYPE, Long.class),
+                GetMatchingMethodClass.class.getMethod("testMethod3", Long.TYPE, Long.class));
+
+        assertEquals(MethodUtils.getMatchingMethod(GetMatchingMethodClass.class, "testMethod3", Long.class, Long.TYPE),
+                GetMatchingMethodClass.class.getMethod("testMethod3", Long.class, Long.TYPE));
+
+        assertEquals(MethodUtils.getMatchingMethod(GetMatchingMethodClass.class, "testMethod3", null, Long.TYPE),
+                GetMatchingMethodClass.class.getMethod("testMethod3", Long.class, Long.TYPE));
+
+        assertEquals(MethodUtils.getMatchingMethod(GetMatchingMethodClass.class, "testMethod3", Long.TYPE, null),
+                GetMatchingMethodClass.class.getMethod("testMethod3", Long.TYPE, Long.class));
+
+        assertThrows(IllegalStateException.class,
+                () -> MethodUtils.getMatchingMethod(GetMatchingMethodClass.class, "testMethod4", null, null));
+    }
+
+    private static final class GetMatchingMethodClass {
+        public String testMethod() {
+            return "testMethod";
+        }
+
+        public String testMethod(Long aLong) {
+            return String.valueOf(aLong);
+        }
+
+        public String testMethod(long aLong) {
+            return String.valueOf(aLong);
+        }
+
+        public String testMethod2(Long aLong) {
+            return String.valueOf(aLong);
+        }
+
+        public String testMethod2(Color aColor) {
+            return String.valueOf(aColor);
+        }
+
+        public String testMethod2(long aLong) {
+            return String.valueOf(aLong);
+        }
+
+        public String testMethod3(long aLong, Long anotherLong) {
+            return aLong + ", " + anotherLong;
+        }
+
+        public String testMethod3(Long aLong, long anotherLong) {
+            return aLong + ", " + anotherLong;
+        }
+
+        public String testMethod3(Long aLong, Long anotherLong) {
+            return aLong + ", " + anotherLong;
+        }
+
+        public String testMethod4(Long aLong, Long anotherLong) {
+            return aLong + ", " + anotherLong;
+        }
+
+        public String testMethod4(Color aColor1, Color aColor2) {
+            return aColor1 + ", " + aColor2;
+        }
     }
 }

--- a/src/test/java/org/apache/commons/lang3/reflect/MethodUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/reflect/MethodUtilsTest.java
@@ -1054,48 +1054,37 @@ public class MethodUtilsTest {
     }
 
     private static final class GetMatchingMethodClass {
-        public String testMethod() {
-            return "testMethod";
+        public void testMethod() {
         }
 
-        public String testMethod(Long aLong) {
-            return String.valueOf(aLong);
+        public void testMethod(final Long aLong) {
         }
 
-        public String testMethod(long aLong) {
-            return String.valueOf(aLong);
+        public void testMethod(final long aLong) {
         }
 
-        public String testMethod2(Long aLong) {
-            return String.valueOf(aLong);
+        public void testMethod2(final Long aLong) {
         }
 
-        public String testMethod2(Color aColor) {
-            return String.valueOf(aColor);
+        public void testMethod2(final Color aColor) {
         }
 
-        public String testMethod2(long aLong) {
-            return String.valueOf(aLong);
+        public void testMethod2(final long aLong) {
         }
 
-        public String testMethod3(long aLong, Long anotherLong) {
-            return aLong + ", " + anotherLong;
+        public void testMethod3(final long aLong, final Long anotherLong) {
         }
 
-        public String testMethod3(Long aLong, long anotherLong) {
-            return aLong + ", " + anotherLong;
+        public void testMethod3(final Long aLong, final long anotherLong) {
         }
 
-        public String testMethod3(Long aLong, Long anotherLong) {
-            return aLong + ", " + anotherLong;
+        public void testMethod3(final Long aLong, final Long anotherLong) {
         }
 
-        public String testMethod4(Long aLong, Long anotherLong) {
-            return aLong + ", " + anotherLong;
+        public void testMethod4(final Long aLong, final Long anotherLong) {
         }
 
-        public String testMethod4(Color aColor1, Color aColor2) {
-            return aColor1 + ", " + aColor2;
+        public void testMethod4(final Color aColor1, final Color aColor2) {
         }
     }
 }

--- a/src/test/java/org/apache/commons/lang3/reflect/MethodUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/reflect/MethodUtilsTest.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.awt.*;
+import java.awt.Color;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.util.Arrays;


### PR DESCRIPTION
- Null guards in place to handle one or more nulls specified as one of the parameters of the method to invoke.
- Check for an exact match of the actual parameter types against all of the methods on the class. This prevents picking an "upcasted" method (i.e. int specified but a method with a double is chosen).
- Throw an IllegalStateException with a helpful message if multiple candidate methods were found. This happens when multiple Methods had the same "distance" from the desired parameter types. Before this change the algorithm would just chose the first one.
- Tests for the above.