### PR TITLE
Syntax for optional tokens in DurationFormatUtils

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -204,6 +204,7 @@ The <action> type attribute can be add,update,fix,remove.
     <action                   type="add" dev="ggregory" due-to="Gary Gregory">Add RegExUtils.dotAll() and dotAllMatcher().</action>
     <action                   type="add" dev="ggregory" due-to="Gary Gregory">Add Pair.accept(FailableBiConsumer).</action>
     <action                   type="add" dev="ggregory" due-to="Gary Gregory">Add Pair.apply(FailableBiFunction).</action>
+    <action issue="LANG-1677" type="add" dev="ggregory" due-to="Dennis Baerten, Gary Gregory">Add ReflectionDiffBuilder.setExcludeFieldNames(...) and DiffExclude a… #838.</action>
     <!-- UPDATE -->
     <action                   type="update" dev="ggregory" due-to="Dependabot, XenoAmess, Gary Gregory">Bump actions/cache from 2.1.4 to 3.0.10 #742, #752, #764, #833, #867, #959, #964.</action>
     <action                   type="update" dev="ggregory" due-to="Dependabot, Gary Gregory">Bump actions/checkout from 2 to 3.1.0 #819, #825, #859, #963.</action>

--- a/src/main/java/org/apache/commons/lang3/time/DurationFormatUtils.java
+++ b/src/main/java/org/apache/commons/lang3/time/DurationFormatUtils.java
@@ -64,7 +64,7 @@ import org.apache.commons.lang3.Validate;
  * <br>
  * <table border="1">
  * <caption>Example Output</caption>
- * <tr><th>pattern</th><th>Duration.ofDays(1)</th><th>Duration.ofHours(1)</th><th>Duration.ofMinutes(1)</th><th>Duration.ofMillis(0)</th></tr>
+ * <tr><th>pattern</th><th>Duration.ofDays(1)</th><th>Duration.ofHours(1)</th><th>Duration.ofMinutes(1)</th><th>Duration.ZERO</th></tr>
  * <tr><td>d'd'H'h'm'm's's'</td><td>1d0h0m0s</td><td>0d1h0m0s</td><td>0d0h1m0s</td><td>0d0h0m0s</td></tr>
  * <tr><td>d'd'[H'h'm'm']s's'</td><td>1d0s</td><td>0d1h0s</td><td>0d1m0s</td><td>0d0s</td></tr>
  * <tr><td>[d'd'H'h'm'm']s's'</td><td>1d0s</td><td>1h0s</td><td>1m0s</td><td>0s</td></tr>

