### PR TITLE
add NPE testcase in LockingVisitorsTest

### DIFF
--- a/src/test/java/org/apache/commons/lang3/concurrent/locks/LockingVisitorsTest.java
+++ b/src/test/java/org/apache/commons/lang3/concurrent/locks/LockingVisitorsTest.java
@@ -30,6 +30,7 @@ import java.util.function.LongConsumer;
 import org.apache.commons.lang3.AbstractLangTest;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.ThreadUtils;
+import org.apache.commons.lang3.concurrent.locks.LockingVisitors;
 import org.apache.commons.lang3.concurrent.locks.LockingVisitors.LockVisitor;
 import org.apache.commons.lang3.concurrent.locks.LockingVisitors.StampedLockVisitor;
 import org.apache.commons.lang3.function.FailableConsumer;
@@ -87,6 +88,13 @@ public class LockingVisitorsTest extends AbstractLangTest {
             booleanArray[offset] = value;
         }
     }
+
+	@Test
+	public void testNull() throws Exception {
+		ReadWriteLock readWriteLock2 = null;
+		Object object1 = new Object();
+		LockingVisitors.create(object1, readWriteLock2);
+	}
 
     @Test
     public void testCreate() {


### PR DESCRIPTION
Hi, I found the test case triggering the NPE bug in LockingVisitors.
https://github.com/apache/commons-lang/blob/8c6d874637b2e3342cbc1770c9a61ff184e483b0/src/main/java/org/apache/commons/lang3/concurrent/locks/LockingVisitors.java#L323-L325
I think this bug needs to be fixed.
Please check this test case.

Thanks.