### PR TITLE
Add method ConcurrentInitializer#isInitialized()

### DIFF
--- a/src/main/java/org/apache/commons/lang3/concurrent/AbstractConcurrentInitializer.java
+++ b/src/main/java/org/apache/commons/lang3/concurrent/AbstractConcurrentInitializer.java
@@ -36,4 +36,13 @@ public abstract class AbstractConcurrentInitializer<T, E extends Exception> impl
      */
     protected abstract T initialize() throws E;
 
+    /**
+     * Returns true if initialization has been completed. If initialization threw an exception this will return false, but it will return true if a subsequent
+     * call to initialize completes successfully. If the implementation of ConcurrentInitializer can initialize multiple objects, this will only return true if
+     * all objects have been initialized.
+     *
+     * @return true if all initialization is complete, otherwise false
+     */
+    protected abstract boolean isInitialized();
+
 }

--- a/src/main/java/org/apache/commons/lang3/concurrent/AtomicInitializer.java
+++ b/src/main/java/org/apache/commons/lang3/concurrent/AtomicInitializer.java
@@ -63,8 +63,10 @@ import java.util.concurrent.atomic.AtomicReference;
  * @param <T> the type of the object managed by this initializer class
  */
 public abstract class AtomicInitializer<T> extends AbstractConcurrentInitializer<T, RuntimeException> {
+
+    private final T NO_INIT = (T) new Object(){};
     /** Holds the reference to the managed object. */
-    private final AtomicReference<T> reference = new AtomicReference<>();
+    private final AtomicReference<T> reference = new AtomicReference<>(NO_INIT);
 
     /**
      * Returns the object managed by this initializer. The object is created if
@@ -79,9 +81,9 @@ public abstract class AtomicInitializer<T> extends AbstractConcurrentInitializer
     public T get() throws ConcurrentException {
         T result = reference.get();
 
-        if (result == null) {
+        if (result == NO_INIT) {
             result = initialize();
-            if (!reference.compareAndSet(null, result)) {
+            if (!reference.compareAndSet(NO_INIT, result)) {
                 // another thread has initialized the reference
                 result = reference.get();
             }

--- a/src/main/java/org/apache/commons/lang3/concurrent/AtomicInitializer.java
+++ b/src/main/java/org/apache/commons/lang3/concurrent/AtomicInitializer.java
@@ -64,7 +64,7 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 public abstract class AtomicInitializer<T> extends AbstractConcurrentInitializer<T, RuntimeException> {
 
-    private static final Object NO_INIT = new Object(){};
+    private static final Object NO_INIT = new Object();
     /** Holds the reference to the managed object. */
     private final AtomicReference<T> reference = new AtomicReference<>((T) NO_INIT);
 

--- a/src/main/java/org/apache/commons/lang3/concurrent/AtomicInitializer.java
+++ b/src/main/java/org/apache/commons/lang3/concurrent/AtomicInitializer.java
@@ -64,9 +64,9 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 public abstract class AtomicInitializer<T> extends AbstractConcurrentInitializer<T, RuntimeException> {
 
-    private final T NO_INIT = (T) new Object(){};
+    private static final Object NO_INIT = new Object(){};
     /** Holds the reference to the managed object. */
-    private final AtomicReference<T> reference = new AtomicReference<>(NO_INIT);
+    private final AtomicReference<T> reference = new AtomicReference<>((T) NO_INIT);
 
     /**
      * Returns the object managed by this initializer. The object is created if
@@ -81,14 +81,25 @@ public abstract class AtomicInitializer<T> extends AbstractConcurrentInitializer
     public T get() throws ConcurrentException {
         T result = reference.get();
 
-        if (result == NO_INIT) {
+        if (result == (T) NO_INIT) {
             result = initialize();
-            if (!reference.compareAndSet(NO_INIT, result)) {
+            if (!reference.compareAndSet((T) NO_INIT, result)) {
                 // another thread has initialized the reference
                 result = reference.get();
             }
         }
 
         return result;
+    }
+
+    /**
+     * Tests whether this instance is initialized. Once initialized, always returns true.
+     *
+     * @return whether this instance is initialized. Once initialized, always returns true.
+     * @since 3.14.0
+     */
+    @Override
+    public boolean isInitialized() {
+        return reference.get() != NO_INIT;
     }
 }

--- a/src/main/java/org/apache/commons/lang3/concurrent/AtomicSafeInitializer.java
+++ b/src/main/java/org/apache/commons/lang3/concurrent/AtomicSafeInitializer.java
@@ -53,12 +53,13 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 public abstract class AtomicSafeInitializer<T> extends AbstractConcurrentInitializer<T, RuntimeException> {
 
+    private final T NO_INIT = (T) new Object(){};
     /** A guard which ensures that initialize() is called only once. */
     private final AtomicReference<AtomicSafeInitializer<T>> factory =
             new AtomicReference<>();
 
     /** Holds the reference to the managed object. */
-    private final AtomicReference<T> reference = new AtomicReference<>();
+    private final AtomicReference<T> reference = new AtomicReference<>(NO_INIT);
 
     /**
      * Gets (and initialize, if not initialized yet) the required object
@@ -71,7 +72,7 @@ public abstract class AtomicSafeInitializer<T> extends AbstractConcurrentInitial
     public final T get() throws ConcurrentException {
         T result;
 
-        while ((result = reference.get()) == null) {
+        while ((result = reference.get()) == NO_INIT) {
             if (factory.compareAndSet(null, this)) {
                 reference.set(initialize());
             }

--- a/src/main/java/org/apache/commons/lang3/concurrent/AtomicSafeInitializer.java
+++ b/src/main/java/org/apache/commons/lang3/concurrent/AtomicSafeInitializer.java
@@ -53,7 +53,7 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 public abstract class AtomicSafeInitializer<T> extends AbstractConcurrentInitializer<T, RuntimeException> {
 
-    private static final Object NO_INIT = new Object(){};
+    private static final Object NO_INIT = new Object();
     /** A guard which ensures that initialize() is called only once. */
     private final AtomicReference<AtomicSafeInitializer<T>> factory =
             new AtomicReference<>();

--- a/src/main/java/org/apache/commons/lang3/concurrent/AtomicSafeInitializer.java
+++ b/src/main/java/org/apache/commons/lang3/concurrent/AtomicSafeInitializer.java
@@ -53,13 +53,13 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 public abstract class AtomicSafeInitializer<T> extends AbstractConcurrentInitializer<T, RuntimeException> {
 
-    private final T NO_INIT = (T) new Object(){};
+    private static final Object NO_INIT = new Object(){};
     /** A guard which ensures that initialize() is called only once. */
     private final AtomicReference<AtomicSafeInitializer<T>> factory =
             new AtomicReference<>();
 
     /** Holds the reference to the managed object. */
-    private final AtomicReference<T> reference = new AtomicReference<>(NO_INIT);
+    private final AtomicReference<T> reference = new AtomicReference<>((T) NO_INIT);
 
     /**
      * Gets (and initialize, if not initialized yet) the required object
@@ -72,12 +72,23 @@ public abstract class AtomicSafeInitializer<T> extends AbstractConcurrentInitial
     public final T get() throws ConcurrentException {
         T result;
 
-        while ((result = reference.get()) == NO_INIT) {
+        while ((result = reference.get()) == (T) NO_INIT) {
             if (factory.compareAndSet(null, this)) {
                 reference.set(initialize());
             }
         }
 
         return result;
+    }
+
+    /**
+     * Tests whether this instance is initialized. Once initialized, always returns true.
+     *
+     * @return whether this instance is initialized. Once initialized, always returns true.
+     * @since 3.14.0
+     */
+    @Override
+    public boolean isInitialized() {
+        return reference.get() != NO_INIT;
     }
 }

--- a/src/main/java/org/apache/commons/lang3/concurrent/BackgroundInitializer.java
+++ b/src/main/java/org/apache/commons/lang3/concurrent/BackgroundInitializer.java
@@ -17,6 +17,7 @@
 package org.apache.commons.lang3.concurrent;
 
 import java.util.concurrent.Callable;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -121,6 +122,28 @@ public abstract class BackgroundInitializer<T> extends AbstractConcurrentInitial
      */
     public final synchronized ExecutorService getExternalExecutor() {
         return externalExecutor;
+    }
+
+    /**
+     * Tests whether this instance is initialized. Once initialized, always returns true.
+     * If initialization failed then the failure will be cached and this will never return
+     * true.
+     *
+     * @return true if initialization completed successfully, otherwise false
+     * @since 3.14.0
+     */
+    @Override
+    public synchronized boolean isInitialized() {
+        if (future == null || ! future.isDone() ) {
+            return false;
+        }
+
+        try {
+            future.get();
+            return true;
+        } catch (CancellationException | ExecutionException | InterruptedException e) {
+            return false;
+        }
     }
 
     /**

--- a/src/main/java/org/apache/commons/lang3/concurrent/ConstantInitializer.java
+++ b/src/main/java/org/apache/commons/lang3/concurrent/ConstantInitializer.java
@@ -81,6 +81,17 @@ public class ConstantInitializer<T> implements ConcurrentInitializer<T> {
     }
 
     /**
+     * As a {@link ConstantInitializer} is initialized on construction this will
+     * always return true.
+     *
+     * @return true.
+     * @since 3.14.0
+     */
+    public boolean isInitialized() {
+        return true;
+    }
+
+    /**
      * Returns a hash code for this object. This implementation returns the hash
      * code of the managed object.
      *

--- a/src/main/java/org/apache/commons/lang3/concurrent/MultiBackgroundInitializer.java
+++ b/src/main/java/org/apache/commons/lang3/concurrent/MultiBackgroundInitializer.java
@@ -200,6 +200,22 @@ public class MultiBackgroundInitializer
     }
 
     /**
+     * Tests whether this all child {@code BackgroundInitializer} objects are initialized.
+     * Once initialized, always returns true.
+     *
+     * @return whether all child {@code BackgroundInitializer} objects instance are initialized. Once initialized, always returns true. If there are no child {@code BackgroundInitializer} objects return false.
+     * @since 3.14.0
+     */
+    @Override
+    public boolean isInitialized() {
+        if (childInitializers.isEmpty()) {
+            return false;
+        }
+
+        return childInitializers.values().stream().allMatch(BackgroundInitializer::isInitialized);
+    }
+
+    /**
      * A data class for storing the results of the background initialization
      * performed by {@link MultiBackgroundInitializer}. Objects of this inner
      * class are returned by {@link MultiBackgroundInitializer#initialize()}.

--- a/src/test/java/org/apache/commons/lang3/concurrent/AbstractConcurrentInitializerTest.java
+++ b/src/test/java/org/apache/commons/lang3/concurrent/AbstractConcurrentInitializerTest.java
@@ -17,7 +17,9 @@
 package org.apache.commons.lang3.concurrent;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.concurrent.CountDownLatch;
 
@@ -44,6 +46,20 @@ public abstract class AbstractConcurrentInitializerTest extends AbstractLangTest
     @Test
     public void testGet() throws ConcurrentException {
         assertNotNull(createInitializer().get(), "No managed object");
+    }
+
+    /**
+     * Tests a simple invocation of the isInitialized() method.
+     */
+    @Test
+    public void testisInitialized() throws Throwable {
+        final ConcurrentInitializer<Object> initializer = createInitializer();
+        if (initializer instanceof AbstractConcurrentInitializer) {
+            AbstractConcurrentInitializer castedInitializer = (AbstractConcurrentInitializer) initializer;
+            assertFalse(castedInitializer.isInitialized(), "was initialized before get()");
+            assertNotNull(castedInitializer.get(), "No managed object");
+            assertTrue(castedInitializer.isInitialized(), "was not initialized after get()");
+        }
     }
 
     /**

--- a/src/test/java/org/apache/commons/lang3/concurrent/AtomicInitializerTest.java
+++ b/src/test/java/org/apache/commons/lang3/concurrent/AtomicInitializerTest.java
@@ -16,6 +16,12 @@
  */
 package org.apache.commons.lang3.concurrent;
 
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.Test;
+
 /**
  * Test class for {@code AtomicInitializer}.
  */
@@ -33,5 +39,24 @@ public class AtomicInitializerTest extends AbstractConcurrentInitializerTest {
                 return new Object();
             }
         };
+    }
+
+    @Test
+    public void testGetThatReturnsNullFirstTime() throws ConcurrentException {
+        final AtomicInitializer<Object> initializer = new AtomicInitializer<Object>() {
+            final AtomicBoolean firstRun = new AtomicBoolean(true);
+
+            @Override
+            protected Object initialize() {
+                if (firstRun.getAndSet(false)) {
+                    return null;
+                } else {
+                    return new Object();
+                }
+            }
+        };
+
+        assertNull(initializer.get());
+        assertNull(initializer.get());
     }
 }

