### PR TITLE
[LANG-1705] SerializationUtils.clone() throws a ClassCastException when override writeReplace()

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -624,7 +624,7 @@
 
     <checkstyle.configdir>src/site/resources/checkstyle</checkstyle.configdir>
 
-    <japicmp.skip>true</japicmp.skip>
+    <japicmp.skip>false</japicmp.skip>
     <!-- 0.6.0 requires Java 11 -->
     <commons.spdx.version>0.5.5</commons.spdx.version>
     <!-- JMH Benchmark related properties, version, target compiler and name of the benchmarking uber jar. -->

--- a/pom.xml
+++ b/pom.xml
@@ -624,7 +624,7 @@
 
     <checkstyle.configdir>src/site/resources/checkstyle</checkstyle.configdir>
 
-    <japicmp.skip>false</japicmp.skip>
+    <japicmp.skip>true</japicmp.skip>
     <!-- 0.6.0 requires Java 11 -->
     <commons.spdx.version>0.5.5</commons.spdx.version>
     <!-- JMH Benchmark related properties, version, target compiler and name of the benchmarking uber jar. -->

--- a/src/main/java/org/apache/commons/lang3/SerializationUtils.java
+++ b/src/main/java/org/apache/commons/lang3/SerializationUtils.java
@@ -127,26 +127,23 @@ public class SerializationUtils {
      * be a simple alternative implementation. Of course all the objects
      * must be {@link Serializable}.</p>
      *
-     * @param <T> the type of the object involved
+     * @param <T> the type of the original object
+     * @param <U> the type of the cloned object
      * @param object  the {@link Serializable} object to clone
      * @return the cloned object
      * @throws SerializationException (runtime) if the serialization fails
      */
-    public static <T extends Serializable> T clone(final T object) {
+    public static <U, T extends Serializable> U clone(final T object) {
         if (object == null) {
             return null;
         }
+
         final byte[] objectData = serialize(object);
         final ByteArrayInputStream bais = new ByteArrayInputStream(objectData);
 
         final Class<T> cls = ObjectUtils.getClass(object);
         try (ClassLoaderAwareObjectInputStream in = new ClassLoaderAwareObjectInputStream(bais, cls.getClassLoader())) {
-            /*
-             * when we serialize and deserialize an object, it is reasonable to assume the deserialized object is of the
-             * same type as the original serialized object
-             */
-            return cls.cast(in.readObject());
-
+            return (U) in.readObject();
         } catch (final ClassNotFoundException | IOException ex) {
             throw new SerializationException(
                 String.format("%s while reading cloned object data", ex.getClass().getSimpleName()), ex);


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/LANG-1705

Due to the possibility that the serialized object type may be a different type after overriding writeReplace(), directly converting the serialized object to the original type(the type of parameter) will result in a ClassCastException.

Fix: Two templates are used for the return value and parameters of SerializationUtils.clone().