### PR TITLE
Add toUnicodeString method to StringUtils for Unicode conversion

### DIFF
--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -188,6 +188,16 @@ public class StringUtils {
     private static final Pattern STRIP_ACCENTS_PATTERN = Pattern.compile("\\p{InCombiningDiacriticalMarks}+"); //$NON-NLS-1$
 
     /**
+     * Unicode escape sequences prefix.
+     */
+    public static final String UNICODE_PREFIX = "\\u";
+
+    /**
+     * Format specifier used to represent a number in 4-digit uppercase hexadecimal format.
+     */
+    public static final String HEX_FORMAT = "%04X";
+
+    /**
      * Abbreviates a String using ellipses. This will turn
      * "Now is the time for all good men" into "Now is the time for..."
      *
@@ -8996,6 +9006,46 @@ public class StringUtils {
     private static String toStringOrEmpty(final Object obj) {
         return Objects.toString(obj, EMPTY);
     }
+
+    /**
+     * Converts a String into a Unicode escape string.
+     *
+     * <p>Each character in the input string is represented by a Unicode escape sequence,
+     * which is a string of the form "&#92;uXXXX", where XXXX is the Unicode code point of
+     * the character in hexadecimal. Characters outside the Basic Multilingual Plane (BMP),
+     * which are represented in Java as a surrogate pair, are represented by a single
+     * Unicode escape sequence.</p>
+     *
+     * <pre>
+     * StringUtils.toUnicodeString(null)   =  null
+     * StringUtils.toUnicodeString("")     =  ""
+     * StringUtils.toUnicodeString("A")    =  "&#92;u0041"
+     * StringUtils.toUnicodeString("?")    =  "&#92;u1F601"
+     * </pre>
+     *
+     * @param str A source String or null.
+     * @return a Unicode escape string representing the input string
+     */
+    public static String toUnicodeString(String str) {
+
+        if (isEmpty(str)) {
+            return str;
+        }
+
+        StringBuilder unicodeStr = new StringBuilder();
+
+        for (int i = 0; i < str.length(); i++) {
+            int codePoint = str.codePointAt(i);
+            // If this is a surrogate pair, increment i to skip the second char
+            if (Character.isSupplementaryCodePoint(codePoint)) {
+                i++;
+            }
+            unicodeStr.append(UNICODE_PREFIX).append(String.format(HEX_FORMAT, codePoint));
+        }
+
+        return unicodeStr.toString();
+    }
+
 
     /**
      * Removes control characters (char &lt;= 32) from both

--- a/src/test/java/org/apache/commons/lang3/StringUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringUtilsTest.java
@@ -3030,6 +3030,18 @@ public class StringUtilsTest extends AbstractLangTest {
         assertEquals(expectedString, StringUtils.toString(expectedBytes, encoding));
     }
 
+    /**
+     * Tests {@link StringUtils#toUnicodeString(String)}
+     */
+    @Test
+    public void testToUnicodeString(){
+        assertEquals(null, StringUtils.toUnicodeString(null));
+        assertEquals("", StringUtils.toUnicodeString(""));
+        assertEquals("\\u0041", StringUtils.toUnicodeString("A"));
+        String emojiUnicodeStr = StringUtils.toUnicodeString("😅");
+        assertEquals("\\u1F605", emojiUnicodeStr);
+    }
+
     @Test
     public void testTruncate_StringInt() {
         assertNull(StringUtils.truncate(null, 12));


### PR DESCRIPTION
Introduce a new method `toUnicodeString` to the `StringUtils` class. This method efficiently converts strings, especially those containing emojis or other special characters, to their Unicode representation.

- Utilizes the `codePointAt` method to cater to surrogate pairs.
- Ensures proper handling of empty strings.
- Returns the complete Unicode string with the respective prefix and formatted in hexadecimal.

This addition will aid in scenarios where a consistent Unicode representation of strings is required, enhancing the utility of the `StringUtils` class.