### PR TITLE
Lang 1689 add optional to objectutils isempty with unpacking the optional

### DIFF
--- a/src/main/java/org/apache/commons/lang3/ObjectUtils.java
+++ b/src/main/java/org/apache/commons/lang3/ObjectUtils.java
@@ -30,6 +30,7 @@ import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.TreeSet;
 import java.util.function.Supplier;
 
@@ -1030,12 +1031,28 @@ public class ObjectUtils {
      * ObjectUtils.isEmpty(1234)             = false
      * </pre>
      *
+     * An {@link Optional} is also supported. In this case, the optional is "unwrapped"
+     * and the value that the optional holds is checked if it is empty. Consider the following
+     * examples:
+     * 
+     * <pre>
+     * ObjectUtils.isEmpty(Optional.empty())              = true
+     * ObjectUtils.isEmpty(Optional.of(""))               = true
+     * ObjectUtils.isEmpty(Optional.of("ab"))             = false
+     * ObjectUtils.isEmpty(Optional.of(new int[]{}))      = true
+     * ObjectUtils.isEmpty(Optional.of(new int[]{1,2,3})) = false
+     * ObjectUtils.isEmpty(Optional.of(1234))             = false
+     * </pre>
+     *
      * @param object  the {@link Object} to test, may be {@code null}
      * @return {@code true} if the object has a supported type and is empty or null,
      * {@code false} otherwise
      * @since 3.9
      */
-    public static boolean isEmpty(final Object object) {
+    public static boolean isEmpty(Object object) {
+        if (object instanceof Optional<?>) {
+            object = ((Optional<?>) object).orElse(null);
+        }
         if (object == null) {
             return true;
         }
@@ -1072,6 +1089,19 @@ public class ObjectUtils {
      * ObjectUtils.isNotEmpty(new int[]{})      = false
      * ObjectUtils.isNotEmpty(new int[]{1,2,3}) = true
      * ObjectUtils.isNotEmpty(1234)             = true
+     * </pre>
+     * 
+     * An {@link Optional} is also supported. In this case, the optional is "unwrapped"
+     * and the value that the optional holds is checked if it is empty. Consider the following
+     * examples:
+     * 
+     * <pre>
+     * ObjectUtils.isNotEmpty(Optional.empty())              = false
+     * ObjectUtils.isNotEmpty(Optional.of(""))               = false
+     * ObjectUtils.isNotEmpty(Optional.of("ab"))             = true
+     * ObjectUtils.isNotEmpty(Optional.of(new int[]{}))      = false
+     * ObjectUtils.isNotEmpty(Optional.of(new int[]{1,2,3})) = true
+     * ObjectUtils.isNotEmpty(Optional.of(1234))             = true
      * </pre>
      *
      * @param object  the {@link Object} to test, may be {@code null}

--- a/src/test/java/org/apache/commons/lang3/ObjectUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/ObjectUtilsTest.java
@@ -42,6 +42,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 
@@ -610,12 +611,28 @@ public class ObjectUtilsTest extends AbstractLangTest {
         assertTrue(ObjectUtils.isEmpty(Collections.emptySet()));
         assertTrue(ObjectUtils.isEmpty(Collections.emptyMap()));
 
+        // assertTrue Optional tests
+        assertTrue(ObjectUtils.isEmpty(Optional.empty()));
+        assertTrue(ObjectUtils.isEmpty(Optional.of("")));
+        assertTrue(ObjectUtils.isEmpty(Optional.of(new int[] {})));
+        assertTrue(ObjectUtils.isEmpty(Optional.of(Collections.emptyList())));
+        assertTrue(ObjectUtils.isEmpty(Optional.of(Collections.emptySet())));
+        assertTrue(ObjectUtils.isEmpty(Optional.of(Collections.emptyMap())));
+
         assertFalse(ObjectUtils.isEmpty("  "));
         assertFalse(ObjectUtils.isEmpty("ab"));
         assertFalse(ObjectUtils.isEmpty(NON_EMPTY_ARRAY));
         assertFalse(ObjectUtils.isEmpty(NON_EMPTY_LIST));
         assertFalse(ObjectUtils.isEmpty(NON_EMPTY_SET));
         assertFalse(ObjectUtils.isEmpty(NON_EMPTY_MAP));
+
+        // assertFalse Optional tests
+        assertFalse(ObjectUtils.isEmpty(Optional.of("  ")));
+        assertFalse(ObjectUtils.isEmpty(Optional.of("ab")));
+        assertFalse(ObjectUtils.isEmpty(Optional.of(NON_EMPTY_ARRAY)));
+        assertFalse(ObjectUtils.isEmpty(Optional.of(NON_EMPTY_LIST)));
+        assertFalse(ObjectUtils.isEmpty(Optional.of(NON_EMPTY_SET)));
+        assertFalse(ObjectUtils.isEmpty(Optional.of(NON_EMPTY_MAP)));
     }
 
     /**
@@ -664,12 +681,29 @@ public class ObjectUtilsTest extends AbstractLangTest {
         assertFalse(ObjectUtils.isNotEmpty(Collections.emptySet()));
         assertFalse(ObjectUtils.isNotEmpty(Collections.emptyMap()));
 
+        // assertFalse Optional tests
+        assertFalse(ObjectUtils.isNotEmpty(Optional.empty()));
+        assertFalse(ObjectUtils.isNotEmpty(Optional.of("")));
+        assertFalse(ObjectUtils.isNotEmpty(Optional.of(new int[] {})));
+        assertFalse(ObjectUtils.isNotEmpty(Optional.of(Collections.emptyList())));
+        assertFalse(ObjectUtils.isNotEmpty(Optional.of(Collections.emptySet())));
+        assertFalse(ObjectUtils.isNotEmpty(Optional.of(Collections.emptyMap())));
+
         assertTrue(ObjectUtils.isNotEmpty("  "));
         assertTrue(ObjectUtils.isNotEmpty("ab"));
         assertTrue(ObjectUtils.isNotEmpty(NON_EMPTY_ARRAY));
         assertTrue(ObjectUtils.isNotEmpty(NON_EMPTY_LIST));
         assertTrue(ObjectUtils.isNotEmpty(NON_EMPTY_SET));
         assertTrue(ObjectUtils.isNotEmpty(NON_EMPTY_MAP));
+
+        // assertTrue Optional tests
+        assertTrue(ObjectUtils.isNotEmpty(Optional.of("  ")));
+        assertTrue(ObjectUtils.isNotEmpty(Optional.of("ab")));
+        assertTrue(ObjectUtils.isNotEmpty(Optional.of(NON_EMPTY_ARRAY)));
+        assertTrue(ObjectUtils.isNotEmpty(Optional.of(NON_EMPTY_LIST)));
+        assertTrue(ObjectUtils.isNotEmpty(Optional.of(NON_EMPTY_SET)));
+        assertTrue(ObjectUtils.isNotEmpty(Optional.of(NON_EMPTY_MAP)));
+
     }
 
     @Test


### PR DESCRIPTION
Note: This PR is related to #933.

Each is a different approach to adding an Optional to ObjectUtils.isEmpty. At most one should me merged.

This approach "unwraps" the optional so that the contents are checked if they are empty or not.