### PR TITLE
[LANG-1694] MethodUtils.getMatchingMethod() fails with "Found multiple candidates"

### DIFF
--- a/src/main/java/org/apache/commons/lang3/reflect/MethodUtils.java
+++ b/src/main/java/org/apache/commons/lang3/reflect/MethodUtils.java
@@ -751,8 +751,11 @@ public class MethodUtils {
         }
 
         final List<Method> bestCandidates = candidates.values().iterator().next();
-        if (bestCandidates.size() == 1) {
-            return bestCandidates.get(0);
+        if (bestCandidates.size() >= 1) {
+            if (bestCandidates.size() == 1 || !Objects.equals(bestCandidates.get(0).getDeclaringClass(),
+                    bestCandidates.get(1).getDeclaringClass())) {
+                return bestCandidates.get(0);
+            }
         }
 
         throw new IllegalStateException(

--- a/src/main/java/org/apache/commons/lang3/reflect/MethodUtils.java
+++ b/src/main/java/org/apache/commons/lang3/reflect/MethodUtils.java
@@ -751,11 +751,9 @@ public class MethodUtils {
         }
 
         final List<Method> bestCandidates = candidates.values().iterator().next();
-        if (bestCandidates.size() >= 1) {
-            if (bestCandidates.size() == 1 || !Objects.equals(bestCandidates.get(0).getDeclaringClass(),
-                    bestCandidates.get(1).getDeclaringClass())) {
-                return bestCandidates.get(0);
-            }
+        if (bestCandidates.size() == 1 || !Objects.equals(bestCandidates.get(0).getDeclaringClass(),
+                bestCandidates.get(1).getDeclaringClass())) {
+            return bestCandidates.get(0);
         }
 
         throw new IllegalStateException(

--- a/src/test/java/org/apache/commons/lang3/reflect/MethodUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/reflect/MethodUtilsTest.java
@@ -1093,7 +1093,7 @@ public class MethodUtilsTest extends AbstractLangTest {
         }
     }
 
-    protected static abstract class AbstractGetMatchingMethod {
+    protected abstract static class AbstractGetMatchingMethod {
         abstract void testMethod5(Exception e);
     }
 

--- a/src/test/java/org/apache/commons/lang3/reflect/MethodUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/reflect/MethodUtilsTest.java
@@ -1053,6 +1053,9 @@ public class MethodUtilsTest extends AbstractLangTest {
 
         assertThrows(IllegalStateException.class,
                 () -> MethodUtils.getMatchingMethod(GetMatchingMethodClass.class, "testMethod4", null, null));
+
+        assertEquals(MethodUtils.getMatchingMethod(GetMatchingMethodImpl.class, "testMethod5", RuntimeException.class),
+                GetMatchingMethodImpl.class.getMethod("testMethod5", Exception.class));
     }
 
     private static final class GetMatchingMethodClass {
@@ -1087,6 +1090,16 @@ public class MethodUtilsTest extends AbstractLangTest {
         }
 
         public void testMethod4(final Color aColor1, final Color aColor2) {
+        }
+    }
+
+    protected static abstract class AbstractGetMatchingMethod {
+        abstract void testMethod5(Exception e);
+    }
+
+    private static class GetMatchingMethodImpl extends AbstractGetMatchingMethod {
+        @Override
+        public void testMethod5(Exception e) {
         }
     }
 }

--- a/src/test/java/org/apache/commons/lang3/reflect/MethodUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/reflect/MethodUtilsTest.java
@@ -1094,12 +1094,12 @@ public class MethodUtilsTest extends AbstractLangTest {
     }
 
     protected abstract static class AbstractGetMatchingMethod {
-        abstract void testMethod5(Exception e);
+        public abstract void testMethod5(Exception exception);
     }
 
     private static class GetMatchingMethodImpl extends AbstractGetMatchingMethod {
         @Override
-        public void testMethod5(Exception e) {
+        public void testMethod5(final Exception exception) {
         }
     }
 }


### PR DESCRIPTION
JIRA: [https://issues.apache.org/jira/browse/LANG-1694](https://issues.apache.org/jira/browse/LANG-1694)

MethodUtils.getMatchingMethod() fails with "Found multiple candidates for method" message if the method is **an override of an abstract method** and parameter types do not exactly match the declared types.

The behavior of this method has changed between versions 3.11 and 3.12.0. Previously, the method would pick the first method that matches the signature and replace it only if a method with a more specific signature is found. Maybe it's a compatibility issue.

Fix: Keep only one candidate to return directly, if there are more than two candidates, continue to compare whether the declaration classes of the first two methods are the same, if not, also consider the first method the best match(Class itself).
