### PR TITLE
Codecov Action v4 requires token to upload coverage reports

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -50,3 +50,4 @@ jobs:
       uses: codecov/codecov-action@7afa10ed9b269c561c2336fd862446844e0cbf71 # v4.2.0
       with:
         files: ./target/site/jacoco/jacoco.xml
+        token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
After a recent update (commit https://github.com/apache/commons-lang/commit/67d5b27421cdaf9c2e43f54f61040cd7baf242eb) to `codecov/codecov-action` with the major v4 release, coverage reports for the `master` branch are no longer being uploaded to Codecov. The error message encountered is as follows:

```
Error: Codecov token not found. Please provide Codecov token with -t flag.
Warning: Codecov: Failed to properly create commit: The process '/home/runner/work/_actions/codecov/codecov-action/7afa10ed9b269c561c2[33](https://github.com/apache/commons-lang/actions/runs/8573073425/job/23497012504#step:6:34)6fd862446844e0cbf71/dist/codecov' failed with exit code 1
```
From the most recent run - https://github.com/apache/commons-lang/actions/runs/8573073425

This issue stems from a breaking change introduced in the v4 release, as outlined in the [documentation](https://github.com/codecov/codecov-action?tab=readme-ov-file#breaking-changes):
> Tokenless uploading is unsupported. However, PRs made from forks to the upstream public repos will support tokenless uploads (e.g., contributors to OS projects do not need the upstream repo's Codecov token).

This pull request addresses the problem by adding the required argument to the action. However, it necessitates the maintainer (@garydgregory) to create a secret named `CODECOV_TOKEN` with a valid token.