### PR TITLE
Add StringUtils.notEqual and StringUtils.notEqualIgnoreCase methods

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -59,6 +59,8 @@ The <action> type attribute can be add,update,fix,remove.
     <action issue="LANG-1724" type="add" dev="ggregory" due-to="Gary Gregory">Add T ArrayUtils.arraycopy(T, int, T, int, int) fluent style.</action>
     <action issue="LANG-1724" type="add" dev="ggregory" due-to="Gary Gregory">Add T ArrayUtils.arraycopy(T, int, int, int, Function) fluent style.</action>
     <action issue="LANG-1724" type="add" dev="ggregory" due-to="Gary Gregory">Add T ArrayUtils.arraycopy(T, int, int, int, Supplier) fluent style.</action>
+    <action                   type="add" dev="tomohavvk" due-to="Ihor Zadyra">StringUtils.notEqual method.</action>
+    <action                   type="add" dev="tomohavvk" due-to="Ihor Zadyra">StringUtils.notEqualIgnoreCase method.</action>
     <!-- FIX -->
     <action                   type="fix" dev="ggregory" due-to="Miklós Karakó, Gary Gregory">Improve Javadoc in ExceptionUtils #1136.</action>
     <action                   type="fix" dev="ggregory" due-to="Saiharshith Karuneegar Ramesh, Gary Gregory">Fixed two non-deterministic tests in EnumUtilsTest.java #1131.</action>

