### PR TITLE
[LANG-1679] Improve performance of StringUtils.unwrap(String, String)

### DIFF
--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -9425,13 +9425,7 @@ public class StringUtils {
         }
 
         if (startsWith(str, wrapToken) && endsWith(str, wrapToken)) {
-            final int startIndex = str.indexOf(wrapToken);
-            final int endIndex = str.lastIndexOf(wrapToken);
-            final int wrapLength = wrapToken.length();
-
-            if (startIndex != -1 && endIndex != -1) {
-                return str.substring(startIndex + wrapLength, endIndex);
-            }
+            return str.substring(wrapToken.length(), str.lastIndexOf(wrapToken));
         }
 
         return str;


### PR DESCRIPTION
There're some redundant method calling and index checking in StringUtils.unwrap(String, String), which can be deleted to make unwrap(,) more concise and efficient.
Please refer to: https://issues.apache.org/jira/browse/LANG-1679 (a JMH test result also provided)