### PR TITLE
[LANG-1643] Construct ArrayList with better default size

### DIFF
--- a/src/main/java/org/apache/commons/lang3/builder/EqualsBuilder.java
+++ b/src/main/java/org/apache/commons/lang3/builder/EqualsBuilder.java
@@ -214,7 +214,7 @@ public class EqualsBuilder implements Builder<Boolean> {
      */
     public EqualsBuilder() {
         // set up default classes to bypass reflection for
-        bypassReflectionClasses = new ArrayList<>();
+        bypassReflectionClasses = new ArrayList<>(1);
         bypassReflectionClasses.add(String.class); //hashCode field being lazy but not transient
     }
 


### PR DESCRIPTION
As pointed by LANG-1643, the `ArrayList<>()` constructor creates an empty List which will always grow at first add, which is done in the next line of code in `EqualsBuilder`