--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -5504,6 +5504,54 @@ public class StringUtils {
     }
 
     /**
+     * Compares two CharSequences, returning {@code true} if they represent
+     * not equal sequences of characters.
+     *
+     * <p>{@code null}s are handled without exceptions. Two {@code null}
+     * references are considered to be equal. The comparison is <strong>case-sensitive</strong>.</p>
+     *
+     * <pre>
+     * StringUtils.notEqual(null, null)   = false
+     * StringUtils.notEqual(null, "abc")  = true
+     * StringUtils.notEqual("abc", null)  = true
+     * StringUtils.notEqual("abc", "abc") = false
+     * StringUtils.notEqual("abc", "ABC") = true
+     * </pre>
+     *
+     * @param cs1  the first CharSequence, may be {@code null}
+     * @param cs2  the second CharSequence, may be {@code null}
+     * @return {@code false} if the CharSequences are equal (case-sensitive), or both {@code null}
+     * @see #notEqualIgnoreCase(CharSequence, CharSequence)
+     */
+    public static boolean notEqual(final CharSequence cs1, final CharSequence cs2) {
+        return !equals(cs1, cs2);
+    }
+
+    /**
+     * Compares two CharSequences, returning {@code true} if they represent
+     * not equal sequences of characters, ignoring case.
+     *
+     * <p>{@code null}s are handled without exceptions. Two {@code null}
+     * references are considered equal. The comparison is <strong>case insensitive</strong>.</p>
+     *
+     * <pre>
+     * StringUtils.notEqualIgnoreCase(null, null)   = false
+     * StringUtils.notEqualIgnoreCase(null, "abc")  = true
+     * StringUtils.notEqualIgnoreCase("abc", null)  = true
+     * StringUtils.notEqualIgnoreCase("abc", "abc") = false
+     * StringUtils.notEqualIgnoreCase("abc", "ABC") = false
+     * </pre>
+     *
+     * @param cs1  the first CharSequence, may be {@code null}
+     * @param cs2  the second CharSequence, may be {@code null}
+     * @return {@code false} if the CharSequences are equal (case-insensitive), or both {@code null}
+     * @see #notEqual(CharSequence, CharSequence)
+     */
+    public static boolean notEqualIgnoreCase(final CharSequence cs1, final CharSequence cs2) {
+        return !equalsIgnoreCase(cs1, cs2);
+    }
+
+    /**
      * Finds the n-th index within a CharSequence, handling {@code null}.
      * This method uses {@link String#indexOf(String)} if possible.
      * <p><b>Note:</b> The code starts looking for a match at the start of the target,

--- a/src/test/java/org/apache/commons/lang3/StringUtilsEqualsIndexOfTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringUtilsEqualsIndexOfTest.java
@@ -719,6 +719,36 @@ public class StringUtilsEqualsIndexOfTest extends AbstractLangTest {
     }
 
     @Test
+    public void testNotEqual() {
+        final CharSequence fooCs = new StringBuilder(FOO), barCs = new StringBuilder(BAR), foobarCs = new StringBuilder(FOOBAR);
+        assertFalse(StringUtils.notEqual(null, null));
+        assertFalse(StringUtils.notEqual(fooCs, fooCs));
+        assertFalse(StringUtils.notEqual(fooCs, new StringBuilder(FOO)));
+        assertFalse(StringUtils.notEqual(fooCs, new String(new char[] { 'f', 'o', 'o' })));
+        assertFalse(StringUtils.notEqual(fooCs, new CustomCharSequence(FOO)));
+        assertFalse(StringUtils.notEqual(new CustomCharSequence(FOO), fooCs));
+        assertTrue(StringUtils.notEqual(fooCs, new String(new char[] { 'f', 'O', 'O' })));
+        assertTrue(StringUtils.notEqual(fooCs, barCs));
+        assertTrue(StringUtils.notEqual(fooCs, null));
+        assertTrue(StringUtils.notEqual(null, fooCs));
+        assertTrue(StringUtils.notEqual(fooCs, foobarCs));
+        assertTrue(StringUtils.notEqual(foobarCs, fooCs));
+    }
+
+    @Test
+    public void testNotEqualIgnoreCase() {
+        assertFalse(StringUtils.notEqualIgnoreCase(null, null));
+        assertFalse(StringUtils.notEqualIgnoreCase(FOO, FOO));
+        assertFalse(StringUtils.notEqualIgnoreCase(FOO, new String(new char[] { 'f', 'o', 'o' })));
+        assertFalse(StringUtils.notEqualIgnoreCase(FOO, new String(new char[] { 'f', 'O', 'O' })));
+        assertTrue(StringUtils.notEqualIgnoreCase(FOO, BAR));
+        assertTrue(StringUtils.notEqualIgnoreCase(FOO, null));
+        assertTrue(StringUtils.notEqualIgnoreCase(null, FOO));
+        assertFalse(StringUtils.notEqualIgnoreCase("", ""));
+        assertTrue(StringUtils.notEqualIgnoreCase("abcd", "abcd "));
+    }
+
+    @Test
     public void testOrdinalIndexOf() {
         assertEquals(-1, StringUtils.ordinalIndexOf(null, null, Integer.MIN_VALUE));
         assertEquals(-1, StringUtils.ordinalIndexOf("", null, Integer.MIN_VALUE));


### PR DESCRIPTION
**Changes Description**:
Added new methods `notEqual` and `notEqualIgnoreCase` to the `StringUtils` class. These methods are intended for comparing two strings for inequality without using the negation operator.

**Motivation**:
In many cases, there is a need to compare strings for inequality without using the negation operator. Adding these methods makes the code more readable and reduces the likelihood of error.
Using the negation operator (e.g., `!StringUtils.equals(str1, str2)`) can be confusing, especially when comparing many strings. Therefore, introducing these methods simplifies code readability and makes it more understandable.
These new methods add consistency to the library, allowing developers to use a standard approach for comparing strings for inequality.
`ObjectUtils.notEqual` is inspired for the naming.

**Usage Example**:
```java
if (StringUtils.notEqual(str1, str2)) {
    // strings are not equal
}

if (StringUtils.notEqualIgnoreCase(str1, str2)) {
    // strings are not equal (case insensitive)
}
```
**Testing**:
Added corresponding unit tests for the `StringUtils.notEqual` and `StringUtils.notEqualIgnoreCase` methods to ensure they work correctly