### PR TITLE
updating javadoc for NullPointerException when Validate.notNull() is called

### DIFF
--- a/src/main/java/org/apache/commons/lang3/CharRange.java
+++ b/src/main/java/org/apache/commons/lang3/CharRange.java
@@ -184,7 +184,7 @@ final class CharRange implements Iterable<Character>, Serializable {
      *
      * @param range  the range to check against
      * @return {@code true} if this range entirely contains the input range
-     * @throws IllegalArgumentException if {@code null} input
+     * @throws NullPointerException if {@code null} input
      */
     public boolean contains(final CharRange range) {
         Validate.notNull(range, "range");

--- a/src/main/java/org/apache/commons/lang3/ThreadUtils.java
+++ b/src/main/java/org/apache/commons/lang3/ThreadUtils.java
@@ -68,7 +68,7 @@ public class ThreadUtils {
          * Predicate constructor
          *
          * @param name thread or thread group name
-         * @throws IllegalArgumentException if the name is {@code null}
+         * @throws NullPointerException if the name is {@code null}
          */
         public NamePredicate(final String name) {
             Validate.notNull(name, "name");
@@ -171,7 +171,8 @@ public class ThreadUtils {
      * @param threadGroupName The thread group name
      * @return The threads which belongs to a thread group with the specified group name and the thread's id match the specified id.
      * {@code null} is returned if no such thread exists
-     * @throws IllegalArgumentException if the specified id is zero or negative or the group name is null
+     * @throws NullPointerException if the group name is null
+     * @throws IllegalArgumentException if the specified id is zero or negative
      * @throws  SecurityException
      *          if the current thread cannot access the system thread group
      *
@@ -194,7 +195,8 @@ public class ThreadUtils {
      * @param threadGroup The thread group
      * @return The thread which belongs to a specified thread group and the thread's id match the specified id.
      * {@code null} is returned if no such thread exists
-     * @throws IllegalArgumentException if the specified id is zero or negative or the group is null
+     * @throws NullPointerException if {@code threadGroup == null}
+     * @throws IllegalArgumentException if the specified id is zero or negative
      * @throws  SecurityException
      *          if the current thread cannot access the system thread group
      *
@@ -217,7 +219,7 @@ public class ThreadUtils {
      * @param recurse if {@code true} then evaluate the predicate recursively on all thread groups in all subgroups of the given group
      * @param predicate the predicate
      * @return An unmodifiable {@code Collection} of active thread groups which match the given predicate and which is a subgroup of the given thread group
-     * @throws IllegalArgumentException if the given group or predicate is null
+     * @throws NullPointerException if the given group or predicate is null
      * @throws  SecurityException  if the current thread cannot modify
      *          thread groups from this thread's thread group up to the system thread group
      */
@@ -247,7 +249,7 @@ public class ThreadUtils {
      *
      * @param predicate the predicate
      * @return An unmodifiable {@code Collection} of active thread groups matching the given predicate
-     * @throws IllegalArgumentException if the predicate is null
+     * @throws NullPointerException if the predicate is null
      * @throws  SecurityException
      *          if the current thread cannot access the system thread group
      * @throws  SecurityException  if the current thread cannot modify
@@ -262,7 +264,7 @@ public class ThreadUtils {
      *
      * @param threadGroupName The thread group name
      * @return the thread groups with the specified group name or an empty collection if no such thread group exists. The collection returned is always unmodifiable.
-     * @throws IllegalArgumentException if group name is null
+     * @throws NullPointerException if group name is null
      * @throws  SecurityException
      *          if the current thread cannot access the system thread group
      *
@@ -280,7 +282,7 @@ public class ThreadUtils {
      * @param recurse if {@code true} then evaluate the predicate recursively on all threads in all subgroups of the given group
      * @param predicate the predicate
      * @return An unmodifiable {@code Collection} of active threads which match the given predicate and which belongs to the given thread group
-     * @throws IllegalArgumentException if the given group or predicate is null
+     * @throws NullPointerException if the given group or predicate is null
      * @throws  SecurityException  if the current thread cannot modify
      *          thread groups from this thread's thread group up to the system thread group
      */
@@ -311,7 +313,7 @@ public class ThreadUtils {
      * @param predicate the predicate
      * @return An unmodifiable {@code Collection} of active threads matching the given predicate
      *
-     * @throws IllegalArgumentException if the predicate is null
+     * @throws NullPointerException if the predicate is null
      * @throws  SecurityException
      *          if the current thread cannot access the system thread group
      * @throws  SecurityException  if the current thread cannot modify
@@ -326,7 +328,7 @@ public class ThreadUtils {
      *
      * @param threadName The thread name
      * @return The threads with the specified name or an empty collection if no such thread exists. The collection returned is always unmodifiable.
-     * @throws IllegalArgumentException if the specified name is null
+     * @throws NullPointerException if the specified name is null
      * @throws  SecurityException
      *          if the current thread cannot access the system thread group
      *
@@ -344,7 +346,7 @@ public class ThreadUtils {
      * @param threadGroupName The thread group name
      * @return The threads which belongs to a thread group with the specified group name and the thread's name match the specified name,
      * An empty collection is returned if no such thread exists. The collection returned is always unmodifiable.
-     * @throws IllegalArgumentException if the specified thread name or group name is null
+     * @throws NullPointerException if the specified thread name or group name is null
      * @throws  SecurityException
      *          if the current thread cannot access the system thread group
      *
@@ -376,7 +378,7 @@ public class ThreadUtils {
      * @param threadGroup The thread group
      * @return The threads which belongs to a thread group and the thread's name match the specified name,
      * An empty collection is returned if no such thread exists. The collection returned is always unmodifiable.
-     * @throws IllegalArgumentException if the specified thread name or group is null
+     * @throws NullPointerException if the specified thread name or group is null
      * @throws  SecurityException
      *          if the current thread cannot access the system thread group
      *

--- a/src/main/java/org/apache/commons/lang3/concurrent/MultiBackgroundInitializer.java
+++ b/src/main/java/org/apache/commons/lang3/concurrent/MultiBackgroundInitializer.java
@@ -128,7 +128,8 @@ public class MultiBackgroundInitializer
      * @param name the name of the initializer (must not be <b>null</b>)
      * @param backgroundInitializer the {@code BackgroundInitializer} to add (must not be
      * <b>null</b>)
-     * @throws IllegalArgumentException if a required parameter is missing
+     * @throws NullPointerException if either {@code name} or {@code backgroundInitializer}
+     *         is {@code null}
      * @throws IllegalStateException if {@code start()} has already been called
      */
     public void addInitializer(final String name, final BackgroundInitializer<?> backgroundInitializer) {


### PR DESCRIPTION
Hello! I updated some javadocs that mentioned `IllegalArgumentException` when an argument is `null` instead of `NullPointerException`. Tests were already checking for NPE, so I didn't write any.
This PR is similar to https://github.com/apache/commons-lang/pull/785.

This is reminiscent of https://github.com/apache/commons-lang/commit/ba607f525b842661d40195d0d4778528e2384e70, when lots of calls to `Validate.isTrue(arg != null)` (throws IAE) were changed to `Validate.notNull(arg)` (throws NPE).

The same wrong javadocs are also still present for `DateUtils` and `FieldUtils`.
I'll be glad to provide PRs for those if you feel it's needed. However, the diffs there will be much larger.
Thanks!