### PR TITLE
Let mid(null), left(null) and right(null) return empty

### DIFF
--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -5221,7 +5221,7 @@ public class StringUtils {
      * an exception. An empty String is returned if len is negative.</p>
      *
      * <pre>
-     * StringUtils.left(null, *)    = null
+     * StringUtils.left(null, *)    = ""
      * StringUtils.left(*, -ve)     = ""
      * StringUtils.left("", *)      = ""
      * StringUtils.left("abc", 0)   = ""
@@ -5231,13 +5231,10 @@ public class StringUtils {
      *
      * @param str  the String to get the leftmost characters from, may be null
      * @param len  the length of the required String
-     * @return the leftmost characters, {@code null} if null String input
+     * @return the leftmost characters, {@code EMPTY} if null String input
      */
     public static String left(final String str, final int len) {
-        if (str == null) {
-            return null;
-        }
-        if (len < 0) {
+        if (str == null || len < 0) {
             return EMPTY;
         }
         if (str.length() <= len) {
@@ -5489,7 +5486,7 @@ public class StringUtils {
      * length of {@code str}.</p>
      *
      * <pre>
-     * StringUtils.mid(null, *, *)    = null
+     * StringUtils.mid(null, *, *)    = ""
      * StringUtils.mid(*, *, -ve)     = ""
      * StringUtils.mid("", 0, *)      = ""
      * StringUtils.mid("abc", 0, 2)   = "ab"
@@ -5505,10 +5502,7 @@ public class StringUtils {
      * @return the middle characters, {@code null} if null String input
      */
     public static String mid(final String str, int pos, final int len) {
-        if (str == null) {
-            return null;
-        }
-        if (len < 0 || pos > str.length()) {
+        if (str == null || len < 0 || pos > str.length()) {
             return EMPTY;
         }
         if (pos < 0) {
@@ -7150,7 +7144,7 @@ public class StringUtils {
      * an exception. An empty String is returned if len is negative.</p>
      *
      * <pre>
-     * StringUtils.right(null, *)    = null
+     * StringUtils.right(null, *)    = ""
      * StringUtils.right(*, -ve)     = ""
      * StringUtils.right("", *)      = ""
      * StringUtils.right("abc", 0)   = ""
@@ -7160,13 +7154,10 @@ public class StringUtils {
      *
      * @param str  the String to get the rightmost characters from, may be null
      * @param len  the length of the required String
-     * @return the rightmost characters, {@code null} if null String input
+     * @return the rightmost characters, {@code EMPTY} if null String input
      */
     public static String right(final String str, final int len) {
-        if (str == null) {
-            return null;
-        }
-        if (len < 0) {
+        if (str == null || len < 0) {
             return EMPTY;
         }
         if (str.length() <= len) {

--- a/src/test/java/org/apache/commons/lang3/StringUtilsSubstringTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringUtilsSubstringTest.java
@@ -75,9 +75,9 @@ public class StringUtilsSubstringTest  {
 
     @Test
     public void testLeft_String() {
-        assertSame(null, StringUtils.left(null, -1));
-        assertSame(null, StringUtils.left(null, 0));
-        assertSame(null, StringUtils.left(null, 2));
+        assertSame("", StringUtils.left(null, -1));
+        assertSame("", StringUtils.left(null, 0));
+        assertSame("", StringUtils.left(null, 2));
 
         assertEquals("", StringUtils.left("", -1));
         assertEquals("", StringUtils.left("", 0));
@@ -91,9 +91,9 @@ public class StringUtilsSubstringTest  {
 
     @Test
     public void testRight_String() {
-        assertSame(null, StringUtils.right(null, -1));
-        assertSame(null, StringUtils.right(null, 0));
-        assertSame(null, StringUtils.right(null, 2));
+        assertSame("", StringUtils.right(null, -1));
+        assertSame("", StringUtils.right(null, 0));
+        assertSame("", StringUtils.right(null, 2));
 
         assertEquals("", StringUtils.right("", -1));
         assertEquals("", StringUtils.right("", 0));
@@ -107,10 +107,10 @@ public class StringUtilsSubstringTest  {
 
     @Test
     public void testMid_String() {
-        assertSame(null, StringUtils.mid(null, -1, 0));
-        assertSame(null, StringUtils.mid(null, 0, -1));
-        assertSame(null, StringUtils.mid(null, 3, 0));
-        assertSame(null, StringUtils.mid(null, 3, 2));
+        assertSame("", StringUtils.mid(null, -1, 0));
+        assertSame("", StringUtils.mid(null, 0, -1));
+        assertSame("", StringUtils.mid(null, 3, 0));
+        assertSame("", StringUtils.mid(null, 3, 2));
 
         assertEquals("", StringUtils.mid("", 0, -1));
         assertEquals("", StringUtils.mid("", 0, 0));


### PR DESCRIPTION
I'm not sure if there is reasoning behind `left(null, n)` returning `null`, but other `StringUtils` functions tends to return empty strings if their inputs are null. Likewise, I think it makes sense that `mid(null, n)`, `left(null, n)` or `right(null, n)` returns an empty string instead of returning null. My use case is lambda logging. I have code like this:

```.java
log.debug("My output (first 256 chars): {}", StringUtils.left(output, 256)::toString);
```

I get an NullPointerExceptions when I do and not properly wrap the call, etc. So I can't take advantage of both the `left` function as well as lambda based logging.