### PR TITLE
Confusing javadoc typo

### DIFF
--- a/src/main/java/org/apache/commons/lang3/math/NumberUtils.java
+++ b/src/main/java/org/apache/commons/lang3/math/NumberUtils.java
@@ -1493,7 +1493,7 @@ public class NumberUtils {
      * value is returned.</p>
      *
      * <pre>
-     *   NumberUtils.toFloat(null, 1.1f)   = 1.0f
+     *   NumberUtils.toFloat(null, 1.1f)   = 1.1f
      *   NumberUtils.toFloat("", 1.1f)     = 1.1f
      *   NumberUtils.toFloat("1.5", 0.0f)  = 1.5f
      * </pre>


### PR DESCRIPTION
Typo fixed. The javadoc was written:
`NumberUtils.toFloat(null, 1.1f)   = 1.0f`

That is not correct, it should be:
`NumberUtils.toFloat(null, 1.1f)   = 1.1f`