### PR TITLE
Lang 1689 add optional to objectutils isempty

### DIFF
--- a/src/main/java/org/apache/commons/lang3/ObjectUtils.java
+++ b/src/main/java/org/apache/commons/lang3/ObjectUtils.java
@@ -1020,6 +1020,7 @@ public class ObjectUtils {
      * <li>{@link Array}: Considered empty if its length is zero.</li>
      * <li>{@link Collection}: Considered empty if it has zero elements.</li>
      * <li>{@link Map}: Considered empty if it has zero key-value mappings.</li>
+     * <li>{@link Optional}: Considered empty if {@link Optional#isPresent} returns false, regardless of the "emptiness" of the contents.</li>
      * </ul>
      *
      * <pre>
@@ -1029,6 +1030,9 @@ public class ObjectUtils {
      * ObjectUtils.isEmpty(new int[]{})      = true
      * ObjectUtils.isEmpty(new int[]{1,2,3}) = false
      * ObjectUtils.isEmpty(1234)             = false
+     * ObjectUtils.isEmpty(1234)             = false
+     * ObjectUtils.isEmpty(Optional.of(""))  = false
+     * ObjectUtils.isEmpty(Optional.empty()) = true
      * </pre>
      *
      * @param object  the {@link Object} to test, may be {@code null}
@@ -1068,6 +1072,7 @@ public class ObjectUtils {
      * <li>{@link Array}: Considered empty if its length is zero.</li>
      * <li>{@link Collection}: Considered empty if it has zero elements.</li>
      * <li>{@link Map}: Considered empty if it has zero key-value mappings.</li>
+     * <li>{@link Optional}: Considered empty if {@link Optional#isPresent} returns false, regardless of the "emptiness" of the contents.</li>
      * </ul>
      *
      * <pre>
@@ -1077,6 +1082,8 @@ public class ObjectUtils {
      * ObjectUtils.isNotEmpty(new int[]{})      = false
      * ObjectUtils.isNotEmpty(new int[]{1,2,3}) = true
      * ObjectUtils.isNotEmpty(1234)             = true
+     * ObjectUtils.isNotEmpty(Optional.of(""))  = true
+     * ObjectUtils.isNotEmpty(Optional.empty()) = false
      * </pre>
      *
      * @param object  the {@link Object} to test, may be {@code null}

--- a/src/main/java/org/apache/commons/lang3/ObjectUtils.java
+++ b/src/main/java/org/apache/commons/lang3/ObjectUtils.java
@@ -1053,7 +1053,7 @@ public class ObjectUtils {
             return ((Map<?, ?>) object).isEmpty();
         }
         if (object instanceof Optional<?>) {
-        	return !((Optional<?>) object).isPresent();
+            return !((Optional<?>) object).isPresent();
         }
         
         return false;

--- a/src/main/java/org/apache/commons/lang3/ObjectUtils.java
+++ b/src/main/java/org/apache/commons/lang3/ObjectUtils.java
@@ -30,6 +30,7 @@ import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.TreeSet;
 import java.util.function.Supplier;
 
@@ -1051,6 +1052,10 @@ public class ObjectUtils {
         if (object instanceof Map<?, ?>) {
             return ((Map<?, ?>) object).isEmpty();
         }
+        if (object instanceof Optional<?>) {
+        	return !((Optional<?>) object).isPresent();
+        }
+        
         return false;
     }
 

--- a/src/main/java/org/apache/commons/lang3/ObjectUtils.java
+++ b/src/main/java/org/apache/commons/lang3/ObjectUtils.java
@@ -1059,7 +1059,6 @@ public class ObjectUtils {
         if (object instanceof Optional<?>) {
             return !((Optional<?>) object).isPresent();
         }
-        
         return false;
     }
 

--- a/src/test/java/org/apache/commons/lang3/ObjectUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/ObjectUtilsTest.java
@@ -668,6 +668,8 @@ public class ObjectUtilsTest extends AbstractLangTest {
         assertFalse(ObjectUtils.isNotEmpty(Collections.emptyList()));
         assertFalse(ObjectUtils.isNotEmpty(Collections.emptySet()));
         assertFalse(ObjectUtils.isNotEmpty(Collections.emptyMap()));
+        assertFalse(ObjectUtils.isNotEmpty(Optional.empty()));
+        assertFalse(ObjectUtils.isNotEmpty(Optional.ofNullable(null)));
 
         assertTrue(ObjectUtils.isNotEmpty("  "));
         assertTrue(ObjectUtils.isNotEmpty("ab"));
@@ -675,6 +677,8 @@ public class ObjectUtilsTest extends AbstractLangTest {
         assertTrue(ObjectUtils.isNotEmpty(NON_EMPTY_LIST));
         assertTrue(ObjectUtils.isNotEmpty(NON_EMPTY_SET));
         assertTrue(ObjectUtils.isNotEmpty(NON_EMPTY_MAP));
+        assertTrue(ObjectUtils.isNotEmpty(Optional.of(new Object())));
+        assertTrue(ObjectUtils.isNotEmpty(Optional.ofNullable(new Object())));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/ObjectUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/ObjectUtilsTest.java
@@ -42,6 +42,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 
@@ -609,6 +610,8 @@ public class ObjectUtilsTest extends AbstractLangTest {
         assertTrue(ObjectUtils.isEmpty(Collections.emptyList()));
         assertTrue(ObjectUtils.isEmpty(Collections.emptySet()));
         assertTrue(ObjectUtils.isEmpty(Collections.emptyMap()));
+        assertTrue(ObjectUtils.isEmpty(Optional.empty()));
+        assertTrue(ObjectUtils.isEmpty(Optional.ofNullable(null)));
 
         assertFalse(ObjectUtils.isEmpty("  "));
         assertFalse(ObjectUtils.isEmpty("ab"));
@@ -616,6 +619,8 @@ public class ObjectUtilsTest extends AbstractLangTest {
         assertFalse(ObjectUtils.isEmpty(NON_EMPTY_LIST));
         assertFalse(ObjectUtils.isEmpty(NON_EMPTY_SET));
         assertFalse(ObjectUtils.isEmpty(NON_EMPTY_MAP));
+        assertFalse(ObjectUtils.isEmpty(Optional.of(new Object())));
+        assertFalse(ObjectUtils.isEmpty(Optional.ofNullable(new Object())));
     }
 
     /**


### PR DESCRIPTION
* Original JIRA ticket (not by me): https://issues.apache.org/jira/projects/LANG/issues/LANG-1689
* Method `isEmpty` in `ObjectUtils` was modified to return the negation of `Optional.isPresent` (i.e. `!optional.isPresent()`) when the passed in object is an Optional.
* The object contained within the Optional is not checked if it is also empty. This gives the caller the option to check if it's present (or not) on their own.
  * For instance, the caller might want to do something like the following:
    `ObjectUtils.isEmpty(optional) && ObjectUtils.isNotEmpty(optional.get())`.