### PR TITLE
Fix Incorrect Javadoc Description in Processor

### DIFF
--- a/src/main/java/org/apache/commons/lang3/arch/Processor.java
+++ b/src/main/java/org/apache/commons/lang3/arch/Processor.java
@@ -190,7 +190,7 @@ public class Processor {
     /**
      * Tests if {@link Processor} is type of Aarch64.
      *
-     * @return {@code true}, if {@link Processor} is {@link Type#X86}, else {@code false}.
+     * @return {@code true}, if {@link Processor} is {@link Type#AARCH_64}, else {@code false}.
      *
      * @since 3.13.0
      */


### PR DESCRIPTION
This PR fixes an incorrect Javadoc description in `Processor` (introduced in 16d587d).