### PR TITLE
Make java.desktop module optional

### DIFF
--- a/src/main/java/org/apache/commons/lang3/concurrent/StateChangeEvent.java
+++ b/src/main/java/org/apache/commons/lang3/concurrent/StateChangeEvent.java
@@ -1,0 +1,17 @@
+package org.apache.commons.lang3.concurrent;
+
+import java.util.EventObject;
+
+public class StateChangeEvent extends EventObject {
+
+    private final AbstractCircuitBreaker.State state;
+
+    public StateChangeEvent(Object source, AbstractCircuitBreaker.State state) {
+        super(source);
+        this.state = state;
+    }
+
+    public AbstractCircuitBreaker.State getState() {
+        return state;
+    }
+}

--- a/src/main/java/org/apache/commons/lang3/concurrent/StateChangeListener.java
+++ b/src/main/java/org/apache/commons/lang3/concurrent/StateChangeListener.java
@@ -1,0 +1,9 @@
+package org.apache.commons.lang3.concurrent;
+
+import java.util.EventListener;
+
+public interface StateChangeListener extends EventListener {
+
+    void stateChange(StateChangeEvent evt);
+
+}


### PR DESCRIPTION
As an alternative to https://github.com/apache/commons-lang/pull/275, this allows existing code to continue to work, while providing a migration path for other users. We can choose to either deprecate or keep the methods that take `PropertyChangeListener`s.

By guarding the construction of the `PropertyChangeSupport` with a try/catch, we can continue to run when the `java.desktop` module is absent.

Relates to [LANG-1339](https://issues.apache.org/jira/browse/LANG-1339)