### PR TITLE
LANG-1722: Catch NegativeArraySizeException

### DIFF
--- a/src/main/java/org/apache/commons/lang3/SerializationUtils.java
+++ b/src/main/java/org/apache/commons/lang3/SerializationUtils.java
@@ -207,7 +207,7 @@ public class SerializationUtils {
             @SuppressWarnings("unchecked")
             final T obj = (T) in.readObject();
             return obj;
-        } catch (final ClassNotFoundException | IOException ex) {
+        } catch (final ClassNotFoundException | IOException | NegativeArraySizeException ex) {
             throw new SerializationException(ex);
         }
     }

--- a/src/test/java/org/apache/commons/lang3/SerializationUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/SerializationUtilsTest.java
@@ -37,6 +37,7 @@ import java.io.Serializable;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
 import java.util.HashMap;
+import java.nio.file.*;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -360,4 +361,13 @@ public class SerializationUtilsTest extends AbstractLangTest {
         assertThrows(SerializationException.class, () -> SerializationUtils.serialize(iMap, streamTest));
     }
 
+    @Test
+    public void testNegativeByteArray() throws IOException {
+        final byte[] byteArray = {
+            (byte)-84, (byte)-19, (byte)0, (byte)5, (byte)125, (byte)-19, (byte)0,
+            (byte)5, (byte)115, (byte)114, (byte)-1, (byte)97, (byte)122, (byte)-48, (byte)-65
+        };
+
+        assertThrows(SerializationException.class, () -> SerializationUtils.deserialize(new ByteArrayInputStream(byteArray)));
+    }
 }


### PR DESCRIPTION
`SerilizationUtils.deserialize(InputStream)` throws unexpected `NegativeArraySizeException` when the size related bytes is negative. This PR fixes it by wrapping the `NegativeArraySizeException` with `SerializationException` to avoid unexpected exceptions thrown.