### PR TITLE
ObjectUtils caught NullPointerException inside defaultIfNull method to return default value

### DIFF
--- a/src/main/java/org/apache/commons/lang3/ObjectUtils.java
+++ b/src/main/java/org/apache/commons/lang3/ObjectUtils.java
@@ -595,7 +595,11 @@ public class ObjectUtils {
      * TODO Rename to getIfNull in 4.0
      */
     public static <T> T defaultIfNull(final T object, final T defaultValue) {
-        return object != null ? object : defaultValue;
+        try {
+            return object != null ? object : defaultValue;
+        } catch (NullPointerException npe) {
+            return defaultValue;
+        }
     }
 
     // Null-safe equals/hashCode


### PR DESCRIPTION
this is a proposal change for the defaultIfNull method, it could be useful when we want a default value with a list or nested object, for example:

```java
defaultIfNull(list.get(0).getValue(), "helloDefault");
```

where list.get(0) is null, so we skip the null pointer and directly return the default value as expected.