### PR TITLE
bug fix

### DIFF
--- a/src/test/java/org/apache/commons/lang3/function/MethodInvokersFailableBiFunctionTest.java
+++ b/src/test/java/org/apache/commons/lang3/function/MethodInvokersFailableBiFunctionTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.lang.reflect.Method;
+import java.util.Arrays;
 
 import org.apache.commons.lang3.exception.CustomCheckedException;
 import org.apache.commons.lang3.exception.CustomUncheckedException;
@@ -31,11 +32,10 @@ import org.junit.jupiter.api.Test;
  * Tests {@link MethodInvokers#asFailableBiFunction(Method)}.
  */
 public class MethodInvokersFailableBiFunctionTest extends MethodFixtures {
-
     @Test
     public void testApply1Arg() throws Throwable {
         // Use a local variable typed to the interface to make sure we compile.
-        final FailableBiFunction<MethodFixtures, String, String[], Throwable> func = MethodInvokers.asFailableBiFunction(getMethodForGetString1ArgChecked());
+        final FailableBiFunction<MethodFixtures, String, String, Throwable> func = MethodInvokers.asFailableBiFunction(getMethodForGetString1ArgChecked());
         assertEquals(INSTANCE.getString1ArgChecked("A"), func.apply(INSTANCE, "A"));
     }
 

--- a/src/test/java/org/apache/commons/lang3/reflect/TypeLiteralTest.java
+++ b/src/test/java/org/apache/commons/lang3/reflect/TypeLiteralTest.java
@@ -45,8 +45,8 @@ public class TypeLiteralTest extends AbstractLangTest {
 
     @Test
     public void testEquals() {
-        assertEquals(new TypeLiteral<String>() {}, new TypeLiteral<String>() {});
-        assertEquals(new TypeLiteral<List<String>>() {}, new TypeLiteral<List<String>>() {});
+        assertEquals(new TypeLiteral<String>() {}.getType(), new TypeLiteral<String>() {}.getType());
+        assertEquals(new TypeLiteral<List<String>>() {}.getType(), new TypeLiteral<List<String>>() {}.getType());
         assertNotEquals(new TypeLiteral<String>() {}, new TypeLiteral<List<String>>() {});
     }
 


### PR DESCRIPTION
Fixed following bugs:
1. Change the assertion arguments to not compare dissimilar types in a Test case in TypeLiteralTest Class.
2. Change the assertion arguments to not compare dissimilar types in a Test case in TypeLiteralTest Class.
that were marked as critical severity bugs
