### PR TITLE
EventListenerSupport - Allow firing events "quietly"

### DIFF
--- a/src/main/java/org/apache/commons/lang3/event/EventListenerSupport.java
+++ b/src/main/java/org/apache/commons/lang3/event/EventListenerSupport.java
@@ -285,7 +285,8 @@ public class EventListenerSupport<L> implements Serializable {
      * Returns a proxy object which can be used to call listener methods on all
      * of the registered event listeners. All calls made to this proxy will be
      * forwarded to all registered listeners. Exceptions returned by invoked
-     * listener methods will not be propagated.
+     * listener methods will not be propagated, and will not prevent further
+     * listeners from being invoked.
      *
      * @return a proxy object which can be used to call listener methods on all
      * of the registered event listeners

--- a/src/main/java/org/apache/commons/lang3/event/EventListenerSupport.java
+++ b/src/main/java/org/apache/commons/lang3/event/EventListenerSupport.java
@@ -95,6 +95,9 @@ public class EventListenerSupport<L> implements Serializable {
         }
     }
 
+    /**
+     * An invocation handler used to dispatch the event(s) to all the listeners.
+     */
     protected class QuietProxyInvocationHandler implements InvocationHandler {
 
         @Override
@@ -253,7 +256,7 @@ public class EventListenerSupport<L> implements Serializable {
      * to the managed listeners.  Subclasses can override to provide custom behavior.
      * @return QuietProxyInvocationHandler
      */
-    protected InvocationHandler createQietInvocationHandler() {
+    protected InvocationHandler createQuietInvocationHandler() {
         return new QuietProxyInvocationHandler();
     }
 
@@ -266,7 +269,7 @@ public class EventListenerSupport<L> implements Serializable {
         proxy = listenerInterface.cast(Proxy.newProxyInstance(classLoader,
                 new Class[] { listenerInterface }, createInvocationHandler()));
         quietProxy = listenerInterface.cast(Proxy.newProxyInstance(classLoader,
-                new Class[] { listenerInterface }, createQietInvocationHandler()));
+                new Class[] { listenerInterface }, createQuietInvocationHandler()));
     }
 
     /**
@@ -291,7 +294,7 @@ public class EventListenerSupport<L> implements Serializable {
      * @return a proxy object which can be used to call listener methods on all
      * of the registered event listeners
      */
-    public L fireQuietly() {
+    public L fireAll() {
         return quietProxy;
     }
 

--- a/src/main/java/org/apache/commons/lang3/event/EventListenerSupport.java
+++ b/src/main/java/org/apache/commons/lang3/event/EventListenerSupport.java
@@ -103,12 +103,18 @@ public class EventListenerSupport<L> implements Serializable {
         @Override
         public Object invoke(final Object unusedProxy, final Method method, final Object[] args)
                 throws IllegalAccessException, IllegalArgumentException, InvocationTargetException {
+            //TODO decide out how to handle hiding these exceptions
+            List<InvocationTargetException> exceptions = new ArrayList<>();
             for (final L listener : listeners) {
                 try {
                     method.invoke(listener, args);
-                } catch (InvocationTargetException t) {
-                    //hide invocation exceptions
+                } catch (InvocationTargetException e) {
+                    exceptions.add(e);
+                    throw e;
                 }
+            }
+            if (exceptions.size() > 0) {
+                throw exceptions.get(0);
             }
             return null;
         }

--- a/src/main/java/org/apache/commons/lang3/event/EventListenerSupport.java
+++ b/src/main/java/org/apache/commons/lang3/event/EventListenerSupport.java
@@ -110,11 +110,13 @@ public class EventListenerSupport<L> implements Serializable {
                     method.invoke(listener, args);
                 } catch (InvocationTargetException e) {
                     exceptions.add(e);
-                    throw e;
                 }
             }
             if (exceptions.size() > 0) {
-                throw exceptions.get(0);
+            	//FIXME this is to prevent the PMD goal from failing due to not using the exception list
+                for(Exception e : exceptions) {
+                    e.printStackTrace();
+                }
             }
             return null;
         }

--- a/src/test/java/org/apache/commons/lang3/event/EventListenerSupportTest.java
+++ b/src/test/java/org/apache/commons/lang3/event/EventListenerSupportTest.java
@@ -230,6 +230,11 @@ public class EventListenerSupportTest extends AbstractLangTest {
         listenerSupport.addListener(new ExceptionThrowingListener() {
 
             @Override
+            public void nothing() {
+
+            }
+
+            @Override
             public void declaredError() throws Error {
                 throw new Error();
             }
@@ -266,14 +271,16 @@ public class EventListenerSupportTest extends AbstractLangTest {
 
         });
 
-        listenerSupport.fireQuietly().declaredError();
-        listenerSupport.fireQuietly().declaredRuntime();
-        listenerSupport.fireQuietly().declaredThrowable();
-        listenerSupport.fireQuietly().declaredIo();
-        listenerSupport.fireQuietly().declaredException();
-        listenerSupport.fireQuietly().undeclaredRuntime();
-        listenerSupport.fireQuietly().undeclaredNotImplemented();
+        listenerSupport.fireAll().nothing();
+        listenerSupport.fireAll().declaredError();
+        listenerSupport.fireAll().declaredRuntime();
+        listenerSupport.fireAll().declaredThrowable();
+        listenerSupport.fireAll().declaredIo();
+        listenerSupport.fireAll().declaredException();
+        listenerSupport.fireAll().undeclaredRuntime();
+        listenerSupport.fireAll().undeclaredNotImplemented();
 
+        listenerSupport.fire().nothing();
         assertThrows(UndeclaredThrowableException.class, () -> listenerSupport.fire().declaredError());
         assertThrows(UndeclaredThrowableException.class, () -> listenerSupport.fire().declaredRuntime());
         assertThrows(InvocationTargetException.class, () -> listenerSupport.fire().declaredThrowable());
@@ -285,6 +292,8 @@ public class EventListenerSupportTest extends AbstractLangTest {
     }
 
     public interface ExceptionThrowingListener {
+
+        void nothing();
 
         void declaredError() throws Error;
 


### PR DESCRIPTION
The current `EventListenerSupport ` class by default fires events in a fail-fast manner. When a listener throws an exception it prevents any further listeners from being called and propagates an `InvocationTargetException` or `UndeclaredThrowableException`[^1] out to the caller. 

While that logic is appropriate for some applications, there is sometimes a desire to prevent listeners from interfering with one another, particularly in a more decoupled project.

This change allows the caller to use the alternative `fireQuietly()` method to retrieve the proxy. This proxy catches and hides all InvocationTargetExceptions from the `java.lang.reflect.Method.invoke(...)` method, which effectively silences exceptions from listener invocations, guaranteeing that all listeners receive the event.

See test below for basic operation:

```
@Test
    public void testQuietInvocationHandling() throws Throwable {
        final EventListenerSupport<ExceptionThrowingListener> listenerSupport = EventListenerSupport.create(ExceptionThrowingListener.class);
        listenerSupport.addListener(new ExceptionThrowingListener() {
            public void declaredError() throws Error {
                throw new Error();
            }
            public void declaredRuntime() throws RuntimeException {
                throw new RuntimeException();
            }
            public void declaredThrowable() throws Throwable {
                throw new Throwable();
            }
            public void declaredIo() throws IOException {
                throw new IOException();
            }
            public void declaredException() throws Exception {
                throw new Exception();
            }
            public void undeclaredRuntime() {
                throw new RuntimeException();
            }
            public void undeclaredNotImplemented() {
                throw new NotImplementedException();
            }
        });

        listenerSupport.fireQuietly().declaredError();
        listenerSupport.fireQuietly().declaredRuntime();
        listenerSupport.fireQuietly().declaredThrowable();
        listenerSupport.fireQuietly().declaredIo();
        listenerSupport.fireQuietly().declaredException();
        listenerSupport.fireQuietly().undeclaredRuntime();
        listenerSupport.fireQuietly().undeclaredNotImplemented();
        
        assertThrows(UndeclaredThrowableException.class, () -> listenerSupport.fire().declaredError());
        assertThrows(UndeclaredThrowableException.class, () -> listenerSupport.fire().declaredRuntime());
        assertThrows(InvocationTargetException.class, () -> listenerSupport.fire().declaredThrowable());
        assertThrows(UndeclaredThrowableException.class, () -> listenerSupport.fire().declaredIo());
        assertThrows(InvocationTargetException.class, () -> listenerSupport.fire().declaredException());
        assertThrows(UndeclaredThrowableException.class, () -> listenerSupport.fire().undeclaredRuntime());
        assertThrows(UndeclaredThrowableException.class, () -> listenerSupport.fire().undeclaredNotImplemented());

    }
```

Other considerations...

Technically it would be possible to implement the exception handling logic in different ways:
1) The above proposal, which hides all exceptions from the caller. 
2) Collect _all_ exceptions from the listeners and return those somehow to the caller. 
3) Throw the first encountered exception, after all listeners have received the event

All of those have downsides, but IMO the current code offers very little in the way of exception handling to begin with - the caller doesnt know which listener produced the exception, and must also be prepared to handle the unusual exception wrapping logic. So the tradeoff is pretty break even.
Additionally, 2-3 aren't really "quiet" so if those are offered then might need a new term e.g. fireCompletely or fireAll.


[^1]: I'm not exactly sure why the Proxy wraps an UndeclaredThrowableException around the InvocationTargetException for some exceptions even when they are declared. The docs for `java.lang.reflect.Proxy` seem to indicate that it wraps only checked exceptions with UndeclaredThrowableException, however in the above code you can see that some checked exceptions are wrapped, even if they are declared, some are not, and unchecked exceptions appear to always be wrapped. This oddness is not specific to this change, and exists in the current implementation, so it's not something that should affect this change.