### PR TITLE
EnumUtils: Add more-generic getEnumMap() method.

### DIFF
--- a/src/main/java/org/apache/commons/lang3/EnumUtils.java
+++ b/src/main/java/org/apache/commons/lang3/EnumUtils.java
@@ -23,6 +23,7 @@ import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 /**
  * <p>Utility library to provide helper methods for Java enums.</p>
@@ -290,6 +291,25 @@ public class EnumUtils {
         final Map<String, E> map = new LinkedHashMap<>();
         for (final E e: enumClass.getEnumConstants()) {
             map.put(e.name(), e);
+        }
+        return map;
+    }
+
+    /**
+     * <p>Gets the {@code Map} of enums.</p>
+     *
+     * <p>This method is useful when you need a map of enums.</p>
+     *
+     * @param <E> the type of enumeration
+     * @param <K> the type of the map key
+     * @param enumClass the class of the enum to query, not null
+     * @param keyFunction the function to query for the key, not null
+     * @return the modifiable map of enums, never null
+     */
+    public static <E extends Enum<E>, K> Map<K, E> getEnumMap(final Class<E> enumClass, final Function<E, K> keyFunction) {
+        final Map<K, E> map = new LinkedHashMap<>();
+        for (final E e: enumClass.getEnumConstants()) {
+            map.put(keyFunction.apply(e), e);
         }
         return map;
     }

--- a/src/test/java/org/apache/commons/lang3/EnumUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/EnumUtilsTest.java
@@ -59,6 +59,39 @@ public class EnumUtilsTest {
     }
 
     @Test
+    public void test_getEnumMap_keyFunction() {
+        final Map<Integer, Month> test = EnumUtils.getEnumMap(Month.class, Month::getId);
+        assertEquals("{1=JAN, 2=FEB, 3=MAR, 4=APR, 5=MAY, 6=JUN, 7=JUL, 8=AUG, 9=SEP, 10=OCT, 11=NOV, 12=DEC}", test.toString(), "getEnumMap not created correctly");
+        assertEquals(12, test.size());
+        assertFalse(test.containsKey(0));
+        assertTrue(test.containsKey(1));
+        assertEquals(Month.JAN, test.get(1));
+        assertTrue(test.containsKey(2));
+        assertEquals(Month.FEB, test.get(2));
+        assertTrue(test.containsKey(3));
+        assertEquals(Month.MAR, test.get(3));
+        assertTrue(test.containsKey(4));
+        assertEquals(Month.APR, test.get(4));
+        assertTrue(test.containsKey(5));
+        assertEquals(Month.MAY, test.get(5));
+        assertTrue(test.containsKey(6));
+        assertEquals(Month.JUN, test.get(6));
+        assertTrue(test.containsKey(7));
+        assertEquals(Month.JUL, test.get(7));
+        assertTrue(test.containsKey(8));
+        assertEquals(Month.AUG, test.get(8));
+        assertTrue(test.containsKey(9));
+        assertEquals(Month.SEP, test.get(9));
+        assertTrue(test.containsKey(10));
+        assertEquals(Month.OCT, test.get(10));
+        assertTrue(test.containsKey(11));
+        assertEquals(Month.NOV, test.get(11));
+        assertTrue(test.containsKey(12));
+        assertEquals(Month.DEC, test.get(12));
+        assertFalse(test.containsKey(13));
+    }
+
+    @Test
     public void test_getEnumList() {
         final List<Traffic> test = EnumUtils.getEnumList(Traffic.class);
         assertEquals(3, test.size());
@@ -485,6 +518,21 @@ public class EnumUtilsTest {
         assertEquals(EnumSet.of(TooMany.A, TooMany.B, TooMany.C, TooMany.M2), EnumUtils.processBitVectors(TooMany.class, 9L, 7L));
     }
 
+}
+
+enum Month {
+    JAN( 1), FEB( 2), MAR( 3), APR( 4), MAY( 5), JUN( 6),
+    JUL( 7), AUG( 8), SEP( 9), OCT(10), NOV(11), DEC(12);
+
+    private final int id;
+
+    Month(int id) {
+        this.id = id;
+    }
+
+    public int getId() {
+        return this.id;
+    }
 }
 
 enum Traffic {


### PR DESCRIPTION
The method accepts a Function object used to supply keys for the map, allowing for keys other than the value names. This may be useful when mapping constants to data.

The behavior of the single-parameter `getEnumMap()` can be emulated with this method by using a reference to the `Enum::name` method. For example,

```groovy
Map<String, Traffic> map = EnumUtils.getEnumMap(Traffic.class);
```

would become
```groovy
Map<String, Traffic> map = EnumUtils.getEnumMap(Traffic.class, Traffic::name);
```

and the resulting map would be identical.