### PR TITLE
LANG-1691: ClassUtils.getShortCanonicalName - using canonicalName rat…

### DIFF
--- a/src/main/java/org/apache/commons/lang3/ClassUtils.java
+++ b/src/main/java/org/apache/commons/lang3/ClassUtils.java
@@ -813,7 +813,7 @@ public class ClassUtils {
         if (cls == null) {
             return StringUtils.EMPTY;
         }
-        return getShortCanonicalName(cls.getName());
+        return getShortCanonicalName(cls.getCanonicalName());
     }
 
     /**
@@ -828,7 +828,7 @@ public class ClassUtils {
         if (object == null) {
             return valueIfNull;
         }
-        return getShortCanonicalName(object.getClass().getName());
+        return getShortCanonicalName(object.getClass().getCanonicalName());
     }
 
     /**

--- a/src/test/java/org/apache/commons/lang3/ClassUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/ClassUtilsTest.java
@@ -517,13 +517,12 @@ public class ClassUtilsTest extends AbstractLangTest {
         class Named {
             // empty
         }
-        // WARNING: this is fragile, implementation may change, naming is not guaranteed
-        assertEquals("ClassUtilsTest.8", ClassUtils.getShortCanonicalName(new Object() {
+        assertEquals("", ClassUtils.getShortCanonicalName(new Object() {
             // empty
         }.getClass()));
         // WARNING: this is fragile, implementation may change, naming is not guaranteed
-        assertEquals("ClassUtilsTest.8Named", ClassUtils.getShortCanonicalName(Named.class));
-        assertEquals("ClassUtilsTest.Inner", ClassUtils.getShortCanonicalName(Inner.class));
+        assertEquals("", ClassUtils.getShortCanonicalName(Named.class));
+        assertEquals("Inner", ClassUtils.getShortCanonicalName(Inner.class));
         assertEquals(StringUtils.EMPTY, ClassUtils.getShortCanonicalName((Class<?>) null));
     }
 
@@ -540,12 +539,11 @@ public class ClassUtilsTest extends AbstractLangTest {
         class Named {
             // empty
         }
-        // WARNING: this is fragile, implementation may change, naming is not guaranteed
-        assertEquals("ClassUtilsTest.9", ClassUtils.getShortCanonicalName(new Object() {
+        assertEquals("", ClassUtils.getShortCanonicalName(new Object() {
             // empty
         }, "<null>"));
-        assertEquals("ClassUtilsTest.9Named", ClassUtils.getShortCanonicalName(new Named(), "<null>"));
-        assertEquals("ClassUtilsTest.Inner", ClassUtils.getShortCanonicalName(new Inner(), "<null>"));
+        assertEquals("", ClassUtils.getShortCanonicalName(new Named(), "<null>"));
+        assertEquals("Inner", ClassUtils.getShortCanonicalName(new Inner(), "<null>"));
     }
 
     @Test


### PR DESCRIPTION
JIRA issue - https://issues.apache.org/jira/browse/LANG-1691

The `getShortCanonicalName` is using class name rather than the canonical name. Fixing it by using the canonicalName.
Also updated the unit tests because of this change. For some of the tests, the canonical name will be null and hence changed the expected value to be an empty string. For inner class, the output will not have the outer class name.