### PR TITLE
LANG-1695: NumberUtils::isParseable does not recognise numbers ending in dot

### DIFF
--- a/src/main/java/org/apache/commons/lang3/math/NumberUtils.java
+++ b/src/main/java/org/apache/commons/lang3/math/NumberUtils.java
@@ -1754,9 +1754,6 @@ public class NumberUtils {
         if (StringUtils.isEmpty(str)) {
             return false;
         }
-        if (str.charAt(str.length() - 1) == '.') {
-            return false;
-        }
         if (str.charAt(0) == '-') {
             if (str.length() == 1) {
                 return false;
@@ -1776,7 +1773,7 @@ public class NumberUtils {
             if (decimalPoints > 1) {
                 return false;
             }
-            if (!isDecimalPoint && !Character.isDigit(str.charAt(i))) {
+            if (!isDecimalPoint && !Character.isDigit(str.charAt(i)) && !(i == str.length() - 1 && str.charAt(i) == '.')) {
                 return false;
             }
         }

--- a/src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java
@@ -918,7 +918,8 @@ public class NumberUtilsTest extends AbstractLangTest {
         assertFalse(NumberUtils.isParsable("pendro"));
         assertFalse(NumberUtils.isParsable("64, 2"));
         assertFalse(NumberUtils.isParsable("64.2.2"));
-        assertFalse(NumberUtils.isParsable("64."));
+        assertTrue(NumberUtils.isParsable("64."));
+        assertTrue(NumberUtils.isParsable("-64."));
         assertFalse(NumberUtils.isParsable("64L"));
         assertFalse(NumberUtils.isParsable("-"));
         assertFalse(NumberUtils.isParsable("--2"));

--- a/src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java
@@ -919,6 +919,7 @@ public class NumberUtilsTest extends AbstractLangTest {
         assertFalse(NumberUtils.isParsable("64, 2"));
         assertFalse(NumberUtils.isParsable("64.2.2"));
         assertTrue(NumberUtils.isParsable("64."));
+        assertFalse(NumberUtils.isParsable("64.."));
         assertTrue(NumberUtils.isParsable("-64."));
         assertFalse(NumberUtils.isParsable("64L"));
         assertFalse(NumberUtils.isParsable("-"));


### PR DESCRIPTION
[LANG-1695](https://issues.apache.org/jira/browse/LANG-1695) allowed for a number (positive or negative) that has only one decimal point and it is at the end of the input, is treated as a valid number