### PR TITLE
LANG-1706 ThreadUtils find methods should not return null items

### DIFF
--- a/src/main/java/org/apache/commons/lang3/ThreadUtils.java
+++ b/src/main/java/org/apache/commons/lang3/ThreadUtils.java
@@ -284,7 +284,7 @@ public class ThreadUtils {
             count = threadGroup.enumerate(threadGroups, recurse);
             //return value of enumerate() must be strictly less than the array size according to Javadoc
         } while (count >= threadGroups.length);
-        return Collections.unmodifiableCollection(Stream.of(threadGroups).filter(predicate).collect(Collectors.toList()));
+        return Collections.unmodifiableCollection(Stream.of(threadGroups).filter(Objects::nonNull).filter(predicate).collect(Collectors.toList()));
     }
 
     /**
@@ -376,7 +376,7 @@ public class ThreadUtils {
             count = threadGroup.enumerate(threads, recurse);
             //return value of enumerate() must be strictly less than the array size according to javadoc
         } while (count >= threads.length);
-        return Collections.unmodifiableCollection(Stream.of(threads).filter(predicate).collect(Collectors.toList()));
+        return Collections.unmodifiableCollection(Stream.of(threads).filter(Objects::nonNull).filter(predicate).collect(Collectors.toList()));
     }
 
     /**

--- a/src/test/java/org/apache/commons/lang3/ThreadUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/ThreadUtilsTest.java
@@ -31,7 +31,9 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 import java.util.function.Predicate;
 
@@ -390,4 +392,19 @@ public class ThreadUtilsTest extends AbstractLangTest {
             alsot1.join();
         }
     }
+    
+    @Test
+    public void testGetAllThreadsDoesNotReturnNull() {
+        // LANG-1706 getAllThreads and findThreads should not return null items
+        Collection<Thread> threads = ThreadUtils.getAllThreads();
+        assertEquals(0, threads.stream().filter(Objects::isNull).count());
+    }
+
+    @Test
+    public void testGetAllThreadGroupsDoesNotReturnNull() {
+        // LANG-1706 getAllThreadGroups and findThreadGroups should not return null items
+        Collection<ThreadGroup> threads = ThreadUtils.getAllThreadGroups();
+        assertEquals(0, threads.stream().filter(Objects::isNull).count());
+    }
+
 }


### PR DESCRIPTION
ThreadUtils.getAllThreads, ThreadUtils.getAllThreadGroups, ThreadUtils.findThreads and ThreadUtils.findThreadGroups should return collections with non-null elements