### PR TITLE
Add Javadoc links from StopWatch to DurationUtils

### DIFF
--- a/src/main/java/org/apache/commons/lang3/time/StopWatch.java
+++ b/src/main/java/org/apache/commons/lang3/time/StopWatch.java
@@ -21,6 +21,8 @@ import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.function.FailableConsumer;
+import org.apache.commons.lang3.function.FailableRunnable;
 
 /**
  * {@link StopWatch} provides a convenient API for timings.
@@ -56,6 +58,9 @@ import org.apache.commons.lang3.StringUtils;
  * <p>
  * This class is not thread-safe
  * </p>
+ *
+ * @see DurationUtils#of(FailableRunnable)
+ * @see DurationUtils#of(FailableConsumer)
  *
  * @since 2.0
  */


### PR DESCRIPTION
Added a JavaDoc link from StopWatch to DurationUtils, as DurationUtils provide similar functiontionality, which could be used in simple use cases.