### PR TITLE
LANG-1699: Corrected value of SystemUtils.JAVA_VENDOR

### DIFF
--- a/src/main/java/org/apache/commons/lang3/SystemUtils.java
+++ b/src/main/java/org/apache/commons/lang3/SystemUtils.java
@@ -438,10 +438,10 @@ public class SystemUtils {
      * sync with that System property.
      * </p>
      *
-     * @see SystemProperties#getJavaVersion()
+     * @see SystemProperties#getJavaVendor()
      * @since Java 1.1
      */
-    public static final String JAVA_VENDOR = SystemProperties.getJavaVersion();
+    public static final String JAVA_VENDOR = SystemProperties.getJavaVendor();
 
     /**
      * The {@code java.vendor.url} System Property. Java vendor URL.


### PR DESCRIPTION
Fixes a typo in the `SystemUtils` class that assigned `JAVA_VENDOR` constant so it now calls `SystemProperties.getJavaVendor()`. Also updated the Javadoc comment.