### PR TITLE
ArchUtils refactoring

### DIFF
--- a/src/main/java/org/apache/commons/lang3/ArchUtils.java
+++ b/src/main/java/org/apache/commons/lang3/ArchUtils.java
@@ -41,48 +41,22 @@ public class ArchUtils {
     }
 
     private static void init() {
-        init_X86_32Bit();
-        init_X86_64Bit();
-        init_IA64_32Bit();
-        init_IA64_64Bit();
-        init_PPC_32Bit();
-        init_PPC_64Bit();
-        init_Aarch_64Bit();
+        initArch(Processor.Arch.BIT_64, Processor.Type.AARCH_64, "aarch64");
+        initArch(Processor.Arch.BIT_32, Processor.Type.X86, "x86", "i386", "i486", "i586", "i686", "pentium");
+        initArch(Processor.Arch.BIT_64, Processor.Type.X86, "x86_64", "amd64", "em64t", "universal");
+        initArch(Processor.Arch.BIT_32, Processor.Type.IA_64, "ia64_32", "ia64n");
+        initArch(Processor.Arch.BIT_64, Processor.Type.IA_64, "ia64", "ia64w");
+        initArch(Processor.Arch.BIT_32, Processor.Type.PPC, "ppc", "power", "powerpc", "power_pc", "power_rs");
+        initArch(Processor.Arch.BIT_64, Processor.Type.PPC, "ppc64", "power64", "powerpc64", "power_pc64", "power_rs64");
     }
 
-    private static void init_Aarch_64Bit() {
-        final Processor processor = new Processor(Processor.Arch.BIT_64, Processor.Type.AARCH_64);
-        addProcessors(processor, "aarch64");
+    private static void initArch(Processor.Arch archType, Processor.Type type, String... arch) {
+        final Processor processor = getProcessor(archType, type);
+        addProcessors(processor, arch);
     }
 
-    private static void init_X86_32Bit() {
-        final Processor processor = new Processor(Processor.Arch.BIT_32, Processor.Type.X86);
-        addProcessors(processor, "x86", "i386", "i486", "i586", "i686", "pentium");
-    }
-
-    private static void init_X86_64Bit() {
-        final Processor processor = new Processor(Processor.Arch.BIT_64, Processor.Type.X86);
-        addProcessors(processor, "x86_64", "amd64", "em64t", "universal");
-    }
-
-    private static void init_IA64_32Bit() {
-        final Processor processor = new Processor(Processor.Arch.BIT_32, Processor.Type.IA_64);
-        addProcessors(processor, "ia64_32", "ia64n");
-    }
-
-    private static void init_IA64_64Bit() {
-        final Processor processor = new Processor(Processor.Arch.BIT_64, Processor.Type.IA_64);
-        addProcessors(processor, "ia64", "ia64w");
-    }
-
-    private static void init_PPC_32Bit() {
-        final Processor processor = new Processor(Processor.Arch.BIT_32, Processor.Type.PPC);
-        addProcessors(processor, "ppc", "power", "powerpc", "power_pc", "power_rs");
-    }
-
-    private static void init_PPC_64Bit() {
-        final Processor processor = new Processor(Processor.Arch.BIT_64, Processor.Type.PPC);
-        addProcessors(processor, "ppc64", "power64", "powerpc64", "power_pc64", "power_rs64");
+    private static Processor getProcessor(Processor.Arch archType, Processor.Type type) {
+        return new Processor(archType, type);
     }
 
     /**


### PR DESCRIPTION
The logic to get the Processor for a given architecture string is spread across the init_* methods. A cleaner design would be to have a separate private method that maps the architecture string to a Processor, and calls that from the init_* methods.