### PR TITLE
LANG-1664 adjust doc to show argument is a primitive character

### DIFF
--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -8589,7 +8589,7 @@ public class StringUtils {
      * </pre>
      *
      * @param str  the String to get a substring from, may be null
-     * @param separator  the character to search.
+     * @param separator  the character (Unicode code point) to search.
      * @return the substring after the first occurrence of the separator,
      *  {@code null} if null String input
      * @since 3.11
@@ -8668,7 +8668,7 @@ public class StringUtils {
      * </pre>
      *
      * @param str  the String to get a substring from, may be null
-     * @param separator  the String to search for, may be null
+     * @param separator  the character (Unicode code point) to search.
      * @return the substring after the last occurrence of the separator,
      *  {@code null} if null String input
      * @since 3.11
@@ -8750,7 +8750,7 @@ public class StringUtils {
      * </pre>
      *
      * @param str the String to get a substring from, may be null
-     * @param separator the String to search for, may be null
+     * @param separator the character (Unicode code point) to search.
      * @return the substring before the first occurrence of the separator, {@code null} if null String input
      * @since 3.12.0
      */


### PR DESCRIPTION
The for the methods
- StringUtils#substringAfterLast(String, int)
- StringUtils#substringBefore(String, int)

the second argument is currently described as String in the doc.

The actual argument is a primitive int meant to be used as a character / unicode code point.
The PR changes the doc to reflect that.
Since the argument is a primitive, the note on null input was dropped.