### PR TITLE
[LANG-1723]: Throw NumberFormatException instead of IndexOutOfBoundsException in NumberUtils.getMantissa(String, int)

### DIFF
--- a/src/main/java/org/apache/commons/lang3/math/NumberUtils.java
+++ b/src/main/java/org/apache/commons/lang3/math/NumberUtils.java
@@ -316,6 +316,7 @@ public class NumberUtils {
         if (str == null) {
             return null;
         }
+
         if (StringUtils.isBlank(str)) {
             throw new NumberFormatException("A blank string is not a valid number");
         }
@@ -492,10 +493,19 @@ public class NumberUtils {
      * @param str the string representation of the number
      * @param stopPos the position of the exponent or decimal point
      * @return mantissa of the given number
+     * @throws NumberFormatException if no mantissa can be retrieved
      */
     private static String getMantissa(final String str, final int stopPos) {
         final char firstChar = str.charAt(0);
         final boolean hasSign = firstChar == '-' || firstChar == '+';
+
+        if (str.length() <= (hasSign? 1 : 0)) {
+           throw new NumberFormatException(str + " is not a valid number.");
+        }
+
+        if (str.length() < stopPos) {
+           throw new NumberFormatException(str + " is not a valid number.");
+        }
 
         return hasSign ? str.substring(1, stopPos) : str.substring(0, stopPos);
     }

--- a/src/main/java/org/apache/commons/lang3/math/NumberUtils.java
+++ b/src/main/java/org/apache/commons/lang3/math/NumberUtils.java
@@ -495,18 +495,16 @@ public class NumberUtils {
      * @throws NumberFormatException if no mantissa can be retrieved
      */
     private static String getMantissa(final String str, final int stopPos) {
-        final char firstChar = str.charAt(0);
-        final boolean hasSign = firstChar == '-' || firstChar == '+';
-
-        if (str.length() <= (hasSign? 1 : 0)) {
-           throw new NumberFormatException(str + " is not a valid number.");
-        }
-
-        if (str.length() < stopPos) {
-           throw new NumberFormatException(str + " is not a valid number.");
-        }
-
-        return hasSign ? str.substring(1, stopPos) : str.substring(0, stopPos);
+         final char firstChar = str.charAt(0);
+         final boolean hasSign = firstChar == '-' || firstChar == '+';
+         final int length = str.length();
+         if (length <= (hasSign ? 1 : 0)) {
+             throw new NumberFormatException(str + " is not a valid number.");
+         }
+         if (length < stopPos) {
+             throw new NumberFormatException(str + " is not a valid number.");
+         }
+         return hasSign ? str.substring(1, stopPos) : str.substring(0, stopPos);
     }
 
     /**

--- a/src/main/java/org/apache/commons/lang3/math/NumberUtils.java
+++ b/src/main/java/org/apache/commons/lang3/math/NumberUtils.java
@@ -498,10 +498,7 @@ public class NumberUtils {
          final char firstChar = str.charAt(0);
          final boolean hasSign = firstChar == '-' || firstChar == '+';
          final int length = str.length();
-         if (length <= (hasSign ? 1 : 0)) {
-             throw new NumberFormatException(str + " is not a valid number.");
-         }
-         if (length < stopPos) {
+         if (length <= (hasSign ? 1 : 0) || length < stopPos) {
              throw new NumberFormatException(str + " is not a valid number.");
          }
          return hasSign ? str.substring(1, stopPos) : str.substring(0, stopPos);

--- a/src/main/java/org/apache/commons/lang3/math/NumberUtils.java
+++ b/src/main/java/org/apache/commons/lang3/math/NumberUtils.java
@@ -316,7 +316,6 @@ public class NumberUtils {
         if (str == null) {
             return null;
         }
-
         if (StringUtils.isBlank(str)) {
             throw new NumberFormatException("A blank string is not a valid number");
         }

--- a/src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 package org.apache.commons.lang3.math;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 package org.apache.commons.lang3.math;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -722,8 +721,9 @@ public class NumberUtilsTest extends AbstractLangTest {
     }
 
     @Test
-    public void testInvalidNumber() {
+    public void testInvalidNumber() throws Exception {
         assertThrows(NumberFormatException.class, () -> NumberUtils.createNumber("E123e.3"));
+        assertThrows(NumberFormatException.class, () -> NumberUtils.createNumber("-"));
     }
 
     /**

--- a/src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java
@@ -721,7 +721,7 @@ public class NumberUtilsTest extends AbstractLangTest {
     }
 
     @Test
-    public void testInvalidNumber() throws Exception {
+    public void testInvalidNumber() {
         assertThrows(NumberFormatException.class, () -> NumberUtils.createNumber("E123e.3"));
         assertThrows(NumberFormatException.class, () -> NumberUtils.createNumber("-"));
     }


### PR DESCRIPTION
This PR wraps possible `IndexOutOfBoundsException` with `NumberFormatException` when invalid string is parsed to `NumberUtils.getMantissa(String, int)` method and cause the String.substring(int, int) throws `IndexOutOfBoundsException`.