--- a/src/main/java/org/apache/commons/lang3/time/DurationFormatUtils.java
+++ b/src/main/java/org/apache/commons/lang3/time/DurationFormatUtils.java
@@ -526,9 +526,11 @@ public class DurationFormatUtils {
             switch (ch) {
             // TODO: Need to handle escaping of '
             case '[':
+                if(inOptional) throw new IllegalArgumentException("Nested optional block at index: "+i);
                 inOptional = true;
                 break;
             case ']':
+                if(!inOptional) throw new IllegalArgumentException("Attempting to close unopened optional block at index: "+i);
                 inOptional = false;
                 break;
             case '\'':

--- a/src/main/java/org/apache/commons/lang3/time/DurationFormatUtils.java
+++ b/src/main/java/org/apache/commons/lang3/time/DurationFormatUtils.java
@@ -686,7 +686,7 @@ public class DurationFormatUtils {
          * @param optionalIndex the index of the optional token within the pattern
          */
         Token(final Object value, final boolean optional, final int optionalIndex) {
-            this.value = value;
+            this.value = Objects.requireNonNull(value, "value");
             this.count = 1;
             if (optional) {
                 this.optionalIndex = optionalIndex;

--- a/src/main/java/org/apache/commons/lang3/time/DurationFormatUtils.java
+++ b/src/main/java/org/apache/commons/lang3/time/DurationFormatUtils.java
@@ -429,48 +429,48 @@ public class DurationFormatUtils {
             final int count = token.getCount();
             optional = token.optional;
             if (value instanceof StringBuilder) {
-            	if(!optional || !lastOutputZero) buffer.append(value.toString());
+                if(!optional || !lastOutputZero) buffer.append(value.toString());
             } else if (value.equals(y)) {
                 lastOutputSeconds = false;
                 lastOutputZero = years == 0;
                 if(!optional || !lastOutputZero) 
-                	buffer.append(paddedValue(years, padWithZeros, count));
+                    buffer.append(paddedValue(years, padWithZeros, count));
             } else if (value.equals(M)) {
                 lastOutputSeconds = false;
                 lastOutputZero = months == 0;
                 if(!optional || !lastOutputZero) 
-                	buffer.append(paddedValue(months, padWithZeros, count));
+                    buffer.append(paddedValue(months, padWithZeros, count));
             } else if (value.equals(d)) {
                 lastOutputSeconds = false;
                 lastOutputZero = days == 0;
                 if(!optional || !lastOutputZero) 
-                	buffer.append(paddedValue(days, padWithZeros, count));
+                    buffer.append(paddedValue(days, padWithZeros, count));
             } else if (value.equals(H)) {
                 lastOutputSeconds = false;
                 lastOutputZero = hours == 0;
                 if(!optional || !lastOutputZero) 
-                	buffer.append(paddedValue(hours, padWithZeros, count));
+                    buffer.append(paddedValue(hours, padWithZeros, count));
             } else if (value.equals(m)) {
                 lastOutputSeconds = false;
                 lastOutputZero = minutes == 0;
                 if(!optional || !lastOutputZero) 
-                	buffer.append(paddedValue(minutes, padWithZeros, count));
+                    buffer.append(paddedValue(minutes, padWithZeros, count));
             } else if (value.equals(s)) {
                 lastOutputSeconds = true;
                 lastOutputZero = seconds == 0;
                 if(!optional || !lastOutputZero) 
-                	buffer.append(paddedValue(seconds, padWithZeros, count));
+                    buffer.append(paddedValue(seconds, padWithZeros, count));
             } else if (value.equals(S)) {
-            	lastOutputZero = milliseconds == 0;
-            	if(!optional || !lastOutputZero) {
+                lastOutputZero = milliseconds == 0;
+                if(!optional || !lastOutputZero) {
                     if (lastOutputSeconds) {
 	                        // ensure at least 3 digits are displayed even if padding is not selected
-	                    	final int width = padWithZeros ? Math.max(3, count) : 3;
+	                        final int width = padWithZeros ? Math.max(3, count) : 3;
 	                        buffer.append(paddedValue(milliseconds, true, width));
                 } else {
-                    	buffer.append(paddedValue(milliseconds, padWithZeros, count));
+                        buffer.append(paddedValue(milliseconds, padWithZeros, count));
                     }
-            	}
+                }
                 lastOutputSeconds = false;
             }
         }
@@ -524,11 +524,11 @@ public class DurationFormatUtils {
             switch (ch) {
             // TODO: Need to handle escaping of '
             case '[':
-            	inOptional = true;
-            	break;
+                inOptional = true;
+                break;
             case ']':
-            	inOptional = false;
-            	break;
+                inOptional = false;
+                break;
             case '\'':
                 if (inLiteral) {
                     buffer = null;

--- a/src/main/java/org/apache/commons/lang3/time/DurationFormatUtils.java
+++ b/src/main/java/org/apache/commons/lang3/time/DurationFormatUtils.java
@@ -65,7 +65,7 @@ import org.apache.commons.lang3.Validate;
  * <tr><td>[d'd'H'h'm'm']s's'</td><td>1d0s</td><td>1h0s</td><td>1m0s</td></tr>
  * <tr><td>[d'd'H'h'm'm's's']</td><td>1d</td><td>1h</td><td>1m</td></tr>
  * <tr><td>['{'d'}']HH':'mm</td><td>{1}00:00</td><td>01:00</td><td>00:01</td></tr>
- * <tr><td>['{'dd'}']['<'HH'>']['('mm')']</td><td>{01}</td><td>&lt;01&gt;</td><td>(00)</td></tr>
+ * <tr><td>['{'dd'}']['&lt;'HH'&gt;']['('mm')']</td><td>{01}</td><td>&lt;01&gt;</td><td>(00)</td></tr>
  * <tr><td>[dHms]</td><td>1</td><td>1</td><td>1</td></tr>
  * </table>
  * <b>Note: Optional blocks cannot be nested.</b>

--- a/src/main/java/org/apache/commons/lang3/time/DurationFormatUtils.java
+++ b/src/main/java/org/apache/commons/lang3/time/DurationFormatUtils.java
@@ -51,7 +51,8 @@ import org.apache.commons.lang3.Validate;
  * <br>
  * Tokens can be marked as optional by surrounding them with brackets [ ]. These tokens will
  * only be printed if the token value is non-zero. Literals within optional blocks will only be
- * printed if the nearest non-literal token before or after (checked in that order) is non-zero.
+ * printed if the preceding non-literal token is non-zero. Leading optional literals will only
+ * be printed if the following non-literal is non-zero.
  * Multiple optional blocks can be used to group literals with the desired token. Note that
  * multiple optional tokens without literals can result in impossible to understand output.
  * (See examples below)

--- a/src/main/java/org/apache/commons/lang3/time/DurationFormatUtils.java
+++ b/src/main/java/org/apache/commons/lang3/time/DurationFormatUtils.java
@@ -48,6 +48,13 @@ import org.apache.commons.lang3.Validate;
  * Token values are printed using decimal digits.
  * A token character can be repeated to ensure that the field occupies a certain minimum
  * size. Values will be left-padded with 0 unless padding is disabled in the method invocation.
+ * <br>
+ * Tokens can be marked as optional by surrounding them with brackets [ ]. These tokens will 
+ * only be printed if the token value is non-zero. Any literals within optional blocks will only be 
+ * printed if the nearest prior non-literal token value was non-zero.
+ * <br>
+ * <b>Note: Optional blocks cannot be nested.</b>
+ * 
  * @since 2.1
  */
 public class DurationFormatUtils {

--- a/src/main/java/org/apache/commons/lang3/time/DurationFormatUtils.java
+++ b/src/main/java/org/apache/commons/lang3/time/DurationFormatUtils.java
@@ -49,12 +49,26 @@ import org.apache.commons.lang3.Validate;
  * A token character can be repeated to ensure that the field occupies a certain minimum
  * size. Values will be left-padded with 0 unless padding is disabled in the method invocation.
  * <br>
- * Tokens can be marked as optional by surrounding them with brackets [ ]. These tokens will 
- * only be printed if the token value is non-zero. Any literals within optional blocks will only be 
- * printed if the nearest prior non-literal token value was non-zero.
+ * Tokens can be marked as optional by surrounding them with brackets [ ]. These tokens will
+ * only be printed if the token value is non-zero. Literals within optional blocks will only be
+ * printed if the nearest non-literal token before or after (checked in that order) is non-zero.
+ * Multiple optional blocks can be used to group literals with the desired token. Note that
+ * multiple optional tokens without literals can result in impossible to understand output.
+ * (See examples below)
  * <br>
+ * <table border="1">
+ * <caption>Example Output</caption>
+ * <tr><th>pattern</th><th>Duration.ofDays(1)</th><th>Duration.ofHours(1)</th><th>Duration.ofMinutes(1)</th></tr>
+ * <tr><td>d'd'H'h'm'm's's'</td><td>1d0h0m0s</td><td>0d1h0m0s</td><td>0d0h1m0s</td></tr>
+ * <tr><td>d'd'[H'h'm'm']s's'</td><td>1d0s</td><td>0d1h0s</td><td>0d1m0s</td></tr>
+ * <tr><td>[d'd'H'h'm'm']s's'</td><td>1d0s</td><td>1h0s</td><td>1m0s</td></tr>
+ * <tr><td>[d'd'H'h'm'm's's']</td><td>1d</td><td>1h</td><td>1m</td></tr>
+ * <tr><td>['{'d'}']HH':'mm</td><td>{1}00:00</td><td>01:00</td><td>00:01</td></tr>
+ * <tr><td>['{'dd'}']['<'HH'>']['('mm')']</td><td>{01}</td><td>&lt;01&gt;</td><td>(00)</td></tr>
+ * <tr><td>[dHms]</td><td>1</td><td>1</td><td>1</td></tr>
+ * </table>
  * <b>Note: Optional blocks cannot be nested.</b>
- * 
+ *
  * @since 2.1
  */
 public class DurationFormatUtils {
@@ -431,47 +445,70 @@ public class DurationFormatUtils {
         final StringBuilder buffer = new StringBuilder();
         boolean lastOutputSeconds = false;
         boolean lastOutputZero = false;
-        boolean optional = false;
+        int optionalStart = -1;
+        boolean firstOptionalNonLiteral = false;
+        int optionalIndex = -1;
+        boolean inOptional = false;
         for (final Token token : tokens) {
             final Object value = token.getValue();
+            final boolean isLiteral = value instanceof StringBuilder;
             final int count = token.getCount();
-            optional = token.optional;
-            if (value instanceof StringBuilder) {
-                if (!optional || !lastOutputZero)
-                    buffer.append(value.toString());
+            if (optionalIndex != token.optionalIndex) {
+              optionalIndex = token.optionalIndex;
+              if (optionalIndex > -1) {
+                //entering new optional block
+                optionalStart = buffer.length();
+                lastOutputZero = false;
+                inOptional = true;
+                firstOptionalNonLiteral = false;
+              } else {
+                //leaving optional block
+                inOptional = false;
+              }
+            }
+            if (isLiteral) {
+               if (!inOptional || !lastOutputZero) {
+                     buffer.append(value.toString());
+               }
             } else if (value.equals(y)) {
                 lastOutputSeconds = false;
                 lastOutputZero = years == 0;
-                if (!optional || !lastOutputZero)
+                if (!inOptional || !lastOutputZero) {
                     buffer.append(paddedValue(years, padWithZeros, count));
+                }
             } else if (value.equals(M)) {
                 lastOutputSeconds = false;
                 lastOutputZero = months == 0;
-                if (!optional || !lastOutputZero)
+                if (!inOptional || !lastOutputZero) {
                     buffer.append(paddedValue(months, padWithZeros, count));
+                }
             } else if (value.equals(d)) {
                 lastOutputSeconds = false;
                 lastOutputZero = days == 0;
-                if (!optional || !lastOutputZero)
+                if (!inOptional || !lastOutputZero) {
                     buffer.append(paddedValue(days, padWithZeros, count));
+                }
             } else if (value.equals(H)) {
                 lastOutputSeconds = false;
                 lastOutputZero = hours == 0;
-                if (!optional || !lastOutputZero)
+                if (!inOptional || !lastOutputZero) {
                     buffer.append(paddedValue(hours, padWithZeros, count));
+                }
             } else if (value.equals(m)) {
                 lastOutputSeconds = false;
                 lastOutputZero = minutes == 0;
-                if (!optional || !lastOutputZero)
+                if (!inOptional || !lastOutputZero) {
                     buffer.append(paddedValue(minutes, padWithZeros, count));
+                }
             } else if (value.equals(s)) {
                 lastOutputSeconds = true;
                 lastOutputZero = seconds == 0;
-                if (!optional || !lastOutputZero)
+                if (!inOptional || !lastOutputZero) {
                     buffer.append(paddedValue(seconds, padWithZeros, count));
+                }
             } else if (value.equals(S)) {
                 lastOutputZero = milliseconds == 0;
-                if (!optional || !lastOutputZero) {
+                if (!inOptional || !lastOutputZero) {
                     if (lastOutputSeconds) {
                         // ensure at least 3 digits are displayed even if padding is not selected
                         final int width = padWithZeros ? Math.max(3, count) : 3;
@@ -481,6 +518,13 @@ public class DurationFormatUtils {
                     }
                 }
                 lastOutputSeconds = false;
+            }
+            //as soon as we hit first nonliteral in optional, check for literal prefix
+            if (inOptional && !isLiteral && !firstOptionalNonLiteral){
+                firstOptionalNonLiteral = true;
+                if (lastOutputZero) {
+                    buffer.delete(optionalStart, buffer.length());
+                }
             }
         }
         return buffer.toString();
@@ -523,6 +567,7 @@ public class DurationFormatUtils {
         StringBuilder buffer = null;
         Token previous = null;
         boolean inOptional = false;
+        int optionalIndex = -1;
         for (int i = 0; i < format.length(); i++) {
             final char ch = format.charAt(i);
             if (inLiteral && ch != '\'') {
@@ -533,11 +578,16 @@ public class DurationFormatUtils {
             switch (ch) {
             // TODO: Need to handle escaping of '
             case '[':
-                if(inOptional) throw new IllegalArgumentException("Nested optional block at index: "+i);
+                if (inOptional) {
+                  throw new IllegalArgumentException("Nested optional block at index: "+i);
+                }
+                optionalIndex++;
                 inOptional = true;
                 break;
             case ']':
-                if(!inOptional) throw new IllegalArgumentException("Attempting to close unopened optional block at index: "+i);
+                if (!inOptional) {
+                  throw new IllegalArgumentException("Attempting to close unopened optional block at index: "+i);
+                }
                 inOptional = false;
                 break;
             case '\'':
@@ -546,7 +596,7 @@ public class DurationFormatUtils {
                     inLiteral = false;
                 } else {
                     buffer = new StringBuilder();
-                    list.add(new Token(buffer,inOptional));
+                    list.add(new Token(buffer, inOptional, optionalIndex));
                     inLiteral = true;
                 }
                 break;
@@ -574,7 +624,7 @@ public class DurationFormatUtils {
             default:
                 if (buffer == null) {
                     buffer = new StringBuilder();
-                    list.add(new Token(buffer,inOptional));
+                    list.add(new Token(buffer, inOptional, optionalIndex));
                 }
                 buffer.append(ch);
             }
@@ -583,7 +633,7 @@ public class DurationFormatUtils {
                 if (previous != null && previous.getValue().equals(value)) {
                     previous.increment();
                 } else {
-                    final Token token = new Token(value,inOptional);
+                    final Token token = new Token(value, inOptional, optionalIndex);
                     list.add(token);
                     previous = token;
                 }
@@ -620,22 +670,23 @@ public class DurationFormatUtils {
 
         private final Object value;
         private int count;
-        private boolean optional = false;
-
+        private int optionalIndex = -1;
         Token(final Object value) {
             this.value = value;
             this.count = 1;
         }
-        
+
         /**
          * Wraps a token around a value. A value would be something like a 'Y'.
          *
          * @param value to wrap
          */
-        Token(final Object value, final boolean optional) {
+        Token(final Object value, final boolean optional, final int optionalIndex) {
             this.value = value;
             this.count = 1;
-            this.optional = optional;
+            if (optional) {
+                this.optionalIndex = optionalIndex;
+            }
         }
 
         /**

--- a/src/main/java/org/apache/commons/lang3/time/DurationFormatUtils.java
+++ b/src/main/java/org/apache/commons/lang3/time/DurationFormatUtils.java
@@ -53,20 +53,24 @@ import org.apache.commons.lang3.Validate;
  * only be printed if the token value is non-zero. Literals within optional blocks will only be
  * printed if the preceding non-literal token is non-zero. Leading optional literals will only
  * be printed if the following non-literal is non-zero.
- * Multiple optional blocks can be used to group literals with the desired token. Note that
- * multiple optional tokens without literals can result in impossible to understand output.
+ * Multiple optional blocks can be used to group literals with the desired token.
+ * <p>
+ * Notes on Optional Tokens:<br>
+ * <b>Multiple optional tokens without literals can result in impossible to understand output.</b><br>
+ * <b>Patterns where all tokens are optional can produce empty strings.</b><br>
  * (See examples below)
+ * </p>
  * <br>
  * <table border="1">
  * <caption>Example Output</caption>
- * <tr><th>pattern</th><th>Duration.ofDays(1)</th><th>Duration.ofHours(1)</th><th>Duration.ofMinutes(1)</th></tr>
- * <tr><td>d'd'H'h'm'm's's'</td><td>1d0h0m0s</td><td>0d1h0m0s</td><td>0d0h1m0s</td></tr>
- * <tr><td>d'd'[H'h'm'm']s's'</td><td>1d0s</td><td>0d1h0s</td><td>0d1m0s</td></tr>
- * <tr><td>[d'd'H'h'm'm']s's'</td><td>1d0s</td><td>1h0s</td><td>1m0s</td></tr>
- * <tr><td>[d'd'H'h'm'm's's']</td><td>1d</td><td>1h</td><td>1m</td></tr>
- * <tr><td>['{'d'}']HH':'mm</td><td>{1}00:00</td><td>01:00</td><td>00:01</td></tr>
- * <tr><td>['{'dd'}']['&lt;'HH'&gt;']['('mm')']</td><td>{01}</td><td>&lt;01&gt;</td><td>(00)</td></tr>
- * <tr><td>[dHms]</td><td>1</td><td>1</td><td>1</td></tr>
+ * <tr><th>pattern</th><th>Duration.ofDays(1)</th><th>Duration.ofHours(1)</th><th>Duration.ofMinutes(1)</th><th>Duration.ofMillis(0)</th></tr>
+ * <tr><td>d'd'H'h'm'm's's'</td><td>1d0h0m0s</td><td>0d1h0m0s</td><td>0d0h1m0s</td><td>0d0h0m0s</td></tr>
+ * <tr><td>d'd'[H'h'm'm']s's'</td><td>1d0s</td><td>0d1h0s</td><td>0d1m0s</td><td>0d0s</td></tr>
+ * <tr><td>[d'd'H'h'm'm']s's'</td><td>1d0s</td><td>1h0s</td><td>1m0s</td><td>0s</td></tr>
+ * <tr><td>[d'd'H'h'm'm's's']</td><td>1d</td><td>1h</td><td>1m</td><td></td></tr>
+ * <tr><td>['{'d'}']HH':'mm</td><td>{1}00:00</td><td>01:00</td><td>00:01</td><td>00:00</td></tr>
+ * <tr><td>['{'dd'}']['&lt;'HH'&gt;']['('mm')']</td><td>{01}</td><td>&lt;01&gt;</td><td>(00)</td><td></td></tr>
+ * <tr><td>[dHms]</td><td>1</td><td>1</td><td>1</td><td></td></tr>
  * </table>
  * <b>Note: Optional blocks cannot be nested.</b>
  *
@@ -672,15 +676,13 @@ public class DurationFormatUtils {
         private final Object value;
         private int count;
         private int optionalIndex = -1;
-        Token(final Object value) {
-            this.value = value;
-            this.count = 1;
-        }
 
         /**
          * Wraps a token around a value. A value would be something like a 'Y'.
          *
-         * @param value to wrap
+         * @param value value to wrap
+         * @param optional whether the token is optional
+         * @param optionalIndex the index of the optional token within the pattern
          */
         Token(final Object value, final boolean optional, final int optionalIndex) {
             this.value = value;
@@ -688,18 +690,6 @@ public class DurationFormatUtils {
             if (optional) {
                 this.optionalIndex = optionalIndex;
             }
-        }
-
-        /**
-         * Wraps a token around a repeated number of a value, for example it would
-         * store 'yyyy' as a value for y and a count of 4.
-         *
-         * @param value to wrap
-         * @param count to wrap
-         */
-        Token(final Object value, final int count) {
-            this.value = value;
-            this.count = count;
         }
 
         /**

--- a/src/main/java/org/apache/commons/lang3/time/DurationFormatUtils.java
+++ b/src/main/java/org/apache/commons/lang3/time/DurationFormatUtils.java
@@ -418,7 +418,8 @@ public class DurationFormatUtils {
      * @param padWithZeros  whether to pad
      * @return the formatted string
      */
-    static String format(final Token[] tokens, final long years, final long months, final long days, final long hours, final long minutes, final long seconds,
+    static String format(final Token[] tokens, final long years, final long months, final long days, final long hours, final long minutes,
+            final long seconds,
             final long milliseconds, final boolean padWithZeros) {
         final StringBuilder buffer = new StringBuilder();
         boolean lastOutputSeconds = false;
@@ -429,45 +430,46 @@ public class DurationFormatUtils {
             final int count = token.getCount();
             optional = token.optional;
             if (value instanceof StringBuilder) {
-                if(!optional || !lastOutputZero) buffer.append(value.toString());
+                if (!optional || !lastOutputZero)
+                    buffer.append(value.toString());
             } else if (value.equals(y)) {
                 lastOutputSeconds = false;
                 lastOutputZero = years == 0;
-                if(!optional || !lastOutputZero) 
+                if (!optional || !lastOutputZero)
                     buffer.append(paddedValue(years, padWithZeros, count));
             } else if (value.equals(M)) {
                 lastOutputSeconds = false;
                 lastOutputZero = months == 0;
-                if(!optional || !lastOutputZero) 
+                if (!optional || !lastOutputZero)
                     buffer.append(paddedValue(months, padWithZeros, count));
             } else if (value.equals(d)) {
                 lastOutputSeconds = false;
                 lastOutputZero = days == 0;
-                if(!optional || !lastOutputZero) 
+                if (!optional || !lastOutputZero)
                     buffer.append(paddedValue(days, padWithZeros, count));
             } else if (value.equals(H)) {
                 lastOutputSeconds = false;
                 lastOutputZero = hours == 0;
-                if(!optional || !lastOutputZero) 
+                if (!optional || !lastOutputZero)
                     buffer.append(paddedValue(hours, padWithZeros, count));
             } else if (value.equals(m)) {
                 lastOutputSeconds = false;
                 lastOutputZero = minutes == 0;
-                if(!optional || !lastOutputZero) 
+                if (!optional || !lastOutputZero)
                     buffer.append(paddedValue(minutes, padWithZeros, count));
             } else if (value.equals(s)) {
                 lastOutputSeconds = true;
                 lastOutputZero = seconds == 0;
-                if(!optional || !lastOutputZero) 
+                if (!optional || !lastOutputZero)
                     buffer.append(paddedValue(seconds, padWithZeros, count));
             } else if (value.equals(S)) {
                 lastOutputZero = milliseconds == 0;
-                if(!optional || !lastOutputZero) {
+                if (!optional || !lastOutputZero) {
                     if (lastOutputSeconds) {
-	                        // ensure at least 3 digits are displayed even if padding is not selected
-	                        final int width = padWithZeros ? Math.max(3, count) : 3;
-	                        buffer.append(paddedValue(milliseconds, true, width));
-                } else {
+                        // ensure at least 3 digits are displayed even if padding is not selected
+                        final int width = padWithZeros ? Math.max(3, count) : 3;
+                        buffer.append(paddedValue(milliseconds, true, width));
+                    } else {
                         buffer.append(paddedValue(milliseconds, padWithZeros, count));
                     }
                 }

--- a/src/test/java/org/apache/commons/lang3/time/DurationFormatUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/DurationFormatUtilsTest.java
@@ -27,6 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
+import java.time.Duration;
 import java.util.Calendar;
 import java.util.TimeZone;
 
@@ -632,6 +633,7 @@ public class DurationFormatUtilsTest extends AbstractLangTest {
         }
     }
 
+
     @Test
     public void testUnmatchedOptionalTokens() {
         assertThrows(IllegalArgumentException.class, () -> DurationFormatUtils.formatDuration(1, "[s"));
@@ -640,58 +642,135 @@ public class DurationFormatUtilsTest extends AbstractLangTest {
     }
 
     @Test
+    public void testOptionalLiteralSpecialCharacters() {
+      assertEquals(
+          DurationFormatUtils.formatDuration(10000L, "s's'"),
+          DurationFormatUtils.formatDuration(10000L, "['['m']']s's'"));
+    }
+
+    @Test
+    public void testAlternatingLiteralOptionals() {
+        String format = "['d'dH'h'][m'm']['s's]['ms'S]";
+
+        assertEquals("d1",
+            DurationFormatUtils.formatDuration(Duration.ofDays(1).toMillis(), format));
+
+        assertEquals("1h",
+            DurationFormatUtils.formatDuration(Duration.ofHours(1).toMillis(), format));
+
+        assertEquals("1m",
+            DurationFormatUtils.formatDuration(Duration.ofMinutes(1).toMillis(), format));
+
+        assertEquals("s1",
+            DurationFormatUtils.formatDuration(Duration.ofSeconds(1).toMillis(), format));
+
+        assertEquals("ms001",
+            DurationFormatUtils.formatDuration(Duration.ofMillis(1).toMillis(), format));
+
+        assertEquals("d1s1",
+            DurationFormatUtils.formatDuration(Duration.ofDays(1).plusSeconds(1).toMillis(), format));
+
+        assertEquals("d11h",
+            DurationFormatUtils.formatDuration(Duration.ofDays(1).plusHours(1).toMillis(), format));
+
+        assertEquals("d11h1m",
+            DurationFormatUtils.formatDuration(Duration.ofDays(1).plusHours(1).plusMinutes(1).toMillis(), format));
+
+        assertEquals("d11h1ms1",
+            DurationFormatUtils.formatDuration(Duration.ofDays(1).plusHours(1).plusMinutes(1).plusSeconds(1).toMillis(), format));
+
+        assertEquals("d11h1ms1ms001",
+            DurationFormatUtils.formatDuration(Duration.ofDays(1).plusHours(1).plusMinutes(1).plusSeconds(1).plusMillis(1).toMillis(), format));
+
+    }
+
+    @Test
+    public void testLiteralPrefixOptionalToken() {
+      assertEquals(
+          DurationFormatUtils.formatDuration(10000L, "s's'"),
+          DurationFormatUtils.formatDuration(10000L, "['['d']']['<'H'>']['{'m'}']s's'"));
+      assertEquals(
+          DurationFormatUtils.formatDuration(10000L, "s's'"),
+          DurationFormatUtils.formatDuration(10000L, "['{'m'}']s's'")
+          );
+    }
+
+    @Test
+    public void testEmptyOptionals() {
+      assertEquals(
+          "",
+          DurationFormatUtils.formatDuration(0L, "[d'd'][H'h'][m'm'][s's']"));
+      assertEquals(
+          "",
+          DurationFormatUtils.formatDuration(0L, "['d''h''m''s's]")
+          );
+    }
+
+    @Test
+    public void testMultipleOptionalBlocks() {
+
+      assertEquals(
+          DurationFormatUtils.formatDuration(Duration.ofHours(1).toMillis(), "'[['H']]'"),
+          DurationFormatUtils.formatDuration(Duration.ofHours(1).toMillis(), "['{'d'}']['[['H']]']"));
+
+      assertEquals(
+          DurationFormatUtils.formatDuration(Duration.ofDays(1).toMillis(), "['{'d'}']"),
+          DurationFormatUtils.formatDuration(Duration.ofDays(1).toMillis(), "['{'d'}']['['H']']"));
+
+    }
+
+    @Test
     public void testOptionalToken() {
 
         //make sure optional formats match corresponding adjusted non-optional formats
         assertEquals(
-                DurationFormatUtils.formatDuration(915361000l, "[d'd'H'h'm'm']s's'"),
-                DurationFormatUtils.formatDuration(915361000l, "d'd'H'h'm'm's's'"));
+                DurationFormatUtils.formatDuration(915361000L, "[d'd'H'h'm'm']s's'"),
+                DurationFormatUtils.formatDuration(915361000L, "d'd'H'h'm'm's's'"));
 
         assertEquals(
-                DurationFormatUtils.formatDuration(9153610l, "[d'd'H'h'm'm']s's'"),
-                DurationFormatUtils.formatDuration(9153610l, "H'h'm'm's's'"));
+                DurationFormatUtils.formatDuration(9153610L, "[d'd'H'h'm'm']s's'"),
+                DurationFormatUtils.formatDuration(9153610L, "H'h'm'm's's'"));
 
         assertEquals(
-                DurationFormatUtils.formatDuration(915361l, "[d'd'H'h'm'm']s's'"),
-                DurationFormatUtils.formatDuration(915361l, "m'm's's'"));
+                DurationFormatUtils.formatDuration(915361L, "[d'd'H'h'm'm']s's'"),
+                DurationFormatUtils.formatDuration(915361L, "m'm's's'"));
 
         assertEquals(
-                DurationFormatUtils.formatDuration(9153l, "[d'd'H'h'm'm']s's'"),
-                DurationFormatUtils.formatDuration(9153l, "s's'"));
-        
-       
-        
-        assertEquals(
-                DurationFormatUtils.formatPeriod(9153610l,915361000l, "[d'd'H'h'm'm']s's'") ,
-                DurationFormatUtils.formatPeriod(9153610l,915361000l, "d'd'H'h'm'm's's'") );
+                DurationFormatUtils.formatDuration(9153L, "[d'd'H'h'm'm']s's'"),
+                DurationFormatUtils.formatDuration(9153L, "s's'"));
 
         assertEquals(
-                DurationFormatUtils.formatPeriod(915361l,9153610l, "[d'd'H'h'm'm']s's'"),
-                DurationFormatUtils.formatPeriod(915361l,9153610l, "H'h'm'm's's'"));
+                DurationFormatUtils.formatPeriod(9153610L, 915361000L, "[d'd'H'h'm'm']s's'"),
+                DurationFormatUtils.formatPeriod(9153610L, 915361000L, "d'd'H'h'm'm's's'") );
 
         assertEquals(
-                DurationFormatUtils.formatPeriod(9153l,915361l, "[d'd'H'h'm'm']s's'") ,
-                DurationFormatUtils.formatPeriod(9153l,915361l, "m'm's's'"));
+                DurationFormatUtils.formatPeriod(915361L, 9153610L, "[d'd'H'h'm'm']s's'"),
+                DurationFormatUtils.formatPeriod(915361L, 9153610L, "H'h'm'm's's'"));
 
         assertEquals(
-                DurationFormatUtils.formatPeriod(0l,9153l, "[d'd'H'h'm'm']s's'"),
-                DurationFormatUtils.formatPeriod(0l,9153l, "s's'"));
-        
+                DurationFormatUtils.formatPeriod(9153L, 915361L, "[d'd'H'h'm'm']s's'"),
+                DurationFormatUtils.formatPeriod(9153L, 915361L, "m'm's's'"));
+
+        assertEquals(
+                DurationFormatUtils.formatPeriod(0L, 9153L, "[d'd'H'h'm'm']s's'"),
+                DurationFormatUtils.formatPeriod(0L, 9153L, "s's'"));
+
         //make sure optional parts are actually omitted when zero
-        
-        assertEquals("2h32m33s610ms",DurationFormatUtils.formatDuration(9153610l, "[d'd'H'h'm'm's's']S'ms'"));
 
-        assertEquals("15m15s361ms",DurationFormatUtils.formatDuration(915361l, "[d'd'H'h'm'm's's']S'ms'"));
+        assertEquals("2h32m33s610ms", DurationFormatUtils.formatDuration(9153610L, "[d'd'H'h'm'm's's']S'ms'"));
 
-        assertEquals("9s153ms", DurationFormatUtils.formatDuration(9153l, "[d'd'H'h'm'm's's']S'ms'"));
-        
-        assertEquals("915ms",DurationFormatUtils.formatDuration(915l, "[d'd'H'h'm'm's's']S'ms'"));
-        
+        assertEquals("15m15s361ms", DurationFormatUtils.formatDuration(915361L, "[d'd'H'h'm'm's's']S'ms'"));
+
+        assertEquals("9s153ms", DurationFormatUtils.formatDuration(9153L, "[d'd'H'h'm'm's's']S'ms'"));
+
+        assertEquals("915ms", DurationFormatUtils.formatDuration(915L, "[d'd'H'h'm'm's's']S'ms'"));
+
         //make sure we can handle omitting multiple literals after a token
 
         assertEquals(
-                DurationFormatUtils.formatPeriod(915361l,9153610l, "[d'd''d2'H'h''h2'm'm']s's'"),
-                DurationFormatUtils.formatPeriod(915361l,9153610l, "H'h''h2'm'm's's'"));
+                DurationFormatUtils.formatPeriod(915361L, 9153610L, "[d'd''d2'H'h''h2'm'm']s's'"),
+                DurationFormatUtils.formatPeriod(915361L, 9153610L, "H'h''h2'm'm's's'"));
     }
+
 
 }

--- a/src/test/java/org/apache/commons/lang3/time/DurationFormatUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/DurationFormatUtilsTest.java
@@ -572,49 +572,49 @@ public class DurationFormatUtilsTest extends AbstractLangTest {
     public void testLexx() {
         // tests each constant
         assertArrayEquals(new DurationFormatUtils.Token[]{
-            new DurationFormatUtils.Token(DurationFormatUtils.y, 1),
-            new DurationFormatUtils.Token(DurationFormatUtils.M, 1),
-            new DurationFormatUtils.Token(DurationFormatUtils.d, 1),
-            new DurationFormatUtils.Token(DurationFormatUtils.H, 1),
-            new DurationFormatUtils.Token(DurationFormatUtils.m, 1),
-            new DurationFormatUtils.Token(DurationFormatUtils.s, 1),
-            new DurationFormatUtils.Token(DurationFormatUtils.S, 1)}, DurationFormatUtils.lexx("yMdHmsS"));
+            createTokenWithCount(DurationFormatUtils.y, 1),
+            createTokenWithCount(DurationFormatUtils.M, 1),
+            createTokenWithCount(DurationFormatUtils.d, 1),
+            createTokenWithCount(DurationFormatUtils.H, 1),
+            createTokenWithCount(DurationFormatUtils.m, 1),
+            createTokenWithCount(DurationFormatUtils.s, 1),
+            createTokenWithCount(DurationFormatUtils.S, 1)}, DurationFormatUtils.lexx("yMdHmsS"));
 
         // tests the ISO 8601-like
         assertArrayEquals(new DurationFormatUtils.Token[]{
-            new DurationFormatUtils.Token(DurationFormatUtils.H, 2),
-            new DurationFormatUtils.Token(new StringBuilder(":"), 1),
-            new DurationFormatUtils.Token(DurationFormatUtils.m, 2),
-            new DurationFormatUtils.Token(new StringBuilder(":"), 1),
-            new DurationFormatUtils.Token(DurationFormatUtils.s, 2),
-            new DurationFormatUtils.Token(new StringBuilder("."), 1),
-            new DurationFormatUtils.Token(DurationFormatUtils.S, 3)}, DurationFormatUtils.lexx("HH:mm:ss.SSS"));
+            createTokenWithCount(DurationFormatUtils.H, 2),
+            createTokenWithCount(new StringBuilder(":"), 1),
+            createTokenWithCount(DurationFormatUtils.m, 2),
+            createTokenWithCount(new StringBuilder(":"), 1),
+            createTokenWithCount(DurationFormatUtils.s, 2),
+            createTokenWithCount(new StringBuilder("."), 1),
+            createTokenWithCount(DurationFormatUtils.S, 3)}, DurationFormatUtils.lexx("HH:mm:ss.SSS"));
 
         // test the iso extended format
         assertArrayEquals(new DurationFormatUtils.Token[]{
-            new DurationFormatUtils.Token(new StringBuilder("P"), 1),
-            new DurationFormatUtils.Token(DurationFormatUtils.y, 4),
-            new DurationFormatUtils.Token(new StringBuilder("Y"), 1),
-            new DurationFormatUtils.Token(DurationFormatUtils.M, 1),
-            new DurationFormatUtils.Token(new StringBuilder("M"), 1),
-            new DurationFormatUtils.Token(DurationFormatUtils.d, 1),
-            new DurationFormatUtils.Token(new StringBuilder("DT"), 1),
-            new DurationFormatUtils.Token(DurationFormatUtils.H, 1),
-            new DurationFormatUtils.Token(new StringBuilder("H"), 1),
-            new DurationFormatUtils.Token(DurationFormatUtils.m, 1),
-            new DurationFormatUtils.Token(new StringBuilder("M"), 1),
-            new DurationFormatUtils.Token(DurationFormatUtils.s, 1),
-            new DurationFormatUtils.Token(new StringBuilder("."), 1),
-            new DurationFormatUtils.Token(DurationFormatUtils.S, 3),
-            new DurationFormatUtils.Token(new StringBuilder("S"), 1)}, DurationFormatUtils
+            createTokenWithCount(new StringBuilder("P"), 1),
+            createTokenWithCount(DurationFormatUtils.y, 4),
+            createTokenWithCount(new StringBuilder("Y"), 1),
+            createTokenWithCount(DurationFormatUtils.M, 1),
+            createTokenWithCount(new StringBuilder("M"), 1),
+            createTokenWithCount(DurationFormatUtils.d, 1),
+            createTokenWithCount(new StringBuilder("DT"), 1),
+            createTokenWithCount(DurationFormatUtils.H, 1),
+            createTokenWithCount(new StringBuilder("H"), 1),
+            createTokenWithCount(DurationFormatUtils.m, 1),
+            createTokenWithCount(new StringBuilder("M"), 1),
+            createTokenWithCount(DurationFormatUtils.s, 1),
+            createTokenWithCount(new StringBuilder("."), 1),
+            createTokenWithCount(DurationFormatUtils.S, 3),
+            createTokenWithCount(new StringBuilder("S"), 1)}, DurationFormatUtils
                 .lexx(DurationFormatUtils.ISO_EXTENDED_FORMAT_PATTERN));
 
         // test failures in equals
-        final DurationFormatUtils.Token token = new DurationFormatUtils.Token(DurationFormatUtils.y, 4);
+        final DurationFormatUtils.Token token = createTokenWithCount(DurationFormatUtils.y, 4);
         assertNotEquals(token, new Object(), "Token equal to non-Token class. ");
-        assertNotEquals(token, new DurationFormatUtils.Token(new Object()), "Token equal to Token with wrong value class. ");
-        assertNotEquals(token, new DurationFormatUtils.Token(DurationFormatUtils.y, 1), "Token equal to Token with different count. ");
-        final DurationFormatUtils.Token numToken = new DurationFormatUtils.Token(Integer.valueOf(1), 4);
+        assertNotEquals(token, createTokenWithCount(new Object(), 1), "Token equal to Token with wrong value class. ");
+        assertNotEquals(token, createTokenWithCount(DurationFormatUtils.y, 1), "Token equal to Token with different count. ");
+        final DurationFormatUtils.Token numToken = createTokenWithCount(Integer.valueOf(1), 4);
         assertEquals(numToken, numToken, "Token with Number value not equal to itself. ");
     }
     // Testing the under a day range in DurationFormatUtils.formatPeriod
@@ -724,36 +724,40 @@ public class DurationFormatUtilsTest extends AbstractLangTest {
 
         //make sure optional formats match corresponding adjusted non-optional formats
         assertEquals(
-                DurationFormatUtils.formatDuration(915361000L, "[d'd'H'h'm'm']s's'"),
-                DurationFormatUtils.formatDuration(915361000L, "d'd'H'h'm'm's's'"));
+                DurationFormatUtils.formatDuration(915361000L, "d'd'H'h'm'm's's'"),
+                DurationFormatUtils.formatDuration(915361000L, "[d'd'H'h'm'm']s's'"));
 
         assertEquals(
-                DurationFormatUtils.formatDuration(9153610L, "[d'd'H'h'm'm']s's'"),
-                DurationFormatUtils.formatDuration(9153610L, "H'h'm'm's's'"));
+                DurationFormatUtils.formatDuration(9153610L, "H'h'm'm's's'"),
+                DurationFormatUtils.formatDuration(9153610L, "[d'd'H'h'm'm']s's'"));
 
         assertEquals(
-                DurationFormatUtils.formatDuration(915361L, "[d'd'H'h'm'm']s's'"),
-                DurationFormatUtils.formatDuration(915361L, "m'm's's'"));
+                DurationFormatUtils.formatDuration(915361L, "m'm's's'"),
+                DurationFormatUtils.formatDuration(915361L, "[d'd'H'h'm'm']s's'"));
 
         assertEquals(
-                DurationFormatUtils.formatDuration(9153L, "[d'd'H'h'm'm']s's'"),
-                DurationFormatUtils.formatDuration(9153L, "s's'"));
+                DurationFormatUtils.formatDuration(9153L, "s's'"),
+                DurationFormatUtils.formatDuration(9153L, "[d'd'H'h'm'm']s's'"));
 
         assertEquals(
-                DurationFormatUtils.formatPeriod(9153610L, 915361000L, "[d'd'H'h'm'm']s's'"),
-                DurationFormatUtils.formatPeriod(9153610L, 915361000L, "d'd'H'h'm'm's's'") );
+                DurationFormatUtils.formatDuration(9153L, "s's'"),
+                DurationFormatUtils.formatDuration(9153L, "[d'd'H'h'm'm']s's'"));
 
         assertEquals(
-                DurationFormatUtils.formatPeriod(915361L, 9153610L, "[d'd'H'h'm'm']s's'"),
-                DurationFormatUtils.formatPeriod(915361L, 9153610L, "H'h'm'm's's'"));
+                DurationFormatUtils.formatPeriod(9153610L, 915361000L, "d'd'H'h'm'm's's'"),
+                DurationFormatUtils.formatPeriod(9153610L, 915361000L, "[d'd'H'h'm'm']s's'"));
 
         assertEquals(
-                DurationFormatUtils.formatPeriod(9153L, 915361L, "[d'd'H'h'm'm']s's'"),
-                DurationFormatUtils.formatPeriod(9153L, 915361L, "m'm's's'"));
+                DurationFormatUtils.formatPeriod(915361L, 9153610L, "H'h'm'm's's'"),
+                DurationFormatUtils.formatPeriod(915361L, 9153610L, "[d'd'H'h'm'm']s's'"));
 
         assertEquals(
-                DurationFormatUtils.formatPeriod(0L, 9153L, "[d'd'H'h'm'm']s's'"),
-                DurationFormatUtils.formatPeriod(0L, 9153L, "s's'"));
+                DurationFormatUtils.formatPeriod(9153L, 915361L, "m'm's's'"),
+                DurationFormatUtils.formatPeriod(9153L, 915361L, "[d'd'H'h'm'm']s's'"));
+
+        assertEquals(
+                DurationFormatUtils.formatPeriod(0L, 9153L, "s's'"),
+                DurationFormatUtils.formatPeriod(0L, 9153L, "[d'd'H'h'm'm']s's'"));
 
         //make sure optional parts are actually omitted when zero
 
@@ -768,9 +772,15 @@ public class DurationFormatUtilsTest extends AbstractLangTest {
         //make sure we can handle omitting multiple literals after a token
 
         assertEquals(
-                DurationFormatUtils.formatPeriod(915361L, 9153610L, "[d'd''d2'H'h''h2'm'm']s's'"),
-                DurationFormatUtils.formatPeriod(915361L, 9153610L, "H'h''h2'm'm's's'"));
+                DurationFormatUtils.formatPeriod(915361L, 9153610L, "H'h''h2'm'm's's'"),
+                DurationFormatUtils.formatPeriod(915361L, 9153610L, "[d'd''d2'H'h''h2'm'm']s's'"));
     }
 
-
+    private DurationFormatUtils.Token createTokenWithCount(final Object value, final int count) {
+        DurationFormatUtils.Token token = new DurationFormatUtils.Token(value, false, -1);
+        for (int i=1; i<count; i++) {
+            token.increment();
+        }
+        return token;
+    }
 }

--- a/src/test/java/org/apache/commons/lang3/time/DurationFormatUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/DurationFormatUtilsTest.java
@@ -691,8 +691,7 @@ public class DurationFormatUtilsTest extends AbstractLangTest {
           DurationFormatUtils.formatDuration(10000L, "['['d']']['<'H'>']['{'m'}']s's'"));
       assertEquals(
           DurationFormatUtils.formatDuration(10000L, "s's'"),
-          DurationFormatUtils.formatDuration(10000L, "['{'m'}']s's'")
-          );
+          DurationFormatUtils.formatDuration(10000L, "['{'m'}']s's'"));
     }
 
     @Test
@@ -702,8 +701,7 @@ public class DurationFormatUtilsTest extends AbstractLangTest {
           DurationFormatUtils.formatDuration(0L, "[d'd'][H'h'][m'm'][s's']"));
       assertEquals(
           "",
-          DurationFormatUtils.formatDuration(0L, "['d''h''m''s's]")
-          );
+          DurationFormatUtils.formatDuration(0L, "['d''h''m''s's]"));
     }
 
     @Test
@@ -716,7 +714,6 @@ public class DurationFormatUtilsTest extends AbstractLangTest {
       assertEquals(
           DurationFormatUtils.formatDuration(Duration.ofDays(1).toMillis(), "['{'d'}']"),
           DurationFormatUtils.formatDuration(Duration.ofDays(1).toMillis(), "['{'d'}']['['H']']"));
-
     }
 
     @Test
@@ -778,7 +775,7 @@ public class DurationFormatUtilsTest extends AbstractLangTest {
 
     private DurationFormatUtils.Token createTokenWithCount(final Object value, final int count) {
         DurationFormatUtils.Token token = new DurationFormatUtils.Token(value, false, -1);
-        for (int i=1; i<count; i++) {
+        for (int i = 1; i < count; i++) {
             token.increment();
         }
         return token;

--- a/src/test/java/org/apache/commons/lang3/time/DurationFormatUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/DurationFormatUtilsTest.java
@@ -631,5 +631,32 @@ public class DurationFormatUtilsTest extends AbstractLangTest {
             }
         }
     }
+    
+    @Test
+    public void testUnmatchedOptionalToken() {
+    	assertThrows(IllegalArgumentException.class, () -> DurationFormatUtils.formatDuration(1, "[s"));
+    }
+    
+    @Test
+    public void testOptionalToken() {
+    	
+    	//make sure optional formats match corresponding adjusted non-optional formats
+    	assertEquals(
+    			DurationFormatUtils.formatDuration(915361000l, "[d'd'H'h'm'm']s's'"), 
+    			DurationFormatUtils.formatDuration(915361000l, "d'd'H'h'm'm's's'"));
+    	
+    	assertEquals(
+    			DurationFormatUtils.formatDuration(9153610l, "[d'd'H'h'm'm']s's'"), 
+    			DurationFormatUtils.formatDuration(9153610l, "H'h'm'm's's'"));
+    	
+    	assertEquals(
+    			DurationFormatUtils.formatDuration(915361l, "[d'd'H'h'm'm']s's'"), 
+    			DurationFormatUtils.formatDuration(915361l, "m'm's's'"));
+    	
+    	assertEquals(
+    			DurationFormatUtils.formatDuration(9153l, "[d'd'H'h'm'm']s's'"), 
+    			DurationFormatUtils.formatDuration(9153l, "s's'"));
+    	
+    }
 
 }

--- a/src/test/java/org/apache/commons/lang3/time/DurationFormatUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/DurationFormatUtilsTest.java
@@ -658,7 +658,40 @@ public class DurationFormatUtilsTest extends AbstractLangTest {
         assertEquals(
                 DurationFormatUtils.formatDuration(9153l, "[d'd'H'h'm'm']s's'"),
                 DurationFormatUtils.formatDuration(9153l, "s's'"));
+        
+       
+        
+        assertEquals(
+                DurationFormatUtils.formatPeriod(9153610l,915361000l, "[d'd'H'h'm'm']s's'") ,
+                DurationFormatUtils.formatPeriod(9153610l,915361000l, "d'd'H'h'm'm's's'") );
 
+        assertEquals(
+                DurationFormatUtils.formatPeriod(915361l,9153610l, "[d'd'H'h'm'm']s's'"),
+                DurationFormatUtils.formatPeriod(915361l,9153610l, "H'h'm'm's's'"));
+
+        assertEquals(
+                DurationFormatUtils.formatPeriod(9153l,915361l, "[d'd'H'h'm'm']s's'") ,
+                DurationFormatUtils.formatPeriod(9153l,915361l, "m'm's's'"));
+
+        assertEquals(
+                DurationFormatUtils.formatPeriod(0l,9153l, "[d'd'H'h'm'm']s's'"),
+                DurationFormatUtils.formatPeriod(0l,9153l, "s's'"));
+        
+        //make sure optional parts are actually omitted when zero
+        
+        assertEquals("2h32m33s610ms",DurationFormatUtils.formatDuration(9153610l, "[d'd'H'h'm'm's's']S'ms'"));
+
+        assertEquals("15m15s361ms",DurationFormatUtils.formatDuration(915361l, "[d'd'H'h'm'm's's']S'ms'"));
+
+        assertEquals("9s153ms", DurationFormatUtils.formatDuration(9153l, "[d'd'H'h'm'm's's']S'ms'"));
+        
+        assertEquals("915ms",DurationFormatUtils.formatDuration(915l, "[d'd'H'h'm'm's's']S'ms'"));
+        
+        //make sure we can handle omitting multiple literals after a token
+
+        assertEquals(
+                DurationFormatUtils.formatPeriod(915361l,9153610l, "[d'd''d2'H'h''h2'm'm']s's'"),
+                DurationFormatUtils.formatPeriod(915361l,9153610l, "H'h''h2'm'm's's'"));
     }
 
 }

--- a/src/test/java/org/apache/commons/lang3/time/DurationFormatUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/DurationFormatUtilsTest.java
@@ -631,32 +631,32 @@ public class DurationFormatUtilsTest extends AbstractLangTest {
             }
         }
     }
