### PR TITLE
LANG-1671: AtomicSafeInitializerTest and LazyInitializerTest modifications using Mockito

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -588,6 +588,18 @@
       <version>3.0.2</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>${commons.mockito.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <version>${commons.mockito.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <distributionManagement>
@@ -656,6 +668,7 @@
     <commons.felix.version>5.1.2</commons.felix.version>
     <biz.aQute.bndlib.version>6.1.0</biz.aQute.bndlib.version>
     <commons.animal-sniffer.version>1.20</commons.animal-sniffer.version>
+    <commons.mockito.version>4.3.1</commons.mockito.version>
     
     <!-- Commons Release Plugin -->
     <commons.bc.version>3.12.0</commons.bc.version>

--- a/src/test/java/org/apache/commons/lang3/concurrent/AbstractConcurrentInitializerTest.java
+++ b/src/test/java/org/apache/commons/lang3/concurrent/AbstractConcurrentInitializerTest.java
@@ -116,5 +116,5 @@ public abstract class AbstractConcurrentInitializerTest {
      *
      * @return the initializer object to be tested
      */
-    protected abstract ConcurrentInitializer<Object> createInitializer();
+    protected abstract ConcurrentInitializer<Object> createInitializer() throws ConcurrentException;
 }

--- a/src/test/java/org/apache/commons/lang3/concurrent/AtomicSafeInitializerTest.java
+++ b/src/test/java/org/apache/commons/lang3/concurrent/AtomicSafeInitializerTest.java
@@ -16,33 +16,33 @@
  */
 package org.apache.commons.lang3.concurrent;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
-import java.util.concurrent.atomic.AtomicInteger;
-
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Test class for {@code AtomicSafeInitializer}.
  */
-public class AtomicSafeInitializerTest extends
-        AbstractConcurrentInitializerTest {
-    /** The instance to be tested. */
-    private AtomicSafeInitializerTestImpl initializer;
+@ExtendWith(MockitoExtension.class)
+public class AtomicSafeInitializerTest extends AbstractConcurrentInitializerTest {
 
-    @BeforeEach
-    public void setUp() {
-        initializer = new AtomicSafeInitializerTestImpl();
-    }
+    @Spy
+    private AtomicSafeInitializer<Object> initializer;
 
     /**
      * Returns the initializer to be tested.
      *
+     * @throws org.apache.commons.lang3.concurrent.ConcurrentException because {@link AtomicSafeInitializer#initialize()} may throw it
      * @return the {@code AtomicSafeInitializer} under test
      */
     @Override
-    protected ConcurrentInitializer<Object> createInitializer() {
+    protected ConcurrentInitializer<Object> createInitializer() throws ConcurrentException {
+        when(initializer.initialize()).thenReturn(new Object());
         return initializer;
     }
 
@@ -55,24 +55,10 @@ public class AtomicSafeInitializerTest extends
     @Test
     public void testNumberOfInitializeInvocations() throws ConcurrentException,
             InterruptedException {
+        when(initializer.initialize()).thenReturn(new Object());
+
         testGetConcurrent();
-        assertEquals(1, initializer.initCounter.get(), "Wrong number of invocations");
-    }
 
-    /**
-     * A concrete test implementation of {@code AtomicSafeInitializer}. This
-     * implementation also counts the number of invocations of the initialize()
-     * method.
-     */
-    private static class AtomicSafeInitializerTestImpl extends
-            AtomicSafeInitializer<Object> {
-        /** A counter for initialize() invocations. */
-        final AtomicInteger initCounter = new AtomicInteger();
-
-        @Override
-        protected Object initialize() {
-            initCounter.incrementAndGet();
-            return new Object();
-        }
+        verify(initializer, times(1)).initialize();
     }
 }

--- a/src/test/java/org/apache/commons/lang3/concurrent/LazyInitializerTest.java
+++ b/src/test/java/org/apache/commons/lang3/concurrent/LazyInitializerTest.java
@@ -16,41 +16,30 @@
  */
 package org.apache.commons.lang3.concurrent;
 
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.when;
 
 /**
  * Test class for {@code LazyInitializer}.
  */
+@ExtendWith(MockitoExtension.class)
 public class LazyInitializerTest extends AbstractConcurrentInitializerTest {
-    /** The initializer to be tested. */
-    private LazyInitializerTestImpl initializer;
 
-    @BeforeEach
-    public void setUp() {
-        initializer = new LazyInitializerTestImpl();
-    }
+    @Spy
+    private LazyInitializer initializer;
 
     /**
-     * Returns the initializer to be tested. This implementation returns the
-     * {@code LazyInitializer} created in the {@code setUp()} method.
+     * Returns the initializer to be tested.
      *
+     * @throws org.apache.commons.lang3.concurrent.ConcurrentException because {@link LazyInitializer#initialize()} may throw it
      * @return the initializer to be tested
      */
     @Override
-    protected ConcurrentInitializer<Object> createInitializer() {
+    protected ConcurrentInitializer<Object> createInitializer() throws ConcurrentException {
+        when(initializer.initialize()).thenReturn(new Object());
         return initializer;
-    }
-
-    /**
-     * A test implementation of LazyInitializer. This class creates a plain
-     * Object. As Object does not provide a specific equals() method, it is easy
-     * to check whether multiple instances were created.
-     */
-    private static class LazyInitializerTestImpl extends
-            LazyInitializer<Object> {
-        @Override
-        protected Object initialize() {
-            return new Object();
-        }
     }
 }


### PR DESCRIPTION
PR contains proposed changes to Jira issue 1671: 
* replacing AtomicSafeInitializerTestImpl  with a spy using Mockito,
* stubbing a method initialize(),
* adding verification that method initialize() is called only once.

Similar modification I’ve done in class LazyInitializerTest.