### PR TITLE
Add toLocalDate to CalendarUtils

### DIFF
--- a/src/main/java/org/apache/commons/lang3/time/CalendarUtils.java
+++ b/src/main/java/org/apache/commons/lang3/time/CalendarUtils.java
@@ -22,7 +22,6 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
-
 import java.util.Calendar;
 import java.util.Locale;
 import java.util.Locale.Category;

--- a/src/main/java/org/apache/commons/lang3/time/CalendarUtils.java
+++ b/src/main/java/org/apache/commons/lang3/time/CalendarUtils.java
@@ -17,10 +17,12 @@
 
 package org.apache.commons.lang3.time;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+
 import java.util.Calendar;
 import java.util.Locale;
 import java.util.Locale.Category;
@@ -223,4 +225,11 @@ public class CalendarUtils {
         return toZonedDateTime(calendar);
     }
 
+     * Creates a LocalDate from a Calendar
+     *
+     * @return a LocalDate
+     */
+    public LocalDate toLocalDate() {
+        return LocalDate.of(getYear(), getMonth()+1, getDayOfMonth());
+    }
 }

--- a/src/main/java/org/apache/commons/lang3/time/CalendarUtils.java
+++ b/src/main/java/org/apache/commons/lang3/time/CalendarUtils.java
@@ -224,9 +224,10 @@ public class CalendarUtils {
         return toZonedDateTime(calendar);
     }
 
-     * Creates a LocalDate from a Calendar
+     * Converts this instance to a {@link LocalDate}.
      *
      * @return a LocalDate
+     * @since 3.17.0
      */
     public LocalDate toLocalDate() {
         return LocalDate.of(getYear(), getMonth()+1, getDayOfMonth());

--- a/src/main/java/org/apache/commons/lang3/time/CalendarUtils.java
+++ b/src/main/java/org/apache/commons/lang3/time/CalendarUtils.java
@@ -224,12 +224,12 @@ public class CalendarUtils {
         return toZonedDateTime(calendar);
     }
 
-     * Converts this instance to a {@link LocalDate}.
+    /** Converts this instance to a {@link LocalDate}.
      *
      * @return a LocalDate
      * @since 3.17.0
      */
     public LocalDate toLocalDate() {
-        return LocalDate.of(getYear(), getMonth()+1, getDayOfMonth());
+        return LocalDate.of(getYear(), getMonth() + 1, getDayOfMonth());
     }
 }

--- a/src/test/java/org/apache/commons/lang3/time/CalendarUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/CalendarUtilsTest.java
@@ -24,6 +24,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.time.Month;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.Locale;
@@ -134,8 +135,8 @@ public class CalendarUtilsTest extends AbstractLangTest {
     public void testToLocalDate() {
         Calendar calendar = new GregorianCalendar(TimeZone.getTimeZone("GMT"));
         calendar.setTimeInMillis(-27078001200000L);
-        assertEquals(LocalDate.of(1111, 12, 1), new CalendarUtils(calendar).toLocalDate());
+        assertEquals(LocalDate.of(1111, Month.DECEMBER, 1), new CalendarUtils(calendar).toLocalDate());
         calendar.setTimeInMillis(1614700215000L);
-        assertEquals(LocalDate.of(2021, 3, 2), new CalendarUtils(calendar).toLocalDate());
+        assertEquals(LocalDate.of(2021, Month.MARCH, 2), new CalendarUtils(calendar).toLocalDate());
     }
 }

--- a/src/test/java/org/apache/commons/lang3/time/CalendarUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/CalendarUtilsTest.java
@@ -135,8 +135,8 @@ public class CalendarUtilsTest extends AbstractLangTest {
     public void testToLocalDate() {
         Calendar calendar = new GregorianCalendar(TimeZone.getTimeZone("GMT"));
         calendar.setTimeInMillis(-27078001200000L);
-        assertEquals(LocalDate.of(1111, 12, 1), new CalendarUtils(calendar).toLocalDate());
+        assertEquals(LocalDate.of(1111, Month.DECEMBER, 1), new CalendarUtils(calendar).toLocalDate());
         calendar.setTimeInMillis(1614700215000L);
-        assertEquals(LocalDate.of(2021, 3, 2), new CalendarUtils(calendar).toLocalDate());
+        assertEquals(LocalDate.of(2021, Month.MARCH, 2), new CalendarUtils(calendar).toLocalDate());
     }
 }

--- a/src/test/java/org/apache/commons/lang3/time/CalendarUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/CalendarUtilsTest.java
@@ -31,6 +31,7 @@ import java.util.Locale;
 import java.util.TimeZone;
 
 import org.apache.commons.lang3.AbstractLangTest;
