### PR TITLE
floor and ceiling for Sorted Arrays

### DIFF
--- a/src/main/java/org/apache/commons/lang3/ArrayUtils.java
+++ b/src/main/java/org/apache/commons/lang3/ArrayUtils.java
@@ -1666,6 +1666,670 @@ public class ArrayUtils {
         return indexOf(array, valueToFind) != INDEX_NOT_FOUND;
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public static int ceiling(final Object[] array, final Object valueToFind) {
+        return ceiling(array, 0, array.length, valueToFind, Comparator.comparing(v -> ((Comparable) v)));
+    }
+
+    public static <T> int ceiling(final T[] array,
+                                  final int fromIndex,
+                                  final int toIndex,
+                                  final T valueToFind,
+                                  final Comparator<T> comparator) {
+        Validate.notNull(array);
+        Validate.notNull(comparator);
+        Validate.inclusiveBetween(0, array.length - 1, fromIndex);
+        Validate.inclusiveBetween(0, array.length, toIndex);
+        if (fromIndex >= toIndex) {
+            return -1;
+        }
+        int lo = fromIndex;
+        int hi = toIndex - 1;
+        if (comparator.compare(valueToFind, array[hi]) > 0) {
+            return -1;
+        }
+        if (comparator.compare(valueToFind, array[lo]) <= 0) {
+            return lo;
+        }
+        while (lo <= hi) {
+            final int mid = (lo + hi) / 2;
+            final int cmp = comparator.compare(array[mid], valueToFind);
+            if (cmp == 0) {
+                return mid;
+            } else if (cmp > 0) {
+                if (lo <= mid - 1 && comparator.compare(array[mid - 1], valueToFind) < 0) {
+                    return mid;
+                }
+                hi = mid - 1;
+            } else {
+                if (mid + 1 <= hi && comparator.compare(array[mid + 1], valueToFind) >= 0) {
+                    return mid + 1;
+                }
+                lo = mid + 1;
+            }
+        }
+        return -1;
+    }
+
+    public static int ceiling(final int[] array, final int valueToFind) {
+        return ceiling(array, 0, array.length, valueToFind);
+    }
+
+    public static int ceiling(final int[] array,
+                              final int fromIndex,
+                              final int toIndex,
+                              final int valueToFind) {
+        Validate.notNull(array);
+        Validate.inclusiveBetween(0, array.length - 1, fromIndex);
+        Validate.inclusiveBetween(0, array.length, toIndex);
+        if (fromIndex >= toIndex) {
+            return -1;
+        }
+        int lo = fromIndex;
+        int hi = toIndex - 1;
+        if (valueToFind > array[hi]) {
+            return -1;
+        }
+        if (valueToFind <= array[lo]) {
+            return lo;
+        }
+        while (lo <= hi) {
+            final int mid = (lo + hi) / 2;
+            if (array[mid] == valueToFind) {
+                return mid;
+            } else if (array[mid] > valueToFind) {
+                if (lo <= mid - 1 && array[mid - 1] < valueToFind) {
+                    return mid;
+                }
+                hi = mid - 1;
+            } else {
+                if (mid + 1 <= hi && array[mid + 1] >= valueToFind) {
+                    return mid + 1;
+                }
+                lo = mid + 1;
+            }
+        }
+        return -1;
+    }
+
+    public static int ceiling(final long[] array, final long valueToFind) {
+        return ceiling(array, 0, array.length, valueToFind);
+    }
+
+    public static int ceiling(final long[] array,
+                              final int fromIndex,
+                              final int toIndex,
+                              final long valueToFind) {
+        Validate.notNull(array);
+        Validate.inclusiveBetween(0, array.length - 1, fromIndex);
+        Validate.inclusiveBetween(0, array.length, toIndex);
+        if (fromIndex >= toIndex) {
+            return -1;
+        }
+        int lo = fromIndex;
+        int hi = toIndex - 1;
+        if (valueToFind > array[hi]) {
+            return -1;
+        }
+        if (valueToFind <= array[lo]) {
+            return lo;
+        }
+        while (lo <= hi) {
+            final int mid = (lo + hi) / 2;
+            if (array[mid] == valueToFind) {
+                return mid;
+            } else if (array[mid] > valueToFind) {
+                if (lo <= mid - 1 && array[mid - 1] < valueToFind) {
+                    return mid;
+                }
+                hi = mid - 1;
+            } else {
+                if (mid + 1 <= hi && array[mid + 1] >= valueToFind) {
+                    return mid + 1;
+                }
+                lo = mid + 1;
+            }
+        }
+        return -1;
+    }
+
+    public static int ceiling(final short[] array, final short valueToFind) {
+        return ceiling(array, 0, array.length, valueToFind);
+    }
+
+    public static int ceiling(final short[] array,
+                              final int fromIndex,
+                              final int toIndex,
+                              final short valueToFind) {
+        Validate.notNull(array);
+        Validate.inclusiveBetween(0, array.length - 1, fromIndex);
+        Validate.inclusiveBetween(0, array.length, toIndex);
+        if (fromIndex >= toIndex) {
+            return -1;
+        }
+        int lo = fromIndex;
+        int hi = toIndex - 1;
+        if (valueToFind > array[hi]) {
+            return -1;
+        }
+        if (valueToFind <= array[lo]) {
+            return lo;
+        }
+        while (lo <= hi) {
+            final int mid = (lo + hi) / 2;
+            if (array[mid] == valueToFind) {
+                return mid;
+            } else if (array[mid] > valueToFind) {
+                if (lo <= mid - 1 && array[mid - 1] < valueToFind) {
+                    return mid;
+                }
+                hi = mid - 1;
+            } else {
+                if (mid + 1 <= hi && array[mid + 1] >= valueToFind) {
+                    return mid + 1;
+                }
+                lo = mid + 1;
+            }
+        }
+        return -1;
+    }
+
+    public static int ceiling(final byte[] array, final byte valueToFind) {
+        return ceiling(array, 0, array.length, valueToFind);
+    }
+
+    public static int ceiling(final byte[] array,
+                              final int fromIndex,
+                              final int toIndex,
+                              final byte valueToFind) {
+        Validate.notNull(array);
+        Validate.inclusiveBetween(0, array.length - 1, fromIndex);
+        Validate.inclusiveBetween(0, array.length, toIndex);
+        if (fromIndex >= toIndex) {
+            return -1;
+        }
+        int lo = fromIndex;
+        int hi = toIndex - 1;
+        if (valueToFind > array[hi]) {
+            return -1;
+        }
+        if (valueToFind <= array[lo]) {
+            return lo;
+        }
+        while (lo <= hi) {
+            final int mid = (lo + hi) / 2;
+            if (array[mid] == valueToFind) {
+                return mid;
+            } else if (array[mid] > valueToFind) {
+                if (lo <= mid - 1 && array[mid - 1] < valueToFind) {
+                    return mid;
+                }
+                hi = mid - 1;
+            } else {
+                if (mid + 1 <= hi && array[mid + 1] >= valueToFind) {
+                    return mid + 1;
+                }
+                lo = mid + 1;
+            }
+        }
+        return -1;
+    }
+
+    public static int ceiling(final char[] array, final char valueToFind) {
+        return ceiling(array, 0, array.length, valueToFind);
+    }
+
+    public static int ceiling(final char[] array,
+                              final int fromIndex,
+                              final int toIndex,
+                              final char valueToFind) {
+        Validate.notNull(array);
+        Validate.inclusiveBetween(0, array.length - 1, fromIndex);
+        Validate.inclusiveBetween(0, array.length, toIndex);
+        if (fromIndex >= toIndex) {
+            return -1;
+        }
+        int lo = fromIndex;
+        int hi = toIndex - 1;
+        if (valueToFind > array[hi]) {
+            return -1;
+        }
+        if (valueToFind <= array[lo]) {
+            return lo;
+        }
+        while (lo <= hi) {
+            final int mid = (lo + hi) / 2;
+            if (array[mid] == valueToFind) {
+                return mid;
+            } else if (array[mid] > valueToFind) {
+                if (lo <= mid - 1 && array[mid - 1] < valueToFind) {
+                    return mid;
+                }
+                hi = mid - 1;
+            } else {
+                if (mid + 1 <= hi && array[mid + 1] >= valueToFind) {
+                    return mid + 1;
+                }
+                lo = mid + 1;
+            }
+        }
+        return -1;
+    }
+
+    public static int ceiling(final float[] array, final float valueToFind) {
+        return ceiling(array, 0, array.length, valueToFind);
+    }
+
+    public static int ceiling(final float[] array,
+                              final int fromIndex,
+                              final int toIndex,
+                              final float valueToFind) {
+        Validate.notNull(array);
+        Validate.inclusiveBetween(0, array.length - 1, fromIndex);
+        Validate.inclusiveBetween(0, array.length, toIndex);
+        if (fromIndex >= toIndex) {
+            return -1;
+        }
+        int lo = fromIndex;
+        int hi = toIndex - 1;
+        if (valueToFind > array[hi]) {
+            return -1;
+        }
+        if (valueToFind <= array[lo]) {
+            return lo;
+        }
+        while (lo <= hi) {
+            final int mid = (lo + hi) / 2;
+            if (array[mid] == valueToFind) {
+                return mid;
+            } else if (array[mid] > valueToFind) {
+                if (lo <= mid - 1 && array[mid - 1] < valueToFind) {
+                    return mid;
+                }
+                hi = mid - 1;
+            } else {
+                if (mid + 1 <= hi && array[mid + 1] >= valueToFind) {
+                    return mid + 1;
+                }
+                lo = mid + 1;
+            }
+        }
+        return -1;
+    }
+
+    public static int ceiling(final double[] array, final double valueToFind) {
+        return ceiling(array, 0, array.length, valueToFind);
+    }
+
+    public static int ceiling(final double[] array,
+                              final int fromIndex,
+                              final int toIndex,
+                              final double valueToFind) {
+        Validate.notNull(array);
+        Validate.inclusiveBetween(0, array.length - 1, fromIndex);
+        Validate.inclusiveBetween(0, array.length, toIndex);
+        if (fromIndex >= toIndex) {
+            return -1;
+        }
+        int lo = fromIndex;
+        int hi = toIndex - 1;
+        if (valueToFind > array[hi]) {
+            return -1;
+        }
+        if (valueToFind <= array[lo]) {
+            return lo;
+        }
+        while (lo <= hi) {
+            final int mid = (lo + hi) / 2;
+            if (array[mid] == valueToFind) {
+                return mid;
+            } else if (array[mid] > valueToFind) {
+                if (lo <= mid - 1 && array[mid - 1] < valueToFind) {
+                    return mid;
+                }
+                hi = mid - 1;
+            } else {
+                if (mid + 1 <= hi && array[mid + 1] >= valueToFind) {
+                    return mid + 1;
+                }
+                lo = mid + 1;
+            }
+        }
+        return -1;
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public static int floor(final Object[] array, final Object valueToFind) {
+        return floor(array, 0, array.length, valueToFind, Comparator.comparing(v -> ((Comparable) v)));
+    }
+
+    public static <T> int floor(final T[] array,
+                                final int fromIndex,
+                                final int toIndex,
+                                final T valueToFind,
+                                final Comparator<T> comparator) {
+        Validate.notNull(array);
+        Validate.notNull(comparator);
+        Validate.inclusiveBetween(0, array.length - 1, fromIndex);
+        Validate.inclusiveBetween(0, array.length, toIndex);
+        if (fromIndex >= toIndex) {
+            return -1;
+        }
+        int lo = fromIndex;
+        int hi = toIndex - 1;
+        if (comparator.compare(array[lo], valueToFind) > 0) {
+            return -1;
+        }
+        if (comparator.compare(array[hi], valueToFind) <= 0) {
+            return hi;
+        }
+        while (lo <= hi) {
+            final int mid = (lo + hi) / 2;
+            final int cmp = comparator.compare(array[mid], valueToFind);
+            if (cmp == 0) {
+                return mid;
+            } else if (cmp > 0) {
+                if (lo <= mid - 1 && comparator.compare(array[mid - 1], valueToFind) <= 0) {
+                    return mid - 1;
+                }
+                hi = mid - 1;
+            } else {
+                if (mid + 1 <= hi && comparator.compare(array[mid + 1], valueToFind) > 0) {
+                    return mid;
+                }
+                lo = mid + 1;
+            }
+        }
+        return -1;
+    }
+
+    public static int floor(final int[] array, final int valueToFind) {
+        return floor(array, 0, array.length, valueToFind);
+    }
+
+    public static int floor(final int[] array,
+                            final int fromIndex,
+                            final int toIndex,
+                            final int valueToFind) {
+        Validate.notNull(array);
+        Validate.inclusiveBetween(0, array.length - 1, fromIndex);
+        Validate.inclusiveBetween(0, array.length, toIndex);
+        if (fromIndex >= toIndex) {
+            return -1;
+        }
+        int lo = fromIndex;
+        int hi = toIndex - 1;
+        if (array[lo] > valueToFind) {
+            return -1;
+        }
+        if (array[hi] <= valueToFind) {
+            return hi;
+        }
+        while (lo <= hi) {
+            final int mid = (lo + hi) / 2;
+            if (array[mid] == valueToFind) {
+                return mid;
+            } else if (array[mid] > valueToFind) {
+                if (lo <= mid - 1 && array[mid - 1] <= valueToFind) {
+                    return mid - 1;
+                }
+                hi = mid - 1;
+            } else {
+                if (mid + 1 <= hi && array[mid + 1] > valueToFind) {
+                    return mid;
+                }
+                lo = mid + 1;
+            }
+        }
+        return -1;
+    }
+
+    public static int floor(final long[] array, final long valueToFind) {
+        return floor(array, 0, array.length, valueToFind);
+    }
+
+    public static int floor(final long[] array,
+                            final int fromIndex,
+                            final int toIndex,
+                            final long valueToFind) {
+        Validate.notNull(array);
+        Validate.inclusiveBetween(0, array.length - 1, fromIndex);
+        Validate.inclusiveBetween(0, array.length, toIndex);
+        if (fromIndex >= toIndex) {
+            return -1;
+        }
+        int lo = fromIndex;
+        int hi = toIndex - 1;
+        if (array[lo] > valueToFind) {
+            return -1;
+        }
+        if (array[hi] <= valueToFind) {
+            return hi;
+        }
+        while (lo <= hi) {
+            final int mid = (lo + hi) / 2;
+            if (array[mid] == valueToFind) {
+                return mid;
+            } else if (array[mid] > valueToFind) {
+                if (lo <= mid - 1 && array[mid - 1] <= valueToFind) {
+                    return mid - 1;
+                }
+                hi = mid - 1;
+            } else {
+                if (mid + 1 <= hi && array[mid + 1] > valueToFind) {
+                    return mid;
+                }
+                lo = mid + 1;
+            }
+        }
+        return -1;
+    }
+
+    public static int floor(final float[] array, final float valueToFind) {
+        return floor(array, 0, array.length, valueToFind);
+    }
+
+    public static int floor(final float[] array,
+                            final int fromIndex,
+                            final int toIndex,
+                            final float valueToFind) {
+        Validate.notNull(array);
+        Validate.inclusiveBetween(0, array.length - 1, fromIndex);
+        Validate.inclusiveBetween(0, array.length, toIndex);
+        if (fromIndex >= toIndex) {
+            return -1;
+        }
+        int lo = fromIndex;
+        int hi = toIndex - 1;
+        if (array[lo] > valueToFind) {
+            return -1;
+        }
+        if (array[hi] <= valueToFind) {
+            return hi;
+        }
+        while (lo <= hi) {
+            final int mid = (lo + hi) / 2;
+            if (array[mid] == valueToFind) {
+                return mid;
+            } else if (array[mid] > valueToFind) {
+                if (lo <= mid - 1 && array[mid - 1] <= valueToFind) {
+                    return mid - 1;
+                }
+                hi = mid - 1;
+            } else {
+                if (mid + 1 <= hi && array[mid + 1] > valueToFind) {
+                    return mid;
+                }
+                lo = mid + 1;
+            }
+        }
+        return -1;
+    }
+
+    public static int floor(final double[] array, final double valueToFind) {
+        return floor(array, 0, array.length, valueToFind);
+    }
+
+    public static int floor(final double[] array,
+                            final int fromIndex,
+                            final int toIndex,
+                            final double valueToFind) {
+        Validate.notNull(array);
+        Validate.inclusiveBetween(0, array.length - 1, fromIndex);
+        Validate.inclusiveBetween(0, array.length, toIndex);
+        if (fromIndex >= toIndex) {
+            return -1;
+        }
+        int lo = fromIndex;
+        int hi = toIndex - 1;
+        if (array[lo] > valueToFind) {
+            return -1;
+        }
+        if (array[hi] <= valueToFind) {
+            return hi;
+        }
+        while (lo <= hi) {
+            final int mid = (lo + hi) / 2;
+            if (array[mid] == valueToFind) {
+                return mid;
+            } else if (array[mid] > valueToFind) {
+                if (lo <= mid - 1 && array[mid - 1] <= valueToFind) {
+                    return mid - 1;
+                }
+                hi = mid - 1;
+            } else {
+                if (mid + 1 <= hi && array[mid + 1] > valueToFind) {
+                    return mid;
+                }
+                lo = mid + 1;
+            }
+        }
+        return -1;
+    }
+
+    public static int floor(final short[] array, final short valueToFind) {
+        return floor(array, 0, array.length, valueToFind);
+    }
+
+    public static int floor(final short[] array,
+                            final int fromIndex,
+                            final int toIndex,
+                            final short valueToFind) {
+        Validate.notNull(array);
+        Validate.inclusiveBetween(0, array.length - 1, fromIndex);
+        Validate.inclusiveBetween(0, array.length, toIndex);
+        if (fromIndex >= toIndex) {
+            return -1;
+        }
+        int lo = fromIndex;
+        int hi = toIndex - 1;
+        if (array[lo] > valueToFind) {
+            return -1;
+        }
+        if (array[hi] <= valueToFind) {
+            return hi;
+        }
+        while (lo <= hi) {
+            final int mid = (lo + hi) / 2;
+            if (array[mid] == valueToFind) {
+                return mid;
+            } else if (array[mid] > valueToFind) {
+                if (lo <= mid - 1 && array[mid - 1] <= valueToFind) {
+                    return mid - 1;
+                }
+                hi = mid - 1;
+            } else {
+                if (mid + 1 <= hi && array[mid + 1] > valueToFind) {
+                    return mid;
+                }
+                lo = mid + 1;
+            }
+        }
+        return -1;
+    }
+
+    public static int floor(final byte[] array, final byte valueToFind) {
+        return floor(array, 0, array.length, valueToFind);
+    }
+
+    public static int floor(final byte[] array,
+                            final int fromIndex,
+                            final int toIndex,
+                            final byte valueToFind) {
+        Validate.notNull(array);
+        Validate.inclusiveBetween(0, array.length - 1, fromIndex);
+        Validate.inclusiveBetween(0, array.length, toIndex);
+        if (fromIndex >= toIndex) {
+            return -1;
+        }
+        int lo = fromIndex;
+        int hi = toIndex - 1;
+        if (array[lo] > valueToFind) {
+            return -1;
+        }
+        if (array[hi] <= valueToFind) {
+            return hi;
+        }
+        while (lo <= hi) {
+            final int mid = (lo + hi) / 2;
+            if (array[mid] == valueToFind) {
+                return mid;
+            } else if (array[mid] > valueToFind) {
+                if (lo <= mid - 1 && array[mid - 1] <= valueToFind) {
+                    return mid - 1;
+                }
+                hi = mid - 1;
+            } else {
+                if (mid + 1 <= hi && array[mid + 1] > valueToFind) {
+                    return mid;
+                }
+                lo = mid + 1;
+            }
+        }
+        return -1;
+    }
+
+    public static int floor(final char[] array, final char valueToFind) {
+        return floor(array, 0, array.length, valueToFind);
+    }
+
+    public static int floor(final char[] array,
+                            final int fromIndex,
+                            final int toIndex,
+                            final char valueToFind) {
+        Validate.notNull(array);
+        Validate.inclusiveBetween(0, array.length - 1, fromIndex);
+        Validate.inclusiveBetween(0, array.length, toIndex);
+        if (fromIndex >= toIndex) {
+            return -1;
+        }
+        int lo = fromIndex;
+        int hi = toIndex - 1;
+        if (array[lo] > valueToFind) {
+            return -1;
+        }
+        if (array[hi] <= valueToFind) {
+            return hi;
+        }
+        while (lo <= hi) {
+            final int mid = (lo + hi) / 2;
+            if (array[mid] == valueToFind) {
+                return mid;
+            } else if (array[mid] > valueToFind) {
+                if (lo <= mid - 1 && array[mid - 1] <= valueToFind) {
+                    return mid - 1;
+                }
+                hi = mid - 1;
+            } else {
+                if (mid + 1 <= hi && array[mid + 1] > valueToFind) {
+                    return mid;
+                }
+                lo = mid + 1;
+            }
+        }
+        return -1;
+    }
+
     /**
      * Returns a copy of the given array of size 1 greater than the argument.
      * The last value of the array is left to the default value.

--- a/src/test/java/org/apache/commons/lang3/ArrayUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/ArrayUtilsTest.java
@@ -358,6 +358,134 @@ public class ArrayUtilsTest {
     }
 
     @Test
+    void testCeilingNullArray() {
+        boolean succeed = false;
+        try {
+            ArrayUtils.ceiling(null, 0, 0, 1, Integer::compareTo);
+        } catch (Exception ignored) {
+            succeed = true;
+        }
+        assertTrue(succeed);
+    }
+
+    @Test
+    void testCeilingNullComparator() {
+        boolean succeed = false;
+        try {
+            ArrayUtils.ceiling(new Integer[] {1, 2}, 0, 0, 1, null);
+        } catch (Exception ignored) {
+            succeed = true;
+        }
+        assertTrue(succeed);
+    }
+
+    @Test
+    void testCeilingBoxedNumbers() {
+        final Integer[] integers = {12, 14, 40, 70, 90};
+        // full array
+        assertEquals(0, ArrayUtils.ceiling(integers, 12));
+        assertEquals(1, ArrayUtils.ceiling(integers, 13));
+        assertEquals(2, ArrayUtils.ceiling(integers, 40));
+        assertEquals(3, ArrayUtils.ceiling(integers, 50));
+        assertEquals(4, ArrayUtils.ceiling(integers, 89));
+        assertEquals(-1, ArrayUtils.ceiling(integers, 91));
+        assertEquals(0, ArrayUtils.ceiling(integers, 0));
+        // range
+        assertEquals(1, ArrayUtils.ceiling(integers,1, 3, 12, Integer::compareTo));
+        assertEquals(1, ArrayUtils.ceiling(integers,1, 3, 13, Integer::compareTo));
+        assertEquals(2, ArrayUtils.ceiling(integers,1, 3, 40, Integer::compareTo));
+        assertEquals(-1, ArrayUtils.ceiling(integers,1, 3, 50, Integer::compareTo));
+        assertEquals(-1, ArrayUtils.ceiling(integers,1, 3, 89, Integer::compareTo));
+        assertEquals(-1, ArrayUtils.ceiling(integers,1, 3, 91, Integer::compareTo));
+        assertEquals(1, ArrayUtils.ceiling(integers,1, 3, 0, Integer::compareTo));
+    }
+
+    @Test
+    void testCeilingPrimitiveNumbers() {
+        final int[] integers = {12, 14, 40, 70, 90};
+        // full array
+        assertEquals(0, ArrayUtils.ceiling(integers, 12));
+        assertEquals(1, ArrayUtils.ceiling(integers, 13));
+        assertEquals(2, ArrayUtils.ceiling(integers, 40));
+        assertEquals(3, ArrayUtils.ceiling(integers, 50));
+        assertEquals(4, ArrayUtils.ceiling(integers, 89));
+        assertEquals(-1, ArrayUtils.ceiling(integers, 91));
+        assertEquals(0, ArrayUtils.ceiling(integers, 0));
+        // range
+        assertEquals(1, ArrayUtils.ceiling(integers,1, 3, 12));
+        assertEquals(1, ArrayUtils.ceiling(integers,1, 3, 13));
+        assertEquals(2, ArrayUtils.ceiling(integers,1, 3, 40));
+        assertEquals(-1, ArrayUtils.ceiling(integers,1, 3, 50));
+        assertEquals(-1, ArrayUtils.ceiling(integers,1, 3, 89));
+        assertEquals(-1, ArrayUtils.ceiling(integers,1, 3, 91));
+        assertEquals(1, ArrayUtils.ceiling(integers,1, 3, 0));
+    }
+
+    @Test
+    void testFloorNullArray() {
+        boolean succeed = false;
+        try {
+            ArrayUtils.floor(null, 0, 0, 1, Integer::compareTo);
+        } catch (Exception ignored) {
+            succeed = true;
+        }
+        assertTrue(succeed);
+    }
+
+    @Test
+    void testFloorNullComparator() {
+        boolean succeed = false;
+        try {
+            ArrayUtils.floor(new Integer[] {1, 2}, 0, 0, 1, null);
+        } catch (Exception ignored) {
+            succeed = true;
+        }
+        assertTrue(succeed);
+    }
+
+    @Test
+    void testFloorBoxedNumbers() {
+        final Integer[] integers = {12, 14, 40, 70, 90};
+        // full array
+        assertEquals(0, ArrayUtils.floor(integers, 12));
+        assertEquals(0, ArrayUtils.floor(integers, 13));
+        assertEquals(2, ArrayUtils.floor(integers, 40));
+        assertEquals(2, ArrayUtils.floor(integers, 50));
+        assertEquals(3, ArrayUtils.floor(integers, 89));
+        assertEquals(4, ArrayUtils.floor(integers, 91));
+        assertEquals(-1, ArrayUtils.floor(integers, 0));
+        // range
+        assertEquals(-1, ArrayUtils.floor(integers,1, 3, 12, Integer::compareTo));
+        assertEquals(-1, ArrayUtils.floor(integers,1, 3, 13, Integer::compareTo));
+        assertEquals(2, ArrayUtils.floor(integers,1, 3, 40, Integer::compareTo));
+        assertEquals(2, ArrayUtils.floor(integers,1, 3, 50, Integer::compareTo));
+        assertEquals(2, ArrayUtils.floor(integers,1, 3, 89, Integer::compareTo));
+        assertEquals(2, ArrayUtils.floor(integers,1, 3, 91, Integer::compareTo));
+        assertEquals(-1, ArrayUtils.floor(integers,1, 3, 0, Integer::compareTo));
+    }
+
+    @Test
+    void testFloorPrimitiveNumbers() {
+        final int[] integers = {12, 14, 40, 70, 90};
+        // full array
+        assertEquals(0, ArrayUtils.floor(integers, 12));
+        assertEquals(0, ArrayUtils.floor(integers, 13));
+        assertEquals(2, ArrayUtils.floor(integers, 40));
+        assertEquals(2, ArrayUtils.floor(integers, 50));
+        assertEquals(3, ArrayUtils.floor(integers, 89));
+        assertEquals(4, ArrayUtils.floor(integers, 91));
+        assertEquals(-1, ArrayUtils.floor(integers, 0));
+        // range
+        assertEquals(-1, ArrayUtils.floor(integers,1, 3, 12));
+        assertEquals(-1, ArrayUtils.floor(integers,1, 3, 13));
+        assertEquals(2, ArrayUtils.floor(integers,1, 3, 40));
+        assertEquals(2, ArrayUtils.floor(integers,1, 3, 50));
+        assertEquals(2, ArrayUtils.floor(integers,1, 3, 89));
+        assertEquals(2, ArrayUtils.floor(integers,1, 3, 91));
+        assertEquals(-1, ArrayUtils.floor(integers,1, 3, 0));
+    }
+
+    @Test
     public void testCreatePrimitiveArray() {
         assertNull(ArrayUtils.toPrimitive((Object[]) null));
         assertArrayEquals(new boolean[]{true}, ArrayUtils.toPrimitive(new Boolean[]{true}));


### PR DESCRIPTION
If I am not mistaking, JDK standard library and the current implementation of Apache Commons Lang do not have functions for binary searching for `floor` and `ceiling` in sorted arrays.

This PR adds efficient implementation for `floor` and `ceiling` inside the class `ArrayUtils` (Java's `Arrays` class has `binarySearch` methods, so I thought this class would be a good place for these methods).
The methods handle various Java types.
A few test cases are also included.
