### PR TITLE
Honor `getValue` method of ReflectionToStringBuilder & its subclasses to get the field value

### DIFF
--- a/src/main/java/org/apache/commons/lang3/builder/ReflectionToStringBuilder.java
+++ b/src/main/java/org/apache/commons/lang3/builder/ReflectionToStringBuilder.java
@@ -658,7 +658,7 @@ public class ReflectionToStringBuilder extends ToStringBuilder {
             final String fieldName = field.getName();
             if (this.accept(field)) {
                 // Warning: Field.get(Object) creates wrappers objects for primitive types.
-                final Object fieldValue = Reflection.getUnchecked(field, getObject());
+                final Object fieldValue = this.getValue(field);
                 if (!excludeNullValues || fieldValue != null) {
                     this.append(fieldName, fieldValue, !field.isAnnotationPresent(ToStringSummary.class));
                 }
@@ -703,13 +703,11 @@ public class ReflectionToStringBuilder extends ToStringBuilder {
      *
      * @throws IllegalArgumentException
      *             see {@link java.lang.reflect.Field#get(Object)}
-     * @throws IllegalAccessException
-     *             see {@link java.lang.reflect.Field#get(Object)}
      *
      * @see java.lang.reflect.Field#get(Object)
      */
-    protected Object getValue(final Field field) throws IllegalAccessException {
-        return field.get(this.getObject());
+    protected Object getValue(final Field field) {
+        return Reflection.getUnchecked(field, getObject());
     }
 
     /**

--- a/src/test/java/org/apache/commons/lang3/builder/ReflectionToStringBuilderCustomImplementationTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/ReflectionToStringBuilderCustomImplementationTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.lang3.builder;
+
+import org.apache.commons.lang3.AbstractLangTest;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Regression test to ensure the {@link ReflectionToStringBuilder} always
+ * uses {@link ReflectionToStringBuilder#getValue(Field)} to get the value of every field in the class.
+ * Any changes to this behavior in the future will break this test.
+ */
+public class ReflectionToStringBuilderCustomImplementationTest extends AbstractLangTest {
+
+    private final String stringField = "string";
+
+    public static class CustomReflectionToStringBuilder extends ReflectionToStringBuilder {
+
+        private static final String CUSTOM_PREFIX = "prefix:";
+
+        public CustomReflectionToStringBuilder(Object object, ToStringStyle toStringStyle) {
+            super(object, toStringStyle);
+        }
+
+        @Override
+        protected Object getValue(Field field) {
+            return CUSTOM_PREFIX + super.getValue(field);
+        }
+    }
+
+    @Test
+    public void testBuild() {
+        assertEquals("[stringField=prefix:string]",
+                new CustomReflectionToStringBuilder(this, ToStringStyle.NO_CLASS_NAME_STYLE).build());
+    }
+
+}

--- a/src/test/java/org/apache/commons/lang3/builder/ReflectionToStringBuilderCustomImplementationTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/ReflectionToStringBuilderCustomImplementationTest.java
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.Test;
 import java.lang.reflect.Field;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Regression test to ensure the {@link ReflectionToStringBuilder} always


### PR DESCRIPTION
Noticed this change recently which removed the usage of the method `getValue` to get the field value. Custom implementations of the `getValue` would not be used anymore.

@garydgregory 