### PR TITLE
[LANG-1745] RandomStringUtils.random() with a negative character index should throw IllegalArgumentException

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -46,14 +46,15 @@ The <action> type attribute can be add,update,fix,remove.
   </properties>
   <body>
   <release version="3.16.0" date="YYYY-MM-DD" description="This is a feature and maintenance release. Java 8 or later is required.">
-      <!-- FIX -->
-      <action                 type="fix" dev="ggregory" due-to="Gary Gregory">Reimplement StopWatch internals to use java.time.</action>
-      <!-- ADD -->
-      <action                 type="add" dev="ggregory" due-to="Gary Gregory">Add StopWatch.getSplitDuration() and deprecate getSplitTime().</action>
-      <action                 type="add" dev="ggregory" due-to="Gary Gregory">Add StopWatch.getStartInstant() and deprecate getStartTime().</action>
-      <action                 type="add" dev="ggregory" due-to="Gary Gregory">Add StopWatch.getStopInstant() and deprecate getStopTime().</action>
-      <action                 type="add" dev="ggregory" due-to="Gary Gregory">Add StopWatch.getDuration() and deprecate getTime().</action>
-      <!-- UPDATE -->
+    <!-- FIX -->
+    <action                   type="fix" dev="ggregory" due-to="Gary Gregory">Reimplement StopWatch internals to use java.time.</action>
+    <action issue="LANG-1745" type="fix" dev="ggregory" due-to="Wang Hailong, Gary Gregory">RandomStringUtils.random() with a negative character index should throw IllegalArgumentException.</action>
+    <!-- ADD -->
+    <action                   type="add" dev="ggregory" due-to="Gary Gregory">Add StopWatch.getSplitDuration() and deprecate getSplitTime().</action>
+    <action                   type="add" dev="ggregory" due-to="Gary Gregory">Add StopWatch.getStartInstant() and deprecate getStartTime().</action>
+    <action                   type="add" dev="ggregory" due-to="Gary Gregory">Add StopWatch.getStopInstant() and deprecate getStopTime().</action>
+    <action                   type="add" dev="ggregory" due-to="Gary Gregory">Add StopWatch.getDuration() and deprecate getTime().</action>
+    <!-- UPDATE -->
   </release>
   <release version="3.15.0" date="2024-07-13" description="New features and bug fixes (Java 8 or above).">
     <!-- ADD -->

