### PR TITLE
Make dependency on java.desktop optional

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
   LTS releases.
   These are 8, 11, 12 and 21 currently, see:
   https://github.com/apache/commons-lang/blob/master/.github/workflows/maven.yml
-  
+
   Please ensure your build environment is up-to-date and kindly report any build issues.
   </description>
 
@@ -111,7 +111,7 @@
       <email>ggregory at apache.org</email>
       <url>https://www.garygregory.com</url>
       <organization>The Apache Software Foundation</organization>
-      <organizationUrl>https://www.apache.org/</organizationUrl>      
+      <organizationUrl>https://www.apache.org/</organizationUrl>
       <roles>
         <role>PMC Member</role>
       </roles>
@@ -775,6 +775,38 @@
           <excludeFilterFile>${basedir}/src/conf/spotbugs-exclude-filter.xml</excludeFilterFile>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>add-module-infos</id>
+            <phase>package</phase>
+            <goals>
+              <goal>add-module-info</goal>
+            </goals>
+            <configuration>
+              <jvmVersion>${moditect.java.version}</jvmVersion>
+              <outputDirectory>${project.build.directory}</outputDirectory>
+              <overwriteExistingFiles>true</overwriteExistingFiles>
+              <failOnWarning>false</failOnWarning>
+              <module>
+                <moduleInfo>
+                  <name>${commons.module.name}</name>
+                  <exports>
+                    *;
+                  </exports>
+                  <requires>
+                    static java.desktop;
+                    *;
+                  </requires>
+                  <addServiceUses>${commons.moditect-maven-plugin.addServiceUses}</addServiceUses>
+                </moduleInfo>
+              </module>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 
@@ -945,10 +977,10 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
               <excludes>
-                <exclude>org/apache/commons/lang3/time/Java15BugFastDateParserTest.java</exclude>               
+                <exclude>org/apache/commons/lang3/time/Java15BugFastDateParserTest.java</exclude>
               </excludes>
             </configuration>
-          </plugin>        
+          </plugin>
         </plugins>
       </build>
     </profile>


### PR DESCRIPTION
There is only one place in commons-lang where anything from `java.desktop` is used, and that is `AbstractCircuitBreaker`.

This changes that code to lazily initialize its internal `PropertyChangeSupport`. This makes it so that it is safe to initialize and use that class without `java.desktop` on the module-path.

Upsides:

* Smaller jlinked images for every apache commons library
* No binary compatibility changes

Downsides:

* Likely a small performance hit 
* It is possible for a user to give a `null` instance of `PropertyChangeListener` without depending on the `java.desktop` module, in which case the behavior of the method will change from "ignores null" to "fails"
* I do not know how to add a test for this to the junit suite. We'd have to run a subset of the tests without `java.desktop` present. Currently I am validating manually like so

```
$ mvn clean compile package
$ jlink --module-path target/commons-lang3-3.15.0-SNAPSHOT.jar --add-modules org.apache.commons.lang3,jdk.jshell --output jre
$ ./jre/bin/java --list-modules
java.base@21.0.1
java.compiler@21.0.1
java.logging@21.0.1
java.prefs@21.0.1
java.xml@21.0.1
jdk.attach@21.0.1
jdk.compiler@21.0.1
jdk.internal.ed@21.0.1
jdk.internal.jvmstat@21.0.1
jdk.internal.le@21.0.1
jdk.internal.opt@21.0.1
jdk.internal.vm.ci@21.0.1
jdk.jdi@21.0.1
jdk.jdwp.agent@21.0.1
jdk.jshell@21.0.1
jdk.zipfs@21.0.1
org.apache.commons.lang3@3.15.0-SNAPSHOT

$ ./jre/bin/jshell

jshell> var breaker = new EventCountCircuitBreaker(1000, 1, java.util.concurrent.TimeUnit.SECONDS);
breaker ==> org.apache.commons.lang3.concurrent.EventCountCircuitBreaker@1ce92674

jshell> breaker.addChangeListener(null);
|  Error:
|  cannot access java.beans.PropertyChangeListener
|    class file for java.beans.PropertyChangeListener not found
|  breaker.addChangeListener(null);
|  ^-----------------------------^
```

