### PR TITLE
fix violations of Sonarqube rule java:S2184

### DIFF
--- a/src/main/java/org/apache/commons/lang3/text/StrBuilder.java
+++ b/src/main/java/org/apache/commons/lang3/text/StrBuilder.java
@@ -162,7 +162,7 @@ public class StrBuilder implements CharSequence, Appendable, Serializable, Build
         @Override
         public long skip(long n) {
             if (pos + n > StrBuilder.this.size()) {
-                n = StrBuilder.this.size() - pos;
+                n = (long) StrBuilder.this.size() - pos;
             }
             if (n < 0) {
                 return 0;

--- a/src/main/java/org/apache/commons/lang3/time/DateUtils.java
+++ b/src/main/java/org/apache/commons/lang3/time/DateUtils.java
@@ -403,10 +403,10 @@ public class DateUtils {
         // Fragments bigger than a day require a breakdown to days
         switch (fragment) {
             case Calendar.YEAR:
-                result += unit.convert(calendar.get(Calendar.DAY_OF_YEAR) - offset, TimeUnit.DAYS);
+                result += unit.convert((long) calendar.get(Calendar.DAY_OF_YEAR) - offset, TimeUnit.DAYS);
                 break;
             case Calendar.MONTH:
-                result += unit.convert(calendar.get(Calendar.DAY_OF_MONTH) - offset, TimeUnit.DAYS);
+                result += unit.convert((long) calendar.get(Calendar.DAY_OF_MONTH) - offset, TimeUnit.DAYS);
                 break;
             default:
                 break;


### PR DESCRIPTION
Hello,

This PR fixes 3 violations of Sonarqube Rule java:S2184 : ['Math operands should be cast before assignment'](https://rules.sonarsource.com/java/RSPEC-2184).
For more details, please see
[MITRE, CWE-190](http://cwe.mitre.org/data/definitions/190) - Integer Overflow or Wraparound
[CERT, NUM50-J.](https://wiki.sei.cmu.edu/confluence/x/AjdGBQ)- Convert integers to floating point for floating-point operations
[CERT, INT18-C.](https://wiki.sei.cmu.edu/confluence/x/I9cxBQ) - Evaluate integer expressions in a larger size before comparing or assigning to that size

The patch was automatically generated using the ViolationFixer tool.