### PR TITLE
Fix inaccessible object exception

### DIFF
--- a/src/main/java/org/apache/commons/lang3/builder/CompareToBuilder.java
+++ b/src/main/java/org/apache/commons/lang3/builder/CompareToBuilder.java
@@ -16,12 +16,16 @@
  */
 package org.apache.commons.lang3.builder;
 
-import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.ObjectUtils;
@@ -116,11 +120,31 @@ public class CompareToBuilder implements Builder<Integer> {
         final String[] excludeFields) {
 
         final Field[] fields = clazz.getDeclaredFields();
-        AccessibleObject.setAccessible(fields, true);
-        for (int i = 0; i < fields.length && builder.comparison == 0; i++) {
-            final Field field = fields[i];
-            if (!ArrayUtils.contains(excludeFields, field.getName())
-                && !field.getName().contains("$")
+
+        // Create a HashSet from excludeFields for more efficient access, check if excludeFields is null first
+        final Set<String> excludeFieldsSet = excludeFields != null ? new HashSet<>(Arrays.asList(excludeFields)) : new HashSet<>();
+
+        final List<Field> accessibleFields = Arrays.stream(fields)
+                .filter(field -> {
+                    // Check if the field name is contained in the excludeFieldsSet HashSet
+                    if (!excludeFieldsSet.contains(field.getName())) {
+                        try {
+                            // Try to set the field to 'accessible'
+                            field.setAccessible(true);
+                            return true;
+                        } catch (Exception e) {
+                            // In case of an exception, ignore this field
+                            return false;
+                        }
+                    }
+                    // If the field name is not in excludeFieldsSet, ignore this field
+                    return false;
+                })
+                .collect(Collectors.toList());
+
+        for (int i = 0; i < accessibleFields.size() && builder.comparison == 0; i++) {
+            final Field field = accessibleFields.get(i);
+            if (!field.getName().contains("$")
                 && (useTransients || !Modifier.isTransient(field.getModifiers()))
                 && !Modifier.isStatic(field.getModifiers())) {
                 // IllegalAccessException can't happen. Would get a Security exception instead.


### PR DESCRIPTION
"field.setAccessible(true);" throws an exception on java-17 because java.lang is not open for reflection. The problem cannot be worked around on the client side because "setAccessible(true)" is executed before evaluating the passed parameter "excludeFields". Both should be fixed with the change.
The existing tests also cover the change.