### PR TITLE
[LANG-1687] fix java Doc

### DIFF
--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -8889,7 +8889,7 @@ public class StringUtils {
      * StringUtils.substringBetween("", "[", "]")        = null
      * StringUtils.substringBetween("yabcz", "", "")     = ""
      * StringUtils.substringBetween("yabcz", "y", "z")   = "abc"
-     * StringUtils.substringBetween("yabczyabcz", "y", "z")   = "abc"
+     * StringUtils.substringBetween("yabczyabcz", "y", "z")   = "abczyabc"
      * </pre>
      *
      * @param str  the String containing the substring, may be null


### PR DESCRIPTION
The example of java document is incorrect.
StringUtils.substringBetween("yabczyabcz", "y", "z")   = "abc" => 
StringUtils.substringBetween("yabczyabcz", "y", "z")   = "abczyabc" => 