+import org.apache.commons.lang3.time.TimeZones;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -133,7 +134,7 @@ public class CalendarUtilsTest extends AbstractLangTest {
 
     @Test
     public void testToLocalDate() {
-        Calendar calendar = new GregorianCalendar(TimeZone.getTimeZone("GMT"));
+        Calendar calendar = new GregorianCalendar(TimeZone.getTimeZone(TimeZones.GMT_ID));
         calendar.setTimeInMillis(-27078001200000L);
         assertEquals(LocalDate.of(1111, Month.DECEMBER, 1), new CalendarUtils(calendar).toLocalDate());
         calendar.setTimeInMillis(1614700215000L);

--- a/src/test/java/org/apache/commons/lang3/time/CalendarUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/CalendarUtilsTest.java
@@ -19,6 +19,7 @@ package org.apache.commons.lang3.time;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
@@ -128,5 +129,13 @@ public class CalendarUtilsTest extends AbstractLangTest {
         final ZonedDateTime zdt1 = ZonedDateTime.of(1, 2, 3, 4, 5, 6, 0, zoneId);
         calendar.setTimeInMillis(zdt1.toInstant().toEpochMilli());
         assertEquals(ZonedDateTime.ofInstant(zdt1.toInstant(), calendar.getTimeZone().toZoneId()), new CalendarUtils(calendar).toZonedDateTime());
+
+    @Test
+    public void testToLocalDate() {
+        Calendar calendar = new GregorianCalendar(TimeZone.getTimeZone("GMT"));
+        calendar.setTimeInMillis(-27078001200000l);
+        assertEquals(LocalDate.of(1111, 12, 1), new CalendarUtils(calendar).toLocalDate());
+        calendar.setTimeInMillis(1614700215000l);
+        assertEquals(LocalDate.of(2021, 3, 2), new CalendarUtils(calendar).toLocalDate());
     }
 }

--- a/src/test/java/org/apache/commons/lang3/time/CalendarUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/CalendarUtilsTest.java
@@ -133,9 +133,9 @@ public class CalendarUtilsTest extends AbstractLangTest {
     @Test
     public void testToLocalDate() {
         Calendar calendar = new GregorianCalendar(TimeZone.getTimeZone("GMT"));
-        calendar.setTimeInMillis(-27078001200000l);
+        calendar.setTimeInMillis(-27078001200000L);
         assertEquals(LocalDate.of(1111, 12, 1), new CalendarUtils(calendar).toLocalDate());
-        calendar.setTimeInMillis(1614700215000l);
+        calendar.setTimeInMillis(1614700215000L);
         assertEquals(LocalDate.of(2021, 3, 2), new CalendarUtils(calendar).toLocalDate());
     }
 }

--- a/src/test/java/org/apache/commons/lang3/time/CalendarUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/CalendarUtilsTest.java
@@ -134,9 +134,9 @@ public class CalendarUtilsTest extends AbstractLangTest {
     @Test
     public void testToLocalDate() {
         Calendar calendar = new GregorianCalendar(TimeZone.getTimeZone("GMT"));
-        calendar.setTimeInMillis(-27078001200000l);
+        calendar.setTimeInMillis(-27078001200000L);
         assertEquals(LocalDate.of(1111, 12, 1), new CalendarUtils(calendar).toLocalDate());
-        calendar.setTimeInMillis(1614700215000l);
+        calendar.setTimeInMillis(1614700215000L);
         assertEquals(LocalDate.of(2021, 3, 2), new CalendarUtils(calendar).toLocalDate());
     }
 }

--- a/src/test/java/org/apache/commons/lang3/time/CalendarUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/CalendarUtilsTest.java
@@ -21,10 +21,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.Month;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.time.Month;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.Locale;

--- a/src/test/java/org/apache/commons/lang3/time/CalendarUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/CalendarUtilsTest.java
@@ -134,9 +134,9 @@ public class CalendarUtilsTest extends AbstractLangTest {
     @Test
     public void testToLocalDate() {
         Calendar calendar = new GregorianCalendar(TimeZone.getTimeZone("GMT"));
-        calendar.setTimeInMillis(-27078001200000L);
-        assertEquals(LocalDate.of(1111, Month.DECEMBER, 1), new CalendarUtils(calendar).toLocalDate());
-        calendar.setTimeInMillis(1614700215000L);
-        assertEquals(LocalDate.of(2021, Month.MARCH, 2), new CalendarUtils(calendar).toLocalDate());
+        calendar.setTimeInMillis(-27078001200000l);
+        assertEquals(LocalDate.of(1111, 12, 1), new CalendarUtils(calendar).toLocalDate());
+        calendar.setTimeInMillis(1614700215000l);
+        assertEquals(LocalDate.of(2021, 3, 2), new CalendarUtils(calendar).toLocalDate());
     }
 }


### PR DESCRIPTION
Using an Instance to create a LocalDate from a Calendar does not work on dates before the Gregorian/Julian cutover.

So use this code instead, and add tests for years before the cutover and after.