### PR TITLE
Add capacity for ReflectionToStringBuilder to include methods annotated with @ToStringInclude

### DIFF
--- a/src/main/java/org/apache/commons/lang3/builder/Reflection.java
+++ b/src/main/java/org/apache/commons/lang3/builder/Reflection.java
@@ -18,6 +18,8 @@
 package org.apache.commons.lang3.builder;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.Objects;
 
 /**
@@ -37,6 +39,23 @@ class Reflection {
         try {
             return Objects.requireNonNull(field, "field").get(obj);
         } catch (IllegalAccessException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    /**
+     * Delegates to {@link Method#invoke(Object, Object...)} and rethrows {@link IllegalAccessException}
+     * and {@link InvocationTargetException} as {@link IllegalArgumentException}.
+     *
+     * @param method The receiver of the invoke call.
+     * @param obj   The argument of the invoke call.
+     * @return The result of the invoke call.
+     * @throws IllegalArgumentException Thrown after catching {@link IllegalAccessException} and {@link InvocationTargetException}.
+     */
+    static Object getUnchecked(final Method method, final Object obj) {
+        try {
+            return Objects.requireNonNull(method, "method").invoke(obj);
+        } catch (IllegalAccessException | InvocationTargetException e) {
             throw new IllegalArgumentException(e);
         }
     }

--- a/src/main/java/org/apache/commons/lang3/builder/ToStringInclude.java
+++ b/src/main/java/org/apache/commons/lang3/builder/ToStringInclude.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.lang3.builder;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Use this annotation to include a method in
+ * {@link ReflectionToStringBuilder}.
+ *
+ * @since 3.6
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface ToStringInclude {
+    String UNDEFINED = "__undefined__";
+
+    String value() default UNDEFINED;
+}

--- a/src/test/java/org/apache/commons/lang3/builder/ReflectionToStringBuilderIncludeWithAnnotationTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/ReflectionToStringBuilderIncludeWithAnnotationTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.lang3.builder;
+
+import org.apache.commons.lang3.AbstractLangTest;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+/**
+ * Test class for ToStringExclude annotation
+ */
+public class ReflectionToStringBuilderIncludeWithAnnotationTest extends AbstractLangTest {
+
+    class TestFixture {
+        @ToStringExclude
+        private final String excludedField = EXCLUDED_FIELD_VALUE;
+
+        @SuppressWarnings("unused")
+        private final String includedField = INCLUDED_FIELD_VALUE;
+
+        @ToStringInclude
+        private String toStringExcludedField() {
+            return EXCLUDED_FIELD_VALUE_MODIFIED;
+        }
+
+        @ToStringInclude("modifiedExcludedField")
+        private String toStringModifiedExcludedField() {
+            return EXCLUDED_FIELD_VALUE_MODIFIED;
+        }
+    }
+
+    private static final String INCLUDED_FIELD_NAME = "includedField";
+
+    private static final String INCLUDED_FIELD_VALUE = "Hello World!";
+
+    private static final String EXCLUDED_FIELD_NAME = "excludedField";
+
+    private static final String EXCLUDED_FIELD_VALUE = "excluded field value";
+    private static final String EXCLUDED_FIELD_VALUE_MODIFIED = "excluded field modified value";
+
+    @Test
+    public void test_toStringInclude() {
+        final String toString = ReflectionToStringBuilder.toString(new TestFixture());
+
+        assertThat(toString, not(containsString(EXCLUDED_FIELD_NAME)));
+        assertThat(toString, not(containsString(EXCLUDED_FIELD_VALUE)));
+        assertThat(toString, containsString(INCLUDED_FIELD_NAME));
+        assertThat(toString, containsString(INCLUDED_FIELD_VALUE));
+
+        assertThat(toString, containsString("toStringExcludedField"));  // method name when annotation value is not set
+        assertThat(toString, containsString("modifiedExcludedField"));  // Annotation value when its set explicitly
+        assertThat(toString, containsString(EXCLUDED_FIELD_VALUE_MODIFIED));
+    }
+
+}


### PR DESCRIPTION
**Note: Please feel free to close this PR if this was previously discussed before and was decided not to be added to this implementation.**

Currently, `ReflectiveToStringBuilder` allows users to exclude fields from the `toString` output by adding an annotation `@ToStringExclude` to the field but there is no support to include methods declared in the class to be included in the `toString` output. 

This PR introduces a new annotation `@ToStringInclude(String)` that can be added to the methods of a class with which, the methods in the toString output.

Some of the points which can be considered
1. Add this implementation to a completely different class instead of modifying the current implementation
2. Wrap this inside a flag, say `allowReflectingMethods` before going into this added implementation.
