### PR TITLE
LANG-1172: Support dash as a delimiter in locales

### DIFF
--- a/src/main/java/org/apache/commons/lang3/LocaleUtils.java
+++ b/src/main/java/org/apache/commons/lang3/LocaleUtils.java
@@ -250,9 +250,9 @@ public class LocaleUtils {
             return new Locale(str);
         }
 
-        final String[] segments = str.indexOf(DASH) != -1
-            ? str.split(String.valueOf(DASH), -1)
-            : str.split(String.valueOf(UNDERSCORE), -1);
+        final String[] segments = str.indexOf(UNDERSCORE) != -1
+            ? str.split(String.valueOf(UNDERSCORE), -1)
+            : str.split(String.valueOf(DASH), -1);
         final String language = segments[0];
         if (segments.length == 2) {
             final String country = segments[1];

--- a/src/main/java/org/apache/commons/lang3/LocaleUtils.java
+++ b/src/main/java/org/apache/commons/lang3/LocaleUtils.java
@@ -248,7 +248,9 @@ public class LocaleUtils {
             return new Locale(str);
         }
 
-        final String[] segments = str.split("_", -1);
+        final String[] segments = str.contains("-")
+            ? str.split("-", -1)
+            : str.split("_", -1);
         final String language = segments[0];
         if (segments.length == 2) {
             final String country = segments[1];
@@ -289,6 +291,7 @@ public class LocaleUtils {
      *   LocaleUtils.toLocale("")           = new Locale("", "")
      *   LocaleUtils.toLocale("en")         = new Locale("en", "")
      *   LocaleUtils.toLocale("en_GB")      = new Locale("en", "GB")
+     *   LocaleUtils.toLocale("en-GB")      = new Locale("en", "GB")
      *   LocaleUtils.toLocale("en_001")     = new Locale("en", "001")
      *   LocaleUtils.toLocale("en_GB_xxx")  = new Locale("en", "GB", "xxx")   (#)
      * </pre>
@@ -300,7 +303,7 @@ public class LocaleUtils {
      * <p>This method validates the input strictly.
      * The language code must be lowercase.
      * The country code must be uppercase.
-     * The separator must be an underscore.
+     * The separator must be an underscore or a dash.
      * The length must be correct.
      * </p>
      *
@@ -325,7 +328,7 @@ public class LocaleUtils {
             throw new IllegalArgumentException("Invalid locale format: " + str);
         }
         final char ch0 = str.charAt(0);
-        if (ch0 == '_') {
+        if (ch0 == '_' || ch0 == '-') {
             if (len < 3) {
                 throw new IllegalArgumentException("Invalid locale format: " + str);
             }
@@ -340,7 +343,7 @@ public class LocaleUtils {
             if (len < 5) {
                 throw new IllegalArgumentException("Invalid locale format: " + str);
             }
-            if (str.charAt(3) != '_') {
+            if (str.charAt(3) != ch0) {
                 throw new IllegalArgumentException("Invalid locale format: " + str);
             }
             return new Locale(StringUtils.EMPTY, str.substring(1, 3), str.substring(4));

--- a/src/main/java/org/apache/commons/lang3/LocaleUtils.java
+++ b/src/main/java/org/apache/commons/lang3/LocaleUtils.java
@@ -36,6 +36,8 @@ import java.util.concurrent.ConcurrentMap;
  * @since 2.2
  */
 public class LocaleUtils {
+    private static final char UNDERSCORE = '_';
+    private static final char DASH = '-';
 
     // class to avoid synchronization (Init on demand)
     static class SyncAvoid {
@@ -248,9 +250,9 @@ public class LocaleUtils {
             return new Locale(str);
         }
 
-        final String[] segments = str.contains("-")
-            ? str.split("-", -1)
-            : str.split("_", -1);
+        final String[] segments = str.indexOf(DASH) != -1
+            ? str.split(String.valueOf(DASH), -1)
+            : str.split(String.valueOf(UNDERSCORE), -1);
         final String language = segments[0];
         if (segments.length == 2) {
             final String country = segments[1];
@@ -328,7 +330,7 @@ public class LocaleUtils {
             throw new IllegalArgumentException("Invalid locale format: " + str);
         }
         final char ch0 = str.charAt(0);
-        if (ch0 == '_' || ch0 == '-') {
+        if (ch0 == UNDERSCORE || ch0 == DASH) {
             if (len < 3) {
                 throw new IllegalArgumentException("Invalid locale format: " + str);
             }

--- a/src/test/java/org/apache/commons/lang3/LocaleUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/LocaleUtilsTest.java
@@ -170,11 +170,10 @@ public class LocaleUtilsTest  {
     @Test
     public void testToLocale_2Part() {
         assertValidToLocale("us_EN", "us", "EN");
+        assertValidToLocale("us-EN", "us", "EN");
         //valid though doesn't exist
         assertValidToLocale("us_ZH", "us", "ZH");
 
-        assertThrows(
-                IllegalArgumentException.class, () -> LocaleUtils.toLocale("us-EN"), "Should fail as not underscore");
         assertThrows(
                 IllegalArgumentException.class,
                 () -> LocaleUtils.toLocale("us_En"),
@@ -203,6 +202,7 @@ public class LocaleUtilsTest  {
     @Test
     public void testToLocale_3Part() {
         assertValidToLocale("us_EN_A", "us", "EN", "A");
+        assertValidToLocale("us-EN-A", "us", "EN", "A");
         // this isn't pretty, but was caused by a jdk bug it seems
         // http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=4210525
         if (SystemUtils.isJavaVersionAtLeast(JAVA_1_4)) {
@@ -214,7 +214,7 @@ public class LocaleUtilsTest  {
         }
 
         assertThrows(
-                IllegalArgumentException.class, () -> LocaleUtils.toLocale("us_EN-a"), "Should fail as not underscore");
+                IllegalArgumentException.class, () -> LocaleUtils.toLocale("us_EN-a"), "Should fail as no consistent delimiter");
         assertThrows(
                 IllegalArgumentException.class, () -> LocaleUtils.toLocale("uu_UU_"), "Must be 3, 5 or 7+ in length");
     }


### PR DESCRIPTION
This pull request is a partial fix for [LANG-1172](https://issues.apache.org/jira/browse/LANG-1172) adding support for dashes as delimiters for locales as per [BCP47](https://tools.ietf.org/html/bcp47#section-4) thus enabling parsing of locales such as `en-GB` in addition to the previously supported (but not to spec) `en_GB`.