### PR TITLE
LANG-1659 - Add null-safe ObjectUtils.isArray()

### DIFF
--- a/src/main/java/org/apache/commons/lang3/AnnotationUtils.java
+++ b/src/main/java/org/apache/commons/lang3/AnnotationUtils.java
@@ -231,7 +231,7 @@ public class AnnotationUtils {
      */
     private static int hashMember(final String name, final Object value) {
         final int part1 = name.hashCode() * 127;
-        if (value.getClass().isArray()) {
+        if (ObjectUtils.isArray(value)) {
             return part1 ^ arrayMemberHash(value.getClass().getComponentType(), value);
         }
         if (value instanceof Annotation) {

--- a/src/main/java/org/apache/commons/lang3/ObjectUtils.java
+++ b/src/main/java/org/apache/commons/lang3/ObjectUtils.java
@@ -240,7 +240,7 @@ public class ObjectUtils {
     public static <T> T clone(final T obj) {
         if (obj instanceof Cloneable) {
             final Object result;
-            if (obj.getClass().isArray()) {
+            if (isArray(obj)) {
                 final Class<?> componentType = obj.getClass().getComponentType();
                 if (componentType.isPrimitive()) {
                     int length = Array.getLength(obj);
@@ -980,6 +980,31 @@ public class ObjectUtils {
             public final static int MAGIC_NUMBER = CONST(5);
      */
 
+    /**
+     * <p>
+     * Checks, whether the given object is an Object array or a primitive array in a null-safe manner.
+     * </p>
+     *
+     * <p>
+     * A {@code null} {@code object} Object will return {@code false}.
+     * </p>
+     *
+     * <pre>
+     * ObjectUtils.isArray(null)             = false
+     * ObjectUtils.isArray("")               = false
+     * ObjectUtils.isArray("ab")             = false
+     * ObjectUtils.isArray(new int[]{})      = true
+     * ObjectUtils.isArray(new int[]{1,2,3}) = true
+     * ObjectUtils.isArray(1234)             = false
+     * </pre>
+     *
+     * @param object the object to check, may be {@code null}
+     * @return {@code true} if the object is an {@code array}, {@code false} otherwise
+     * @since 3.13.0
+     */
+    public static boolean isArray(final Object object) {
+        return object != null && object.getClass().isArray();
+    }
 
     /**
      * <p>Checks if an Object is empty or null.</p>
@@ -1013,7 +1038,7 @@ public class ObjectUtils {
         if (object instanceof CharSequence) {
             return ((CharSequence) object).length() == 0;
         }
-        if (object.getClass().isArray()) {
+        if (isArray(object)) {
             return Array.getLength(object) == 0;
         }
         if (object instanceof Collection<?>) {

--- a/src/main/java/org/apache/commons/lang3/builder/CompareToBuilder.java
+++ b/src/main/java/org/apache/commons/lang3/builder/CompareToBuilder.java
@@ -24,6 +24,7 @@ import java.util.Comparator;
 import java.util.Objects;
 
 import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.ObjectUtils;
 
 /**
  * Assists in implementing {@link java.lang.Comparable#compareTo(Object)} methods.
@@ -414,7 +415,7 @@ public class CompareToBuilder implements Builder<Integer> {
             comparison = 1;
             return this;
         }
-        if (lhs.getClass().isArray()) {
+        if (ObjectUtils.isArray(lhs)) {
             // factor out array case in order to keep method small enough to be inlined
             appendArray(lhs, rhs, comparator);
         } else // the simple case, not an array, just test the element

--- a/src/main/java/org/apache/commons/lang3/builder/DiffBuilder.java
+++ b/src/main/java/org/apache/commons/lang3/builder/DiffBuilder.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.Validate;
 
 /**
@@ -819,7 +820,7 @@ public class DiffBuilder<T> implements Builder<DiffResult<T>> {
             objectToTest = rhs;
         }
 
-        if (objectToTest.getClass().isArray()) {
+        if (ObjectUtils.isArray(objectToTest)) {
             if (objectToTest instanceof boolean[]) {
                 return append(fieldName, (boolean[]) lhs, (boolean[]) rhs);
             }

--- a/src/main/java/org/apache/commons/lang3/builder/HashCodeBuilder.java
+++ b/src/main/java/org/apache/commons/lang3/builder/HashCodeBuilder.java
@@ -27,6 +27,7 @@ import java.util.Set;
 
 import org.apache.commons.lang3.ArraySorter;
 import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.Validate;
 
 /**
@@ -842,7 +843,7 @@ public class HashCodeBuilder implements Builder<Integer> {
         if (object == null) {
             iTotal = iTotal * iConstant;
 
-        } else if (object.getClass().isArray()) {
+        } else if (ObjectUtils.isArray(object)) {
             // factor out array case in order to keep method small enough
             // to be inlined
             appendArray(object);

--- a/src/main/java/org/apache/commons/lang3/builder/ToStringStyle.java
+++ b/src/main/java/org/apache/commons/lang3/builder/ToStringStyle.java
@@ -568,7 +568,7 @@ public abstract class ToStringStyle implements Serializable {
                     appendSummary(buffer, fieldName, (boolean[]) value);
                 }
 
-            } else if (value.getClass().isArray()) {
+            } else if (ObjectUtils.isArray(value)) {
                 if (detail) {
                     appendDetail(buffer, fieldName, (Object[]) value);
                 } else {

--- a/src/test/java/org/apache/commons/lang3/ObjectUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/ObjectUtilsTest.java
@@ -618,6 +618,43 @@ public class ObjectUtilsTest {
         assertFalse(ObjectUtils.isEmpty(NON_EMPTY_MAP));
     }
 
+    /**
+     * Test for {@link ObjectUtils#isArray(Object)}.
+     */
+    @Test
+    public void testArray() {
+        assertFalse(ObjectUtils.isArray(null));
+        assertFalse(ObjectUtils.isArray(""));
+        assertFalse(ObjectUtils.isArray("abg"));
+        assertFalse(ObjectUtils.isArray(123));
+        assertTrue(ObjectUtils.isArray(NON_EMPTY_ARRAY));
+        assertTrue(ObjectUtils.isArray(new int[]{1, 2, 3}));
+        assertTrue(ObjectUtils.isArray(ArrayUtils.EMPTY_BOOLEAN_ARRAY));
+        assertTrue(ObjectUtils.isArray(ArrayUtils.EMPTY_BOOLEAN_ARRAY));
+        assertTrue(ObjectUtils.isArray(ArrayUtils.EMPTY_BOOLEAN_OBJECT_ARRAY));
+        assertTrue(ObjectUtils.isArray(ArrayUtils.EMPTY_BYTE_ARRAY));
+        assertTrue(ObjectUtils.isArray(ArrayUtils.EMPTY_BYTE_OBJECT_ARRAY));
+        assertTrue(ObjectUtils.isArray(ArrayUtils.EMPTY_CHAR_ARRAY));
+        assertTrue(ObjectUtils.isArray(ArrayUtils.EMPTY_CHARACTER_OBJECT_ARRAY));
+        assertTrue(ObjectUtils.isArray(ArrayUtils.EMPTY_CLASS_ARRAY));
+        assertTrue(ObjectUtils.isArray(ArrayUtils.EMPTY_DOUBLE_ARRAY));
+        assertTrue(ObjectUtils.isArray(ArrayUtils.EMPTY_DOUBLE_OBJECT_ARRAY));
+        assertTrue(ObjectUtils.isArray(ArrayUtils.EMPTY_FIELD_ARRAY));
+        assertTrue(ObjectUtils.isArray(ArrayUtils.EMPTY_FLOAT_ARRAY));
+        assertTrue(ObjectUtils.isArray(ArrayUtils.EMPTY_FLOAT_OBJECT_ARRAY));
+        assertTrue(ObjectUtils.isArray(ArrayUtils.EMPTY_INT_ARRAY));
+        assertTrue(ObjectUtils.isArray(ArrayUtils.EMPTY_INTEGER_OBJECT_ARRAY));
+        assertTrue(ObjectUtils.isArray(ArrayUtils.EMPTY_LONG_ARRAY));
+        assertTrue(ObjectUtils.isArray(ArrayUtils.EMPTY_LONG_OBJECT_ARRAY));
+        assertTrue(ObjectUtils.isArray(ArrayUtils.EMPTY_METHOD_ARRAY));
+        assertTrue(ObjectUtils.isArray(ArrayUtils.EMPTY_OBJECT_ARRAY));
+        assertTrue(ObjectUtils.isArray(ArrayUtils.EMPTY_SHORT_ARRAY));
+        assertTrue(ObjectUtils.isArray(ArrayUtils.EMPTY_SHORT_OBJECT_ARRAY));
+        assertTrue(ObjectUtils.isArray(ArrayUtils.EMPTY_STRING_ARRAY));
+        assertTrue(ObjectUtils.isArray(ArrayUtils.EMPTY_THROWABLE_ARRAY));
+        assertTrue(ObjectUtils.isArray(ArrayUtils.EMPTY_TYPE_ARRAY));
+    }
+
     @Test
     public void testIsNotEmpty() {
         assertFalse(ObjectUtils.isNotEmpty(null));


### PR DESCRIPTION
The idea it's have a method that determine whether the given object is an array. Change all the reference of `.getClass().isArray()` in favor of `ObjectUtils.isArray(value)`
