### PR TITLE
Refactor BooleanUtils#toBooleanObject for readability

### DIFF
--- a/src/main/java/org/apache/commons/lang3/BooleanUtils.java
+++ b/src/main/java/org/apache/commons/lang3/BooleanUtils.java
@@ -743,82 +743,28 @@ public class BooleanUtils {
         if (str == null) {
             return null;
         }
-        switch (str.length()) {
-            case 1: {
-                final char ch0 = str.charAt(0);
-                if (ch0 == 'y' || ch0 == 'Y' ||
-                    ch0 == 't' || ch0 == 'T' ||
-                    ch0 == '1') {
-                    return Boolean.TRUE;
-                }
-                if (ch0 == 'n' || ch0 == 'N' ||
-                    ch0 == 'f' || ch0 == 'F' ||
-                    ch0 == '0') {
-                    return Boolean.FALSE;
-                }
-                break;
+        // The left array (index%2==0) is the Boolean.TRUE strings, the right (index%2==1) is the Boolean.FALSE strings.
+        // The strings have the same length (index%2==0?index:index+1) for each pair.
+        final String[][] booleanValues = new String[][]{
+                {}, {},
+                {"y", "t", "1"}, {"n", "f", "0"},
+                {ON}, {NO},
+                {YES}, {OFF},
+                {TRUE}, {},
+                {}, {FALSE},
+        };
+        final String[] trueValuesWithSameLength = booleanValues[str.length() << 1];
+        for (String trueValue : trueValuesWithSameLength) {
+            if (trueValue.equalsIgnoreCase(str)) {
+                return Boolean.TRUE;
             }
-            case 2: {
-                final char ch0 = str.charAt(0);
-                final char ch1 = str.charAt(1);
-                if ((ch0 == 'o' || ch0 == 'O') &&
-                    (ch1 == 'n' || ch1 == 'N') ) {
-                    return Boolean.TRUE;
-                }
-                if ((ch0 == 'n' || ch0 == 'N') &&
-                    (ch1 == 'o' || ch1 == 'O') ) {
-                    return Boolean.FALSE;
-                }
-                break;
-            }
-            case 3: {
-                final char ch0 = str.charAt(0);
-                final char ch1 = str.charAt(1);
-                final char ch2 = str.charAt(2);
-                if ((ch0 == 'y' || ch0 == 'Y') &&
-                    (ch1 == 'e' || ch1 == 'E') &&
-                    (ch2 == 's' || ch2 == 'S') ) {
-                    return Boolean.TRUE;
-                }
-                if ((ch0 == 'o' || ch0 == 'O') &&
-                    (ch1 == 'f' || ch1 == 'F') &&
-                    (ch2 == 'f' || ch2 == 'F') ) {
-                    return Boolean.FALSE;
-                }
-                break;
-            }
-            case 4: {
-                final char ch0 = str.charAt(0);
-                final char ch1 = str.charAt(1);
-                final char ch2 = str.charAt(2);
-                final char ch3 = str.charAt(3);
-                if ((ch0 == 't' || ch0 == 'T') &&
-                    (ch1 == 'r' || ch1 == 'R') &&
-                    (ch2 == 'u' || ch2 == 'U') &&
-                    (ch3 == 'e' || ch3 == 'E') ) {
-                    return Boolean.TRUE;
-                }
-                break;
-            }
-            case 5: {
-                final char ch0 = str.charAt(0);
-                final char ch1 = str.charAt(1);
-                final char ch2 = str.charAt(2);
-                final char ch3 = str.charAt(3);
-                final char ch4 = str.charAt(4);
-                if ((ch0 == 'f' || ch0 == 'F') &&
-                    (ch1 == 'a' || ch1 == 'A') &&
-                    (ch2 == 'l' || ch2 == 'L') &&
-                    (ch3 == 's' || ch3 == 'S') &&
-                    (ch4 == 'e' || ch4 == 'E') ) {
-                    return Boolean.FALSE;
-                }
-                break;
-            }
-        default:
-            break;
         }
-
+        final String[] falseValuesWithSameLength = booleanValues[(str.length() << 1) + 1];
+        for (String falseValue : falseValuesWithSameLength) {
+            if (falseValue.equalsIgnoreCase(str)) {
+                return Boolean.FALSE;
+            }
+        }
         return null;
     }
 


### PR DESCRIPTION
- Remove the unnecessary unboxing(**removed**)
- Use special boolean values array instead of hard code:
```java
      // The left array (index%2==0) is the Boolean.TRUE strings, the right (index%2==1) is the Boolean.FALSE strings.
      // The strings have the same length (index%2==0?index:index+1) for each pair.
      final String[][] booleanValues = new String[][]{
              {}, {},
              {"y", "t", "1"}, {"n", "f", "0"},
              {ON}, {NO},
              {YES}, {OFF},
              {TRUE}, {},
              {}, {FALSE},
      };
``` 
It has two advantages:

1. For `OCP`, if we add new boolean values, we just need adjust the array
2. Keep the same performance with old code

It is good for short values such as `T`, `OK`, `NOT`, but it is not good for too long values such as `truthful`.
```java
{
  {}, {},
  {}, {},
  {}, {},
  {}, {},
  {}, {},
  {}, {},
  {}, {},  // empty array for seize a seat, :(
  {}, {},
  { "truthful" }, {},
 
}
``` 
