### PR TITLE
LANG-1717: support RISC-V in ArchUtils

### DIFF
--- a/src/main/java/org/apache/commons/lang3/ArchUtils.java
+++ b/src/main/java/org/apache/commons/lang3/ArchUtils.java
@@ -96,6 +96,8 @@ public class ArchUtils {
         init_PPC_32Bit();
         init_PPC_64Bit();
         init_Aarch_64Bit();
+        init_RISCV_32Bit();
+        init_RISCV_64Bit();
     }
 
     private static void init_Aarch_64Bit() {
@@ -116,6 +118,14 @@ public class ArchUtils {
 
     private static void init_PPC_64Bit() {
         addProcessors(new Processor(Processor.Arch.BIT_64, Processor.Type.PPC), "ppc64", "power64", "powerpc64", "power_pc64", "power_rs64");
+    }
+
+    private static void init_RISCV_32Bit() {
+        addProcessors(new Processor(Processor.Arch.BIT_32, Processor.Type.RISCV), "riscv32");
+    }
+
+    private static void init_RISCV_64Bit() {
+        addProcessors(new Processor(Processor.Arch.BIT_64, Processor.Type.RISCV), "riscv64");
     }
 
     private static void init_X86_32Bit() {

--- a/src/main/java/org/apache/commons/lang3/arch/Processor.java
+++ b/src/main/java/org/apache/commons/lang3/arch/Processor.java
@@ -79,6 +79,7 @@ public class Processor {
      *     <li>x86</li>
      *     <li>ia64</li>
      *     <li>PPC</li>
+     *     <li>RISCV</li>
      *     <li>Unknown</li>
      * </ul>
      */
@@ -105,6 +106,11 @@ public class Processor {
          * Apple–IBM–Motorola PowerPC architecture.
          */
         PPC("PPC"),
+
+        /**
+         * RISC-V architecture.
+         */
+        RISCV("RISC-V"),
 
         /**
          * Unknown architecture.
@@ -223,6 +229,15 @@ public class Processor {
      */
     public boolean isX86() {
         return Type.X86 == type;
+    }
+
+    /**
+     * Tests if {@link Processor} is type of RISC-V.
+     *
+     * @return {@code true}. if {@link Processor} is {@link Type#RISCV}, else {@code false}.
+     */
+    public boolean isRISCV() {
+        return Type.RISCV == type;
     }
 
     @Override

--- a/src/main/java/org/apache/commons/lang3/arch/Processor.java
+++ b/src/main/java/org/apache/commons/lang3/arch/Processor.java
@@ -109,6 +109,8 @@ public class Processor {
 
         /**
          * RISC-V architecture.
+         *
+         * @since 3.14.0
          */
         RISCV("RISC-V"),
 
@@ -235,6 +237,7 @@ public class Processor {
      * Tests if {@link Processor} is type of RISC-V.
      *
      * @return {@code true}. if {@link Processor} is {@link Type#RISCV}, else {@code false}.
+     * @since 3.14.0
      */
     public boolean isRISCV() {
         return Type.RISCV == type;

--- a/src/test/java/org/apache/commons/lang3/ArchUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/ArchUtilsTest.java
@@ -40,6 +40,8 @@ public class ArchUtilsTest extends AbstractLangTest {
     private static final String X86 = "x86";
     private static final String X86_64 = "x86_64";
     private static final String AARCH_64 = "aarch64";
+    private static final String RISCV_64 = "riscv64";
+    private static final String RISCV_32 = "riscv32";
 
     private void assertEqualsArchNotNull(final Processor.Arch arch, final Processor processor) {
         assertNotNull(arch);
@@ -100,6 +102,14 @@ public class ArchUtilsTest extends AbstractLangTest {
         processor = ArchUtils.getProcessor(AARCH_64);
         assertEqualsTypeNotNull(Processor.Type.AARCH_64, processor);
         assertTrue(processor.isAarch64());
+
+        processor = ArchUtils.getProcessor(RISCV_32);
+        assertEqualsTypeNotNull(Processor.Type.RISCV, processor);
+        assertTrue(processor.isRISCV());
+
+        processor = ArchUtils.getProcessor(RISCV_64);
+        assertEqualsTypeNotNull(Processor.Type.RISCV, processor);
+        assertTrue(processor.isRISCV());
     }
 
     @Test
@@ -134,6 +144,10 @@ public class ArchUtilsTest extends AbstractLangTest {
         assertEqualsArchNotNull(Processor.Arch.BIT_32, processor);
         processor.is32Bit();
 
+        processor = ArchUtils.getProcessor(RISCV_32);
+        assertEqualsArchNotNull(Processor.Arch.BIT_32, processor);
+        assertTrue(processor.is32Bit());
+
         processor = ArchUtils.getProcessor(X86_64);
         assertNotEqualsArchNotNull(Processor.Arch.BIT_32, processor);
         assertFalse(processor.is32Bit());
@@ -143,6 +157,10 @@ public class ArchUtilsTest extends AbstractLangTest {
         assertFalse(processor.is32Bit());
 
         processor = ArchUtils.getProcessor(IA64);
+        assertNotEqualsArchNotNull(Processor.Arch.BIT_32, processor);
+        assertFalse(processor.is32Bit());
+
+        processor = ArchUtils.getProcessor(RISCV_64);
         assertNotEqualsArchNotNull(Processor.Arch.BIT_32, processor);
         assertFalse(processor.is32Bit());
     }
@@ -161,6 +179,10 @@ public class ArchUtilsTest extends AbstractLangTest {
         assertEqualsArchNotNull(Processor.Arch.BIT_64, processor);
         assertTrue(processor.is64Bit());
 
+        processor = ArchUtils.getProcessor(RISCV_64);
+        assertEqualsArchNotNull(Processor.Arch.BIT_64, processor);
+        assertTrue(processor.is64Bit());
+
         processor = ArchUtils.getProcessor(X86);
         assertNotEqualsArchNotNull(Processor.Arch.BIT_64, processor);
         assertFalse(processor.is64Bit());
@@ -170,6 +192,10 @@ public class ArchUtilsTest extends AbstractLangTest {
         assertFalse(processor.is64Bit());
 
         processor = ArchUtils.getProcessor(IA64_32);
+        assertNotEqualsArchNotNull(Processor.Arch.BIT_64, processor);
+        assertFalse(processor.is64Bit());
+
+        processor = ArchUtils.getProcessor(RISCV_32);
         assertNotEqualsArchNotNull(Processor.Arch.BIT_64, processor);
         assertFalse(processor.is64Bit());
 


### PR DESCRIPTION
Add RISC-V support to ArchUtils and its dependency class, Processor.