### PR TITLE
Revert #896 spotbugs update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -639,7 +639,7 @@
     <checkstyle.configdir>src/site/resources/checkstyle</checkstyle.configdir>
 
     <commons.spotbugs.plugin.version>4.7.0.0</commons.spotbugs.plugin.version>
-    <commons.spotbugs.impl.version>4.7.0</commons.spotbugs.impl.version>
+    <commons.spotbugs.impl.version>4.6.0</commons.spotbugs.impl.version>
     <japicmp.skip>false</japicmp.skip>
     <clirr.skip>true</clirr.skip>
 

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -142,7 +142,7 @@ The <action> type attribute can be add,update,fix,remove.
     <action                   type="update" dev="ggregory" due-to="Dependabot">Bump actions/checkout from 2 to 3 #819, #825, #859.</action>
     <action                   type="update" dev="ggregory" due-to="Gary Gregory">Bump actions/setup-java from v1.4.3 to 3 #879.</action>
     <action                   type="update" dev="ggregory" due-to="Dependabot, Gary Gregory">Bump spotbugs-maven-plugin from 4.2.0 to 4.7.0.0 #735, #808, #822, #834, #868, #895.</action>
-    <action                   type="update" dev="ggregory" due-to="Dependabot, Gary Gregory">Bump spotbugs from 4.2.2 to 4.7.0 #744, #896.</action>
+    <action                   type="update" dev="ggregory" due-to="Dependabot, Gary Gregory">Bump spotbugs from 4.2.2 to 4.6.0 #744.</action>
     <action                   type="update" dev="ggregory" due-to="Dependabot, Gary Gregory">Bump checkstyle from 8.41 to 9.2.1 #739, #768, #787, #811, #824, #843.</action>
     <action                   type="update" dev="ggregory" due-to="Dependabot">Bump easymock from 4.2 to 4.3 #746.</action>
     <action                   type="update" dev="ggregory" due-to="Gary Gregory">Bump commons.jacoco.version 0.8.6 -> 0.8.7.</action>

--- a/src/conf/spotbugs-exclude-filter.xml
+++ b/src/conf/spotbugs-exclude-filter.xml
@@ -30,9 +30,6 @@
       <Bug pattern="EI_EXPOSE_REP" />
       <Bug pattern="EI_EXPOSE_REP2" />
       <Bug pattern="MS_EXPOSE_REP" />
-      <Bug pattern="THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION" />
-      <Bug pattern="THROWS_METHOD_THROWS_CLAUSE_THROWABLE" />
-      <Bug pattern="THROWS_METHOD_THROWS_RUNTIMEEXCEPTION" />
     </Or>
   </Match>
 


### PR DESCRIPTION
Reverts #896 as we can do a better job with the Spotbugs issues that are reported in the new release, instead of simply ignoring everything and bumping spotbugs.