-    
+
     @Test
     public void testUnmatchedOptionalToken() {
-    	assertThrows(IllegalArgumentException.class, () -> DurationFormatUtils.formatDuration(1, "[s"));
+        assertThrows(IllegalArgumentException.class, () -> DurationFormatUtils.formatDuration(1, "[s"));
     }
-    
+
     @Test
     public void testOptionalToken() {
-    	
-    	//make sure optional formats match corresponding adjusted non-optional formats
-    	assertEquals(
-    			DurationFormatUtils.formatDuration(915361000l, "[d'd'H'h'm'm']s's'"), 
-    			DurationFormatUtils.formatDuration(915361000l, "d'd'H'h'm'm's's'"));
-    	
-    	assertEquals(
-    			DurationFormatUtils.formatDuration(9153610l, "[d'd'H'h'm'm']s's'"), 
-    			DurationFormatUtils.formatDuration(9153610l, "H'h'm'm's's'"));
-    	
-    	assertEquals(
-    			DurationFormatUtils.formatDuration(915361l, "[d'd'H'h'm'm']s's'"), 
-    			DurationFormatUtils.formatDuration(915361l, "m'm's's'"));
-    	
-    	assertEquals(
-    			DurationFormatUtils.formatDuration(9153l, "[d'd'H'h'm'm']s's'"), 
-    			DurationFormatUtils.formatDuration(9153l, "s's'"));
-    	
+
+        //make sure optional formats match corresponding adjusted non-optional formats
+        assertEquals(
+                DurationFormatUtils.formatDuration(915361000l, "[d'd'H'h'm'm']s's'"),
+                DurationFormatUtils.formatDuration(915361000l, "d'd'H'h'm'm's's'"));
+
+        assertEquals(
+                DurationFormatUtils.formatDuration(9153610l, "[d'd'H'h'm'm']s's'"),
+                DurationFormatUtils.formatDuration(9153610l, "H'h'm'm's's'"));
+
+        assertEquals(
+                DurationFormatUtils.formatDuration(915361l, "[d'd'H'h'm'm']s's'"),
+                DurationFormatUtils.formatDuration(915361l, "m'm's's'"));
+
+        assertEquals(
+                DurationFormatUtils.formatDuration(9153l, "[d'd'H'h'm'm']s's'"),
+                DurationFormatUtils.formatDuration(9153l, "s's'"));
+
     }
 
 }

--- a/src/test/java/org/apache/commons/lang3/time/DurationFormatUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/DurationFormatUtilsTest.java
@@ -633,8 +633,10 @@ public class DurationFormatUtilsTest extends AbstractLangTest {
     }
 
     @Test
-    public void testUnmatchedOptionalToken() {
+    public void testUnmatchedOptionalTokens() {
         assertThrows(IllegalArgumentException.class, () -> DurationFormatUtils.formatDuration(1, "[s"));
+        assertThrows(IllegalArgumentException.class, () -> DurationFormatUtils.formatDuration(1, "[[s"));
+        assertThrows(IllegalArgumentException.class, () -> DurationFormatUtils.formatDuration(1, "[s]]"));
     }
 
     @Test


### PR DESCRIPTION
Relatively simple low-impact implementation of optional tokens within DurationFormatUtils. Useful when you need more human readable duration strings.

Brackets [] are used to denote optional tokens. Optional tokens are only printed if non-zero. Optional literals are only printed if the preceding non-literal was non-zero.

e.g. A single format:  `[d'd 'H'h 'm'm ']s's'`
Can produce outputs like:
```
1d 2h 3m 14s
2h 3m 14s
3m 14s
14s
0s
```

2 unit tests added.