### PR TITLE
StringUtils.stripAccents(String) doesn't handle "\u0111" and "\u0110" (Vietnamese)

### DIFF
--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -1410,6 +1410,10 @@ public class StringUtils {
                 decomposed.setCharAt(i, 'L');
             } else if (decomposed.charAt(i) == '\u0142') {
                 decomposed.setCharAt(i, 'l');
+            } else if (decomposed.charAt(i) == '\u0110') {
+                decomposed.setCharAt(i, 'D');
+            } else if (decomposed.charAt(i) == '\u0111') {
+                decomposed.setCharAt(i, 'd');
             }
         }
     }

--- a/src/test/java/org/apache/commons/lang3/StringUtilsTrimStripTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringUtilsTrimStripTest.java
@@ -84,8 +84,8 @@ public class StringUtilsTrimStripTest extends AbstractLangTest {
         assertEquals("", StringUtils.stripAccents(""), "Failed empty String");
         assertEquals("control", StringUtils.stripAccents("control"), "Failed to handle non-accented text");
         assertEquals("eclair", StringUtils.stripAccents("\u00E9clair"), "Failed to handle easy example");
-        assertEquals("ALOSZZCN aloszzcn",
-                StringUtils.stripAccents("\u0104\u0141\u00D3\u015A\u017B\u0179\u0106\u0143 \u0105\u0142\u00F3\u015B\u017C\u017A\u0107\u0144"));
+        assertEquals("ALOSZZCND aloszzcnd",
+                StringUtils.stripAccents("\u0104\u0141\u00D3\u015A\u017B\u0179\u0106\u0143\u0110 \u0105\u0142\u00F3\u015B\u017C\u017A\u0107\u0144\u0111"));
         assertEquals("The cafe\u2019s pinata gave me deja vu.", StringUtils.stripAccents("The caf\u00e9\u2019s pi\u00f1ata gave me d\u00e9j\u00e0 vu."),
                 "Failed to handle accented text");
         assertEquals("fluid quest", StringUtils.stripAccents("\ufb02uid que\ufb06"), "Failed to handle ligatures");


### PR DESCRIPTION
In Vietnamese, we have the characters "đ" and "Đ" (For reference, here is the Wikipedia page about this character: https://en.wikipedia.org/wiki/D_with_stroke.) When using your function, we need to manually replace these characters to remove their diacritical marks. It would be wonderful if you could add support for removing the diacritical marks from these two characters in your library. Thank you!