### PR TITLE
Fix unstable coverage of CharSequenceUtils tests noticed during merge of PRs 898 and 899

### DIFF
--- a/src/test/java/org/apache/commons/lang3/CharSequenceUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/CharSequenceUtilsTest.java
@@ -246,6 +246,10 @@ public class CharSequenceUtilsTest {
         testNewLastIndexOfSingle("apache", "x");
         testNewLastIndexOfSingle("oraoraoraora", "r");
         testNewLastIndexOfSingle("mudamudamudamuda", "d");
+        // There is a route through checkLaterThan1#checkLaterThan1
+        // which only gets touched if there is a two letter (or more) partial match
+        // (in this case "st") earlier in the searched string.
+        testNewLastIndexOfSingle("junk-ststarting", "starting");
 
         final Random random = new Random();
         final StringBuilder seg = new StringBuilder();


### PR DESCRIPTION
Line 36 in CharSequenceUtils usually returns true for at least one test in a test run, but occasionally (for instance in PR 898) it doesn't. This is because the majority of the tests rely on randomly generated strings.

Contributed on behalf of the @opencastsoftware open source team