### PR TITLE
(doc) Point to right getShortClassName flavor in Javadoc for relevant notes

### DIFF
--- a/src/main/java/org/apache/commons/lang3/ClassUtils.java
+++ b/src/main/java/org/apache/commons/lang3/ClassUtils.java
@@ -925,7 +925,7 @@ public class ClassUtils {
      * Gets the class name minus the package name from a {@link Class}.
      *
      * <p>
-     * This method simply gets the name using {@code Class.getName()} and then calls {@link #getShortClassName(Class)}. See
+     * This method simply gets the name using {@code Class.getName()} and then calls {@link #getShortClassName(String)}. See
      * relevant notes there.
      * </p>
      *


### PR DESCRIPTION
I was reading the Javadoc [online](https://commons.apache.org/proper/commons-lang/apidocs/org/apache/commons/lang3/ClassUtils.html#getShortClassName-java.lang.Class-) and was confused by the reference, until I noticed that instead of pointing to itself, the idea is to point to `getShortClassName(String)`. 