### PR TITLE
ObjectUtils: Add nullSafeEquals method for Object compare. 

### DIFF
--- a/src/main/java/org/apache/commons/lang3/ObjectUtils.java
+++ b/src/main/java/org/apache/commons/lang3/ObjectUtils.java
@@ -755,7 +755,8 @@ public class ObjectUtils {
      * @param targetPath object target path to be checked.
      * @param value value to compare.
      * @return {@code true} if the objects are same, {@code false} otherwise
-     * @throws IllegalAccessException, IllegalArgumentException if an Access or Argument error occurs.
+     * @throws IllegalAccessException if an Access error occurs.
+     * @throws IllegalArgumentException if an Argument error occurs.
      */
     public static boolean nullSafeEquals(final Object source, String targetPath, Object value) throws IllegalAccessException, IllegalArgumentException {
         if (source == null || StringUtils.isBlank(targetPath)) {

--- a/src/main/java/org/apache/commons/lang3/ObjectUtils.java
+++ b/src/main/java/org/apache/commons/lang3/ObjectUtils.java
@@ -19,9 +19,11 @@ package org.apache.commons.lang3;
 import java.io.IOException;
 import java.io.Serializable;
 import java.lang.reflect.Array;
+import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -710,6 +712,94 @@ public class ObjectUtils {
             }
         }
         return null;
+    }
+
+    /**
+     * <p>Compare two objects for equality. Even if the object to be compared is null,
+     * it safely returns false and compares nulls.</p>
+     *
+     * <pre>
+     * class Baz {
+     *     String testBazString = "test";
+     * }
+     *
+     * class Bar {
+     *     String testBarString = "test";
+     *     Baz baz = new Baz();
+     *     Baz nullBaz;
+     * }
+     *
+     * class Foo {
+     *     Bar bar = new Bar();
+     *     Bar nullBar;
+     *     int primitiveInt = 1;
+     *     String testFooString = "test";
+     *
+     *     public static final String PUBLIC_STATIC_FINAL_FOO = "foo";
+     *     public static String PUBLIC_STATIC_NULL_FOO;
+     * }
+     *
+     * Foo foo = new Foo();
+     *
+     * ObjectUtils.nullSafeEquals(foo, "nullBar", null)                          = true
+     * ObjectUtils.nullSafeEquals(foo, "nullBar.testBarString", "test")          = false
+     * ObjectUtils.nullSafeEquals(foo, "bar.testBarString", "test")              = true
+     * ObjectUtils.nullSafeEquals(foo, "bar.nullBaz.testBazString", "test")      = false
+     * ObjectUtils.nullSafeEquals(foo, "primitiveInt", 1)                        = true
+     * ObjectUtils.nullSafeEquals(foo, "primitiveInt", 2)                        = false
+     * ObjectUtils.nullSafeEquals(foo, "PUBLIC_STATIC_FINAL_FOO", "foo")         = true
+     * ObjectUtils.nullSafeEquals(foo, "PUBLIC_STATIC_NULL_FOO", "foo")          = false
+     * </pre>
+     *
+     * @param source the first object.
+     * @param targetPath object target path to be checked.
+     * @param value value to compare.
+     * @return {@code true} if the objects are same, {@code false} otherwise
+     * @throws IllegalAccessException, IllegalArgumentException if an Access or Argument error occurs.
+     */
+    public static boolean nullSafeEquals(final Object source, String targetPath, Object value) throws IllegalAccessException, IllegalArgumentException {
+        if (source == null || StringUtils.isBlank(targetPath)) {
+            return false;
+        }
+        String[] targetValues = targetPath.split("\\.");
+        if (targetValues.length == 0) {
+            return false;
+        }
+        if (source.getClass().getSimpleName().equals(targetValues[0]) && targetPath.contains(".")) {
+            targetValues = Arrays.copyOfRange(targetValues, 1, targetValues.length);
+        }
+        final Field[] fields = source.getClass().getDeclaredFields();
+        if (targetValues.length == 1) {
+            for (Field field : fields) {
+                if (!field.getName().equalsIgnoreCase(targetValues[0])) {
+                    continue;
+                }
+
+                field.setAccessible(true);
+                final Object compareValue = field.get(source);
+                if (value == null) {
+                    return compareValue == null;
+                } else {
+                    return value.equals(compareValue);
+                }
+            }
+        } else {
+            for (int i=0; i<fields.length; i++) {
+                final Field field = fields[i];
+                if (!field.getName().equalsIgnoreCase(targetValues[0])) {
+                    continue;
+                }
+
+                field.setAccessible(true);
+                final Object nextSource = field.get(source);
+                if (nextSource == null) {
+                    return false;
+                } else if (targetValues.length >= (i+1)) {
+                    return nullSafeEquals(nextSource, targetPath.substring(targetValues[0].length()+1), value);
+                }
+            }
+        }
+        return false;
     }
 
     /**

--- a/src/test/java/org/apache/commons/lang3/ObjectUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/ObjectUtilsTest.java
@@ -47,6 +47,7 @@ import java.util.function.Supplier;
 import org.apache.commons.lang3.exception.CloneFailedException;
 import org.apache.commons.lang3.mutable.MutableInt;
 import org.apache.commons.lang3.mutable.MutableObject;
+import org.apache.commons.lang3.test.nullsafeequals.NullSafeEqualsParent;
 import org.apache.commons.lang3.text.StrBuilder;
 import org.junit.jupiter.api.Test;
 
@@ -401,6 +402,30 @@ public class ObjectUtilsTest {
         assertTrue(!ObjectUtils.equals(null, BAR), "ObjectUtils.equals(null, \"bar\") returned true");
         assertTrue(!ObjectUtils.equals(FOO, BAR), "ObjectUtils.equals(\"foo\", \"bar\") returned true");
         assertTrue(ObjectUtils.equals(FOO, FOO), "ObjectUtils.equals(\"foo\", \"foo\") returned false");
+    }
+
+    @Test
+    public void testNullSafeEquals() throws IllegalAccessException {
+        final NullSafeEqualsParent nullSafeEqualsParent = new NullSafeEqualsParent();
+
+        assertTrue(ObjectUtils.nullSafeEquals(nullSafeEqualsParent, "foo", "parentFoo"), "ObjectUtils.nullSafeEquals(ParentFoo, \"foo\", \"parentFoo\") returned true");
+        assertTrue(ObjectUtils.nullSafeEquals(nullSafeEqualsParent, "nullSafeEqualsChildPrivate.foo", "fooValue"), "ObjectUtils.nullSafeEquals(ParentFoo, \"nullSafeEqualsChildPrivate.foo\", \"fooValue\") returned true");
+        assertTrue(ObjectUtils.nullSafeEquals(nullSafeEqualsParent, "nullSafeEqualsChildPrivate.nullSafeEqualsGrandChild.var", "varValue"), "ObjectUtils.nullSafeEquals(ParentFoo, \"nullSafeEqualsChildPrivate.nullSafeEqualsGrandChild.var\", \"varValue\") returned true");
+        assertFalse(ObjectUtils.nullSafeEquals(nullSafeEqualsParent, "nullSafeEqualsChildPrivate.foo", "foo1Value"), "ObjectUtils.nullSafeEquals(ParentFoo, \"nullSafeEqualsChildPrivate.foo\", \"fooValue\") returned false");
+        assertFalse(ObjectUtils.nullSafeEquals(nullSafeEqualsParent, "nullSafeEqualsChildPrivate.nullSafeEqualsGrandChild.var", "var1Value"), "ObjectUtils.nullSafeEquals(ParentFoo, \"nullSafeEqualsChildPrivate.nullSafeEqualsGrandChild.var\", \"varValue\") returned false");
+        assertTrue(ObjectUtils.nullSafeEquals(nullSafeEqualsParent, "nullSafeEqualsChildPrivate.primitiveValue", 1), "ObjectUtils.nullSafeEquals(ParentFoo, \"nullSafeEqualsChildPrivate.primitiveValue\", 1) returned true");
+        assertFalse(ObjectUtils.nullSafeEquals(nullSafeEqualsParent, "nullSafeEqualsChildPrivate.primitiveValue", 12), "ObjectUtils.nullSafeEquals(ParentFoo, \"nullSafeEqualsChildPrivate.primitiveValue\", 12) returned false");
+        assertTrue(ObjectUtils.nullSafeEquals(nullSafeEqualsParent, "nullSafeEqualsChildPublic", null), "ObjectUtils.nullSafeEquals(ParentFoo, \"nullSafeEqualsChildPublic\", null) returned true");
+        assertTrue(ObjectUtils.nullSafeEquals(nullSafeEqualsParent, "nullSafeEqualsChildPrivate.nullSafeEqualsGrandChildNull", null), "ObjectUtils.nullSafeEquals(ParentFoo, \"nullSafeEqualsChildPrivate.nullSafeEqualsGrandChildNull\", null) returned true");
+        assertFalse(ObjectUtils.nullSafeEquals(nullSafeEqualsParent, "nullSafeEqualsChildPrivate.nullSafeEqualsGrandChildNull.var", "varValue"), "ObjectUtils.nullSafeEquals(ParentFoo, \"nullSafeEqualsChildPrivate.nullSafeEqualsGrandChildNull\", null) returned false");
+        assertTrue(ObjectUtils.nullSafeEquals(nullSafeEqualsParent, "STATIC_FINAL_FOO", "foo"), "ObjectUtils.nullSafeEquals(ParentFoo, \"STATIC_FINAL_FOO\", \"foo\") returned true");
+        assertTrue(ObjectUtils.nullSafeEquals(nullSafeEqualsParent, "STATIC_FOO", "foo"), "ObjectUtils.nullSafeEquals(ParentFoo, \"STATIC_FINAL_FOO\", \"foo\") returned true");
+        assertTrue(ObjectUtils.nullSafeEquals(nullSafeEqualsParent, "NullSafeEqualsParent.PUBLIC_STATIC_FINAL_FOO", "foo"), "ObjectUtils.nullSafeEquals(ParentFoo, \"NullSafeEqualsParent.PUBLIC_STATIC_FINAL_FOO\", \"foo\") returned true");
+        assertTrue(ObjectUtils.nullSafeEquals(nullSafeEqualsParent, "NullSafeEqualsParent.STATIC_FINAL_FOO", "foo"), "ObjectUtils.nullSafeEquals(ParentFoo, \"NullSafeEqualsParent.STATIC_FINAL_FOO\", \"foo\") returned true");
+        assertFalse(ObjectUtils.nullSafeEquals(nullSafeEqualsParent, "NullSafeEqualsParent.PUBLIC_STATIC_FINAL_FOO", null), "ObjectUtils.nullSafeEquals(ParentFoo, \"NullSafeEqualsParent.PUBLIC_STATIC_FINAL_FOO\", null) returned false");
+        assertFalse(ObjectUtils.nullSafeEquals(nullSafeEqualsParent, "NullSafeEqualsParent.PUBLIC_STATIC_FINAL_FOO", "bar"), "ObjectUtils.nullSafeEquals(ParentFoo, \"NullSafeEqualsParent.PUBLIC_STATIC_FINAL_FOO\", null) returned false");
+        assertFalse(ObjectUtils.nullSafeEquals(nullSafeEqualsParent, "NullSafeEqualsParent.PUBLIC_STATIC_NULL_FOO", "foo"), "ObjectUtils.nullSafeEquals(ParentFoo, \"NullSafeEqualsParent.PUBLIC_STATIC_NULL_FOO\", \"foo\") returned false");
+        assertTrue(ObjectUtils.nullSafeEquals(nullSafeEqualsParent, "NullSafeEqualsParent.PUBLIC_STATIC_NULL_FOO", null), "ObjectUtils.nullSafeEquals(ParentFoo, \"NullSafeEqualsParent.PUBLIC_STATIC_NULL_FOO\", null) returned true");
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/test/nullsafeequals/NullSafeEqualsChild.java
+++ b/src/test/java/org/apache/commons/lang3/test/nullsafeequals/NullSafeEqualsChild.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.lang3.test.nullsafeequals;
+
+public class NullSafeEqualsChild {
+
+    private final String foo = "fooValue";
+    private final NullSafeEqualsGrandChild nullSafeEqualsGrandChild = new NullSafeEqualsGrandChild();
+    private NullSafeEqualsGrandChild nullSafeEqualsGrandChildNull;
+    private final int primitiveValue = 1;
+
+    public String getFoo() {
+        return this.foo;
+    }
+}

--- a/src/test/java/org/apache/commons/lang3/test/nullsafeequals/NullSafeEqualsGrandChild.java
+++ b/src/test/java/org/apache/commons/lang3/test/nullsafeequals/NullSafeEqualsGrandChild.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.lang3.test.nullsafeequals;
+
+public class NullSafeEqualsGrandChild {
+
+    private final String var = "varValue";
+
+    public String getVar() {
+        return this.var;
+    }
+}

--- a/src/test/java/org/apache/commons/lang3/test/nullsafeequals/NullSafeEqualsParent.java
+++ b/src/test/java/org/apache/commons/lang3/test/nullsafeequals/NullSafeEqualsParent.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.lang3.test.nullsafeequals;
+
+public class NullSafeEqualsParent {
+
+    private NullSafeEqualsChild nullSafeEqualsChildPrivate = new NullSafeEqualsChild();
+    public NullSafeEqualsChild nullSafeEqualsChildPublic;
+    NullSafeEqualsChild nullSafeEqualsChildPackageDefault;
+    private String foo = "parentFoo";
+
+    private static final String STATIC_FINAL_FOO = "foo";
+    private static String STATIC_FOO = "foo";
+    public static final String PUBLIC_STATIC_FINAL_FOO = "foo";
+    public static String PUBLIC_STATIC_NULL_FOO;
+
+    public NullSafeEqualsChild getNullSafeEqualsChildPrivate() {
+        return nullSafeEqualsChildPrivate;
+    }
+}


### PR DESCRIPTION
When we compare Object values, if it enters more than 2depth, it may become a bit annoying.

For example

```java
class Bar {
    String testBarString = "test";
}

class Foo {
    Bar bar = new Bar();
}

Foo foo = new Foo();

if ( foo.getBar() != null && "test".equals(foo.getBar().getTestBarString()) ) {
    // TODO
}
```

So I made a feature that can be compared at once and is null safe.

```java
// AS-IS
if ( foo.getBar() != null && "test".equals(foo.getBar().getTestBarString()) ) {
    // TODO
}

// TO-BE
if ( ObjectUtils.nullSafeEquals(foo, "bar.testBarString", "test') ) {
    // TODO
}
```

I made it because it didn't seem to have a similar function like this before.
Do you have a similar method in ObjectUtils?