### PR TITLE
Fix links in Javadoc and documentations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ Getting Started
   + Clearly describe the issue including steps to reproduce when it is a bug.
   + Make sure you fill in the earliest version that you know has the issue.
 + Find the corresponding [repository on GitHub](https://github.com/apache/?query=commons-),
-[fork](https://help.github.com/articles/fork-a-repo/) and check out your forked repository.
+[fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo) and check out your forked repository.
 
 Making Changes
 --------------
@@ -106,8 +106,8 @@ Additional Resources
 + [Contributing patches](https://commons.apache.org/patches.html)
 + [Apache Commons Lang JIRA project page][jira]
 + [Contributor License Agreement][cla]
-+ [General GitHub documentation](https://help.github.com/)
-+ [GitHub pull request documentation](https://help.github.com/articles/creating-a-pull-request/)
++ [General GitHub documentation](https://docs.github.com/)
++ [GitHub pull request documentation](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request)
 + [Apache Commons Twitter Account](https://twitter.com/ApacheCommons)
 + `#apache-commons` IRC channel on `irc.freenode.net`
 

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -736,7 +736,7 @@ JAVA 9 SUPPORT
 ==============
 
 Java 9 introduces a new version-string scheme. Details of this new scheme are
-documented in JEP-223 (http://openjdk.java.net/jeps/223). In order to support
+documented in JEP-223 (https://openjdk.org/jeps/223). In order to support
 JEP-223 two classes had to be changed:
 
 o org.apache.commons.lang3.JavaVersion
@@ -756,7 +756,7 @@ BUILDING ON JAVA 9
 
 Java 8 introduced the Unicode Consortium's Common Locale Data Repository as
 alternative source for locale data. Java 9 will use the CLDR provider as
-default provider for locale data (see http://openjdk.java.net/jeps/252). This
+default provider for locale data (see https://openjdk.org/jeps/252). This
 causes an number of locale-sensitive test in Commons Lang to fail. In order
 to build Commons Lang 3.5 on Java 9, the locale provider has to be set to
 'JRE':

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -1095,7 +1095,7 @@ The <action> type attribute can be add,update,fix,remove.
     <action type="add" issue="LANG-351">Extension to ClassUtils: Obtain the primitive class from a wrapper.</action>
     <action type="fix" issue="LANG-399">Javadoc bugs - cannot find object.</action>
     <action type="add" issue="LANG-345">Optimize HashCodeBuilder.append(Object).</action>
-    <action type="fix" issue="LANG-385">https://commons.apache.org/lang/developerguide.html "Building" section is incorrect and incomplete.</action>
+    <action type="fix" issue="LANG-385">https://commons.apache.org/proper/commons-lang/developerguide.html "Building" section is incorrect and incomplete.</action>
     <action type="fix" issue="LANG-410">Ambiguous / confusing names in StringUtils replace* methods.</action>
     <action type="add" issue="LANG-257">Add new splitByWholeSeparatorPreserveAllTokens() methods to StringUtils.</action>
     <action type="add" issue="LANG-356">Add getStartTime to StopWatch.</action>

--- a/src/changes/release-notes.vm
+++ b/src/changes/release-notes.vm
@@ -53,7 +53,7 @@ $introduction.replaceAll("(?<!\015)\012", "
 ").replaceAll("(?m)^ +","")
 
 ## N.B. the available variables are described here:
-## http://maven.apache.org/plugins/maven-changes-plugin/examples/using-a-custom-announcement-template.html
+## https://maven.apache.org/plugins/maven-changes-plugin/examples/using-a-custom-announcement-template.html
 ##
 ## Hack to improve layout: replace all pairs of spaces with a single new-line
 $release.description.replaceAll("  ", "

--- a/src/main/java/org/apache/commons/lang3/CharEncoding.java
+++ b/src/main/java/org/apache/commons/lang3/CharEncoding.java
@@ -23,14 +23,14 @@ import java.nio.charset.IllegalCharsetNameException;
 /**
  * <p>Character encoding names required of every implementation of the Java platform.</p>
  *
- * <p>According to <a href="http://docs.oracle.com/javase/1.3/docs/api/java/lang/package-summary.html#charenc">JRE character
+ * <p>According to <a href="https://docs.oracle.com/javase/8/docs/api/java/nio/charset/Charset.html">JRE character
  * encoding names</a>:</p>
  *
  * <p><cite>Every implementation of the Java platform is required to support the following character encodings.
  * Consult the release documentation for your implementation to see if any other encodings are supported.
  * </cite></p>
  *
- * @see <a href="http://docs.oracle.com/javase/6/docs/technotes/guides/intl/encoding.doc.html">JRE character encoding names</a>
+ * @see <a href="https://docs.oracle.com/javase/8/docs/technotes/guides/intl/encoding.doc.html">JRE character encoding names</a>
  * @since 2.1
  * @deprecated Java 7 introduced {@link java.nio.charset.StandardCharsets}, which defines these constants as
  * {@link Charset} objects. Use {@link Charset#name()} to get the string values provided in this class.
@@ -87,7 +87,7 @@ public class CharEncoding {
      * <p>Returns whether the named charset is supported.</p>
      *
      * <p>This is similar to <a
-     * href="http://docs.oracle.com/javase/6/docs/api/java/nio/charset/Charset.html#isSupported%28java.lang.String%29">
+     * href="https://docs.oracle.com/javase/8/docs/api/java/nio/charset/Charset.html#isSupported%28java.lang.String%29">
      * java.nio.charset.Charset.isSupported(String)</a> but handles more formats</p>
      *
      * @param name  the name of the requested charset; may be either a canonical name or an alias, null returns false

--- a/src/main/java/org/apache/commons/lang3/CharUtils.java
+++ b/src/main/java/org/apache/commons/lang3/CharUtils.java
@@ -37,7 +37,7 @@ public class CharUtils {
     /**
      * Linefeed character LF ({@code '\n'}, Unicode 000a).
      *
-     * @see <a href="http://docs.oracle.com/javase/specs/jls/se7/html/jls-3.html#jls-3.10.6">JLF: Escape Sequences
+     * @see <a href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-3.html#jls-3.10.6">JLF: Escape Sequences
      *      for Character and String Literals</a>
      * @since 2.2
      */
@@ -46,7 +46,7 @@ public class CharUtils {
     /**
      * Carriage return character CR ('\r', Unicode 000d).
      *
-     * @see <a href="http://docs.oracle.com/javase/specs/jls/se7/html/jls-3.html#jls-3.10.6">JLF: Escape Sequences
+     * @see <a href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-3.html#jls-3.10.6">JLF: Escape Sequences
      *      for Character and String Literals</a>
      * @since 2.2
      */

--- a/src/main/java/org/apache/commons/lang3/ClassUtils.java
+++ b/src/main/java/org/apache/commons/lang3/ClassUtils.java
@@ -802,7 +802,7 @@ public class ClassUtils {
      * <p>
      * Returns the desired Method much like {@code Class.getMethod}, however it ensures that the returned Method is from a
      * public class or interface and not from an anonymous inner class. This means that the Method is invokable and doesn't
-     * fall foul of Java bug <a href="http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=4071957">4071957</a>).
+     * fall foul of Java bug <a href="https://bugs.java.com/bugdatabase/view_bug.do?bug_id=4071957">4071957</a>).
      * </p>
      *
      * <pre>
@@ -1269,7 +1269,7 @@ public class ClassUtils {
      * <p>
      * Specifically, this method tests whether the type represented by the specified {@link Class} parameter can be
      * converted to the type represented by this {@link Class} object via an identity conversion widening primitive or
-     * widening reference conversion. See <em><a href="http://docs.oracle.com/javase/specs/">The Java Language
+     * widening reference conversion. See <em><a href="https://docs.oracle.com/javase/specs/">The Java Language
      * Specification</a></em>, sections 5.1.1, 5.1.2 and 5.1.4 for details.
      * </p>
      *
@@ -1310,7 +1310,7 @@ public class ClassUtils {
      * <p>
      * Specifically, this method tests whether the type represented by the specified {@link Class} parameter can be
      * converted to the type represented by this {@link Class} object via an identity conversion widening primitive or
-     * widening reference conversion. See <em><a href="http://docs.oracle.com/javase/specs/">The Java Language
+     * widening reference conversion. See <em><a href="https://docs.oracle.com/javase/specs/">The Java Language
      * Specification</a></em>, sections 5.1.1, 5.1.2 and 5.1.4 for details.
      * </p>
      *
@@ -1406,7 +1406,7 @@ public class ClassUtils {
      * <p>
      * Specifically, this method tests whether the type represented by the specified {@link Class} parameter can be
      * converted to the type represented by this {@link Class} object via an identity conversion widening primitive or
-     * widening reference conversion. See <em><a href="http://docs.oracle.com/javase/specs/">The Java Language
+     * widening reference conversion. See <em><a href="https://docs.oracle.com/javase/specs/">The Java Language
      * Specification</a></em>, sections 5.1.1, 5.1.2 and 5.1.4 for details.
      * </p>
      *
@@ -1453,7 +1453,7 @@ public class ClassUtils {
      * <p>
      * Specifically, this method tests whether the type represented by the specified {@link Class} parameter can be
      * converted to the type represented by this {@link Class} object via an identity conversion widening primitive or
-     * widening reference conversion. See <em><a href="http://docs.oracle.com/javase/specs/">The Java Language
+     * widening reference conversion. See <em><a href="https://docs.oracle.com/javase/specs/">The Java Language
      * Specification</a></em>, sections 5.1.1, 5.1.2 and 5.1.4 for details.
      * </p>
      *

--- a/src/main/java/org/apache/commons/lang3/RandomStringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/RandomStringUtils.java
@@ -31,7 +31,7 @@ import java.util.concurrent.ThreadLocalRandom;
  * RandomStringGenerator</a> instead.</p>
  *
  * <p>The Apache Commons project provides
- * <a href="https://commons.apache.org/rng">Commons RNG</a> dedicated to pseudo-random number generation, that may be
+ * <a href="https://commons.apache.org/proper/commons-rng/">Commons RNG</a> dedicated to pseudo-random number generation, that may be
  * a better choice for applications with more stringent requirements
  * (performance and/or correctness).</p>
  *

--- a/src/main/java/org/apache/commons/lang3/RandomUtils.java
+++ b/src/main/java/org/apache/commons/lang3/RandomUtils.java
@@ -26,7 +26,7 @@ import java.util.concurrent.ThreadLocalRandom;
  *
  * <p>Please note that the Apache Commons project provides a component
  * dedicated to pseudo-random number generation, namely
- * <a href="https://commons.apache.org/rng">Commons RNG</a>, that may be
+ * <a href="https://commons.apache.org/proper/commons-rng/">Commons RNG</a>, that may be
  * a better choice for applications with more stringent requirements
  * (performance and/or correctness).</p>
  *

--- a/src/main/java/org/apache/commons/lang3/StringEscapeUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringEscapeUtils.java
@@ -493,7 +493,7 @@ public class StringEscapeUtils {
      * <p>The only difference between Java strings and Json strings
      * is that in Json, forward-slash (/) is escaped.</p>
      *
-     * <p>See http://www.ietf.org/rfc/rfc4627.txt for further details. </p>
+     * <p>See https://www.ietf.org/rfc/rfc4627.txt for further details. </p>
      *
      * <p>Example:</p>
      * <pre>
@@ -576,11 +576,11 @@ public class StringEscapeUtils {
      * @param input  the {@link String} to escape, may be null
      * @return a new escaped {@link String}, {@code null} if null string input
      *
-     * @see <a href="http://hotwired.lycos.com/webmonkey/reference/special_characters/">ISO Entities</a>
-     * @see <a href="http://www.w3.org/TR/REC-html32#latin1">HTML 3.2 Character Entities for ISO Latin-1</a>
-     * @see <a href="http://www.w3.org/TR/REC-html40/sgml/entities.html">HTML 4.0 Character entity references</a>
-     * @see <a href="http://www.w3.org/TR/html401/charset.html#h-5.3">HTML 4.01 Character References</a>
-     * @see <a href="http://www.w3.org/TR/html401/charset.html#code-position">HTML 4.01 Code positions</a>
+     * @see <a href="https://web.archive.org/web/20060225074150/https://hotwired.lycos.com/webmonkey/reference/special_characters/">ISO Entities</a>
+     * @see <a href="https://www.w3.org/TR/REC-html32#latin1">HTML 3.2 Character Entities for ISO Latin-1</a>
+     * @see <a href="https://www.w3.org/TR/REC-html40/sgml/entities.html">HTML 4.0 Character entity references</a>
+     * @see <a href="https://www.w3.org/TR/html401/charset.html#h-5.3">HTML 4.01 Character References</a>
+     * @see <a href="https://www.w3.org/TR/html401/charset.html#code-position">HTML 4.01 Code positions</a>
      *
      * @since 3.0
      */
@@ -757,8 +757,8 @@ public class StringEscapeUtils {
      * <p>If the value does not contain a comma, newline or double quote, then the
      *    String value is returned unchanged.</p>
      *
-     * see <a href="http://en.wikipedia.org/wiki/Comma-separated_values">Wikipedia</a> and
-     * <a href="http://tools.ietf.org/html/rfc4180">RFC 4180</a>.
+     * see <a href="https://en.wikipedia.org/wiki/Comma-separated_values">Wikipedia</a> and
+     * <a href="https://datatracker.ietf.org/doc/html/rfc4180">RFC 4180</a>.
      *
      * @param input the input CSV column String, may be null
      * @return the input String, enclosed in double quotes if the value contains a comma,
@@ -782,8 +782,8 @@ public class StringEscapeUtils {
      * <p>If the value is not enclosed in double quotes, or is and does not contain a
      *    comma, newline or double quote, then the String value is returned unchanged.</p>
      *
-     * see <a href="http://en.wikipedia.org/wiki/Comma-separated_values">Wikipedia</a> and
-     * <a href="http://tools.ietf.org/html/rfc4180">RFC 4180</a>.
+     * see <a href="https://en.wikipedia.org/wiki/Comma-separated_values">Wikipedia</a> and
+     * <a href="https://datatracker.ietf.org/doc/html/rfc4180">RFC 4180</a>.
      *
      * @param input the input CSV column String, may be null
      * @return the input String, with enclosing double quotes removed and embedded double

--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -157,7 +157,7 @@ public class StringUtils {
     /**
      * A String for linefeed LF ("\n").
      *
-     * @see <a href="http://docs.oracle.com/javase/specs/jls/se7/html/jls-3.html#jls-3.10.6">JLF: Escape Sequences
+     * @see <a href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-3.html#jls-3.10.6">JLF: Escape Sequences
      *      for Character and String Literals</a>
      * @since 3.2
      */
@@ -166,7 +166,7 @@ public class StringUtils {
     /**
      * A String for carriage return CR ("\r").
      *
-     * @see <a href="http://docs.oracle.com/javase/specs/jls/se7/html/jls-3.html#jls-3.10.6">JLF: Escape Sequences
+     * @see <a href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-3.html#jls-3.10.6">JLF: Escape Sequences
      *      for Character and String Literals</a>
      * @since 3.2
      */
@@ -2251,7 +2251,7 @@ public class StringUtils {
      * Winkler increased this measure for matching initial characters.</p>
      *
      * <p>This implementation is based on the Jaro Winkler similarity algorithm
-     * from <a href="http://en.wikipedia.org/wiki/Jaro%E2%80%93Winkler_distance">http://en.wikipedia.org/wiki/Jaro%E2%80%93Winkler_distance</a>.</p>
+     * from <a href="https://en.wikipedia.org/wiki/Jaro%E2%80%93Winkler_distance">https://en.wikipedia.org/wiki/Jaro%E2%80%93Winkler_distance</a>.</p>
      *
      * <pre>
      * StringUtils.getJaroWinklerDistance(null, null)          = IllegalArgumentException
@@ -2305,8 +2305,8 @@ public class StringUtils {
      * insertion or substitution).</p>
      *
      * <p>The implementation uses a single-dimensional array of length s.length() + 1. See
-     * <a href="http://blog.softwx.net/2014/12/optimizing-levenshtein-algorithm-in-c.html">
-     * http://blog.softwx.net/2014/12/optimizing-levenshtein-algorithm-in-c.html</a> for details.</p>
+     * <a href="https://blog.softwx.net/2014/12/optimizing-levenshtein-algorithm-in-c.html">
+     * https://blog.softwx.net/2014/12/optimizing-levenshtein-algorithm-in-c.html</a> for details.</p>
      *
      * <pre>
      * StringUtils.getLevenshteinDistance(null, *)             = IllegalArgumentException
@@ -2398,7 +2398,7 @@ public class StringUtils {
      *
      * <p>This implementation follows from Algorithms on Strings, Trees and Sequences by Dan Gusfield
      * and Chas Emerick's implementation of the Levenshtein distance algorithm from
-     * <a href="http://www.merriampark.com/ld.htm">http://www.merriampark.com/ld.htm</a></p>
+     * <a href="https://web.archive.org/web/20120212021906/http%3A//www.merriampark.com/ld.htm">http://www.merriampark.com/ld.htm</a></p>
      *
      * <pre>
      * StringUtils.getLevenshteinDistance(null, *, *)             = IllegalArgumentException
@@ -5531,7 +5531,7 @@ public class StringUtils {
     /**
      * <p>
      * Similar to <a
-     * href="http://www.w3.org/TR/xpath/#function-normalize-space">http://www.w3.org/TR/xpath/#function-normalize
+     * href="https://www.w3.org/TR/xpath/#function-normalize-space">https://www.w3.org/TR/xpath/#function-normalize
      * -space</a>
      * </p>
      * <p>
@@ -5540,7 +5540,7 @@ public class StringUtils {
      * and then replacing sequences of whitespace characters by a single space.
      * </p>
      * In XML Whitespace characters are the same as those allowed by the <a
-     * href="http://www.w3.org/TR/REC-xml/#NT-S">S</a> production, which is S ::= (#x20 | #x9 | #xD | #xA)+
+     * href="https://www.w3.org/TR/REC-xml/#NT-S">S</a> production, which is S ::= (#x20 | #x9 | #xD | #xA)+
      * <p>
      * Java's regexp pattern \s defines whitespace as [ \t\n\x0B\f\r]
      *
@@ -5563,7 +5563,7 @@ public class StringUtils {
      * @see Pattern
      * @see #trim(String)
      * @see <a
-     *      href="http://www.w3.org/TR/xpath/#function-normalize-space">http://www.w3.org/TR/xpath/#function-normalize-space</a>
+     *      href="https://www.w3.org/TR/xpath/#function-normalize-space">https://www.w3.org/TR/xpath/#function-normalize-space</a>
      * @param str the source String to normalize whitespaces from, may be null
      * @return the modified string with whitespace normalized, {@code null} if null String input
      *
@@ -6267,7 +6267,7 @@ public class StringUtils {
      * </pre>
      *
      * <p>Note: this method does not support padding with
-     * <a href="http://www.unicode.org/glossary/#supplementary_character">Unicode Supplementary Characters</a>
+     * <a href="https://www.unicode.org/glossary/#supplementary_character">Unicode Supplementary Characters</a>
      * as they require a pair of {@code char}s to be represented.
      * If you are needing to support full I18N of your applications
      * consider using {@link #repeat(String, int)} instead.

--- a/src/main/java/org/apache/commons/lang3/SystemUtils.java
+++ b/src/main/java/org/apache/commons/lang3/SystemUtils.java
@@ -1084,9 +1084,8 @@ public class SystemUtils {
     // -----------------------------------------------------------------------
     // These MUST be declared after those above as they depend on the
     // values being set up
-    // OS names from http://www.vamphq.com/os.html
-    // Selected ones included - please advise dev@commons.apache.org
-    // if you want another added or a mistake corrected
+    // Please advise dev@commons.apache.org if you want another added
+    // or a mistake corrected
 
     /**
      * <p>

--- a/src/main/java/org/apache/commons/lang3/Validate.java
+++ b/src/main/java/org/apache/commons/lang3/Validate.java
@@ -32,7 +32,7 @@ import java.util.regex.Pattern;
  * </ul>
  *
  * <p>All exceptions messages are
- * <a href="http://docs.oracle.com/javase/1.5.0/docs/api/java/util/Formatter.html#syntax">format strings</a>
+ * <a href="https://docs.oracle.com/javase/8/docs/api/java/util/Formatter.html#syntax">format strings</a>
  * as defined by the Java platform. For example:</p>
  *
  * <pre>

--- a/src/main/java/org/apache/commons/lang3/builder/EqualsBuilder.java
+++ b/src/main/java/org/apache/commons/lang3/builder/EqualsBuilder.java
@@ -34,7 +34,7 @@ import org.apache.commons.lang3.tuple.Pair;
  *
  * <p> This class provides methods to build a good equals method for any
  * class. It follows rules laid out in
- * <a href="http://www.oracle.com/technetwork/java/effectivejava-136174.html">Effective Java</a>
+ * <a href="https://www.oracle.com/technetwork/java/effectivejava-136174.html">Effective Java</a>
  * , by Joshua Bloch. In particular the rule for comparing {@code doubles},
  * {@code floats}, and arrays can be tricky. Also, making sure that
  * {@code equals()} and {@code hashCode()} are consistent can be

--- a/src/main/java/org/apache/commons/lang3/builder/EqualsBuilder.java
+++ b/src/main/java/org/apache/commons/lang3/builder/EqualsBuilder.java
@@ -34,7 +34,7 @@ import org.apache.commons.lang3.tuple.Pair;
  *
  * <p> This class provides methods to build a good equals method for any
  * class. It follows rules laid out in
- * <a href="https://www.oracle.com/technetwork/java/effectivejava-136174.html">Effective Java</a>
+ * <a href="https://www.oracle.com/java/technologies/effectivejava.html">Effective Java</a>
  * , by Joshua Bloch. In particular the rule for comparing {@code doubles},
  * {@code floats}, and arrays can be tricky. Also, making sure that
  * {@code equals()} and {@code hashCode()} are consistent can be

--- a/src/main/java/org/apache/commons/lang3/builder/HashCodeBuilder.java
+++ b/src/main/java/org/apache/commons/lang3/builder/HashCodeBuilder.java
@@ -37,7 +37,7 @@ import org.apache.commons.lang3.Validate;
  *
  * <p>
  * This class enables a good {@code hashCode} method to be built for any class. It follows the rules laid out in
- * the book <a href="http://www.oracle.com/technetwork/java/effectivejava-136174.html">Effective Java</a> by Joshua Bloch. Writing a
+ * the book <a href="https://www.oracle.com/technetwork/java/effectivejava-136174.html">Effective Java</a> by Joshua Bloch. Writing a
  * good {@code hashCode} method is actually quite difficult. This class aims to simplify the process.
  * </p>
  *

--- a/src/main/java/org/apache/commons/lang3/builder/ToStringStyle.java
+++ b/src/main/java/org/apache/commons/lang3/builder/ToStringStyle.java
@@ -157,7 +157,7 @@ public abstract class ToStringStyle implements Serializable {
      * when calling {@code toString()} on them.
      *
      * @since 3.4
-     * @see <a href="http://json.org">json.org</a>
+     * @see <a href="https://www.json.org/">json.org</a>
      */
     public static final ToStringStyle JSON_STYLE = new JsonToStringStyle();
 
@@ -2248,7 +2248,7 @@ public abstract class ToStringStyle implements Serializable {
      * </p>
      *
      * @since 3.4
-     * @see <a href="http://json.org">json.org</a>
+     * @see <a href="https://www.json.org/">json.org</a>
      */
     private static final class JsonToStringStyle extends ToStringStyle {
 

--- a/src/main/java/org/apache/commons/lang3/concurrent/CircuitBreaker.java
+++ b/src/main/java/org/apache/commons/lang3/concurrent/CircuitBreaker.java
@@ -19,7 +19,7 @@ package org.apache.commons.lang3.concurrent;
 /**
  * <p>
  * An interface describing a <a
- * href="http://martinfowler.com/bliki/CircuitBreaker.html">Circuit Breaker</a> component.
+ * href="https://martinfowler.com/bliki/CircuitBreaker.html">Circuit Breaker</a> component.
  * </p>
  * <p>
  * A <em>circuit breaker</em> can be used to protect an application against unreliable

--- a/src/main/java/org/apache/commons/lang3/concurrent/EventCountCircuitBreaker.java
+++ b/src/main/java/org/apache/commons/lang3/concurrent/EventCountCircuitBreaker.java
@@ -25,7 +25,7 @@ import java.util.concurrent.atomic.AtomicReference;
 /**
  * <p>
  * A simple implementation of the <a
- * href="http://martinfowler.com/bliki/CircuitBreaker.html">Circuit Breaker</a> pattern
+ * href="https://martinfowler.com/bliki/CircuitBreaker.html">Circuit Breaker</a> pattern
  * that counts specific events.
  * </p>
  * <p>

--- a/src/main/java/org/apache/commons/lang3/concurrent/ThresholdCircuitBreaker.java
+++ b/src/main/java/org/apache/commons/lang3/concurrent/ThresholdCircuitBreaker.java
@@ -21,7 +21,7 @@ import java.util.concurrent.atomic.AtomicLong;
 /**
  * <p>
  * A simple implementation of the <a
- * href="http://martinfowler.com/bliki/CircuitBreaker.html">Circuit Breaker</a> pattern
+ * href="https://martinfowler.com/bliki/CircuitBreaker.html">Circuit Breaker</a> pattern
  * that opens if the requested increment amount is greater than a given threshold.
  * </p>
  *

--- a/src/main/java/org/apache/commons/lang3/math/Fraction.java
+++ b/src/main/java/org/apache/commons/lang3/math/Fraction.java
@@ -233,7 +233,7 @@ public final class Fraction extends Number implements Comparable<Fraction> {
     /**
      * <p>Creates a {@link Fraction} instance from a {@code double} value.</p>
      *
-     * <p>This method uses the <a href="http://archives.math.utk.edu/articles/atuyl/confrac/">
+     * <p>This method uses the <a href="https://web.archive.org/web/20210516065058/http%3A//archives.math.utk.edu/articles/atuyl/confrac/">
      *  continued fraction algorithm</a>, computing a maximum of
      *  25 convergents and bounding the denominator by 10,000.</p>
      *

--- a/src/main/java/org/apache/commons/lang3/math/IEEE754rUtils.java
+++ b/src/main/java/org/apache/commons/lang3/math/IEEE754rUtils.java
@@ -21,7 +21,7 @@ import org.apache.commons.lang3.Validate;
 /**
  * <p>Provides IEEE-754r variants of NumberUtils methods. </p>
  *
- * <p>See: <a href="http://en.wikipedia.org/wiki/IEEE_754r">http://en.wikipedia.org/wiki/IEEE_754r</a></p>
+ * <p>See: <a href="https://en.wikipedia.org/wiki/IEEE_754r">https://en.wikipedia.org/wiki/IEEE_754r</a></p>
  *
  * @since 2.4
  */

--- a/src/main/java/org/apache/commons/lang3/math/package-info.java
+++ b/src/main/java/org/apache/commons/lang3/math/package-info.java
@@ -17,7 +17,7 @@
 /**
  * <p>Extends {@link java.math} for business mathematical classes.
  * This package is intended for business mathematical use, not scientific use.
- * See <a href="https://commons.apache.org/math/">Commons Math</a> for a more complete set of mathematical classes.
+ * See <a href="https://commons.apache.org/proper/commons-math/">Commons Math</a> for a more complete set of mathematical classes.
  * These classes are immutable, and therefore thread-safe.</p>
  *
  * <p>Although Commons Math also exists, some basic mathematical functions are contained within Lang.

--- a/src/main/java/org/apache/commons/lang3/reflect/FieldUtils.java
+++ b/src/main/java/org/apache/commons/lang3/reflect/FieldUtils.java
@@ -704,7 +704,7 @@ public class FieldUtils {
      *             if the field is {@code null}
      * @deprecated As of Java 12, we can no longer drop the {@code final} modifier, thus
      *             rendering this method obsolete. The JDK discussion about this change can be found
-     *             here: http://mail.openjdk.java.net/pipermail/core-libs-dev/2018-November/056486.html
+     *             here: https://mail.openjdk.java.net/pipermail/core-libs-dev/2018-November/056486.html
      * @since 3.3
      */
     @Deprecated

--- a/src/main/java/org/apache/commons/lang3/text/translate/EntityArrays.java
+++ b/src/main/java/org/apache/commons/lang3/text/translate/EntityArrays.java
@@ -148,7 +148,7 @@ public class EntityArrays {
     private static final String[][] ISO8859_1_UNESCAPE = invert(ISO8859_1_ESCAPE);
 
     /**
-     * Mapping to escape additional <a href="http://www.w3.org/TR/REC-html40/sgml/entities.html">character entity
+     * Mapping to escape additional <a href="https://www.w3.org/TR/REC-html40/sgml/entities.html">character entity
      * references</a>. Note that this must be used with {@link #ISO8859_1_ESCAPE()} to get the full list of
      * HTML 4.0 character entities.
      * @return the mapping table

--- a/src/main/java/org/apache/commons/lang3/time/DurationFormatUtils.java
+++ b/src/main/java/org/apache/commons/lang3/time/DurationFormatUtils.java
@@ -263,7 +263,7 @@ public class DurationFormatUtils {
      * choosing March -&gt; February = 1 month and then calculating days
      * backwards. </p>
      *
-     * <p>For more control, the <a href="http://joda-time.sf.net/">Joda-Time</a>
+     * <p>For more control, the <a href="https://www.joda.org/joda-time/">Joda-Time</a>
      * library is recommended.</p>
      *
      * @param startMillis  the start of the duration

--- a/src/main/java/org/apache/commons/lang3/time/FastDateParser.java
+++ b/src/main/java/org/apache/commons/lang3/time/FastDateParser.java
@@ -59,7 +59,7 @@ import org.apache.commons.lang3.LocaleUtils;
  * This class is especially useful in multi-threaded server environments.
  * {@link SimpleDateFormat} is not thread-safe in any JDK version,
  * nor will it be as Sun has closed the
- * <a href="http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=4228335">bug</a>/RFE.
+ * <a href="https://bugs.java.com/bugdatabase/view_bug.do?bug_id=4228335">bug</a>/RFE.
  * </p>
  *
  * <p>Only parsing is supported by this class, but all patterns are compatible with

--- a/src/site/resources/lang2-lang3-clirr-report.html
+++ b/src/site/resources/lang2-lang3-clirr-report.html
@@ -59,9 +59,9 @@ limitations under the License.
         <span id="publishDate">Last Published: 13 July 2011</span>
                   &nbsp;| <span id="projectVersion">Version: 3.0</span>
                       </div>
-            <div class="xright">                    <a href="http://www.apachecon.com/" class="externalLink" title="ApacheCon">ApacheCon</a>
+            <div class="xright">                    <a href="https://www.apachecon.com/" class="externalLink" title="ApacheCon">ApacheCon</a>
             |
-                        <a href="http://www.apache.org" class="externalLink" title="Apache">Apache</a>
+                        <a href="https://www.apache.org" class="externalLink" title="Apache">Apache</a>
             |
                         <a href="../" title="Commons">Commons</a>
               
@@ -182,7 +182,7 @@ limitations under the License.
                           <a href="../" title="Home">Home</a>
             </li>
                   <li class="none">
-                          <a href="http://www.apache.org/licenses/" class="externalLink" title="License">License</a>
+                          <a href="https://www.apache.org/licenses/" class="externalLink" title="License">License</a>
             </li>
                                                                     <li class="collapsed">
                           <a href="../components.html" title="Components">Components</a>
@@ -209,32 +209,32 @@ limitations under the License.
                           <a href="../releases/index.html" title="Releasing Components">Releasing Components</a>
             </li>
                   <li class="none">
-                          <a href="http://wiki.apache.org/commons/FrontPage" class="externalLink" title="Wiki">Wiki</a>
+                          <a href="https://cwiki.apache.org/confluence/display/commons/FrontPage" class="externalLink" title="Wiki">Wiki</a>
             </li>
           </ul>
                        <h5>ASF</h5>
                   <ul>
                   <li class="none">
-                          <a href="http://www.apache.org/foundation/how-it-works.html" class="externalLink" title="How the ASF works">How the ASF works</a>
+                          <a href="https://www.apache.org/foundation/how-it-works.html" class="externalLink" title="How the ASF works">How the ASF works</a>
             </li>
                   <li class="none">
-                          <a href="http://www.apache.org/foundation/getinvolved.html" class="externalLink" title="Get Involved">Get Involved</a>
+                          <a href="https://www.apache.org/foundation/getinvolved.html" class="externalLink" title="Get Involved">Get Involved</a>
             </li>
                   <li class="none">
-                          <a href="http://www.apache.org/dev/" class="externalLink" title="Developer Resources">Developer Resources</a>
+                          <a href="https://www.apache.org/dev/" class="externalLink" title="Developer Resources">Developer Resources</a>
             </li>
                   <li class="none">
-                          <a href="http://www.apache.org/foundation/sponsorship.html" class="externalLink" title="Sponsorship">Sponsorship</a>
+                          <a href="https://www.apache.org/foundation/sponsorship.html" class="externalLink" title="Sponsorship">Sponsorship</a>
             </li>
                   <li class="none">
-                          <a href="http://www.apache.org/foundation/thanks.html" class="externalLink" title="Thanks">Thanks</a>
+                          <a href="https://www.apache.org/foundation/thanks.html" class="externalLink" title="Thanks">Thanks</a>
             </li>
           </ul>
-                                                                                                                   <a href="http://www.apache.org/events/current-event.html" title="ApacheCon" class="poweredBy">
-        <img class="poweredBy"  alt="ApacheCon" src="http://www.apache.org/events/current-event-125x125.png"    />
+                                                                                                                   <a href="https://apachecon.com/" title="ApacheCon" class="poweredBy">
+        <img class="poweredBy"  alt="ApacheCon" src="https://www.apache.org/events/current-event-125x125.png"    />
       </a>
-                                                                                                    <a href="http://maven.apache.org/" title="Maven" class="poweredBy">
-        <img class="poweredBy"  alt="Maven" src="http://maven.apache.org/images/logos/maven-feather.png"    />
+                                                                                                    <a href="https://maven.apache.org/" title="Maven" class="poweredBy">
+        <img class="poweredBy"  alt="Maven" src="https://maven.apache.org/images/logos/maven-feather.png"    />
       </a>
                        
                 
@@ -250,7 +250,7 @@ limitations under the License.
     </div>
     <div id="footer">
       <div class="center">Copyright &#169;                    2001-2011
-                        <a href="http://www.apache.org/">The Apache Software Foundation</a>.
+                        <a href="https://www.apache.org/">The Apache Software Foundation</a>.
             All Rights Reserved.      
                 
       </div>

--- a/src/site/resources/release-notes/RELEASE-NOTES-2.1.txt
+++ b/src/site/resources/release-notes/RELEASE-NOTES-2.1.txt
@@ -42,7 +42,7 @@ However, we don't recommend that as a long-term solution.)
 If your code previously relied on unusual aspects, it may no longer work.
 
 - Starting with version 2.1, Ant version 1.6.x is required to build. Copy 
-junit.jar to ANT_HOME/lib. You can get JUnit from http://www.junit.org. See the developer's guide
+junit.jar to ANT_HOME/lib. You can get JUnit from https://www.junit.org. See the developer's guide
 for more details.
 
 

--- a/src/site/resources/release-notes/RELEASE-NOTES-2.2.txt
+++ b/src/site/resources/release-notes/RELEASE-NOTES-2.2.txt
@@ -45,7 +45,7 @@ However, we don't recommend that as a long-term solution.)
 If your code previously relied on unusual aspects, it may no longer work.
 
 - Starting with version 2.1, Ant version 1.6.x is required to build. Copy 
-junit.jar to ANT_HOME/lib. You can get JUnit from http://www.junit.org. See the developer's guide
+junit.jar to ANT_HOME/lib. You can get JUnit from https://www.junit.org. See the developer's guide
 for more details.
 
 DEPRECATIONS FROM 2.1 to 2.2:

--- a/src/site/resources/release-notes/RELEASE-NOTES-2.3.txt
+++ b/src/site/resources/release-notes/RELEASE-NOTES-2.3.txt
@@ -47,7 +47,7 @@ However, we don't recommend that as a long-term solution.)
 If your code previously relied on unusual aspects, it may no longer work.
 
 - Starting with version 2.1, Ant version 1.6.x is required to build. Copy 
-junit.jar to ANT_HOME/lib. You can get JUnit from http://www.junit.org. See the developer's guide
+junit.jar to ANT_HOME/lib. You can get JUnit from https://www.junit.org. See the developer's guide
 for more details.
 
 DEPRECATIONS FROM 2.2 to 2.3:

--- a/src/site/resources/release-notes/RELEASE-NOTES-2.4.txt
+++ b/src/site/resources/release-notes/RELEASE-NOTES-2.4.txt
@@ -53,7 +53,7 @@ However, we don't recommend that as a long-term solution.)
 If your code previously relied on unusual aspects, it may no longer work.
 
 - Starting with version 2.1, Ant version 1.6.x is required to build. Copy 
-junit.jar to ANT_HOME/lib. You can get JUnit from http://www.junit.org. See the developer's guide
+junit.jar to ANT_HOME/lib. You can get JUnit from https://www.junit.org. See the developer's guide
 for more details.
 
 DEPRECATIONS FROM 2.3 to 2.4:
@@ -103,7 +103,7 @@ BUG FIXES IN 2.4:
     * [LANG-372] - ToStringBuilder: MULTI_LINE_STYLE does not print anything from appendToString methods.
     * [LANG-380] - infinite loop in Fraction.reduce when numerator == 0
     * [LANG-381] - NumberUtils.min(floatArray) returns wrong value if floatArray[0] happens to be Float.NaN
-    * [LANG-385] - https://commons.apache.org/lang/developerguide.html "Building" section is incorrect and incomplete
+    * [LANG-385] - https://commons.apache.org/proper/commons-lang/developerguide.html "Building" section is incorrect and incomplete
     * [LANG-393] - EqualsBuilder don't compare BigDecimals correctly
     * [LANG-399] - Javadoc bugs - cannot find object
     * [LANG-410] - Ambiguous / confusing names in StringUtils replace* methods

--- a/src/site/resources/release-notes/RELEASE-NOTES-3.5.txt
+++ b/src/site/resources/release-notes/RELEASE-NOTES-3.5.txt
@@ -66,7 +66,7 @@ JAVA 9 SUPPORT
 ==============
 
 Java 9 introduces a new version-string scheme. Details of this new scheme are
-documented in JEP-223 (http://openjdk.java.net/jeps/223). In order to support
+documented in JEP-223 (https://openjdk.org/jeps/223). In order to support
 JEP-223 two classes had to be changed:
 
 o org.apache.commons.lang3.JavaVersion
@@ -86,7 +86,7 @@ BUILDING ON JAVA 9
 
 Java 8 introduced the Unicode Consortium's Common Locale Data Repository as
 alternative source for locale data. Java 9 will use the CLDR provider as
-default provider for locale data (see http://openjdk.java.net/jeps/252). This
+default provider for locale data (see https://openjdk.org/jeps/252). This
 causes a number of locale-sensitive test in Commons Lang to fail. In order
 to build Commons Lang 3.5 on Java 9, the locale provider has to be set to
 'JRE':

--- a/src/site/resources/release-notes/RELEASE-NOTES-3.6.txt
+++ b/src/site/resources/release-notes/RELEASE-NOTES-3.6.txt
@@ -250,7 +250,7 @@ JAVA 9 SUPPORT
 ==============
 
 Java 9 introduces a new version-string scheme. Details of this new scheme are
-documented in JEP-223 (http://openjdk.java.net/jeps/223). In order to support
+documented in JEP-223 (https://openjdk.org/jeps/223). In order to support
 JEP-223 two classes had to be changed:
 
 o org.apache.commons.lang3.JavaVersion
@@ -270,7 +270,7 @@ BUILDING ON JAVA 9
 
 Java 8 introduced the Unicode Consortium's Common Locale Data Repository as
 alternative source for locale data. Java 9 will use the CLDR provider as
-default provider for locale data (see http://openjdk.java.net/jeps/252). This
+default provider for locale data (see https://openjdk.org/jeps/252). This
 causes an number of locale-sensitive test in Commons Lang to fail. In order
 to build Commons Lang 3.5 on Java 9, the locale provider has to be set to
 'JRE':

--- a/src/site/resources/release-notes/RELEASE-NOTES-3.7.txt
+++ b/src/site/resources/release-notes/RELEASE-NOTES-3.7.txt
@@ -302,7 +302,7 @@ JAVA 9 SUPPORT
 ==============
 
 Java 9 introduces a new version-string scheme. Details of this new scheme are
-documented in JEP-223 (http://openjdk.java.net/jeps/223). In order to support
+documented in JEP-223 (https://openjdk.org/jeps/223). In order to support
 JEP-223 two classes had to be changed:
 
 o org.apache.commons.lang3.JavaVersion
@@ -322,7 +322,7 @@ BUILDING ON JAVA 9
 
 Java 8 introduced the Unicode Consortium's Common Locale Data Repository as
 alternative source for locale data. Java 9 will use the CLDR provider as
-default provider for locale data (see http://openjdk.java.net/jeps/252). This
+default provider for locale data (see https://openjdk.org/jeps/252). This
 causes an number of locale-sensitive test in Commons Lang to fail. In order
 to build Commons Lang 3.5 on Java 9, the locale provider has to be set to
 'JRE':

--- a/src/site/resources/release-notes/RELEASE-NOTES-3.8.1.txt
+++ b/src/site/resources/release-notes/RELEASE-NOTES-3.8.1.txt
@@ -396,7 +396,7 @@ JAVA 9 SUPPORT
 ==============
 
 Java 9 introduces a new version-string scheme. Details of this new scheme are
-documented in JEP-223 (http://openjdk.java.net/jeps/223). In order to support
+documented in JEP-223 (https://openjdk.org/jeps/223). In order to support
 JEP-223 two classes had to be changed:
 
 o org.apache.commons.lang3.JavaVersion
@@ -416,7 +416,7 @@ BUILDING ON JAVA 9
 
 Java 8 introduced the Unicode Consortium's Common Locale Data Repository as
 alternative source for locale data. Java 9 will use the CLDR provider as
-default provider for locale data (see http://openjdk.java.net/jeps/252). This
+default provider for locale data (see https://openjdk.org/jeps/252). This
 causes an number of locale-sensitive test in Commons Lang to fail. In order
 to build Commons Lang 3.5 on Java 9, the locale provider has to be set to
 'JRE':

--- a/src/site/resources/release-notes/RELEASE-NOTES-3.8.txt
+++ b/src/site/resources/release-notes/RELEASE-NOTES-3.8.txt
@@ -363,7 +363,7 @@ JAVA 9 SUPPORT
 ==============
 
 Java 9 introduces a new version-string scheme. Details of this new scheme are
-documented in JEP-223 (http://openjdk.java.net/jeps/223). In order to support
+documented in JEP-223 (https://openjdk.org/jeps/223). In order to support
 JEP-223 two classes had to be changed:
 
 o org.apache.commons.lang3.JavaVersion
@@ -383,7 +383,7 @@ BUILDING ON JAVA 9
 
 Java 8 introduced the Unicode Consortium's Common Locale Data Repository as
 alternative source for locale data. Java 9 will use the CLDR provider as
-default provider for locale data (see http://openjdk.java.net/jeps/252). This
+default provider for locale data (see https://openjdk.org/jeps/252). This
 causes an number of locale-sensitive test in Commons Lang to fail. In order
 to build Commons Lang 3.5 on Java 9, the locale provider has to be set to
 'JRE':

--- a/src/site/resources/release-notes/RELEASE-NOTES-3.9.txt
+++ b/src/site/resources/release-notes/RELEASE-NOTES-3.9.txt
@@ -419,7 +419,7 @@ JAVA 9 SUPPORT
 ==============
 
 Java 9 introduces a new version-string scheme. Details of this new scheme are
-documented in JEP-223 (http://openjdk.java.net/jeps/223). In order to support
+documented in JEP-223 (https://openjdk.org/jeps/223). In order to support
 JEP-223 two classes had to be changed:
 
 o org.apache.commons.lang3.JavaVersion
@@ -439,7 +439,7 @@ BUILDING ON JAVA 9
 
 Java 8 introduced the Unicode Consortium's Common Locale Data Repository as
 alternative source for locale data. Java 9 will use the CLDR provider as
-default provider for locale data (see http://openjdk.java.net/jeps/252). This
+default provider for locale data (see https://openjdk.org/jeps/252). This
 causes an number of locale-sensitive test in Commons Lang to fail. In order
 to build Commons Lang 3.5 on Java 9, the locale provider has to be set to
 'JRE':

--- a/src/site/xdoc/article2_4.xml
+++ b/src/site/xdoc/article2_4.xml
@@ -28,11 +28,11 @@ limitations under the License.
 issue to see what went on in the year of development between Lang 2.3 and 2.4.</p>
 <section name="Deprecations">
 <p>First, let us start with a couple of deprecations. As you can see in the release notes, we chose
-to deprecate the <a href="https://commons.apache.org/lang/api-release/org/apache/commons/lang/ObjectUtils.html#appendIdentityToString(java.lang.StringBuffer,%20java.lang.Object)"><code>ObjectUtils.appendIdentityToString(StringBuffer, Object)</code></a> method as its
+to deprecate the <a href="https://commons.apache.org/proper/commons-lang/javadocs/api-2.4/org/apache/commons/lang/ObjectUtils.html#appendIdentityToString(java.lang.StringBuffer,%20java.lang.Object)"><code>ObjectUtils.appendIdentityToString(StringBuffer, Object)</code></a> method as its
 null handling did not match its design (see <a href="https://issues.apache.org/jira/browse/LANG-360">LANG-360</a>
 for more details. Instead users should use <code>ObjectUtils.identityToString(StringBuffer, Object)</code>.</p>
 
-<p>We also deprecated <a href="https://commons.apache.org/lang/api-release/org/apache/commons/lang/time/DateUtils.html#add(java.util.Date,%20int,%20int)"><code>DateUtils.add(java.util.Date, int, int)</code></a>. It should have been <code>private</code>
+<p>We also deprecated <a href="https://commons.apache.org/proper/commons-lang/javadocs/api-2.4/org/apache/commons/lang/time/DateUtils.html#add(java.util.Date,%20int,%20int)"><code>DateUtils.add(java.util.Date, int, int)</code></a>. It should have been <code>private</code>
 from the beginning; please let us know if you actually use it.</p>
 </section>
 <section name="The build">
@@ -42,15 +42,15 @@ successfully under Java 1.3, and that the classes compiled under Java 1.2. As it
 </section>
 <section name="New classes">
 <p>Three new classes were added, so let's cover those next.</p>
-<p>Firstly, we added an <a href="https://commons.apache.org/lang/api-release/org/apache/commons/lang/math/IEEE754rUtils.html"><code>IEEE754rUtils</code></a>
+<p>Firstly, we added an <a href="https://commons.apache.org/proper/commons-lang/javadocs/api-2.4/org/apache/commons/lang/math/IEEE754rUtils.html"><code>IEEE754rUtils</code></a>
 class to the <code>org.apache.commons.lang.math</code> package.
-This candidate for ugly name of the month was needed to add <a href="http://en.wikipedia.org/wiki/IEEE_754r#min_and_max">IEEE-754r</a>
+This candidate for ugly name of the month was needed to add <a href="https://en.wikipedia.org/wiki/IEEE_754r#min_and_max">IEEE-754r</a>
 semantics for some of the <code>NumberUtils</code> methods. The relevant part of that
 IEEE specification in this case is the NaN handling for <code>min</code> and <code>max</code> methods, and
 you can read more about it in <a href="https://issues.apache.org/jira/browse/LANG-381">LANG-381</a>.
 </p>
-<p>Second and third on our newcomers list are the <a href="https://commons.apache.org/lang/api-release/org/apache/commons/lang/text/ExtendedMessageFormat.html"><code>ExtendedMessageFormat</code></a> class and its peer
-<a href="https://commons.apache.org/lang/api-release/org/apache/commons/lang/text/FormatFactory.html"><code>FormatFactory</code></a>
+<p>Second and third on our newcomers list are the <a href="https://commons.apache.org/proper/commons-lang/javadocs/api-2.4/org/apache/commons/lang/text/ExtendedMessageFormat.html"><code>ExtendedMessageFormat</code></a> class and its peer
+<a href="https://commons.apache.org/proper/commons-lang/javadocs/api-2.4/org/apache/commons/lang/text/FormatFactory.html"><code>FormatFactory</code></a>
 interface, both found in the <code>org.apache.commons.lang.text</code> package.</p>
 <p>Together they allow you to take the <code>java.text.MessageFormat</code> class further and insert your own formatting elements.</p>
 <p>
@@ -132,42 +132,42 @@ cases as a <em>true</em> drop-in replacement.
 <section name="New methods">
 <p>There were 58 new methods added to existing Commons Lang classes. Going through each one, one at a time would be dull,
 and fortunately there are some nice groupings that we can discuss instead:</p>
-<p>CharSet <a href="https://commons.apache.org/lang/api-release/org/apache/commons/lang/CharSet.html#getInstance(java.lang.String[])">getInstance(String[])</a> adds an additional builder method by which you can build a CharSet from multiple sets of characters at the same time. If you weren't aware of the CharSet class, it holds a set of characters created by a simple pattern language allowing constructs such as <code>"a-z"</code> and <code>"^a"</code> (everything but 'a'). It's most used by the CharSetUtils class, and came out of CharSetUtils.translate, a simple variant of the UNIX tr command.</p>
-<p>ClassUtils <a href="https://commons.apache.org/lang/api-release/org/apache/commons/lang/ClassUtils.html">canonical name</a> methods are akin to the non '<code>Canonical</code>' methods, except they work with the more human readable <code>int[]</code> type names rather than the JVM versions of <code>[I</code>. This makes them useful for parsing input from developer's configuration files. </p>
-<p>ClassUtils <a href="https://commons.apache.org/lang/api-release/org/apache/commons/lang/ClassUtils.html#toClass(java.lang.Object[])">toClass(String[])</a> is very easy to explain - it calls <code>toClass</code> on each <code>Object</code> in the array and returns an array of <code>Class</code> objects.</p>
-<p>ClassUtils <a href="https://commons.apache.org/lang/api-release/org/apache/commons/lang/ClassUtils.html#wrappersToPrimitives(java.lang.Class[])">wrapper-&gt;primitive</a> conversions are the reflection of the pre-existing <code>primitiveToWrapper</code> methods. Again easy to explain, they turn an array of <code>Integer</code> into an array of <code>int[]</code>.</p>
-<p>ObjectUtils <a href="https://commons.apache.org/lang/api-release/org/apache/commons/lang/ObjectUtils.html#identityToString(java.lang.StringBuffer,%20java.lang.Object)">identityToString(StringBuffer, Object)</a> is the StringBuffer variant of the pre-existing <code>identityToString</code> method. In case you've not met that before, it produces the toString that would have been produced by an Object if it hadn't been overridden.</p>
-<p>StringEscapeUtils <a href="https://commons.apache.org/lang/api-release/org/apache/commons/lang/StringEscapeUtils.html#escapeCsv(java.lang.String)">CSV methods</a> are a new addition to our range of simple parser/printers. These, quite as expected, parse and unparse CSV text as per <a href="http://tools.ietf.org/html/rfc4180">RFC-4180</a>.</p>
+<p>CharSet <a href="https://commons.apache.org/proper/commons-lang/javadocs/api-2.4/org/apache/commons/lang/CharSet.html#getInstance(java.lang.String[])">getInstance(String[])</a> adds an additional builder method by which you can build a CharSet from multiple sets of characters at the same time. If you weren't aware of the CharSet class, it holds a set of characters created by a simple pattern language allowing constructs such as <code>"a-z"</code> and <code>"^a"</code> (everything but 'a'). It's most used by the CharSetUtils class, and came out of CharSetUtils.translate, a simple variant of the UNIX tr command.</p>
+<p>ClassUtils <a href="https://commons.apache.org/proper/commons-lang/javadocs/api-2.4/org/apache/commons/lang/ClassUtils.html">canonical name</a> methods are akin to the non '<code>Canonical</code>' methods, except they work with the more human readable <code>int[]</code> type names rather than the JVM versions of <code>[I</code>. This makes them useful for parsing input from developer's configuration files. </p>
+<p>ClassUtils <a href="https://commons.apache.org/proper/commons-lang/javadocs/api-2.4/org/apache/commons/lang/ClassUtils.html#toClass(java.lang.Object[])">toClass(String[])</a> is very easy to explain - it calls <code>toClass</code> on each <code>Object</code> in the array and returns an array of <code>Class</code> objects.</p>
+<p>ClassUtils <a href="https://commons.apache.org/proper/commons-lang/javadocs/api-2.4/org/apache/commons/lang/ClassUtils.html#wrappersToPrimitives(java.lang.Class[])">wrapper-&gt;primitive</a> conversions are the reflection of the pre-existing <code>primitiveToWrapper</code> methods. Again easy to explain, they turn an array of <code>Integer</code> into an array of <code>int[]</code>.</p>
+<p>ObjectUtils <a href="https://commons.apache.org/proper/commons-lang/javadocs/api-2.4/org/apache/commons/lang/ObjectUtils.html#identityToString(java.lang.StringBuffer,%20java.lang.Object)">identityToString(StringBuffer, Object)</a> is the StringBuffer variant of the pre-existing <code>identityToString</code> method. In case you've not met that before, it produces the toString that would have been produced by an Object if it hadn't been overridden.</p>
+<p>StringEscapeUtils <a href="https://commons.apache.org/proper/commons-lang/javadocs/api-2.4/org/apache/commons/lang/StringEscapeUtils.html#escapeCsv(java.lang.String)">CSV methods</a> are a new addition to our range of simple parser/printers. These, quite as expected, parse and unparse CSV text as per <a href="https://datatracker.ietf.org/doc/html/rfc4180">RFC-4180</a>.</p>
 <p>StringUtils has a host of new methods, as always, and we'll leave these for later.</p>
-<p>WordUtils <a href="https://commons.apache.org/lang/api-release/org/apache/commons/lang/WordUtils.html#abbreviate(java.lang.String,%20int,%20int,%20java.lang.String)">abbreviate</a> finds the first space after the lower limit and abbreviates the text.</p>
-<p>math.<a href="https://commons.apache.org/lang/api-release/org/apache/commons/lang/math/IntRange.html#toArray()">IntRange</a>/<a href="https://commons.apache.org/lang/api-release/org/apache/commons/lang/math/LongRange.html#toArray()">LongRange.toArray</a> turn the range into an array of primitive <code>int</code>/<code>long</code>s contained in the range.</p>
-<p>text.StrMatch.<a href="https://commons.apache.org/lang/api-release/org/apache/commons/lang/text/StrMatcher.html#isMatch(char[],%20int)">isMatch(char[], int)</a> is a helper method for checking whether there was a match with the StrMatcher objects.</p>
-<p>time.DateFormatUtils <a href="https://commons.apache.org/lang/api-release/org/apache/commons/lang/time/DateFormatUtils.html">format(Calendar, ...)</a> provide Calendar variants for the pre-existing format methods. If these are new to you, they are helper methods to formatting a date.</p>
-<p>time.DateUtils <a href="https://commons.apache.org/lang/api-release/org/apache/commons/lang/time/DateUtils.html">getFragment*</a> methods are used to splice the time element out of Date. If you have <code>2008/12/13 14:57</code>, then these could, for example, pull out the 13.</p>
-<p>time.DateUtils <a href="https://commons.apache.org/lang/api-release/org/apache/commons/lang/time/DateUtils.html">setXxx methods</a> round off our walk through the methods - the setXxx variant of the existing addXxx helper methods.</p>
+<p>WordUtils <a href="https://commons.apache.org/proper/commons-lang/javadocs/api-2.4/org/apache/commons/lang/WordUtils.html#abbreviate(java.lang.String,%20int,%20int,%20java.lang.String)">abbreviate</a> finds the first space after the lower limit and abbreviates the text.</p>
+<p>math.<a href="https://commons.apache.org/proper/commons-lang/javadocs/api-2.4/org/apache/commons/lang/math/IntRange.html#toArray()">IntRange</a>/<a href="https://commons.apache.org/proper/commons-lang/javadocs/api-2.4/org/apache/commons/lang/math/LongRange.html#toArray()">LongRange.toArray</a> turn the range into an array of primitive <code>int</code>/<code>long</code>s contained in the range.</p>
+<p>text.StrMatch.<a href="https://commons.apache.org/proper/commons-lang/javadocs/api-2.4/org/apache/commons/lang/text/StrMatcher.html#isMatch(char[],%20int)">isMatch(char[], int)</a> is a helper method for checking whether there was a match with the StrMatcher objects.</p>
+<p>time.DateFormatUtils <a href="https://commons.apache.org/proper/commons-lang/javadocs/api-2.4/org/apache/commons/lang/time/DateFormatUtils.html">format(Calendar, ...)</a> provide Calendar variants for the pre-existing format methods. If these are new to you, they are helper methods to formatting a date.</p>
+<p>time.DateUtils <a href="https://commons.apache.org/proper/commons-lang/javadocs/api-2.4/org/apache/commons/lang/time/DateUtils.html">getFragment*</a> methods are used to splice the time element out of Date. If you have <code>2008/12/13 14:57</code>, then these could, for example, pull out the 13.</p>
+<p>time.DateUtils <a href="https://commons.apache.org/proper/commons-lang/javadocs/api-2.4/org/apache/commons/lang/time/DateUtils.html">setXxx methods</a> round off our walk through the methods - the setXxx variant of the existing addXxx helper methods.</p>
 </section>
 
 <section name="StringUtils methods">
 <p>The <code>StringUtils</code> class is a little large, isn't it? Sorry, but it's gotten bigger.
 </p>
 <ul>
-  <li><a href="https://commons.apache.org/lang/api-release/org/apache/commons/lang/StringUtils.html#containsOnly(java.lang.String,%20char[])">boolean containsAny(String, char[])</a></li>
-  <li><a href="https://commons.apache.org/lang/api-release/org/apache/commons/lang/StringUtils.html#containsOnly(java.lang.String,%20java.lang.String)">boolean containsAny(String, String)</a></li>
-  <li><a href="https://commons.apache.org/lang/api-release/org/apache/commons/lang/StringUtils.html#endsWith(java.lang.String,%20java.lang.String)">boolean endsWith(String, String)</a></li>
-  <li><a href="https://commons.apache.org/lang/api-release/org/apache/commons/lang/StringUtils.html#endsWithIgnoreCase(java.lang.String,%20java.lang.String)">boolean endsWithIgnoreCase(String, String)</a></li>
-  <li><a href="https://commons.apache.org/lang/api-release/org/apache/commons/lang/StringUtils.html#getCommonPrefix(java.lang.String[])">String getCommonPrefix(String[])</a></li>
-  <li><a href="https://commons.apache.org/lang/api-release/org/apache/commons/lang/StringUtils.html#indexOfDifference(java.lang.String[])">int indexOfDifference(String[])</a></li>
-  <li><a href="https://commons.apache.org/lang/api-release/org/apache/commons/lang/StringUtils.html#length(java.lang.String)">int length(String)</a></li>
-  <li><a href="https://commons.apache.org/lang/api-release/org/apache/commons/lang/StringUtils.html#removeEndIgnoreCase(java.lang.String,%20java.lang.String)">String removeEndIgnoreCase(String, String)</a></li>
-  <li><a href="https://commons.apache.org/lang/api-release/org/apache/commons/lang/StringUtils.html#removeStartIgnoreCase(java.lang.String,%20java.lang.String)">String removeStartIgnoreCase(String, String)</a></li>
-  <li><a href="https://commons.apache.org/lang/api-release/org/apache/commons/lang/StringUtils.html#replaceEach(java.lang.String,%20java.lang.String[],%20java.lang.String[])">String replaceEach(String, String[], String[])</a></li>
-  <li><a href="https://commons.apache.org/lang/api-release/org/apache/commons/lang/StringUtils.html#replaceEachRepeatedly(java.lang.String,%20java.lang.String[],%20java.lang.String[])">String replaceEachRepeatedly(String, String[], String[])</a></li>
-  <li><a href="https://commons.apache.org/lang/api-release/org/apache/commons/lang/StringUtils.html#splitByCharacterType(java.lang.String)">String[] splitByCharacterType(String)</a></li>
-  <li><a href="https://commons.apache.org/lang/api-release/org/apache/commons/lang/StringUtils.html#splitByCharacterTypeCamelCase(java.lang.String)">String[] splitByCharacterTypeCamelCase(String)</a></li>
-  <li><a href="https://commons.apache.org/lang/api-release/org/apache/commons/lang/StringUtils.html#splitByWholeSeparatorPreserveAllTokens(java.lang.String,%20java.lang.String)">String[] splitByWholeSeparatorPreserveAllTokens(String, String)</a></li>
-  <li><a href="https://commons.apache.org/lang/api-release/org/apache/commons/lang/StringUtils.html#splitByWholeSeparatorPreserveAllTokens(java.lang.String,%20java.lang.String,%20int)">String[] splitByWholeSeparatorPreserveAllTokens(String, String, int)</a></li>
-  <li><a href="https://commons.apache.org/lang/api-release/org/apache/commons/lang/StringUtils.html#startsWith(java.lang.String,%20java.lang.String)">boolean startsWith(String, String)</a></li>
-  <li><a href="https://commons.apache.org/lang/api-release/org/apache/commons/lang/StringUtils.html#startsWithIgnoreCase(java.lang.String,%20java.lang.String)">boolean startsWithIgnoreCase(String, String)</a></li>
+  <li><a href="https://commons.apache.org/proper/commons-lang/javadocs/api-2.4/org/apache/commons/lang/StringUtils.html#containsOnly(java.lang.String,%20char[])">boolean containsAny(String, char[])</a></li>
+  <li><a href="https://commons.apache.org/proper/commons-lang/javadocs/api-2.4/org/apache/commons/lang/StringUtils.html#containsOnly(java.lang.String,%20java.lang.String)">boolean containsAny(String, String)</a></li>
+  <li><a href="https://commons.apache.org/proper/commons-lang/javadocs/api-2.4/org/apache/commons/lang/StringUtils.html#endsWith(java.lang.String,%20java.lang.String)">boolean endsWith(String, String)</a></li>
+  <li><a href="https://commons.apache.org/proper/commons-lang/javadocs/api-2.4/org/apache/commons/lang/StringUtils.html#endsWithIgnoreCase(java.lang.String,%20java.lang.String)">boolean endsWithIgnoreCase(String, String)</a></li>
+  <li><a href="https://commons.apache.org/proper/commons-lang/javadocs/api-2.4/org/apache/commons/lang/StringUtils.html#getCommonPrefix(java.lang.String[])">String getCommonPrefix(String[])</a></li>
+  <li><a href="https://commons.apache.org/proper/commons-lang/javadocs/api-2.4/org/apache/commons/lang/StringUtils.html#indexOfDifference(java.lang.String[])">int indexOfDifference(String[])</a></li>
+  <li><a href="https://commons.apache.org/proper/commons-lang/javadocs/api-2.4/org/apache/commons/lang/StringUtils.html#length(java.lang.String)">int length(String)</a></li>
+  <li><a href="https://commons.apache.org/proper/commons-lang/javadocs/api-2.4/org/apache/commons/lang/StringUtils.html#removeEndIgnoreCase(java.lang.String,%20java.lang.String)">String removeEndIgnoreCase(String, String)</a></li>
+  <li><a href="https://commons.apache.org/proper/commons-lang/javadocs/api-2.4/org/apache/commons/lang/StringUtils.html#removeStartIgnoreCase(java.lang.String,%20java.lang.String)">String removeStartIgnoreCase(String, String)</a></li>
+  <li><a href="https://commons.apache.org/proper/commons-lang/javadocs/api-2.4/org/apache/commons/lang/StringUtils.html#replaceEach(java.lang.String,%20java.lang.String[],%20java.lang.String[])">String replaceEach(String, String[], String[])</a></li>
+  <li><a href="https://commons.apache.org/proper/commons-lang/javadocs/api-2.4/org/apache/commons/lang/StringUtils.html#replaceEachRepeatedly(java.lang.String,%20java.lang.String[],%20java.lang.String[])">String replaceEachRepeatedly(String, String[], String[])</a></li>
+  <li><a href="https://commons.apache.org/proper/commons-lang/javadocs/api-2.4/org/apache/commons/lang/StringUtils.html#splitByCharacterType(java.lang.String)">String[] splitByCharacterType(String)</a></li>
+  <li><a href="https://commons.apache.org/proper/commons-lang/javadocs/api-2.4/org/apache/commons/lang/StringUtils.html#splitByCharacterTypeCamelCase(java.lang.String)">String[] splitByCharacterTypeCamelCase(String)</a></li>
+  <li><a href="https://commons.apache.org/proper/commons-lang/javadocs/api-2.4/org/apache/commons/lang/StringUtils.html#splitByWholeSeparatorPreserveAllTokens(java.lang.String,%20java.lang.String)">String[] splitByWholeSeparatorPreserveAllTokens(String, String)</a></li>
+  <li><a href="https://commons.apache.org/proper/commons-lang/javadocs/api-2.4/org/apache/commons/lang/StringUtils.html#splitByWholeSeparatorPreserveAllTokens(java.lang.String,%20java.lang.String,%20int)">String[] splitByWholeSeparatorPreserveAllTokens(String, String, int)</a></li>
+  <li><a href="https://commons.apache.org/proper/commons-lang/javadocs/api-2.4/org/apache/commons/lang/StringUtils.html#startsWith(java.lang.String,%20java.lang.String)">boolean startsWith(String, String)</a></li>
+  <li><a href="https://commons.apache.org/proper/commons-lang/javadocs/api-2.4/org/apache/commons/lang/StringUtils.html#startsWithIgnoreCase(java.lang.String,%20java.lang.String)">boolean startsWithIgnoreCase(String, String)</a></li>
 </ul>
 
 <p>Hopefully they are in many cases self-describing. Rather than spend a lot of time describing them, we'll let you read the Javadoc of the ones that interest you.</p>

--- a/src/site/xdoc/article2_5.xml
+++ b/src/site/xdoc/article2_5.xml
@@ -48,19 +48,19 @@ The classes are: </p>
 </section>
 <section name="New fields">
 <p>With both Java 7 and Windows 7 becoming a reality, 
-<a href="https://commons.apache.org/lang/api-release/org/apache/commons/lang/SystemUtils.html">SystemUtils</a> was updated to 
+<a href="https://commons.apache.org/proper/commons-lang/javadocs/api-2.5/org/apache/commons/lang/SystemUtils.html">SystemUtils</a> was updated to
 provide boolean fields for both versions. </p>
 </section>
 <section name="New methods">
 <p>There were 66 new methods added to existing Commons Lang classes. </p>
-<p>The <a href="https://commons.apache.org/lang/api-release/org/apache/commons/lang/ArrayUtils.html">ArrayUtils</a> class 
+<p>The <a href="https://commons.apache.org/proper/commons-lang/javadocs/api-2.5/org/apache/commons/lang/ArrayUtils.html">ArrayUtils</a> class
 received two new types of methods. Firstly, a boolean isNotEmpty(array) set of methods, identifying whether the particular 
 array is null or an empty sized array. This makes it the inverse of the existing isEmpty(array) methods. Secondly, an array 
 nullToEmpty(array) set of methods that converts null or empty arrays to a singleton empty array already available from the 
 ArrayUtils class. Non-null/empty arrays are left untouched. </p>
 
 <p>The constructor for the 
-<a href="https://commons.apache.org/lang/api-release/org/apache/commons/lang/CharRange.html">CharRange</a> class is somewhat 
+<a href="https://commons.apache.org/proper/commons-lang/javadocs/api-2.5/org/apache/commons/lang/CharRange.html">CharRange</a> class is somewhat
 confusing. It takes a boolean parameter that when set to true means the CharRange is negated. To make code easier to read, the 
 following static helper methods were added: </p>
 <ul>
@@ -71,18 +71,18 @@ following static helper methods were added: </p>
 </ul>
 <p>An iterator() method was also added to provide another way of walking the range. </p>
 
-<p>The <a href="https://commons.apache.org/lang/api-release/org/apache/commons/lang/builder/EqualsBuilder.html">EqualsBuilder</a> 
+<p>The <a href="https://commons.apache.org/proper/commons-lang/javadocs/api-2.5/org/apache/commons/lang/builder/EqualsBuilder.html">EqualsBuilder</a>
 obtained a new reset() method to allow for reuse, while the 
-<a href="https://commons.apache.org/lang/api-release/org/apache/commons/lang/builder/HashCodeBuilder.html">HashCodeBuilder</a> 
+<a href="https://commons.apache.org/proper/commons-lang/javadocs/api-2.5/org/apache/commons/lang/builder/HashCodeBuilder.html">HashCodeBuilder</a>
 received a hashCode() method that returns the built hash code instead of the natural hash code of the builder object itself. It 
 doesn't really matter what the builder chooses to use as a hash code and this stops accidental use of the hashCode() instead of 
 toHashCode() method from causing lots of pain. </p>
 
 <p>Helper isFalse(), isTrue() and toBoolean() methods were added to 
-<a href="https://commons.apache.org/lang/api-release/org/apache/commons/lang/mutable/MutableBoolean.html">MutableBoolean</a>, 
+<a href="https://commons.apache.org/proper/commons-lang/javadocs/api-2.5/org/apache/commons/lang/mutable/MutableBoolean.html">MutableBoolean</a>,
 while the other mutable classes received String argument constructors. </p>
 
-<p>Lastly, the <a href="https://commons.apache.org/lang/api-release/org/apache/commons/lang/time/DateUtils.html">DateUtils</a> 
+<p>Lastly, the <a href="https://commons.apache.org/proper/commons-lang/javadocs/api-2.5/org/apache/commons/lang/time/DateUtils.html">DateUtils</a>
 class received a new ceiling set of methods to truncate upwards, and a parseDateStrictly method to parse a Date with the 
 supplied DateFormat classes leniency set to false. </p>
 
@@ -90,7 +90,7 @@ supplied DateFormat classes leniency set to false. </p>
 
 <section name="StringUtils methods">
 <p>As with 2.4, the 
-<a href="https://commons.apache.org/lang/api-release/org/apache/commons/lang/StringUtils.html">StringUtils</a> class has 
+<a href="https://commons.apache.org/proper/commons-lang/javadocs/api-2.5/org/apache/commons/lang/StringUtils.html">StringUtils</a> class has
 grown and we cover its new methods in its own section. </p>
 <ul>
 <li>abbreviateMiddle(String, String, int);String - This method turns aRatherLongNameSuchAsAFileName into 'aRatherLo...AFileName'. 

--- a/src/site/xdoc/building.xml
+++ b/src/site/xdoc/building.xml
@@ -24,8 +24,7 @@ limitations under the License.
 <!-- ================================================== -->
 <section name="Overview">
 <p>
-  Commons Lang uses <a href="http://maven.apache.org">Maven</a> or
-  <a href="http://ant.apache.org">Ant</a> as a build system.
+  Commons Lang uses <a href="https://maven.apache.org">Maven</a>.
 </p>
 <p>
   You may also be interested in the upgrade notes:

--- a/src/site/xdoc/issue-tracking.xml
+++ b/src/site/xdoc/issue-tracking.xml
@@ -57,7 +57,7 @@ limitations under the License.
       <p>
       To use JIRA you may need to <a href="https://issues.apache.org/jira/secure/Signup!default.jspa">create an account</a>
       (if you have previously created/updated Commons issues using Bugzilla an account will have been automatically
-      created and you can use the <a href="https://issues.apache.org/jira/secure/ForgotPassword!default.jspa">Forgot Password</a>
+      created and you can use the <a href="https://issues.apache.org/jira/secure/ForgotLoginDetails.jspa">Forgot Password</a>
       page to get a new password).
       </p>
 

--- a/src/site/xdoc/upgradeto2_1.xml
+++ b/src/site/xdoc/upgradeto2_1.xml
@@ -49,7 +49,7 @@ However, we don't recommend that as a long-term solution.)
 If your code previously relied on unusual aspects, it may no longer work.
 
 - Starting with version 2.1, Ant version 1.6.x is required to build. Copy 
-junit.jar to ANT_HOME/lib. You can get JUnit from http://www.junit.org. See the developer's guide
+junit.jar to ANT_HOME/lib. You can get JUnit from https://www.junit.org. See the developer's guide
 for more details.
 
 

--- a/src/site/xdoc/upgradeto2_3.xml
+++ b/src/site/xdoc/upgradeto2_3.xml
@@ -54,7 +54,7 @@ However, we don't recommend that as a long-term solution.)
 If your code previously relied on unusual aspects, it may no longer work.
 
 - Starting with version 2.1, Ant version 1.6.x is required to build. Copy 
-junit.jar to ANT_HOME/lib. You can get JUnit from http://www.junit.org. See the developer's guide
+junit.jar to ANT_HOME/lib. You can get JUnit from https://www.junit.org. See the developer's guide
 for more details.
 
 DEPRECATIONS FROM 2.2 to 2.3:

--- a/src/site/xdoc/upgradeto2_4.xml
+++ b/src/site/xdoc/upgradeto2_4.xml
@@ -60,7 +60,7 @@ However, we don't recommend that as a long-term solution.)
 If your code previously relied on unusual aspects, it may no longer work.
 
 - Starting with version 2.1, Ant version 1.6.x is required to build. Copy 
-junit.jar to ANT_HOME/lib. You can get JUnit from http://www.junit.org. See the developer's guide
+junit.jar to ANT_HOME/lib. You can get JUnit from https://www.junit.org. See the developer's guide
 for more details.
 
 DEPRECATIONS FROM 2.3 to 2.4:
@@ -110,7 +110,7 @@ BUG FIXES IN 2.4:
     * [LANG-372] - ToStringBuilder: MULTI_LINE_STYLE does not print anything from appendToString methods.
     * [LANG-380] - infinite loop in Fraction.reduce when numerator == 0
     * [LANG-381] - NumberUtils.min(floatArray) returns wrong value if floatArray[0] happens to be Float.NaN
-    * [LANG-385] - https://commons.apache.org/lang/developerguide.html "Building" section is incorrect and incomplete
+    * [LANG-385] - https://commons.apache.org/proper/commons-lang/developerguide.html "Building" section is incorrect and incomplete
     * [LANG-393] - EqualsBuilder don't compare BigDecimals correctly
     * [LANG-399] - Javadoc bugs - cannot find object
     * [LANG-410] - Ambiguous / confusing names in StringUtils replace* methods

--- a/src/test/java/org/apache/commons/lang3/ClassUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/ClassUtilsTest.java
@@ -1424,7 +1424,7 @@ public class ClassUtilsTest extends AbstractLangTest {
         assertNull(ClassUtils.primitiveToWrapper(null), "null -> null");
     }
 
-    // Show the Java bug: http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=4071957
+    // Show the Java bug: https://bugs.java.com/bugdatabase/view_bug.do?bug_id=4071957
     // We may have to delete this if a JDK fixes the bug.
     @Test
     public void testShowJavaBug() throws Exception {

--- a/src/test/java/org/apache/commons/lang3/LocaleUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/LocaleUtilsTest.java
@@ -204,7 +204,7 @@ public class LocaleUtilsTest extends AbstractLangTest {
         assertValidToLocale("us_EN_A", "us", "EN", "A");
         assertValidToLocale("us-EN-A", "us", "EN", "A");
         // this isn't pretty, but was caused by a jdk bug it seems
-        // http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=4210525
+        // https://bugs.java.com/bugdatabase/view_bug.do?bug_id=4210525
         if (SystemUtils.isJavaVersionAtLeast(JAVA_1_4)) {
             assertValidToLocale("us_EN_a", "us", "EN", "a");
             assertValidToLocale("us_EN_SFsafdFDsdfF", "us", "EN", "SFsafdFDsdfF");

--- a/src/test/java/org/apache/commons/lang3/StringEscapeUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringEscapeUtilsTest.java
@@ -318,7 +318,7 @@ public class StringEscapeUtilsTest extends AbstractLangTest {
     /**
      * Tests Supplementary characters.
      * <p>
-     * From http://www.w3.org/International/questions/qa-escapes
+     * From https://www.w3.org/International/questions/qa-escapes
      * </p>
      * <blockquote>
      * Supplementary characters are those Unicode characters that have code points higher than the characters in
@@ -327,7 +327,7 @@ public class StringEscapeUtilsTest extends AbstractLangTest {
      * - you must use the single, code point value for that character. For example, use &amp;&#35;x233B4&#59; rather than
      * &amp;&#35;xD84C&#59;&amp;&#35;xDFB4&#59;.
      * </blockquote>
-     * @see <a href="http://www.w3.org/International/questions/qa-escapes">Using character escapes in markup and CSS</a>
+     * @see <a href="https://www.w3.org/International/questions/qa-escapes">Using character escapes in markup and CSS</a>
      * @see <a href="https://issues.apache.org/jira/browse/LANG-728">LANG-728</a>
      */
     @Test
@@ -344,7 +344,7 @@ public class StringEscapeUtilsTest extends AbstractLangTest {
 
     @Test
     public void testEscapeXmlAllCharacters() {
-        // http://www.w3.org/TR/xml/#charsets says:
+        // https://www.w3.org/TR/xml/#charsets says:
         // Char ::= #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF] /* any Unicode character,
         // excluding the surrogate blocks, FFFE, and FFFF. */
         final CharSequenceTranslator escapeXml = StringEscapeUtils.ESCAPE_XML
@@ -374,8 +374,8 @@ public class StringEscapeUtilsTest extends AbstractLangTest {
                 "Supplementary characters mixed with basic characters should be decoded correctly");
     }
 
-    // Tests issue #38569
-    // https://issues.apache.org/bugzilla/show_bug.cgi?id=38569
+    // Tests issue LANG-150
+    // https://issues.apache.org/jira/browse/LANG-150
     @Test
     public void testStandaloneAmphersand() {
         assertEquals("<P&O>", StringEscapeUtils.unescapeHtml4("&lt;P&O&gt;"));

--- a/src/test/java/org/apache/commons/lang3/StringUtilsContainsTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringUtilsContainsTest.java
@@ -61,7 +61,7 @@ public class StringUtilsContainsTest extends AbstractLangTest {
     }
 
     /**
-     * See http://www.oracle.com/technetwork/articles/javase/supplementary-142654.html
+     * See https://www.oracle.com/technical-resources/articles/javase/supplementary.html
      */
     @Test
     public void testContains_StringWithBadSupplementaryChars() {
@@ -76,7 +76,7 @@ public class StringUtilsContainsTest extends AbstractLangTest {
     }
 
     /**
-     * See http://www.oracle.com/technetwork/articles/javase/supplementary-142654.html
+     * See https://www.oracle.com/technical-resources/articles/javase/supplementary.html
      */
     @Test
     public void testContains_StringWithSupplementaryChars() {
@@ -105,7 +105,7 @@ public class StringUtilsContainsTest extends AbstractLangTest {
     }
 
     /**
-     * See http://www.oracle.com/technetwork/articles/javase/supplementary-142654.html
+     * See https://www.oracle.com/technical-resources/articles/javase/supplementary.html
      */
     @Test
     public void testContainsAny_StringCharArrayWithBadSupplementaryChars() {
@@ -120,7 +120,7 @@ public class StringUtilsContainsTest extends AbstractLangTest {
     }
 
     /**
-     * See http://www.oracle.com/technetwork/articles/javase/supplementary-142654.html
+     * See https://www.oracle.com/technical-resources/articles/javase/supplementary.html
      */
     @Test
     public void testContainsAny_StringCharArrayWithSupplementaryChars() {
@@ -200,7 +200,7 @@ public class StringUtilsContainsTest extends AbstractLangTest {
     }
 
     /**
-     * See http://www.oracle.com/technetwork/articles/javase/supplementary-142654.html
+     * See https://www.oracle.com/technical-resources/articles/javase/supplementary.html
      */
     @Test
     public void testContainsAny_StringWithBadSupplementaryChars() {
@@ -214,7 +214,7 @@ public class StringUtilsContainsTest extends AbstractLangTest {
     }
 
     /**
-     * See http://www.oracle.com/technetwork/articles/javase/supplementary-142654.html
+     * See https://www.oracle.com/technical-resources/articles/javase/supplementary.html
      */
     @Test
     public void testContainsAny_StringWithSupplementaryChars() {
@@ -315,7 +315,7 @@ public class StringUtilsContainsTest extends AbstractLangTest {
     }
 
     /**
-     * See http://www.oracle.com/technetwork/articles/javase/supplementary-142654.html
+     * See https://www.oracle.com/technical-resources/articles/javase/supplementary.html
      */
     @Test
     public void testContainsNone_CharArrayWithBadSupplementaryChars() {
@@ -330,7 +330,7 @@ public class StringUtilsContainsTest extends AbstractLangTest {
     }
 
     /**
-     * See http://www.oracle.com/technetwork/articles/javase/supplementary-142654.html
+     * See https://www.oracle.com/technical-resources/articles/javase/supplementary.html
      */
     @Test
     public void testContainsNone_CharArrayWithSupplementaryChars() {
@@ -372,7 +372,7 @@ public class StringUtilsContainsTest extends AbstractLangTest {
     }
 
     /**
-     * See http://www.oracle.com/technetwork/articles/javase/supplementary-142654.html
+     * See https://www.oracle.com/technical-resources/articles/javase/supplementary.html
      */
     @Test
     public void testContainsNone_StringWithBadSupplementaryChars() {
@@ -387,7 +387,7 @@ public class StringUtilsContainsTest extends AbstractLangTest {
     }
 
     /**
-     * See http://www.oracle.com/technetwork/articles/javase/supplementary-142654.html
+     * See https://www.oracle.com/technical-resources/articles/javase/supplementary.html
      */
     @Test
     public void testContainsNone_StringWithSupplementaryChars() {

--- a/src/test/java/org/apache/commons/lang3/StringUtilsEqualsIndexOfTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringUtilsEqualsIndexOfTest.java
@@ -369,7 +369,7 @@ public class StringUtilsEqualsIndexOfTest extends AbstractLangTest {
     }
 
     /**
-     * See http://www.oracle.com/technetwork/articles/javase/supplementary-142654.html
+     * See https://www.oracle.com/technical-resources/articles/javase/supplementary.html
      */
     @Test
     public void testIndexOfAny_StringCharArrayWithSupplementaryChars() {
@@ -415,7 +415,7 @@ public class StringUtilsEqualsIndexOfTest extends AbstractLangTest {
     }
 
     /**
-     * See http://www.oracle.com/technetwork/articles/javase/supplementary-142654.html
+     * See https://www.oracle.com/technical-resources/articles/javase/supplementary.html
      */
     @Test
     public void testIndexOfAny_StringStringWithSupplementaryChars() {

--- a/src/test/java/org/apache/commons/lang3/Supplementary.java
+++ b/src/test/java/org/apache/commons/lang3/Supplementary.java
@@ -20,29 +20,29 @@ package org.apache.commons.lang3;
 /**
  * Supplementary character test fixtures.
  *
- * See http://www.oracle.com/technetwork/articles/javase/supplementary-142654.html
+ * See https://www.oracle.com/technical-resources/articles/javase/supplementary.html
  */
 public class Supplementary {
 
     /**
-     * Supplementary character U+20000 See http://www.oracle.com/technetwork/articles/javase/supplementary-142654.html
+     * Supplementary character U+20000 See https://www.oracle.com/technical-resources/articles/javase/supplementary.html
      */
     static final String CharU20000 = "\uD840\uDC00";
 
     /**
-     * Supplementary character U+20001 See http://www.oracle.com/technetwork/articles/javase/supplementary-142654.html
+     * Supplementary character U+20001 See https://www.oracle.com/technical-resources/articles/javase/supplementary.html
      */
     static final String CharU20001 = "\uD840\uDC01";
 
     /**
      * Incomplete supplementary character U+20000, high surrogate only. See
-     * http://www.oracle.com/technetwork/articles/javase/supplementary-142654.html
+     * https://www.oracle.com/technical-resources/articles/javase/supplementary.html
      */
     static final String CharUSuppCharHigh = "\uDC00";
 
     /**
      * Incomplete supplementary character U+20000, low surrogate only. See
-     * http://www.oracle.com/technetwork/articles/javase/supplementary-142654.html
+     * https://www.oracle.com/technical-resources/articles/javase/supplementary.html
      */
     static final String CharUSuppCharLow = "\uD840";
 

--- a/src/test/java/org/apache/commons/lang3/builder/EqualsBuilderTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/EqualsBuilderTest.java
@@ -1186,7 +1186,7 @@ public class EqualsBuilderTest extends AbstractLangTest {
     /**
      * Tests two instances of classes that can be equal and that are not "related". The two classes are not subclasses
      * of each other and do not share a parent aside from Object.
-     * See https://issues.apache.org/bugzilla/show_bug.cgi?id=33069
+     * See https://issues.apache.org/jira/browse/LANG-6
      */
     @Test
     public void testUnrelatedClasses() {
@@ -1210,7 +1210,7 @@ public class EqualsBuilderTest extends AbstractLangTest {
     }
 
     /**
-     * Test from https://issues.apache.org/bugzilla/show_bug.cgi?id=33067
+     * Test from https://issues.apache.org/jira/browse/LANG-42
      */
     @Test
     public void testNpeForNullElement() {
@@ -1218,7 +1218,7 @@ public class EqualsBuilderTest extends AbstractLangTest {
         final Object[] x2 = {Integer.valueOf(1), Integer.valueOf(2), Integer.valueOf(3)};
 
         // causes an NPE in 2.0 according to:
-        // https://issues.apache.org/bugzilla/show_bug.cgi?id=33067
+        // https://issues.apache.org/jira/browse/LANG-42
         new EqualsBuilder().append(x1, x2);
     }
 

--- a/src/test/java/org/apache/commons/lang3/time/DurationFormatUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/DurationFormatUtilsTest.java
@@ -484,7 +484,7 @@ public class DurationFormatUtilsTest extends AbstractLangTest {
         text = DurationFormatUtils.formatPeriod(base.getTime().getTime(), cal.getTime().getTime(),
                 DurationFormatUtils.ISO_EXTENDED_FORMAT_PATTERN, false, timeZone);
         assertEquals("P32Y1M22DT9H11M12.001S", text);
-        // test fixture from example in http://www.w3.org/TR/xmlschema-2/#duration
+        // test fixture from example in https://www.w3.org/TR/xmlschema-2/#duration
         cal.set(1971, Calendar.FEBRUARY, 3, 10, 30, 0);
         cal.set(Calendar.MILLISECOND, 0);
         text = DurationFormatUtils.formatPeriod(base.getTime().getTime(), cal.getTime().getTime(),

--- a/src/test/java/org/apache/commons/lang3/time/FastDateParserTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/FastDateParserTest.java
@@ -151,7 +151,7 @@ public class FastDateParserTest extends AbstractLangTest {
         final Calendar cal = Calendar.getInstance(zone, locale);
         cal.clear();
 
-        // http://docs.oracle.com/javase/6/docs/technotes/guides/intl/calendar.doc.html
+        // https://docs.oracle.com/javase/8/docs/technotes/guides/intl/calendar.doc.html
         if (locale.equals(FastDateParser.JAPANESE_IMPERIAL)) {
             if (year < 1868) {
                 cal.set(Calendar.ERA, 0);


### PR DESCRIPTION
- fix broken links (using their new URL, an alternative URL or a Wayback Machine link),
- use direct links instead of redirects,
- use HTTPS where possible.