--- a/src/main/java/org/apache/commons/lang3/RandomStringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/RandomStringUtils.java
@@ -232,6 +232,8 @@ public class RandomStringUtils {
             }
         } else if (end <= start) {
             throw new IllegalArgumentException("Parameter end (" + end + ") must be greater than start (" + start + ")");
+        } else if (start < 0 || end < 0) {
+            throw new IllegalArgumentException("Character positions MUST be >= 0");
         }
 
         if (end > Character.MAX_CODE_POINT) {

--- a/src/test/java/org/apache/commons/lang3/RandomStringUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/RandomStringUtilsTest.java
@@ -93,23 +93,43 @@ public class RandomStringUtilsTest extends AbstractLangTest {
     }
 
     @Test
-    public void testExceptions() {
-        final char[] DUMMY = { 'a' }; // valid char array
+    public void testExceptionsRandom() {
         assertThrows(IllegalArgumentException.class, () -> RandomStringUtils.random(-1));
         assertThrows(IllegalArgumentException.class, () -> RandomStringUtils.random(-1, true, true));
-        assertThrows(IllegalArgumentException.class, () -> RandomStringUtils.random(-1, DUMMY));
+        assertThrows(IllegalArgumentException.class, () -> RandomStringUtils.random(-1, new char[] { 'a' }));
         assertThrows(IllegalArgumentException.class, () -> RandomStringUtils.random(1, new char[0]));
         assertThrows(IllegalArgumentException.class, () -> RandomStringUtils.random(-1, ""));
         assertThrows(IllegalArgumentException.class, () -> RandomStringUtils.random(-1, (String) null));
         assertThrows(IllegalArgumentException.class, () -> RandomStringUtils.random(-1, 'a', 'z', false, false));
-        assertThrows(IllegalArgumentException.class, () -> RandomStringUtils.random(-1, 'a', 'z', false, false, DUMMY));
-        assertThrows(IllegalArgumentException.class, () -> RandomStringUtils.random(-1, 'a', 'z', false, false, DUMMY, new Random()));
+        assertThrows(IllegalArgumentException.class, () -> RandomStringUtils.random(-1, 'a', 'z', false, false, new char[] { 'a' }));
+        assertThrows(IllegalArgumentException.class, () -> RandomStringUtils.random(-1, 'a', 'z', false, false, new char[] { 'a' }, new Random()));
         assertThrows(IllegalArgumentException.class, () -> RandomStringUtils.random(8, 32, 48, false, true));
         assertThrows(IllegalArgumentException.class, () -> RandomStringUtils.random(8, 32, 65, true, false));
+        assertThrows(IllegalArgumentException.class, () -> RandomStringUtils.random(1, Integer.MIN_VALUE, -10, false, false, null));
+    }
+
+    @Test
+    public void testExceptionsRandomAlphabetic() {
         assertThrows(IllegalArgumentException.class, () -> RandomStringUtils.randomAlphabetic(-1));
+    }
+
+    @Test
+    public void testExceptionsRandomAscii() {
         assertThrows(IllegalArgumentException.class, () -> RandomStringUtils.randomAscii(-1));
+    }
+
+    @Test
+    public void testExceptionsRandomGraph() {
         assertThrows(IllegalArgumentException.class, () -> RandomStringUtils.randomGraph(-1));
+    }
+
+    @Test
+    public void testExceptionsRandomNumeric() {
         assertThrows(IllegalArgumentException.class, () -> RandomStringUtils.randomNumeric(-1));
+    }
+
+    @Test
+    public void testExceptionsRandomPrint() {
         assertThrows(IllegalArgumentException.class, () -> RandomStringUtils.randomPrint(-1));
     }
 

--- a/src/test/java/org/apache/commons/lang3/time/FastDateFormatTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/FastDateFormatTest.java
@@ -47,6 +47,9 @@ import org.junitpioneer.jupiter.DefaultTimeZone;
  * Unit tests {@link org.apache.commons.lang3.time.FastDateFormat}.
  */
 public class FastDateFormatTest extends AbstractLangTest {
+
+    private static final String ISO_8601_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ssZZ";
+
     private static final int NTHREADS = 10;
 
     private static final int NROUNDS = 10000;
@@ -267,6 +270,20 @@ public class FastDateFormatTest extends AbstractLangTest {
     public void testLANG_954() {
         final String pattern = "yyyy-MM-dd'T'";
         FastDateFormat.getInstance(pattern);
+    }
+
+    @Test
+    public void testLang1641() {
+        assertSame(FastDateFormat.getInstance(ISO_8601_DATE_FORMAT), FastDateFormat.getInstance(ISO_8601_DATE_FORMAT));
+        // commons-lang's GMT TimeZone
+        assertSame(FastDateFormat.getInstance(ISO_8601_DATE_FORMAT, FastTimeZone.getGmtTimeZone()),
+                FastDateFormat.getInstance(ISO_8601_DATE_FORMAT, FastTimeZone.getGmtTimeZone()));
+        // default TimeZone
+        assertSame(FastDateFormat.getInstance(ISO_8601_DATE_FORMAT, TimeZone.getDefault()),
+                FastDateFormat.getInstance(ISO_8601_DATE_FORMAT, TimeZone.getDefault()));
+        // TimeZones that are identical in every way except ID
+        assertNotSame(FastDateFormat.getInstance(ISO_8601_DATE_FORMAT, TimeZone.getTimeZone("Australia/Broken_Hill")),
+                FastDateFormat.getInstance(ISO_8601_DATE_FORMAT, TimeZone.getTimeZone("Australia/Yancowinna")));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/time/FastDateFormatTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/FastDateFormatTest.java
@@ -248,7 +248,7 @@ public class FastDateFormatTest extends AbstractLangTest {
     }
 
     @Test
-    public void testLANG_1152() {
+    public void testLang1152() {
         final TimeZone utc = FastTimeZone.getGmtTimeZone();
         final Date date = new Date(Long.MAX_VALUE);
 
@@ -259,17 +259,8 @@ public class FastDateFormatTest extends AbstractLangTest {
         assertEquals("17/08/292278994", dateAsString);
     }
     @Test
-    public void testLANG_1267() {
+    public void testLang1267() {
         FastDateFormat.getInstance("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
-    }
-
-    /**
-     * According to LANG-954 (https://issues.apache.org/jira/browse/LANG-954) this is broken in Android 2.1.
-     */
-    @Test
-    public void testLANG_954() {
-        final String pattern = "yyyy-MM-dd'T'";
-        FastDateFormat.getInstance(pattern);
     }
 
     @Test
@@ -284,6 +275,15 @@ public class FastDateFormatTest extends AbstractLangTest {
         // TimeZones that are identical in every way except ID
         assertNotSame(FastDateFormat.getInstance(ISO_8601_DATE_FORMAT, TimeZone.getTimeZone("Australia/Broken_Hill")),
                 FastDateFormat.getInstance(ISO_8601_DATE_FORMAT, TimeZone.getTimeZone("Australia/Yancowinna")));
+    }
+
+    /**
+     * According to LANG-954 (https://issues.apache.org/jira/browse/LANG-954) this is broken in Android 2.1.
+     */
+    @Test
+    public void testLang954() {
+        final String pattern = "yyyy-MM-dd'T'";
+        FastDateFormat.getInstance(pattern);
     }
 
     @Test


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/LANG-1745
