### PR TITLE
LANG-1720: Fix Javadoc description of exceptions thrown for Conversion class

### DIFF
--- a/src/main/java/org/apache/commons/lang3/Conversion.java
+++ b/src/main/java/org/apache/commons/lang3/Conversion.java
@@ -788,6 +788,7 @@ public class Conversion {
      * @param nHex the number of Chars to convert
      * @return a byte containing the selected bits
      * @throws IllegalArgumentException if {@code (nHexs-1)*4+dstPos >= 8}
+     * @throws StringIndexOutOfBoundsException if {@code srcPos + nHex > src.length}
      */
     public static byte hexToByte(final String src, final int srcPos, final byte dstInit, final int dstPos,
             final int nHex) {
@@ -819,6 +820,7 @@ public class Conversion {
      * @param nHex the number of Chars to convert
      * @return an int containing the selected bits
      * @throws IllegalArgumentException if {@code (nHexs-1)*4+dstPos >= 32}
+     * @throws StringIndexOutOfBoundsException if {@code srcPos + nHex > src.length}
      */
     public static int hexToInt(final String src, final int srcPos, final int dstInit, final int dstPos, final int nHex) {
         if (0 == nHex) {
@@ -849,6 +851,7 @@ public class Conversion {
      * @param nHex the number of Chars to convert
      * @return a long containing the selected bits
      * @throws IllegalArgumentException if {@code (nHexs-1)*4+dstPos >= 64}
+     * @throws StringIndexOutOfBoundsException if {@code srcPos + nHex > src.length}
      */
     public static long hexToLong(final String src, final int srcPos, final long dstInit, final int dstPos,
             final int nHex) {
@@ -880,6 +883,7 @@ public class Conversion {
      * @param nHex the number of Chars to convert
      * @return a short containing the selected bits
      * @throws IllegalArgumentException if {@code (nHexs-1)*4+dstPos >= 16}
+     * @throws StringIndexOutOfBoundsException if {@code srcPos + nHex > src.length}
      */
     public static short hexToShort(final String src, final int srcPos, final short dstInit, final int dstPos,
             final int nHex) {


### PR DESCRIPTION
The Javadoc description comments for most methods of the Conversion class, it contains a detailed description of the reason for some expected exceptions thrown by each method. These exceptions include but are not limited to different `IndexOutOfBoundsException` or `NullPointerException`. It is found that all variants of the `hexTo*()` method will throw `StringIndexOutOfBoundsException` if `srcPos + nHex > src.length` but this is not documented. Thus this PR provides an improvement of the relative Javadoc, mentioning that these methods could throw `StringIndexOutOfBoundsException`.