### PR TITLE
[LANG-1631] - Check if Character is defined

### DIFF
--- a/src/main/java/org/apache/commons/lang3/CharSequenceUtils.java
+++ b/src/main/java/org/apache/commons/lang3/CharSequenceUtils.java
@@ -109,6 +109,7 @@ public class CharSequenceUtils {
                     return i;
                 }
             }
+            return NOT_FOUND;
         }
         //supplementary characters (LANG1300)
         if (searchChar <= Character.MAX_CODE_POINT) {
@@ -195,6 +196,7 @@ public class CharSequenceUtils {
                     return i;
                 }
             }
+            return NOT_FOUND;
         }
         //supplementary characters (LANG1300)
         //NOTE - we must do a forward traversal for this to avoid duplicating code points
@@ -244,7 +246,7 @@ public class CharSequenceUtils {
         }
 
         if (start < 0 || len2 < 0 || len2 > len1) {
-            return -1;
+            return NOT_FOUND;
         }
 
         if (len2 == 0) {
@@ -272,7 +274,7 @@ public class CharSequenceUtils {
             while (cs.charAt(i) != char0) {
                 i--;
                 if (i < 0) {
-                    return -1;
+                    return NOT_FOUND;
                 }
             }
             if (checkLaterThan1(cs, searchChar, len2, i)) {
@@ -280,7 +282,7 @@ public class CharSequenceUtils {
             }
             i--;
             if (i < 0) {
-                return -1;
+                return NOT_FOUND;
             }
         }
     }

--- a/src/test/java/org/apache/commons/lang3/StringUtilsEqualsIndexOfTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringUtilsEqualsIndexOfTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.nio.CharBuffer;
 import java.util.Locale;
 
 import org.hamcrest.core.IsNot;
@@ -275,6 +276,7 @@ public class StringUtilsEqualsIndexOfTest  {
         assertEquals(2, StringUtils.indexOf("aabaabaa", 'b'));
 
         assertEquals(2, StringUtils.indexOf(new StringBuilder("aabaabaa"), 'b'));
+        assertEquals(StringUtils.INDEX_NOT_FOUND, StringUtils.indexOf(new StringBuilder("aabaabaa"), -1738));
     }
 
     @Test
@@ -564,6 +566,7 @@ public class StringUtilsEqualsIndexOfTest  {
         assertEquals(1, StringUtils.lastIndexOf(builder, CODE_POINT, 1 ));
         assertEquals(-1, StringUtils.lastIndexOf(builder.toString(), CODE_POINT, 0));
         assertEquals(1, StringUtils.lastIndexOf(builder.toString(), CODE_POINT, 1));
+        assertEquals(StringUtils.INDEX_NOT_FOUND, StringUtils.lastIndexOf(CharBuffer.wrap("[%{.c.0rro"), -1738, 982));
     }
 
     @Test


### PR DESCRIPTION
Crash when the the char to be searched value it's out of range >=  '\u0000' <= '\uFFFF'
 Getting the next error -->
 
`java.lang.IllegalArgumentException: Not a valid Unicode code point: 0xFFFFF936`

Basically the problem is that when it is verified that the character to search is less than MIN_SUPPLEMENTARY_CODE_POINT, the search is not exited of the loop. It continues searching but this time values less than or equal to Character.MAX_CODE_POIN

