### PR TITLE
Add method defaultIfEmpty with lazy default string computation

### DIFF
--- a/src/main/java/org/apache/commons/lang3/ObjectUtils.java
+++ b/src/main/java/org/apache/commons/lang3/ObjectUtils.java
@@ -1153,6 +1153,20 @@ public class ObjectUtils {
     }
 
     /**
+     * Get passed {@code object} in case it is not null, otherwise return the value produced by supplier
+     *
+     * Consider to utilize this method if lazy computation of default value makes sense in your case
+     *
+     * @param object to get if not null else to apply passed {@link Supplier}
+     * @param supplier {@link Supplier} to utilize in case provided {@code object} is null
+     * @param <T> the type of the object
+     * @return passed {@code object} in case it is not null, otherwise return the value produced by supplier
+     */
+    public static <T> T defaultIfNull(T object, Supplier<T> supplier) {
+        return object == null ? supplier.get() : object;
+    }
+
+    /**
      * <p>Null safe comparison of Comparables.</p>
      * <p>TODO Move to ComparableUtils.</p>
      *

--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -1525,6 +1525,26 @@ public class StringUtils {
 
     /**
      * <p>Returns either the passed in CharSequence, or if the CharSequence is
+     * whitespace, empty ("") or {@code null}, the value produced by {@code supplier}.</p>
+     *
+     * Consider to utilize this method instead of {@link #defaultIfBlank(CharSequence, CharSequence)}
+     * in case of lazy computation of default string make sense
+     *
+     * <p>Whitespace is defined by {@link Character#isWhitespace(char)}.</p>
+     *
+     * @param source - CharSequence to check, may be null
+     * @param supplier represents the supplier, that should return instance
+     *                 of type {@literal T} in case source string is empty
+     * @param <T> represents the specific kind of CharSequence
+     * @return the passed source instance of CharSequence in case it is not blank,
+     *                 otherwise the value returned by {@link Supplier}
+     */
+    public static <T extends CharSequence> T defaultIfEmpty(final T source, final Supplier<T> supplier) {
+        return isBlank(source) ? supplier.get() : source;
+    }
+
+    /**
+     * <p>Returns either the passed in CharSequence, or if the CharSequence is
      * empty or {@code null}, the value of {@code defaultStr}.</p>
      *
      * <pre>

--- a/src/test/java/org/apache/commons/lang3/ObjectUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/ObjectUtilsTest.java
@@ -17,6 +17,7 @@
 package org.apache.commons.lang3;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -43,6 +44,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
 import org.apache.commons.lang3.exception.CloneFailedException;
@@ -723,6 +725,26 @@ public class ObjectUtilsTest {
     @Test
     public void testMedian_nullItems() {
         assertThrows(NullPointerException.class, () -> ObjectUtils.median((String[]) null));
+    }
+
+    @Test
+    void testDefaultIfNull_Lazy() {
+        final String result = ObjectUtils.defaultIfNull(null, () -> "result");
+        assertEquals("result", result);
+
+        ArrayList<?> arrayList = assertDoesNotThrow(() -> ObjectUtils.defaultIfNull(new ArrayList<>(), (Supplier<ArrayList<?>>) () -> {
+            throw new RuntimeException();
+        }));
+
+        assertNotNull(arrayList);
+
+        AtomicInteger atomicInteger = new AtomicInteger(0);
+
+        final Integer integer = assertDoesNotThrow(() -> ObjectUtils.defaultIfNull(1, atomicInteger::incrementAndGet));
+
+        assertEquals(1, integer);
+        assertEquals(0, atomicInteger.get());
+
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/StringUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringUtilsTest.java
@@ -627,7 +627,7 @@ public class StringUtilsTest {
     }
 
     @Test
-    void testDefaultStringLazyComputations() {
+    void testDefaultIfEmpty() {
         String sourceString = "not empty string";
         String result = assertDoesNotThrow(() -> StringUtils.defaultIfEmpty(sourceString, (Supplier<String>) () -> { throw new RuntimeException(); }));
         assertEquals(result, sourceString);

--- a/src/test/java/org/apache/commons/lang3/StringUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringUtilsTest.java
@@ -17,6 +17,7 @@
 package org.apache.commons.lang3;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -39,6 +40,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 import java.util.regex.PatternSyntaxException;
 
@@ -622,6 +624,28 @@ public class StringUtilsTest {
         assertEquals("", StringUtils.defaultString(null));
         assertEquals("", StringUtils.defaultString(""));
         assertEquals("abc", StringUtils.defaultString("abc"));
+    }
+
+    @Test
+    void testDefaultStringLazyComputations() {
+        String sourceString = "not empty string";
+        String result = assertDoesNotThrow(() -> StringUtils.defaultIfEmpty(sourceString, (Supplier<String>) () -> { throw new RuntimeException(); }));
+        assertEquals(result, sourceString);
+
+        AtomicInteger counter = new AtomicInteger(0);
+        result = StringUtils.defaultIfEmpty("", (Supplier<String>) () -> {
+            counter.incrementAndGet();
+            return "default";
+        });
+        assertEquals(1, counter.get());
+        assertEquals(result, "default");
+
+        result = StringUtils.defaultIfEmpty("not empty", (Supplier<String>) () -> {
+            counter.incrementAndGet();
+            return "default";
+        });
+        assertEquals(1, counter.get());
+        assertEquals(result, "not empty");
     }
 
     @Test


### PR DESCRIPTION
I have encountered a following use case: we have a java object in the local cache, that might have or might have not a `String` field. In case this String field is empty we need to do AWS S3 lookup for that object and fetch this String field from pulled object. Problem is that `defaultIfEmpty(final T source, final T default)` method that already present in `StringUtils` will do S3 lookup in any case, even if source String is present. I think it would be a great idea to create almost the same method but with lazy computation of default string, exactly for that kind of use cases.