### PR TITLE
Drop obsolete JDK 13 Maven profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -927,16 +927,6 @@
       </properties>
     </profile>
     <profile>
-      <id>java13+</id>
-      <activation>
-        <jdk>[13,)</jdk>
-      </activation>
-      <properties>
-        <!-- jacoco does not work with java 13 yet -->
-        <jacoco.skip>true</jacoco.skip>
-      </properties>
-    </profile>
-    <profile>
       <id>java15</id>
       <activation>
         <!-- This is ONLY activated for Java 15 -->


### PR DESCRIPTION
Back in 2019, there were issues with generating coverage reports with Jacoco v0.8.3 on JDK 13 (PR #433). Since then, Jacoco has been updated to v0.8.10, which officially supports JDK 19/20. Since coverage reports can now be generated with JDK 13+, it is proposed that this profile be removed as obsolete.

https://github.com/jacoco/jacoco/releases