### PR TITLE
[LANG-1462] Use TimeZone from calendar in DateFormatUtils.

### DIFF
--- a/src/main/java/org/apache/commons/lang3/time/DateFormatUtils.java
+++ b/src/main/java/org/apache/commons/lang3/time/DateFormatUtils.java
@@ -271,7 +271,8 @@ public class DateFormatUtils {
     }
 
     /**
-     * <p>Formats a calendar into a specific pattern.</p>
+     * <p>Formats a calendar into a specific pattern. Timezone from the calendar
+     * will be used for formatting.</p>
      *
      * @param calendar  the calendar to format, not null
      * @param pattern  the pattern to use to format the calendar, not null
@@ -280,7 +281,7 @@ public class DateFormatUtils {
      * @since 2.4
      */
     public static String format(final Calendar calendar, final String pattern) {
-        return format(calendar, pattern, null, null);
+        return format(calendar, pattern, calendar == null ? null : calendar.getTimeZone(), null);
     }
 
     /**
@@ -346,7 +347,8 @@ public class DateFormatUtils {
     }
 
     /**
-     * <p>Formats a calendar into a specific pattern in a locale.</p>
+     * <p>Formats a calendar into a specific pattern in a locale. Timezone from the calendar
+     * will be used for formatting.</p>
      *
      * @param calendar  the calendar to format, not null
      * @param pattern  the pattern to use to format the calendar, not null
@@ -356,7 +358,7 @@ public class DateFormatUtils {
      * @since 2.4
      */
     public static String format(final Calendar calendar, final String pattern, final Locale locale) {
-        return format(calendar, pattern, null, locale);
+        return format(calendar, pattern, calendar == null ? null : calendar.getTimeZone(), locale);
     }
 
     /**

--- a/src/test/java/org/apache/commons/lang3/time/DateFormatUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/DateFormatUtilsTest.java
@@ -231,6 +231,15 @@ public class DateFormatUtilsTest {
         testUTC("09:11:12Z", DateFormatUtils.ISO_TIME_NO_T_TIME_ZONE_FORMAT.getPattern());
     }
 
+    @Test
+    public void testLANG1462() {
+        TimeZone timeZone = TimeZone.getTimeZone("GMT-3");
+        Calendar calendar = createJuneTestDate(timeZone);
+        assertEquals("20030608101112", DateFormatUtils.format(calendar, "yyyyMMddHHmmss"));
+        calendar.setTimeZone(TimeZone.getTimeZone("JST"));
+        assertEquals("20030608221112", DateFormatUtils.format(calendar, "yyyyMMddHHmmss"));
+    }
+
     private void testUTC(final String expectedValue, final String pattern) {
         final TimeZone timeZone = FastTimeZone.getGmtTimeZone();
         assertFormats(expectedValue, pattern, timeZone, createFebruaryTestDate(timeZone));


### PR DESCRIPTION
Uses timezone from the calendar object when no timezone is specified.