### PR TITLE
Remove unnecessary conditions. It's no need it after assigns tmp to duration

### DIFF
--- a/src/main/java/org/apache/commons/lang3/time/DurationFormatUtils.java
+++ b/src/main/java/org/apache/commons/lang3/time/DurationFormatUtils.java
@@ -190,9 +190,6 @@ public class DurationFormatUtils {
                     duration = tmp;
                     tmp = StringUtils.replaceOnce(duration, " 0 minutes", StringUtils.EMPTY);
                     duration = tmp;
-                    if (tmp.length() != duration.length()) {
-                        duration = StringUtils.replaceOnce(tmp, " 0 seconds", StringUtils.EMPTY);
-                    }
                 }
             }
             if (!duration.isEmpty()) {


### PR DESCRIPTION
We don't need that conditions. Its always false and will never reach it.  And just because in the line 192 we assigns tmp to duration.