### PR TITLE
LANG-1675 - Improve performance of StringUtils.join for primitives

### DIFF
--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -3930,7 +3930,7 @@ public class StringUtils {
         if (endIndex - startIndex <= 0) {
             return EMPTY;
         }
-        // Using StringBuilder for joining primitives
+
         StringBuilder stringBuilder = new StringBuilder();
         for (int i = startIndex; i < endIndex; i++) {
             stringBuilder.append(array[i]);
@@ -4011,11 +4011,14 @@ public class StringUtils {
         if (endIndex - startIndex <= 0) {
             return EMPTY;
         }
-        final StringJoiner joiner = newStringJoiner(delimiter);
+        StringBuilder stringBuilder = new StringBuilder();
         for (int i = startIndex; i < endIndex; i++) {
-            joiner.add(String.valueOf(array[i]));
+            stringBuilder.append(array[i]);
+            if (i != endIndex - 1) {
+                   stringBuilder.append(delimiter);
+            }
         }
-        return joiner.toString();
+        return stringBuilder.toString();
     }
 
     /**
@@ -4088,11 +4091,15 @@ public class StringUtils {
         if (endIndex - startIndex <= 0) {
             return EMPTY;
         }
-        final StringJoiner joiner = newStringJoiner(delimiter);
+
+        StringBuilder stringBuilder = new StringBuilder();
         for (int i = startIndex; i < endIndex; i++) {
-            joiner.add(String.valueOf(array[i]));
+            stringBuilder.append(array[i]);
+            if (i != endIndex - 1) {
+                stringBuilder.append(delimiter);
+            }
         }
-        return joiner.toString();
+        return stringBuilder.toString();
     }
 
     /**
@@ -4165,11 +4172,14 @@ public class StringUtils {
         if (endIndex - startIndex <= 0) {
             return EMPTY;
         }
-        final StringJoiner joiner = newStringJoiner(delimiter);
+        final StringBuilder stringBuilder = new StringBuilder();
         for (int i = startIndex; i < endIndex; i++) {
-            joiner.add(String.valueOf(array[i]));
+            stringBuilder.append(array[i]);
+            if (i != endIndex - 1) {
+                stringBuilder.append(delimiter);
+            }
         }
-        return joiner.toString();
+        return stringBuilder.toString();
     }
 
     /**
@@ -4242,11 +4252,14 @@ public class StringUtils {
         if (endIndex - startIndex <= 0) {
             return EMPTY;
         }
-        final StringJoiner joiner = newStringJoiner(delimiter);
+        final StringBuilder stringBuilder = new StringBuilder();
         for (int i = startIndex; i < endIndex; i++) {
-            joiner.add(String.valueOf(array[i]));
+            stringBuilder.append(array[i]);
+            if (i != endIndex - 1) {
+                stringBuilder.append(delimiter);
+            }
         }
-        return joiner.toString();
+        return stringBuilder.toString();
     }
 
     /**
@@ -4319,11 +4332,14 @@ public class StringUtils {
         if (endIndex - startIndex <= 0) {
             return EMPTY;
         }
-        final StringJoiner joiner = newStringJoiner(delimiter);
+        final StringBuilder stringBuilder = new StringBuilder();
         for (int i = startIndex; i < endIndex; i++) {
-            joiner.add(String.valueOf(array[i]));
+            stringBuilder.append(array[i]);
+            if (i != endIndex - 1) {
+                stringBuilder.append(delimiter);
+            }
         }
-        return joiner.toString();
+        return stringBuilder.toString();
     }
 
     /**
@@ -4605,11 +4621,14 @@ public class StringUtils {
         if (endIndex - startIndex <= 0) {
             return EMPTY;
         }
-        final StringJoiner joiner = newStringJoiner(delimiter);
+        final StringBuilder stringBuilder = new StringBuilder();
         for (int i = startIndex; i < endIndex; i++) {
-            joiner.add(String.valueOf(array[i]));
+            stringBuilder.append(array[i]);
+            if (i != endIndex - 1) {
+                stringBuilder.append(delimiter);
+            }
         }
-        return joiner.toString();
+        return stringBuilder.toString();
     }
 
     /**
@@ -4668,17 +4687,7 @@ public class StringUtils {
      * @since 2.0
      */
     public static String join(final Object[] array, final char delimiter, final int startIndex, final int endIndex) {
-        if (array == null) {
-            return null;
-        }
-        if (endIndex - startIndex <= 0) {
-            return EMPTY;
-        }
-        final StringJoiner joiner = newStringJoiner(delimiter);
-        for (int i = startIndex; i < endIndex; i++) {
-            joiner.add(toStringOrEmpty(array[i]));
-        }
-        return joiner.toString();
+        return join(array, String.valueOf(delimiter), startIndex, endIndex);
     }
 
     /**
@@ -4830,11 +4839,14 @@ public class StringUtils {
         if (endIndex - startIndex <= 0) {
             return EMPTY;
         }
-        final StringJoiner joiner = newStringJoiner(delimiter);
+        final StringBuilder stringBuilder = new StringBuilder();
         for (int i = startIndex; i < endIndex; i++) {
-            joiner.add(String.valueOf(array[i]));
+            stringBuilder.append(array[i]);
+            if (i != endIndex - 1) {
+                stringBuilder.append(delimiter);
+            }
         }
-        return joiner.toString();
+        return stringBuilder.toString();
     }
 
     /**
@@ -5524,10 +5536,6 @@ public class StringUtils {
             return str.substring(pos);
         }
         return str.substring(pos, pos + len);
-    }
-
-    private static StringJoiner newStringJoiner(final char delimiter) {
-        return new StringJoiner(String.valueOf(delimiter));
     }
 
     /**

--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -3930,11 +3930,15 @@ public class StringUtils {
         if (endIndex - startIndex <= 0) {
             return EMPTY;
         }
-        final StringJoiner joiner = newStringJoiner(delimiter);
+        // Using StringBuilder for joining primitives
+        StringBuilder stringBuilder = new StringBuilder();
         for (int i = startIndex; i < endIndex; i++) {
-            joiner.add(String.valueOf(array[i]));
+            stringBuilder.append(array[i]);
+            if (i != endIndex - 1) {
+                stringBuilder.append(delimiter);
+            }
         }
-        return joiner.toString();
+        return stringBuilder.toString();
     }
 
     /**

--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -3930,7 +3930,7 @@ public class StringUtils {
         if (endIndex - startIndex <= 0) {
             return EMPTY;
         }
-        final StringBuilder stringBuilder = new StringBuilder( array.length * 5 + array.length - 1);
+        final StringBuilder stringBuilder = new StringBuilder(array.length * 5 + array.length - 1);
         for (int i = startIndex; i < endIndex; i++) {
             stringBuilder
                     .append(array[i])
@@ -4088,7 +4088,7 @@ public class StringUtils {
         if (endIndex - startIndex <= 0) {
             return EMPTY;
         }
-        final StringBuilder stringBuilder = new StringBuilder( array.length * 2 - 1);
+        final StringBuilder stringBuilder = new StringBuilder(array.length * 2 - 1);
         for (int i = startIndex; i < endIndex; i++) {
             stringBuilder
                     .append(array[i])

--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -3930,15 +3930,15 @@ public class StringUtils {
         if (endIndex - startIndex <= 0) {
             return EMPTY;
         }
-
-        StringBuilder stringBuilder = new StringBuilder();
+        final StringBuilder stringBuilder = new StringBuilder();
         for (int i = startIndex; i < endIndex; i++) {
-            stringBuilder.append(array[i]);
-            if (i != endIndex - 1) {
-                stringBuilder.append(delimiter);
-            }
+            stringBuilder
+                    .append(array[i])
+                    .append(delimiter);
         }
-        return stringBuilder.toString();
+        return stringBuilder
+                .deleteCharAt(stringBuilder.length() - 1)
+                .toString();
     }
 
     /**
@@ -4011,14 +4011,15 @@ public class StringUtils {
         if (endIndex - startIndex <= 0) {
             return EMPTY;
         }
-        StringBuilder stringBuilder = new StringBuilder();
+        final StringBuilder stringBuilder = new StringBuilder();
         for (int i = startIndex; i < endIndex; i++) {
-            stringBuilder.append(array[i]);
-            if (i != endIndex - 1) {
-                   stringBuilder.append(delimiter);
-            }
+            stringBuilder
+                    .append(array[i])
+                    .append(delimiter);
         }
-        return stringBuilder.toString();
+        return stringBuilder
+                .deleteCharAt(stringBuilder.length() - 1)
+                .toString();
     }
 
     /**
@@ -4091,15 +4092,15 @@ public class StringUtils {
         if (endIndex - startIndex <= 0) {
             return EMPTY;
         }
-
-        StringBuilder stringBuilder = new StringBuilder();
+        final StringBuilder stringBuilder = new StringBuilder();
         for (int i = startIndex; i < endIndex; i++) {
-            stringBuilder.append(array[i]);
-            if (i != endIndex - 1) {
-                stringBuilder.append(delimiter);
-            }
+            stringBuilder
+                    .append(array[i])
+                    .append(delimiter);
         }
-        return stringBuilder.toString();
+        return stringBuilder
+                .deleteCharAt(stringBuilder.length() - 1)
+                .toString();
     }
 
     /**
@@ -4174,12 +4175,13 @@ public class StringUtils {
         }
         final StringBuilder stringBuilder = new StringBuilder();
         for (int i = startIndex; i < endIndex; i++) {
-            stringBuilder.append(array[i]);
-            if (i != endIndex - 1) {
-                stringBuilder.append(delimiter);
-            }
+            stringBuilder
+                    .append(array[i])
+                    .append(delimiter);
         }
-        return stringBuilder.toString();
+        return stringBuilder
+                .deleteCharAt(stringBuilder.length() - 1)
+                .toString();
     }
 
     /**
@@ -4254,12 +4256,13 @@ public class StringUtils {
         }
         final StringBuilder stringBuilder = new StringBuilder();
         for (int i = startIndex; i < endIndex; i++) {
-            stringBuilder.append(array[i]);
-            if (i != endIndex - 1) {
-                stringBuilder.append(delimiter);
-            }
+            stringBuilder
+                    .append(array[i])
+                    .append(delimiter);
         }
-        return stringBuilder.toString();
+        return stringBuilder
+                .deleteCharAt(stringBuilder.length() - 1)
+                .toString();
     }
 
     /**
@@ -4334,12 +4337,13 @@ public class StringUtils {
         }
         final StringBuilder stringBuilder = new StringBuilder();
         for (int i = startIndex; i < endIndex; i++) {
-            stringBuilder.append(array[i]);
-            if (i != endIndex - 1) {
-                stringBuilder.append(delimiter);
-            }
+            stringBuilder
+                    .append(array[i])
+                    .append(delimiter);
         }
-        return stringBuilder.toString();
+        return stringBuilder
+                .deleteCharAt(stringBuilder.length() - 1)
+                .toString();
     }
 
     /**
@@ -4623,12 +4627,13 @@ public class StringUtils {
         }
         final StringBuilder stringBuilder = new StringBuilder();
         for (int i = startIndex; i < endIndex; i++) {
-            stringBuilder.append(array[i]);
-            if (i != endIndex - 1) {
-                stringBuilder.append(delimiter);
-            }
+            stringBuilder
+                    .append(array[i])
+                    .append(delimiter);
         }
-        return stringBuilder.toString();
+        return stringBuilder
+                .deleteCharAt(stringBuilder.length() - 1)
+                .toString();
     }
 
     /**
@@ -4841,12 +4846,13 @@ public class StringUtils {
         }
         final StringBuilder stringBuilder = new StringBuilder();
         for (int i = startIndex; i < endIndex; i++) {
-            stringBuilder.append(array[i]);
-            if (i != endIndex - 1) {
-                stringBuilder.append(delimiter);
-            }
+            stringBuilder
+                    .append(array[i])
+                    .append(delimiter);
         }
-        return stringBuilder.toString();
+        return stringBuilder
+                .deleteCharAt(stringBuilder.length() - 1)
+                .toString();
     }
 
     /**

--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -3930,15 +3930,13 @@ public class StringUtils {
         if (endIndex - startIndex <= 0) {
             return EMPTY;
         }
-        final StringBuilder stringBuilder = new StringBuilder();
+        final StringBuilder stringBuilder = new StringBuilder( array.length * 5 + array.length - 1);
         for (int i = startIndex; i < endIndex; i++) {
             stringBuilder
                     .append(array[i])
                     .append(delimiter);
         }
-        return stringBuilder
-                .deleteCharAt(stringBuilder.length() - 1)
-                .toString();
+        return stringBuilder.substring(0, stringBuilder.length() - 1);
     }
 
     /**
@@ -4017,9 +4015,7 @@ public class StringUtils {
                     .append(array[i])
                     .append(delimiter);
         }
-        return stringBuilder
-                .deleteCharAt(stringBuilder.length() - 1)
-                .toString();
+        return stringBuilder.substring(0, stringBuilder.length() - 1);
     }
 
     /**
@@ -4092,15 +4088,13 @@ public class StringUtils {
         if (endIndex - startIndex <= 0) {
             return EMPTY;
         }
-        final StringBuilder stringBuilder = new StringBuilder();
+        final StringBuilder stringBuilder = new StringBuilder( array.length * 2 - 1);
         for (int i = startIndex; i < endIndex; i++) {
             stringBuilder
                     .append(array[i])
                     .append(delimiter);
         }
-        return stringBuilder
-                .deleteCharAt(stringBuilder.length() - 1)
-                .toString();
+        return stringBuilder.substring(0, stringBuilder.length() - 1);
     }
 
     /**
@@ -4179,9 +4173,7 @@ public class StringUtils {
                     .append(array[i])
                     .append(delimiter);
         }
-        return stringBuilder
-                .deleteCharAt(stringBuilder.length() - 1)
-                .toString();
+        return stringBuilder.substring(0, stringBuilder.length() - 1);
     }
 
     /**
@@ -4260,9 +4252,7 @@ public class StringUtils {
                     .append(array[i])
                     .append(delimiter);
         }
-        return stringBuilder
-                .deleteCharAt(stringBuilder.length() - 1)
-                .toString();
+        return stringBuilder.substring(0, stringBuilder.length() - 1);
     }
 
     /**
@@ -4341,9 +4331,7 @@ public class StringUtils {
                     .append(array[i])
                     .append(delimiter);
         }
-        return stringBuilder
-                .deleteCharAt(stringBuilder.length() - 1)
-                .toString();
+        return stringBuilder.substring(0, stringBuilder.length() - 1);
     }
 
     /**
@@ -4631,9 +4619,7 @@ public class StringUtils {
                     .append(array[i])
                     .append(delimiter);
         }
-        return stringBuilder
-                .deleteCharAt(stringBuilder.length() - 1)
-                .toString();
+        return stringBuilder.substring(0, stringBuilder.length() - 1);
     }
 
     /**
@@ -4850,9 +4836,7 @@ public class StringUtils {
                     .append(array[i])
                     .append(delimiter);
         }
-        return stringBuilder
-                .deleteCharAt(stringBuilder.length() - 1)
-                .toString();
+        return stringBuilder.substring(0, stringBuilder.length() - 1);
     }
 
     /**


### PR DESCRIPTION
This PR replaces StringJoiner by StringBuilder in StringUtils.join methods. 
The change is limited to methods which use primitives as input only. 

## More 
Please find more details here: 
1. https://issues.apache.org/jira/browse/LANG-1675
2. https://github.com/apache/commons-lang/pull/784

## JMH with example results
JMH tests -  StringBuilder vs StringJoiner may be found in dedicated repository. Full logs, code and results included.
https://github.com/HubertWo/apache-commons-lang-jmh