### PR TITLE
Updates javadoc of ExceptionUtils.getRootCause()

### DIFF
--- a/src/main/java/org/apache/commons/lang3/exception/ExceptionUtils.java
+++ b/src/main/java/org/apache/commons/lang3/exception/ExceptionUtils.java
@@ -296,8 +296,7 @@ public class ExceptionUtils {
      *
      * <p>From version 2.2, this method handles recursive cause structures
      * that might otherwise cause infinite loops. If the throwable parameter
-     * has a cause of itself, then null will be returned. If the throwable
-     * parameter cause chain loops, the last element in the chain before the
+     * cause chain loops, the last element in the chain before the
      * loop is returned.</p>
      *
      * @param throwable  the throwable to get the root cause for, may be null


### PR DESCRIPTION
getRootCause() does not return null anymore when the input throwable has a cause of itself. The behavior was changed in commit 60412131f.