### PR TITLE
Fixing reversed Javadoc descriptions in StopWatch

### DIFF
--- a/src/main/java/org/apache/commons/lang3/time/StopWatch.java
+++ b/src/main/java/org/apache/commons/lang3/time/StopWatch.java
@@ -249,9 +249,9 @@ public class StopWatch {
     }
 
     /**
-     * Returns the time formatted by {@link DurationFormatUtils#formatDurationHMS}.
+     * Returns the split time formatted by {@link DurationFormatUtils#formatDurationHMS}.
      *
-     * @return the time formatted by {@link DurationFormatUtils#formatDurationHMS}.
+     * @return the split time formatted by {@link DurationFormatUtils#formatDurationHMS}.
      * @since 3.10
      */
     public String formatSplitTime() {
@@ -259,9 +259,9 @@ public class StopWatch {
     }
 
     /**
-     * Returns the split time formatted by {@link DurationFormatUtils#formatDurationHMS}.
+     * Returns the time formatted by {@link DurationFormatUtils#formatDurationHMS}.
      *
-     * @return the split time formatted by {@link DurationFormatUtils#formatDurationHMS}.
+     * @return the time formatted by {@link DurationFormatUtils#formatDurationHMS}.
      * @since 3.10
      */
     public String formatTime() {


### PR DESCRIPTION
The descriptions for `formatTime()` and `formatSplitTime()` were reversed; the former said "Returns the split time" and the latter said "returns the time".

This PR switches their descriptions so that they now match the behavior of the methods.