### PR TITLE
Fix broken Javadoc links to commons-text

### DIFF
--- a/src/main/java/org/apache/commons/lang3/text/StrLookup.java
+++ b/src/main/java/org/apache/commons/lang3/text/StrLookup.java
@@ -34,7 +34,7 @@ import java.util.Map;
  * @param <V> Unused.
  * @since 2.2
  * @deprecated as of 3.6, use commons-text
- * <a href="https://commons.apache.org/proper/commons-text/javadocs/api-release/org/apache/commons/text/StringLookupFactory.html">
+ * <a href="https://commons.apache.org/proper/commons-text/javadocs/api-release/org/apache/commons/text/lookup/StringLookupFactory.html">
  * StringLookupFactory</a> instead
  */
 @Deprecated

--- a/src/main/java/org/apache/commons/lang3/text/StrMatcher.java
+++ b/src/main/java/org/apache/commons/lang3/text/StrMatcher.java
@@ -30,7 +30,7 @@ import org.apache.commons.lang3.StringUtils;
  *
  * @since 2.2
  * @deprecated as of 3.6, use commons-text
- * <a href="https://commons.apache.org/proper/commons-text/javadocs/api-release/org/apache/commons/text/StringMatcherFactory.html">
+ * <a href="https://commons.apache.org/proper/commons-text/javadocs/api-release/org/apache/commons/text/matcher/StringMatcherFactory.html">
  * StringMatcherFactory</a> instead
  */
 @Deprecated

--- a/src/main/java/org/apache/commons/lang3/text/translate/AggregateTranslator.java
+++ b/src/main/java/org/apache/commons/lang3/text/translate/AggregateTranslator.java
@@ -27,7 +27,7 @@ import org.apache.commons.lang3.ArrayUtils;
  *
  * @since 3.0
  * @deprecated as of 3.6, use commons-text
- * <a href="https://commons.apache.org/proper/commons-text/javadocs/api-release/org/apache/commons/text/AggregateTranslator.html">
+ * <a href="https://commons.apache.org/proper/commons-text/javadocs/api-release/org/apache/commons/text/translate/AggregateTranslator.html">
  * AggregateTranslator</a> instead
  */
 @Deprecated


### PR DESCRIPTION
All were missing a subpackage