### PR TITLE
LANG-1721: Fix wrong number check that cause StringIndexOutOfBoundsException

### DIFF
--- a/src/main/java/org/apache/commons/lang3/math/NumberUtils.java
+++ b/src/main/java/org/apache/commons/lang3/math/NumberUtils.java
@@ -361,7 +361,7 @@ public class NumberUtils {
         final boolean requestType = !Character.isDigit(lastChar) && lastChar != '.';
         if (decPos > -1) { // there is a decimal point
             if (expPos > -1) { // there is an exponent
-                if (expPos < decPos || expPos > length) { // prevents double exponent causing IOOBE
+                if (expPos <= decPos || expPos > length) { // prevents double exponent causing IOOBE
                     throw new NumberFormatException(str + " is not a valid number.");
                 }
                 dec = str.substring(decPos + 1, expPos);

--- a/src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java
@@ -1746,6 +1746,6 @@ public class NumberUtilsTest extends AbstractLangTest {
 
     @Test
     public void testInvalidNumber() {
-        NumberUtils.createNumber("E123e.3");
+        assertThrows(NumberFormatException.class, () -> NumberUtils.createNumber("E123e.3"));
     }
 }

--- a/src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java
@@ -1743,4 +1743,9 @@ public class NumberUtilsTest extends AbstractLangTest {
         assertEquals(12345, NumberUtils.toShort("12345", (short) 5), "toShort(String, short) 1 failed");
         assertEquals(5, NumberUtils.toShort("1234.5", (short) 5), "toShort(String, short) 2 failed");
     }
+
+    @Test
+    public void testInvalidNumber() {
+        NumberUtils.createNumber("E123e.3");
+    }
 }


### PR DESCRIPTION
`NumberUtils.createNumber(String)` method implements lots of number checks to ensure the provided string is indeed a number. But there is a wrong conditional checking in the code, that could result in unexpected StringIndexOutOfBoundsException if a specially crafted input is provided. This PR fixes the problem by changing the conditional check criterion. 