### PR TITLE
[LANG-1692] Cast FieldUtils.readField result to the recipient type

### DIFF
--- a/src/main/java/org/apache/commons/lang3/builder/ReflectionDiffBuilder.java
+++ b/src/main/java/org/apache/commons/lang3/builder/ReflectionDiffBuilder.java
@@ -110,8 +110,9 @@ public class ReflectionDiffBuilder<T> implements Builder<DiffResult<T>> {
         for (final Field field : FieldUtils.getAllFields(clazz)) {
             if (accept(field)) {
                 try {
-                    diffBuilder.append(field.getName(), readField(field, left, true),
-                            readField(field, right, true));
+                    Object leftObject = readField(field, left, true);
+                    Object rightObject = readField(field, right, true);
+                    diffBuilder.append(field.getName(), leftObject, rightObject);
                 } catch (final IllegalAccessException ex) {
                     //this can't happen. Would get a Security exception instead
                     //throw a runtime exception in case the impossible happens.

--- a/src/main/java/org/apache/commons/lang3/builder/ReflectionDiffBuilder.java
+++ b/src/main/java/org/apache/commons/lang3/builder/ReflectionDiffBuilder.java
@@ -110,9 +110,8 @@ public class ReflectionDiffBuilder<T> implements Builder<DiffResult<T>> {
         for (final Field field : FieldUtils.getAllFields(clazz)) {
             if (accept(field)) {
                 try {
-                    Object leftObject = readField(field, left, true);
-                    Object rightObject = readField(field, right, true);
-                    diffBuilder.append(field.getName(), leftObject, rightObject);
+                    diffBuilder.append(field.getName(), readField(field, left, true),
+                            readField(field, right, true));
                 } catch (final IllegalAccessException ex) {
                     //this can't happen. Would get a Security exception instead
                     //throw a runtime exception in case the impossible happens.

--- a/src/main/java/org/apache/commons/lang3/reflect/FieldUtils.java
+++ b/src/main/java/org/apache/commons/lang3/reflect/FieldUtils.java
@@ -254,8 +254,8 @@ public class FieldUtils {
     /**
      * Reads an accessible {@code static} {@link Field}.
      *
-     * @param field
-     *            to read
+     * @param <T> the recipient type
+     * @param field to read
      * @return the field value
      * @throws IllegalArgumentException
      *             if the field is {@code null}, or not {@code static}
@@ -269,8 +269,8 @@ public class FieldUtils {
     /**
      * Reads a static {@link Field}.
      *
-     * @param field
-     *            to read
+     * @param <T> the recipient type
+     * @param field to read
      * @param forceAccess
      *            whether to break scope restrictions using the
      *            {@link java.lang.reflect.AccessibleObject#setAccessible(boolean)} method.
@@ -289,6 +289,7 @@ public class FieldUtils {
     /**
      * Reads the named {@code public static} {@link Field}. Superclasses will be considered.
      *
+     * @param <T> the recipient type
      * @param cls
      *            the {@link Class} to reflect, must not be {@code null}
      * @param fieldName
@@ -307,6 +308,7 @@ public class FieldUtils {
     /**
      * Reads the named {@code static} {@link Field}. Superclasses will be considered.
      *
+     * @param <T> the recipient type
      * @param cls
      *            the {@link Class} to reflect, must not be {@code null}
      * @param fieldName
@@ -333,6 +335,7 @@ public class FieldUtils {
      * Gets the value of a {@code static} {@link Field} by name. The field must be {@code public}. Only the specified
      * class will be considered.
      *
+     * @param <T> the recipient type
      * @param cls
      *            the {@link Class} to reflect, must not be {@code null}
      * @param fieldName
@@ -351,6 +354,7 @@ public class FieldUtils {
     /**
      * Gets the value of a {@code static} {@link Field} by name. Only the specified class will be considered.
      *
+     * @param <T> the recipient type
      * @param cls
      *            the {@link Class} to reflect, must not be {@code null}
      * @param fieldName
@@ -376,8 +380,8 @@ public class FieldUtils {
     /**
      * Reads an accessible {@link Field}.
      *
-     * @param field
-     *            the field to use
+     * @param <T> the recipient type
+     * @param field to read
      * @param target
      *            the object to call on, may be {@code null} for {@code static} fields
      * @return the field value
@@ -393,8 +397,8 @@ public class FieldUtils {
     /**
      * Reads a {@link Field}.
      *
-     * @param field
-     *            the field to use
+     * @param <T> the recipient type
+     * @param field to read
      * @param target
      *            the object to call on, may be {@code null} for {@code static} fields
      * @param forceAccess
@@ -420,6 +424,7 @@ public class FieldUtils {
     /**
      * Reads the named {@code public} {@link Field}. Superclasses will be considered.
      *
+     * @param <T> the recipient type
      * @param target
      *            the object to reflect, must not be {@code null}
      * @param fieldName
@@ -437,6 +442,7 @@ public class FieldUtils {
     /**
      * Reads the named {@link Field}. Superclasses will be considered.
      *
+     * @param <T> the recipient type
      * @param target
      *            the object to reflect, must not be {@code null}
      * @param fieldName
@@ -463,6 +469,7 @@ public class FieldUtils {
     /**
      * Reads the named {@code public} {@link Field}. Only the class of the specified object will be considered.
      *
+     * @param <T> the recipient type
      * @param target
      *            the object to reflect, must not be {@code null}
      * @param fieldName
@@ -480,6 +487,7 @@ public class FieldUtils {
     /**
      * Gets a {@link Field} value by name. Only the class of the specified object will be considered.
      *
+     * @param <T> the recipient type
      * @param target
      *            the object to reflect, must not be {@code null}
      * @param fieldName

--- a/src/main/java/org/apache/commons/lang3/reflect/FieldUtils.java
+++ b/src/main/java/org/apache/commons/lang3/reflect/FieldUtils.java
@@ -262,7 +262,7 @@ public class FieldUtils {
      * @throws IllegalAccessException
      *             if the field is not accessible
      */
-    public static Object readStaticField(final Field field) throws IllegalAccessException {
+    public static <T> T readStaticField(final Field field) throws IllegalAccessException {
         return readStaticField(field, false);
     }
 
@@ -280,7 +280,7 @@ public class FieldUtils {
      * @throws IllegalAccessException
      *             if the field is not made accessible
      */
-    public static Object readStaticField(final Field field, final boolean forceAccess) throws IllegalAccessException {
+    public static <T> T readStaticField(final Field field, final boolean forceAccess) throws IllegalAccessException {
         Validate.notNull(field, "field");
         Validate.isTrue(MemberUtils.isStatic(field), "The field '%s' is not static", field.getName());
         return readField(field, (Object) null, forceAccess);
@@ -300,7 +300,7 @@ public class FieldUtils {
      * @throws IllegalAccessException
      *             if the field is not accessible
      */
-    public static Object readStaticField(final Class<?> cls, final String fieldName) throws IllegalAccessException {
+    public static <T> T readStaticField(final Class<?> cls, final String fieldName) throws IllegalAccessException {
         return readStaticField(cls, fieldName, false);
     }
 
@@ -322,7 +322,7 @@ public class FieldUtils {
      * @throws IllegalAccessException
      *             if the field is not made accessible
      */
-    public static Object readStaticField(final Class<?> cls, final String fieldName, final boolean forceAccess) throws IllegalAccessException {
+    public static <T> T readStaticField(final Class<?> cls, final String fieldName, final boolean forceAccess) throws IllegalAccessException {
         final Field field = getField(cls, fieldName, forceAccess);
         Validate.notNull(field, "Cannot locate field '%s' on %s", fieldName, cls);
         // already forced access above, don't repeat it here:
@@ -344,7 +344,7 @@ public class FieldUtils {
      * @throws IllegalAccessException
      *             if the field is not accessible
      */
-    public static Object readDeclaredStaticField(final Class<?> cls, final String fieldName) throws IllegalAccessException {
+    public static <T> T readDeclaredStaticField(final Class<?> cls, final String fieldName) throws IllegalAccessException {
         return readDeclaredStaticField(cls, fieldName, false);
     }
 
@@ -366,7 +366,7 @@ public class FieldUtils {
      * @throws IllegalAccessException
      *             if the field is not made accessible
      */
-    public static Object readDeclaredStaticField(final Class<?> cls, final String fieldName, final boolean forceAccess) throws IllegalAccessException {
+    public static <T> T readDeclaredStaticField(final Class<?> cls, final String fieldName, final boolean forceAccess) throws IllegalAccessException {
         final Field field = getDeclaredField(cls, fieldName, forceAccess);
         Validate.notNull(field, "Cannot locate declared field %s.%s", cls.getName(), fieldName);
         // already forced access above, don't repeat it here:
@@ -386,7 +386,7 @@ public class FieldUtils {
      * @throws IllegalAccessException
      *             if the field is not accessible
      */
-    public static Object readField(final Field field, final Object target) throws IllegalAccessException {
+    public static <T> T readField(final Field field, final Object target) throws IllegalAccessException {
         return readField(field, target, false);
     }
 
@@ -406,14 +406,15 @@ public class FieldUtils {
      * @throws IllegalAccessException
      *             if the field is not made accessible
      */
-    public static Object readField(final Field field, final Object target, final boolean forceAccess) throws IllegalAccessException {
+    @SuppressWarnings("unchecked")
+    public static <T> T readField(final Field field, final Object target, final boolean forceAccess) throws IllegalAccessException {
         Validate.notNull(field, "field");
         if (forceAccess && !field.isAccessible()) {
             field.setAccessible(true);
         } else {
             MemberUtils.setAccessibleWorkaround(field);
         }
-        return field.get(target);
+        return (T) field.get(target);
     }
 
     /**
@@ -429,7 +430,7 @@ public class FieldUtils {
      * @throws IllegalAccessException
      *             if the named field is not {@code public}
      */
-    public static Object readField(final Object target, final String fieldName) throws IllegalAccessException {
+    public static <T> T readField(final Object target, final String fieldName) throws IllegalAccessException {
         return readField(target, fieldName, false);
     }
 
@@ -450,7 +451,7 @@ public class FieldUtils {
      * @throws IllegalAccessException
      *             if the named field is not made accessible
      */
-    public static Object readField(final Object target, final String fieldName, final boolean forceAccess) throws IllegalAccessException {
+    public static <T> T readField(final Object target, final String fieldName, final boolean forceAccess) throws IllegalAccessException {
         Validate.notNull(target, "target");
         final Class<?> cls = target.getClass();
         final Field field = getField(cls, fieldName, forceAccess);
@@ -472,7 +473,7 @@ public class FieldUtils {
      * @throws IllegalAccessException
      *             if the named field is not {@code public}
      */
-    public static Object readDeclaredField(final Object target, final String fieldName) throws IllegalAccessException {
+    public static <T> T readDeclaredField(final Object target, final String fieldName) throws IllegalAccessException {
         return readDeclaredField(target, fieldName, false);
     }
 
@@ -493,7 +494,7 @@ public class FieldUtils {
      * @throws IllegalAccessException
      *             if the field is not made accessible
      */
-    public static Object readDeclaredField(final Object target, final String fieldName, final boolean forceAccess) throws IllegalAccessException {
+    public static <T> T readDeclaredField(final Object target, final String fieldName, final boolean forceAccess) throws IllegalAccessException {
         Validate.notNull(target, "target");
         final Class<?> cls = target.getClass();
         final Field field = getDeclaredField(cls, fieldName, forceAccess);

--- a/src/test/java/org/apache/commons/lang3/reflect/FieldUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/reflect/FieldUtilsTest.java
@@ -678,6 +678,43 @@ public class FieldUtilsTest extends AbstractLangTest {
     }
 
     @Test
+    public void testReadFieldGeneric() throws Exception {
+        String fieldValue;
+
+        final Field parentS = FieldUtils.getDeclaredField(parentClass, "s");
+
+        fieldValue = FieldUtils.readField(parentS, publicChild);
+        assertEquals("s", fieldValue);
+        fieldValue = FieldUtils.readField(parentS, publicChild, true);
+        assertEquals("s", fieldValue);
+        fieldValue = FieldUtils.readField(publicChild, "s");
+        assertEquals("s", fieldValue);
+        fieldValue = FieldUtils.readField(publicChild, "s", true);
+        assertEquals("s", fieldValue);
+
+        fieldValue = FieldUtils.readDeclaredField(publiclyShadowedChild, "s");
+        assertEquals("ss", fieldValue);
+        fieldValue = FieldUtils.readDeclaredField(publiclyShadowedChild, "s", true);
+        assertEquals("ss", fieldValue);
+
+        final Field fooValue = FieldUtils.getField(Foo.class, "VALUE");
+
+        fieldValue = FieldUtils.readStaticField(fooValue);
+        assertEquals(Foo.VALUE, fieldValue);
+        fieldValue = FieldUtils.readStaticField(fooValue, true);
+        assertEquals(Foo.VALUE, fieldValue);
+        fieldValue = FieldUtils.readStaticField(Foo.class, "VALUE");
+        assertEquals(Foo.VALUE, fieldValue);
+        fieldValue = FieldUtils.readStaticField(Foo.class, "VALUE", true);
+        assertEquals(Foo.VALUE, fieldValue);
+
+        fieldValue = FieldUtils.readDeclaredStaticField(Foo.class, "VALUE");
+        assertEquals(Foo.VALUE, fieldValue);
+        fieldValue = FieldUtils.readDeclaredStaticField(Foo.class, "VALUE", true);
+        assertEquals(Foo.VALUE, fieldValue);
+    }
+
+    @Test
     public void testWriteStaticField() throws Exception {
         final Field field = StaticContainer.class.getDeclaredField("mutablePublic");
         FieldUtils.writeStaticField(field, "new");


### PR DESCRIPTION
This patch should be easy to understand.

Generally, it won't affect user cases as long as the type can be inferred by the recipient or JDK rules. There's a case as shown in `ReflectionDiffBuilder.java` that if the type inference results in ambiguity, it may cause compile error.

Thus, I'm unsure whether this is proper to be included with a minor version bump. I don't think adding another series of methods helps - it causes further confusion.

This patch doesn't cause extra class cast exception because if the recipient is `Object` the cast should always succeed. And if the recipient already cast it into another type, there will be an exception if the cast cannot be performed.