### PR TITLE
LANG-1720: Fix Javadoc description of exceptions thrown for existing classes

### DIFF
--- a/src/main/java/org/apache/commons/lang3/Conversion.java
+++ b/src/main/java/org/apache/commons/lang3/Conversion.java
@@ -280,6 +280,9 @@ public class Conversion {
         if (src.length - srcPos < 4) {
             throw new IllegalArgumentException("src.length-srcPos<4: src.length=" + src.length + ", srcPos=" + srcPos);
         }
+        if (srcPos >= 0) {
+            throw new IllegalArgumentException("srcPos>=0: srcPos=" + srcPos);
+        }
         if (src[srcPos + 3]) {
             if (src[srcPos + 2]) {
                 if (src[srcPos + 1]) {
@@ -788,6 +791,7 @@ public class Conversion {
      * @param nHex the number of Chars to convert
      * @return a byte containing the selected bits
      * @throws IllegalArgumentException if {@code (nHex-1)*4+dstPos >= 8}
+     * @throws StringIndexOutOfBoundsException if {@code srcPos < 0 || srcPos + nHex >= src.length()}
      */
     public static byte hexToByte(final String src, final int srcPos, final byte dstInit, final int dstPos,
             final int nHex) {
@@ -819,6 +823,7 @@ public class Conversion {
      * @param nHex the number of Chars to convert
      * @return an int containing the selected bits
      * @throws IllegalArgumentException if {@code (nHexs-1)*4+dstPos >= 32}
+     * @throws StringIndexOutOfBoundsException if {@code srcPos < 0 || srcPos + nHex >= src.length()}
      */
     public static int hexToInt(final String src, final int srcPos, final int dstInit, final int dstPos, final int nHex) {
         if (0 == nHex) {
@@ -849,6 +854,7 @@ public class Conversion {
      * @param nHex the number of Chars to convert
      * @return a long containing the selected bits
      * @throws IllegalArgumentException if {@code (nHexs-1)*4+dstPos >= 64}
+     * @throws StringIndexOutOfBoundsException if {@code srcPos < 0 || srcPos + nHex >= src.length()}
      */
     public static long hexToLong(final String src, final int srcPos, final long dstInit, final int dstPos,
             final int nHex) {
@@ -880,6 +886,7 @@ public class Conversion {
      * @param nHex the number of Chars to convert
      * @return a short containing the selected bits
      * @throws IllegalArgumentException if {@code (nHexs-1)*4+dstPos >= 16}
+     * @throws StringIndexOutOfBoundsException if {@code srcPos < 0 || srcPos + nHex >= src.length()}
      */
     public static short hexToShort(final String src, final int srcPos, final short dstInit, final int dstPos,
             final int nHex) {

--- a/src/main/java/org/apache/commons/lang3/Conversion.java
+++ b/src/main/java/org/apache/commons/lang3/Conversion.java
@@ -791,7 +791,7 @@ public class Conversion {
      * @param nHex the number of Chars to convert
      * @return a byte containing the selected bits
      * @throws IllegalArgumentException if {@code (nHex-1)*4+dstPos >= 8}
-     * @throws StringIndexOutOfBoundsException if {@code srcPos < 0 || srcPos + nHex >= src.length()}
+     * @throws StringIndexOutOfBoundsException if {@code srcPos < 0}
      */
     public static byte hexToByte(final String src, final int srcPos, final byte dstInit, final int dstPos,
             final int nHex) {
@@ -823,7 +823,7 @@ public class Conversion {
      * @param nHex the number of Chars to convert
      * @return an int containing the selected bits
      * @throws IllegalArgumentException if {@code (nHexs-1)*4+dstPos >= 32}
-     * @throws StringIndexOutOfBoundsException if {@code srcPos < 0 || srcPos + nHex >= src.length()}
+     * @throws StringIndexOutOfBoundsException if {@code srcPos < 0}
      */
     public static int hexToInt(final String src, final int srcPos, final int dstInit, final int dstPos, final int nHex) {
         if (0 == nHex) {
@@ -854,7 +854,7 @@ public class Conversion {
      * @param nHex the number of Chars to convert
      * @return a long containing the selected bits
      * @throws IllegalArgumentException if {@code (nHexs-1)*4+dstPos >= 64}
-     * @throws StringIndexOutOfBoundsException if {@code srcPos < 0 || srcPos + nHex >= src.length()}
+     * @throws StringIndexOutOfBoundsException if {@code srcPos < 0}
      */
     public static long hexToLong(final String src, final int srcPos, final long dstInit, final int dstPos,
             final int nHex) {
@@ -886,7 +886,7 @@ public class Conversion {
      * @param nHex the number of Chars to convert
      * @return a short containing the selected bits
      * @throws IllegalArgumentException if {@code (nHexs-1)*4+dstPos >= 16}
-     * @throws StringIndexOutOfBoundsException if {@code srcPos < 0 || srcPos + nHex >= src.length()}
+     * @throws StringIndexOutOfBoundsException if {@code srcPos < 0}
      */
     public static short hexToShort(final String src, final int srcPos, final short dstInit, final int dstPos,
             final int nHex) {

--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -3916,6 +3916,7 @@ public class StringUtils {
      *            the index to stop joining from (exclusive). It is an error to pass in an end index past the end of
      *            the array
      * @return the joined String, {@code null} if null array input
+     * @throws ArrayIndexOutOfBoundsException if {@code startIndex < 0 || endIndex >= array.length}
      * @since 3.12.0
      */
     public static String join(final boolean[] array, final char delimiter, final int startIndex, final int endIndex) {
@@ -3991,6 +3992,7 @@ public class StringUtils {
      *            the index to stop joining from (exclusive). It is an error to pass in an end index past the end of
      *            the array
      * @return the joined String, {@code null} if null array input
+     * @throws ArrayIndexOutOfBoundsException if {@code startIndex < 0 || endIndex >= array.length}
      * @since 3.2
      */
     public static String join(final byte[] array, final char delimiter, final int startIndex, final int endIndex) {
@@ -4066,6 +4068,7 @@ public class StringUtils {
      *            the index to stop joining from (exclusive). It is an error to pass in an end index past the end of
      *            the array
      * @return the joined String, {@code null} if null array input
+     * @throws ArrayIndexOutOfBoundsException if {@code startIndex < 0 || endIndex >= array.length}
      * @since 3.2
      */
     public static String join(final char[] array, final char delimiter, final int startIndex, final int endIndex) {
@@ -4141,6 +4144,7 @@ public class StringUtils {
      *            the index to stop joining from (exclusive). It is an error to pass in an end index past the end of
      *            the array
      * @return the joined String, {@code null} if null array input
+     * @throws ArrayIndexOutOfBoundsException if {@code startIndex < 0 || endIndex >= array.length}
      * @since 3.2
      */
     public static String join(final double[] array, final char delimiter, final int startIndex, final int endIndex) {
@@ -4216,6 +4220,7 @@ public class StringUtils {
      *            the index to stop joining from (exclusive). It is an error to pass in an end index past the end of
      *            the array
      * @return the joined String, {@code null} if null array input
+     * @throws ArrayIndexOutOfBoundsException if {@code startIndex < 0 || endIndex >= array.length}
      * @since 3.2
      */
     public static String join(final float[] array, final char delimiter, final int startIndex, final int endIndex) {
@@ -4418,6 +4423,7 @@ public class StringUtils {
      * @param endIndex the index to stop joining from (exclusive). It is
      * an error to pass in an end index past the end of the list
      * @return the joined String, {@code null} if null list input
+     * @throws ArrayIndexOutOfBoundsException if {@code startIndex < 0 || endIndex >= list.size()}
      * @since 3.8
      */
     public static String join(final List<?> list, final char separator, final int startIndex, final int endIndex) {
@@ -4456,6 +4462,7 @@ public class StringUtils {
      * @param endIndex the index to stop joining from (exclusive). It is
      * an error to pass in an end index past the end of the list
      * @return the joined String, {@code null} if null list input
+     * @throws ArrayIndexOutOfBoundsException if {@code startIndex < 0 || endIndex >= list.size()}
      * @since 3.8
      */
     public static String join(final List<?> list, final String separator, final int startIndex, final int endIndex) {
@@ -4728,6 +4735,7 @@ public class StringUtils {
      *            the index to stop joining from (exclusive). It is an error to pass in an end index past the end of
      *            the array
      * @return the joined String, {@code null} if null array input
+     * @throws ArrayIndexOutOfBoundsException if {@code startIndex < 0 || endIndex >= array.length}
      * @since 3.2
      */
     public static String join(final short[] array, final char delimiter, final int startIndex, final int endIndex) {

--- a/src/main/java/org/apache/commons/lang3/text/StrSubstitutor.java
+++ b/src/main/java/org/apache/commons/lang3/text/StrSubstitutor.java
@@ -538,6 +538,7 @@ public class StrSubstitutor {
      * @param offset  the start offset within the array, must be valid
      * @param length  the length within the array to be processed, must be valid
      * @return the result of the replace operation
+     * @throws StringIndexOutOfBoundsException if {@code offset < 0 || offset + length >= source.length}
      */
     public String replace(final char[] source, final int offset, final int length) {
         if (source == null) {
@@ -577,6 +578,7 @@ public class StrSubstitutor {
      * @param offset  the start offset within the array, must be valid
      * @param length  the length within the array to be processed, must be valid
      * @return the result of the replace operation
+     * @throws StringIndexOutOfBoundsException if {@code offset < 0 || offset + length >= source.length}
      * @since 3.2
      */
     public String replace(final CharSequence source, final int offset, final int length) {
@@ -675,6 +677,7 @@ public class StrSubstitutor {
      * @param offset  the start offset within the array, must be valid
      * @param length  the length within the array to be processed, must be valid
      * @return the result of the replace operation
+     * @throws StringIndexOutOfBoundsException if {@code offset < 0 || offset + length >= source.length}
      */
     public String replace(final String source, final int offset, final int length) {
         if (source == null) {
@@ -717,6 +720,7 @@ public class StrSubstitutor {
      * @param offset  the start offset within the array, must be valid
      * @param length  the length within the array to be processed, must be valid
      * @return the result of the replace operation
+     * @throws StringIndexOutOfBoundsException if {@code offset < 0 || offset + length >= source.length}
      */
     public String replace(final StringBuffer source, final int offset, final int length) {
         if (source == null) {
@@ -753,6 +757,7 @@ public class StrSubstitutor {
      * @param offset  the start offset within the array, must be valid
      * @param length  the length within the builder to be processed, must be valid
      * @return true if altered
+     * @throws StringIndexOutOfBoundsException if {@code offset < 0 || offset + length >= source.length}
      */
     public boolean replaceIn(final StrBuilder source, final int offset, final int length) {
         if (source == null) {
@@ -789,6 +794,7 @@ public class StrSubstitutor {
      * @param offset  the start offset within the array, must be valid
      * @param length  the length within the buffer to be processed, must be valid
      * @return true if altered
+     * @throws StringIndexOutOfBoundsException if {@code offset < 0 || offset + length >= source.length}
      */
     public boolean replaceIn(final StringBuffer source, final int offset, final int length) {
         if (source == null) {

--- a/src/main/java/org/apache/commons/lang3/text/translate/CharSequenceTranslator.java
+++ b/src/main/java/org/apache/commons/lang3/text/translate/CharSequenceTranslator.java
@@ -79,6 +79,7 @@ public abstract class CharSequenceTranslator {
      * @param out Writer to translate the text to
      * @return int count of code points consumed
      * @throws IOException if and only if the Writer produces an IOException
+     * @throws StringIndexOutOfBoundsException if {@code index < 0 || index >= input.length()}
      */
     public abstract int translate(CharSequence input, int index, Writer out) throws IOException;
 


### PR DESCRIPTION
During my usage of commons-lang, I have noticed some exceptions (in `StringUtils`, `StrSubstitutor`, `CharSequenceTranslator` and `Conversion`) that are not documented in the Javadoc, which I consider to be unhandled exceptions.

Before creating my this PR, I noticed  #1139, which addresses similar issues. In order to avoid conflicts and show my respect, I have removed some of the Javadoc comments I added in `Conversion.java`, aligning with PR #1139.