--- a/src/test/java/org/apache/commons/lang3/concurrent/AtomicSafeInitializerTest.java
+++ b/src/test/java/org/apache/commons/lang3/concurrent/AtomicSafeInitializerTest.java
@@ -17,7 +17,9 @@
 package org.apache.commons.lang3.concurrent;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -56,6 +58,25 @@ public class AtomicSafeInitializerTest extends AbstractConcurrentInitializerTest
     public void testNumberOfInitializeInvocations() throws ConcurrentException, InterruptedException {
         testGetConcurrent();
         assertEquals(1, initializer.initCounter.get(), "Wrong number of invocations");
+    }
+
+    @Test
+    public void testGetThatReturnsNullFirstTime() throws ConcurrentException {
+        final AtomicSafeInitializer<Object> initializer = new AtomicSafeInitializer<Object>() {
+            final AtomicBoolean firstRun = new AtomicBoolean(true);
+
+            @Override
+            protected Object initialize() {
+                if (firstRun.getAndSet(false)) {
+                    return null;
+                } else {
+                    return new Object();
+                }
+            }
+        };
+
+        assertNull(initializer.get());
+        assertNull(initializer.get());
     }
 
     /**

--- a/src/test/java/org/apache/commons/lang3/concurrent/ConstantInitializerTest.java
+++ b/src/test/java/org/apache/commons/lang3/concurrent/ConstantInitializerTest.java
@@ -130,4 +130,14 @@ public class ConstantInitializerTest extends AbstractLangTest {
         final String s = new ConstantInitializer<>(null).toString();
         assertTrue(s.indexOf("object = null") > 0, "Object not found: " + s);
     }
+
+    /**
+     * Tests a simple invocation of the isInitialized() method.
+     */
+    @Test
+    public void testisInitialized() {
+        assertTrue(init.isInitialized(), "was not initialized before get()");
+        assertEquals(VALUE, init.getObject(), "Wrong object");
+        assertTrue(init.isInitialized(), "was not initialized after get()");
+    }
 }


### PR DESCRIPTION
This is associated with https://issues.apache.org/jira/browse/LANG-1716

See also discussion on #1119

------

This pull request adds a method `isInitialized()` to all implementations of ConcurrentInitializer. 

Here are the design decisions I made, and the rationales for them:
* Using `NO_INIT` for `AtomicInitializer` and `AtomicSafeInitializer`
* * Apart from making it easier to write an `isInitialized()` method this ensures that if `Atomic*Initializer` returns null it will correctly cache that behaviour as the docs say it should. This is a bug fix, but it may break backwards compatibility if someone inadvertently depends on the old behaviour. I chose to the correct thing now, and am drawing attention to it here to discuss if we actually want this fix.
* Including `isInitialized()` in `ConstantInitializer`
* * This is not strictly needed but I included it just for consistency.