### PR TITLE
Improve handling of malformed `Validate` messages

### DIFF
--- a/src/test/java/org/apache/commons/lang3/ValidateTest.java
+++ b/src/test/java/org/apache/commons/lang3/ValidateTest.java
@@ -29,6 +29,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.IllegalFormatException;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -724,6 +725,13 @@ public class ValidateTest extends AbstractLangTest {
                 final IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> Validate.isTrue(false, "MSG"));
                 assertEquals("MSG", ex.getMessage());
             }
+
+            @Test
+            void shouldThrowExceptionWithGivenMalformedMessageForFalseExpression() {
+                final IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> Validate.isTrue(false, "MSG %d", "bad arg"));
+                assertEquals("MSG %d\nValues: [bad arg]", ex.getMessage());
+                assertTrue(ex.getSuppressed()[0] instanceof IllegalFormatException);
+            }
         }
 
         @Nested
@@ -821,6 +829,13 @@ public class ValidateTest extends AbstractLangTest {
                 }
 
                 @Test
+                void shouldThrowIllegalArgumentExceptionWithGivenMessageAndValuesForArrayWithNullElement() {
+                    final IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                        () -> Validate.noNullElements(new String[] {"a", null}, "MSG %s at %d", "arg"));
+                    assertEquals("MSG arg at 1", ex.getMessage());
+                }
+
+                @Test
                 void shouldThrowNullPointerExceptionWithDefaultMessageForNullArray() {
                     final NullPointerException ex = assertThrows(NullPointerException.class, () -> Validate.noNullElements((Object[]) null, "MSG"));
                     assertEquals("array", ex.getMessage());
@@ -877,6 +892,13 @@ public class ValidateTest extends AbstractLangTest {
                     final IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
                         () -> Validate.noNullElements(Collections.singleton(null), "MSG"));
                     assertEquals("MSG", ex.getMessage());
+                }
+
+                @Test
+                void shouldThrowIllegalArgumentExceptionWithGivenMessageAndValuesForCollectionWithNullElement() {
+                    final IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                        () -> Validate.noNullElements(Collections.singleton(null), "MSG %s at %d", "arg"));
+                    assertEquals("MSG arg at 0", ex.getMessage());
                 }
 
                 @Test


### PR DESCRIPTION
With these changes if the call to `String.format` fails it will generate the message as `message + "\nValues: " + Arrays.toString(values)` and add the `IllegalFormatException` as suppressed exception.
If the message and values are wellformed the behavior remains the same as before.

Rationale:
- Even if the message is malformed, showing it to the user still allows them to troubleshoot the `Validate` failure, which would not be possible when only propagating the `IllegalFormatException`
 This is similar to [Guava's `Preconditions`](https://javadoc.io/doc/com.google.guava/guava/latest/com/google/common/base/Preconditions.html) which also does not fail on malformed messages
- Since the message is only constructed in the error case, it is likely that unit tests of the user don't cover it since they normally mostly focus on the 'happy path'

However, #953 has in the past already improved the situation for `Validate` a lot, so maybe these changes here are not that important or useful? What do you think?