### PR TITLE
LANG-1641: GmtTimeZone now implements #equals(Object) using it's time…

### DIFF
--- a/src/main/java/org/apache/commons/lang3/time/GmtTimeZone.java
+++ b/src/main/java/org/apache/commons/lang3/time/GmtTimeZone.java
@@ -17,6 +17,8 @@
 package org.apache.commons.lang3.time;
 
 import java.util.Date;
+import java.util.Objects;
+import java.util.SimpleTimeZone;
 import java.util.TimeZone;
 
 /**
@@ -33,8 +35,7 @@ class GmtTimeZone extends TimeZone {
     // Serializable!
     static final long serialVersionUID = 1L;
 
-    private final int offset;
-    private final String zoneId;
+    private final SimpleTimeZone m_delegate;
 
     GmtTimeZone(final boolean negate, final int hours, final int minutes) {
         if (hours >= HOURS_PER_DAY) {
@@ -44,11 +45,12 @@ class GmtTimeZone extends TimeZone {
             throw new IllegalArgumentException(minutes + " minutes out of range");
         }
         final int milliseconds = (minutes + (hours * MINUTES_PER_HOUR)) * MILLISECONDS_PER_MINUTE;
-        offset = negate ? -milliseconds : milliseconds;
-        zoneId = twoDigits(
+        final int offset = negate ? -milliseconds : milliseconds;
+        final String zoneId = twoDigits(
             twoDigits(new StringBuilder(9).append("GMT").append(negate ? '-' : '+'), hours)
                 .append(':'), minutes).toString();
 
+        m_delegate = new SimpleTimeZone(offset, zoneId);
     }
 
     private static StringBuilder twoDigits(final StringBuilder sb, final int n) {
@@ -57,7 +59,7 @@ class GmtTimeZone extends TimeZone {
 
     @Override
     public int getOffset(final int era, final int year, final int month, final int day, final int dayOfWeek, final int milliseconds) {
-        return offset;
+        return m_delegate.getOffset(era, year, month, day, dayOfWeek, milliseconds);
     }
 
     @Override
@@ -67,39 +69,39 @@ class GmtTimeZone extends TimeZone {
 
     @Override
     public int getRawOffset() {
-        return offset;
+        return m_delegate.getRawOffset();
     }
 
     @Override
     public String getID() {
-        return zoneId;
+        return m_delegate.getID();
     }
 
     @Override
     public boolean useDaylightTime() {
-        return false;
+        return m_delegate.useDaylightTime();
     }
 
     @Override
     public boolean inDaylightTime(final Date date) {
-        return false;
+        return m_delegate.inDaylightTime(date);
     }
 
     @Override
     public String toString() {
-        return "[GmtTimeZone id=\"" + zoneId + "\",offset=" + offset + ']';
+        return "[GmtTimeZone id=\"" + getID() + "\",offset=" + getRawOffset() + ']';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        final GmtTimeZone that = (GmtTimeZone) o;
+        return m_delegate.equals(that.m_delegate);
     }
 
     @Override
     public int hashCode() {
-        return offset;
-    }
-
-    @Override
-    public boolean equals(final Object other) {
-        if (!(other instanceof GmtTimeZone)) {
-            return false;
-        }
-        return zoneId == ((GmtTimeZone) other).zoneId;
+        return Objects.hash(getID(), m_delegate);
     }
 }

--- a/src/main/java/org/apache/commons/lang3/time/GmtTimeZone.java
+++ b/src/main/java/org/apache/commons/lang3/time/GmtTimeZone.java
@@ -103,6 +103,7 @@ class GmtTimeZone extends TimeZone {
         final GmtTimeZone that = (GmtTimeZone) o;
         return m_delegate.equals(that.m_delegate);
     }
+
     @Override
     public int hashCode() {
         return Objects.hash(getID(), m_delegate);

--- a/src/main/java/org/apache/commons/lang3/time/GmtTimeZone.java
+++ b/src/main/java/org/apache/commons/lang3/time/GmtTimeZone.java
@@ -103,7 +103,6 @@ class GmtTimeZone extends TimeZone {
         final GmtTimeZone that = (GmtTimeZone) o;
         return m_delegate.equals(that.m_delegate);
     }
-    
     @Override
     public int hashCode() {
         return Objects.hash(getID(), m_delegate);

--- a/src/main/java/org/apache/commons/lang3/time/GmtTimeZone.java
+++ b/src/main/java/org/apache/commons/lang3/time/GmtTimeZone.java
@@ -26,7 +26,7 @@ import java.util.TimeZone;
  *
  * @since 3.7
  */
