### PR TITLE
Use Set instead of List for checking the contains() method

### DIFF
--- a/src/main/java/org/apache/commons/lang3/LocaleUtils.java
+++ b/src/main/java/org/apache/commons/lang3/LocaleUtils.java
@@ -117,13 +117,13 @@ public class LocaleUtils {
     }
 
     /**
-     * <p>Checks if the locale specified is in the list of available locales.</p>
+     * <p>Checks if the locale specified is in the set of available locales.</p>
      *
      * @param locale the Locale object to check if it is available
      * @return true if the locale is a known locale
      */
     public static boolean isAvailableLocale(final Locale locale) {
-        return availableLocaleList().contains(locale);
+        return availableLocaleSet().contains(locale);
     }
 
     /**


### PR DESCRIPTION
Use the HashSet collection for using the **contains()** method on the given Locale object.
The change improves the time complexity of this method from O(n) for ArrayList to O(1) for HashSet