### PR TITLE
SystemUtils.java: Fix and updates related to macOS

### DIFF
--- a/src/main/java/org/apache/commons/lang3/SystemUtils.java
+++ b/src/main/java/org/apache/commons/lang3/SystemUtils.java
@@ -1462,6 +1462,7 @@ public class SystemUtils {
      * <p>
      * This value is initialized when the class is loaded.
      * </p>
+     * @since 3.13.0
      */
     public static final boolean IS_OS_MAC_OSX_MONTEREY = getOsMatches("Mac OS X", "12");
 
@@ -1474,6 +1475,7 @@ public class SystemUtils {
      * <p>
      * This value is initialized when the class is loaded.
      * </p>
+     * @since 3.13.0
      */
     public static final boolean IS_OS_MAC_OSX_VENTURA = getOsMatches("Mac OS X", "13");
 

--- a/src/main/java/org/apache/commons/lang3/SystemUtils.java
+++ b/src/main/java/org/apache/commons/lang3/SystemUtils.java
@@ -1454,6 +1454,30 @@ public class SystemUtils {
     public static final boolean IS_OS_MAC_OSX_BIG_SUR = getOsMatches("Mac OS X", "11");
 
     /**
+     * Is {@code true} if this is Mac OS X Monterey.
+     *
+     * <p>
+     * The field will return {@code false} if {@code OS_NAME} is {@code null}.
+     * </p>
+     * <p>
+     * This value is initialized when the class is loaded.
+     * </p>
+     */
+    public static final boolean IS_OS_MAC_OSX_MONTEREY = getOsMatches("Mac OS X", "12");
+
+    /**
+     * Is {@code true} if this is Mac OS X Ventura.
+     *
+     * <p>
+     * The field will return {@code false} if {@code OS_NAME} is {@code null}.
+     * </p>
+     * <p>
+     * This value is initialized when the class is loaded.
+     * </p>
+     */
+    public static final boolean IS_OS_MAC_OSX_VENTURA = getOsMatches("Mac OS X", "13");
+
+    /**
      * Is {@code true} if this is FreeBSD.
      *
      * <p>

--- a/src/main/java/org/apache/commons/lang3/SystemUtils.java
+++ b/src/main/java/org/apache/commons/lang3/SystemUtils.java
@@ -1451,7 +1451,7 @@ public class SystemUtils {
      *
      * @since 3.12.0
      */
-    public static final boolean IS_OS_MAC_OSX_BIG_SUR = getOsMatches("Mac OS X", "10.16");
+    public static final boolean IS_OS_MAC_OSX_BIG_SUR = getOsMatches("Mac OS X", "11");
 
     /**
      * Is {@code true} if this is FreeBSD.


### PR DESCRIPTION
This PR contains fixing macOS Big Sur detection, which started from version 11 and adds support for detecting macOS Monterey (12) and Ventura (13). Note that it might be beneficial to add `@since x.x` comment to the respective docs since I didn't know which version they're being included in.