-class GmtTimeZone extends TimeZone {
+final class GmtTimeZone extends TimeZone {
 
     private static final int MILLISECONDS_PER_MINUTE = 60 * 1000;
     private static final int MINUTES_PER_HOUR = 60;
@@ -35,7 +35,7 @@ class GmtTimeZone extends TimeZone {
     // Serializable!
     static final long serialVersionUID = 1L;
 
-    private final SimpleTimeZone m_delegate;
+    private final SimpleTimeZone delegate;
 
     GmtTimeZone(final boolean negate, final int hours, final int minutes) {
         if (hours >= HOURS_PER_DAY) {
@@ -50,7 +50,7 @@ class GmtTimeZone extends TimeZone {
             twoDigits(new StringBuilder(9).append("GMT").append(negate ? '-' : '+'), hours)
                 .append(':'), minutes).toString();
 
-        m_delegate = new SimpleTimeZone(offset, zoneId);
+        delegate = new SimpleTimeZone(offset, zoneId);
     }
 
     private static StringBuilder twoDigits(final StringBuilder sb, final int n) {
@@ -59,7 +59,7 @@ class GmtTimeZone extends TimeZone {
 
     @Override
     public int getOffset(final int era, final int year, final int month, final int day, final int dayOfWeek, final int milliseconds) {
-        return m_delegate.getOffset(era, year, month, day, dayOfWeek, milliseconds);
+        return delegate.getOffset(era, year, month, day, dayOfWeek, milliseconds);
     }
 
     @Override
@@ -69,22 +69,22 @@ class GmtTimeZone extends TimeZone {
 
     @Override
     public int getRawOffset() {
-        return m_delegate.getRawOffset();
+        return delegate.getRawOffset();
     }
 
     @Override
     public String getID() {
-        return m_delegate.getID();
+        return delegate.getID();
     }
 
     @Override
     public boolean useDaylightTime() {
-        return m_delegate.useDaylightTime();
+        return delegate.useDaylightTime();
     }
 
     @Override
     public boolean inDaylightTime(final Date date) {
-        return m_delegate.inDaylightTime(date);
+        return delegate.inDaylightTime(date);
     }
 
     @Override
@@ -101,11 +101,11 @@ class GmtTimeZone extends TimeZone {
             return false;
         }
         final GmtTimeZone that = (GmtTimeZone) o;
-        return m_delegate.equals(that.m_delegate);
+        return delegate.equals(that.delegate);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getID(), m_delegate);
+        return Objects.hash(getID(), delegate);
     }
 }

--- a/src/main/java/org/apache/commons/lang3/time/GmtTimeZone.java
+++ b/src/main/java/org/apache/commons/lang3/time/GmtTimeZone.java
@@ -94,12 +94,16 @@ class GmtTimeZone extends TimeZone {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         final GmtTimeZone that = (GmtTimeZone) o;
         return m_delegate.equals(that.m_delegate);
     }
-
+    
     @Override
     public int hashCode() {
         return Objects.hash(getID(), m_delegate);

--- a/src/test/java/org/apache/commons/lang3/time/FastDateFormatTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/FastDateFormatTest.java
@@ -45,6 +45,8 @@ import org.junitpioneer.jupiter.DefaultTimeZone;
  * @since 2.0
  */
 public class FastDateFormatTest {
+    private static final String ISO_8601_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ssZZ";
+
     /*
      * Only the cache methods need to be tested here.
      * The print methods are tested by {@link FastDateFormat_PrinterTest}
@@ -318,5 +320,38 @@ public class FastDateFormatTest {
     @Test
     public void testLANG_1267() {
         FastDateFormat.getInstance("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
+    }
+
+    @Test
+    public void testCache() {
+        {
+            final FastDateFormat actualInstance1 = FastDateFormat.getInstance(ISO_8601_DATE_FORMAT);
+            final FastDateFormat actualInstance2 = FastDateFormat.getInstance(ISO_8601_DATE_FORMAT);
+
+            assertSame(actualInstance1, actualInstance2);
+        }
+
+        // commons-lang's GMT TimeZone
+        {
+            final FastDateFormat actualInstance1 = FastDateFormat.getInstance(ISO_8601_DATE_FORMAT, FastTimeZone.getGmtTimeZone());
+            final FastDateFormat actualInstance2 = FastDateFormat.getInstance(ISO_8601_DATE_FORMAT, FastTimeZone.getGmtTimeZone());
+
+            assertSame(actualInstance1, actualInstance2);
+        }
+
+        // default TimeZone
+        {
+            final FastDateFormat actualInstance1 = FastDateFormat.getInstance(ISO_8601_DATE_FORMAT, TimeZone.getDefault());
+            final FastDateFormat actualInstance2 = FastDateFormat.getInstance(ISO_8601_DATE_FORMAT, TimeZone.getDefault());
+
+            assertSame(actualInstance1, actualInstance2);
+        }
+
+        // TimeZones that are identical in every way except ID
+        {
+            final FastDateFormat actualInstance1 = FastDateFormat.getInstance(ISO_8601_DATE_FORMAT, TimeZone.getTimeZone("Australia/Broken_Hill"));
+            final FastDateFormat actualInstance2 = FastDateFormat.getInstance(ISO_8601_DATE_FORMAT, TimeZone.getTimeZone("Australia/Yancowinna"));
+            assertNotSame(actualInstance1, actualInstance2);
+        }
     }
 }


### PR DESCRIPTION
LANG-1641: GmtTimeZone now implements #equals(Object) using it's time zone ID. Added tests to verify caching of GmtTimeZone instances.