### PR TITLE
refactor: Only use static imports to import assert methods in tests

### DIFF
--- a/src/test/java/org/apache/commons/lang3/AnnotationUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/AnnotationUtilsTest.java
@@ -16,12 +16,6 @@
  */
 package org.apache.commons.lang3;
 
-import static java.lang.annotation.ElementType.FIELD;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
-import static org.apache.commons.lang3.AnnotationUtilsTest.Stooge.CURLY;
-import static org.apache.commons.lang3.AnnotationUtilsTest.Stooge.LARRY;
-import static org.apache.commons.lang3.AnnotationUtilsTest.Stooge.MOE;
-import static org.apache.commons.lang3.AnnotationUtilsTest.Stooge.SHEMP;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -78,8 +72,8 @@ public class AnnotationUtilsTest extends AbstractLangTest {
                     longValues = { 0 },
                     shortValue = 0,
                     shortValues = { 0 },
-                    stooge = CURLY,
-                    stooges = { MOE, LARRY, SHEMP },
+                    stooge = Stooge.CURLY,
+                    stooges = { Stooge.MOE, Stooge.LARRY, Stooge.SHEMP },
                     string = "",
                     strings = { "" },
                     type = Object.class,
@@ -103,8 +97,8 @@ public class AnnotationUtilsTest extends AbstractLangTest {
                         longValues = { 0 },
                         shortValue = 0,
                         shortValues = { 0 },
-                        stooge = CURLY,
-                        stooges = { MOE, LARRY, SHEMP },
+                        stooge = Stooge.CURLY,
+                        stooges = { Stooge.MOE, Stooge.LARRY, Stooge.SHEMP },
                         string = "",
                         strings = { "" },
                         type = Object[].class,
@@ -113,8 +107,8 @@ public class AnnotationUtilsTest extends AbstractLangTest {
             },
             shortValue = 0,
             shortValues = { 0 },
-            stooge = SHEMP,
-            stooges = { MOE, LARRY, CURLY },
+            stooge = Stooge.SHEMP,
+            stooges = { Stooge.MOE, Stooge.LARRY, Stooge.CURLY },
             string = "",
             strings = { "" },
             type = Object.class,
@@ -154,8 +148,8 @@ public class AnnotationUtilsTest extends AbstractLangTest {
                     longValues = { 0 },
                     shortValue = 0,
                     shortValues = { 0 },
-                    stooge = CURLY,
-                    stooges = { MOE, LARRY, SHEMP },
+                    stooge = Stooge.CURLY,
+                    stooges = { Stooge.MOE, Stooge.LARRY, Stooge.SHEMP },
                     string = "",
                     strings = { "" },
                     type = Object.class,
@@ -179,8 +173,8 @@ public class AnnotationUtilsTest extends AbstractLangTest {
                         longValues = { 0 },
                         shortValue = 0,
                         shortValues = { 0 },
-                        stooge = CURLY,
-                        stooges = { MOE, LARRY, SHEMP },
+                        stooge = Stooge.CURLY,
+                        stooges = { Stooge.MOE, Stooge.LARRY, Stooge.SHEMP },
                         string = "",
                         strings = { "" },
                         type = Object[].class,
@@ -189,8 +183,8 @@ public class AnnotationUtilsTest extends AbstractLangTest {
             },
             shortValue = 0,
             shortValues = { 0 },
-            stooge = SHEMP,
-            stooges = { MOE, LARRY, CURLY },
+            stooge = Stooge.SHEMP,
+            stooges = { Stooge.MOE, Stooge.LARRY, Stooge.CURLY },
             string = "",
             strings = { "" },
             type = Object.class,
@@ -230,8 +224,8 @@ public class AnnotationUtilsTest extends AbstractLangTest {
                     longValues = { 0 },
                     shortValue = 0,
                     shortValues = { 0 },
-                    stooge = CURLY,
-                    stooges = { MOE, LARRY, SHEMP },
+                    stooge = Stooge.CURLY,
+                    stooges = { Stooge.MOE, Stooge.LARRY, Stooge.SHEMP },
                     string = "",
                     strings = { "" },
                     type = Object.class,
@@ -255,8 +249,8 @@ public class AnnotationUtilsTest extends AbstractLangTest {
                         longValues = { 0 },
                         shortValue = 0,
                         shortValues = { 0 },
-                        stooge = CURLY,
-                        stooges = { MOE, LARRY, SHEMP },
+                        stooge = Stooge.CURLY,
+                        stooges = { Stooge.MOE, Stooge.LARRY, Stooge.SHEMP },
                         string = "",
                         strings = { "" },
                         type = Object[].class,
@@ -280,8 +274,8 @@ public class AnnotationUtilsTest extends AbstractLangTest {
                         longValues = { 0 },
                         shortValue = 0,
                         shortValues = { 0 },
-                        stooge = CURLY,
-                        stooges = { MOE, LARRY, SHEMP },
+                        stooge = Stooge.CURLY,
+                        stooges = { Stooge.MOE, Stooge.LARRY, Stooge.SHEMP },
                         string = "",
                         strings = { "" },
                         type = Object[].class,
@@ -290,8 +284,8 @@ public class AnnotationUtilsTest extends AbstractLangTest {
             },
             shortValue = 0,
             shortValues = { 0 },
-            stooge = SHEMP,
-            stooges = { MOE, LARRY, CURLY },
+            stooge = Stooge.SHEMP,
+            stooges = { Stooge.MOE, Stooge.LARRY, Stooge.CURLY },
             string = "",
             strings = { "" },
             type = Object.class,
@@ -316,8 +310,8 @@ public class AnnotationUtilsTest extends AbstractLangTest {
             longValues = { 0 },
             shortValue = 0,
             shortValues = { 0 },
-            stooge = CURLY,
-            stooges = { MOE, LARRY, SHEMP },
+            stooge = Stooge.CURLY,
+            stooges = { Stooge.MOE, Stooge.LARRY, Stooge.SHEMP },
             string = "",
             strings = { "" },
             type = Object[].class,
@@ -325,8 +319,8 @@ public class AnnotationUtilsTest extends AbstractLangTest {
     )
     public Object dummy4;
 
-    @Target(FIELD)
-    @Retention(RUNTIME)
+    @Target(ElementType.FIELD)
+    @Retention(RetentionPolicy.RUNTIME)
     public @interface TestAnnotation {
         String string();
         String[] strings();
@@ -354,7 +348,7 @@ public class AnnotationUtilsTest extends AbstractLangTest {
         NestAnnotation[] nests();
     }
 
-    @Retention(RUNTIME)
+    @Retention(RetentionPolicy.RUNTIME)
     public @interface NestAnnotation {
         String string();
         String[] strings();

--- a/src/test/java/org/apache/commons/lang3/text/FormattableUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/FormattableUtilsTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.commons.lang3.text;
 
-import static java.util.FormattableFlags.LEFT_JUSTIFY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.util.FormattableFlags;
 import java.util.Formatter;
 
 import org.apache.commons.lang3.AbstractLangTest;
@@ -39,10 +39,10 @@ public class FormattableUtilsTest extends AbstractLangTest {
         assertEquals("   foo", FormattableUtils.append("foo", new Formatter(), 0, 6, -1).toString());
         assertEquals(" fo", FormattableUtils.append("foo", new Formatter(), 0, 3, 2).toString());
         assertEquals("   fo", FormattableUtils.append("foo", new Formatter(), 0, 5, 2).toString());
-        assertEquals("foo ", FormattableUtils.append("foo", new Formatter(), LEFT_JUSTIFY, 4, -1).toString());
-        assertEquals("foo   ", FormattableUtils.append("foo", new Formatter(), LEFT_JUSTIFY, 6, -1).toString());
-        assertEquals("fo ", FormattableUtils.append("foo", new Formatter(), LEFT_JUSTIFY, 3, 2).toString());
-        assertEquals("fo   ", FormattableUtils.append("foo", new Formatter(), LEFT_JUSTIFY, 5, 2).toString());
+        assertEquals("foo ", FormattableUtils.append("foo", new Formatter(), FormattableFlags.LEFT_JUSTIFY, 4, -1).toString());
+        assertEquals("foo   ", FormattableUtils.append("foo", new Formatter(), FormattableFlags.LEFT_JUSTIFY, 6, -1).toString());
+        assertEquals("fo ", FormattableUtils.append("foo", new Formatter(), FormattableFlags.LEFT_JUSTIFY, 3, 2).toString());
+        assertEquals("fo   ", FormattableUtils.append("foo", new Formatter(), FormattableFlags.LEFT_JUSTIFY, 5, 2).toString());
     }
 
     @Test
@@ -54,10 +54,10 @@ public class FormattableUtilsTest extends AbstractLangTest {
         assertEquals("___foo", FormattableUtils.append("foo", new Formatter(), 0, 6, -1, pad).toString());
         assertEquals("_fo", FormattableUtils.append("foo", new Formatter(), 0, 3, 2, pad).toString());
         assertEquals("___fo", FormattableUtils.append("foo", new Formatter(), 0, 5, 2, pad).toString());
-        assertEquals("foo_", FormattableUtils.append("foo", new Formatter(), LEFT_JUSTIFY, 4, -1, pad).toString());
-        assertEquals("foo___", FormattableUtils.append("foo", new Formatter(), LEFT_JUSTIFY, 6, -1, pad).toString());
-        assertEquals("fo_", FormattableUtils.append("foo", new Formatter(), LEFT_JUSTIFY, 3, 2, pad).toString());
-        assertEquals("fo___", FormattableUtils.append("foo", new Formatter(), LEFT_JUSTIFY, 5, 2, pad).toString());
+        assertEquals("foo_", FormattableUtils.append("foo", new Formatter(), FormattableFlags.LEFT_JUSTIFY, 4, -1, pad).toString());
+        assertEquals("foo___", FormattableUtils.append("foo", new Formatter(), FormattableFlags.LEFT_JUSTIFY, 6, -1, pad).toString());
+        assertEquals("fo_", FormattableUtils.append("foo", new Formatter(), FormattableFlags.LEFT_JUSTIFY, 3, 2, pad).toString());
+        assertEquals("fo___", FormattableUtils.append("foo", new Formatter(), FormattableFlags.LEFT_JUSTIFY, 5, 2, pad).toString());
     }
 
     @Test
@@ -68,10 +68,10 @@ public class FormattableUtilsTest extends AbstractLangTest {
         assertEquals("   foo", FormattableUtils.append("foo", new Formatter(), 0, 6, -1, "*").toString());
         assertEquals(" f*", FormattableUtils.append("foo", new Formatter(), 0, 3, 2, "*").toString());
         assertEquals("   f*", FormattableUtils.append("foo", new Formatter(), 0, 5, 2, "*").toString());
-        assertEquals("foo ", FormattableUtils.append("foo", new Formatter(), LEFT_JUSTIFY, 4, -1, "*").toString());
-        assertEquals("foo   ", FormattableUtils.append("foo", new Formatter(), LEFT_JUSTIFY, 6, -1, "*").toString());
-        assertEquals("f* ", FormattableUtils.append("foo", new Formatter(), LEFT_JUSTIFY, 3, 2, "*").toString());
-        assertEquals("f*   ", FormattableUtils.append("foo", new Formatter(), LEFT_JUSTIFY, 5, 2, "*").toString());
+        assertEquals("foo ", FormattableUtils.append("foo", new Formatter(), FormattableFlags.LEFT_JUSTIFY, 4, -1, "*").toString());
+        assertEquals("foo   ", FormattableUtils.append("foo", new Formatter(), FormattableFlags.LEFT_JUSTIFY, 6, -1, "*").toString());
+        assertEquals("f* ", FormattableUtils.append("foo", new Formatter(), FormattableFlags.LEFT_JUSTIFY, 3, 2, "*").toString());
+        assertEquals("f*   ", FormattableUtils.append("foo", new Formatter(), FormattableFlags.LEFT_JUSTIFY, 5, 2, "*").toString());
 
         assertEquals("foo", FormattableUtils.append("foo", new Formatter(), 0, -1, -1, "+*").toString());
         assertEquals("+*", FormattableUtils.append("foo", new Formatter(), 0, -1, 2, "+*").toString());
@@ -79,10 +79,10 @@ public class FormattableUtilsTest extends AbstractLangTest {
         assertEquals("   foo", FormattableUtils.append("foo", new Formatter(), 0, 6, -1, "+*").toString());
         assertEquals(" +*", FormattableUtils.append("foo", new Formatter(), 0, 3, 2, "+*").toString());
         assertEquals("   +*", FormattableUtils.append("foo", new Formatter(), 0, 5, 2, "+*").toString());
-        assertEquals("foo ", FormattableUtils.append("foo", new Formatter(), LEFT_JUSTIFY, 4, -1, "+*").toString());
-        assertEquals("foo   ", FormattableUtils.append("foo", new Formatter(), LEFT_JUSTIFY, 6, -1, "+*").toString());
-        assertEquals("+* ", FormattableUtils.append("foo", new Formatter(), LEFT_JUSTIFY, 3, 2, "+*").toString());
-        assertEquals("+*   ", FormattableUtils.append("foo", new Formatter(), LEFT_JUSTIFY, 5, 2, "+*").toString());
+        assertEquals("foo ", FormattableUtils.append("foo", new Formatter(), FormattableFlags.LEFT_JUSTIFY, 4, -1, "+*").toString());
+        assertEquals("foo   ", FormattableUtils.append("foo", new Formatter(), FormattableFlags.LEFT_JUSTIFY, 6, -1, "+*").toString());
+        assertEquals("+* ", FormattableUtils.append("foo", new Formatter(), FormattableFlags.LEFT_JUSTIFY, 3, 2, "+*").toString());
+        assertEquals("+*   ", FormattableUtils.append("foo", new Formatter(), FormattableFlags.LEFT_JUSTIFY, 5, 2, "+*").toString());
     }
 
     @Test
@@ -98,10 +98,10 @@ public class FormattableUtilsTest extends AbstractLangTest {
         assertEquals("___foo", FormattableUtils.append("foo", new Formatter(), 0, 6, -1, '_', "*").toString());
         assertEquals("_f*", FormattableUtils.append("foo", new Formatter(), 0, 3, 2, '_', "*").toString());
         assertEquals("___f*", FormattableUtils.append("foo", new Formatter(), 0, 5, 2, '_', "*").toString());
-        assertEquals("foo_", FormattableUtils.append("foo", new Formatter(), LEFT_JUSTIFY, 4, -1, '_', "*").toString());
-        assertEquals("foo___", FormattableUtils.append("foo", new Formatter(), LEFT_JUSTIFY, 6, -1, '_', "*").toString());
-        assertEquals("f*_", FormattableUtils.append("foo", new Formatter(), LEFT_JUSTIFY, 3, 2, '_', "*").toString());
-        assertEquals("f*___", FormattableUtils.append("foo", new Formatter(), LEFT_JUSTIFY, 5, 2, '_', "*").toString());
+        assertEquals("foo_", FormattableUtils.append("foo", new Formatter(), FormattableFlags.LEFT_JUSTIFY, 4, -1, '_', "*").toString());
+        assertEquals("foo___", FormattableUtils.append("foo", new Formatter(), FormattableFlags.LEFT_JUSTIFY, 6, -1, '_', "*").toString());
+        assertEquals("f*_", FormattableUtils.append("foo", new Formatter(), FormattableFlags.LEFT_JUSTIFY, 3, 2, '_', "*").toString());
+        assertEquals("f*___", FormattableUtils.append("foo", new Formatter(), FormattableFlags.LEFT_JUSTIFY, 5, 2, '_', "*").toString());
 
         assertEquals("foo", FormattableUtils.append("foo", new Formatter(), 0, -1, -1, '_', "+*").toString());
         assertEquals("+*", FormattableUtils.append("foo", new Formatter(), 0, -1, 2, '_', "+*").toString());
@@ -109,10 +109,10 @@ public class FormattableUtilsTest extends AbstractLangTest {
         assertEquals("___foo", FormattableUtils.append("foo", new Formatter(), 0, 6, -1, '_', "+*").toString());
         assertEquals("_+*", FormattableUtils.append("foo", new Formatter(), 0, 3, 2, '_', "+*").toString());
         assertEquals("___+*", FormattableUtils.append("foo", new Formatter(), 0, 5, 2, '_', "+*").toString());
-        assertEquals("foo_", FormattableUtils.append("foo", new Formatter(), LEFT_JUSTIFY, 4, -1, '_', "+*").toString());
-        assertEquals("foo___", FormattableUtils.append("foo", new Formatter(), LEFT_JUSTIFY, 6, -1, '_', "+*").toString());
-        assertEquals("+*_", FormattableUtils.append("foo", new Formatter(), LEFT_JUSTIFY, 3, 2, '_', "+*").toString());
-        assertEquals("+*___", FormattableUtils.append("foo", new Formatter(), LEFT_JUSTIFY, 5, 2, '_', "+*").toString());
+        assertEquals("foo_", FormattableUtils.append("foo", new Formatter(), FormattableFlags.LEFT_JUSTIFY, 4, -1, '_', "+*").toString());
+        assertEquals("foo___", FormattableUtils.append("foo", new Formatter(), FormattableFlags.LEFT_JUSTIFY, 6, -1, '_', "+*").toString());
+        assertEquals("+*_", FormattableUtils.append("foo", new Formatter(), FormattableFlags.LEFT_JUSTIFY, 3, 2, '_', "+*").toString());
+        assertEquals("+*___", FormattableUtils.append("foo", new Formatter(), FormattableFlags.LEFT_JUSTIFY, 5, 2, '_', "+*").toString());
     }
 
 }


### PR DESCRIPTION
Only use `static` imports to import `assert methods` in tests.