### PR TITLE
fix StringUtils.upperCase(String str) java doc

### DIFF
--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -9446,7 +9446,7 @@ public class StringUtils {
      *
      * <p><strong>Note:</strong> As described in the documentation for {@link String#toUpperCase()},
      * the result of this method is affected by the current locale.
-     * For platform-independent case transformations, the method {@link #lowerCase(String, Locale)}
+     * For platform-independent case transformations, the method {@link #upperCase(String, Locale)}
      * should be used with a specific locale (e.g. {@link Locale#ENGLISH}).</p>
      *
      * @param str  the String to upper case, may be null


### PR DESCRIPTION
This MR fixes a typo with the StringUtils.upperCase(String str) javadoc
Updated #lowerCase to #upperCase in scenarios where Locale needs to be provided for case transformation