### PR TITLE
Fix handling of non-ASCII letters & numbers in RandomStringUtils

### DIFF
--- a/src/test/java/org/apache/commons/lang3/RandomStringUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/RandomStringUtilsTest.java
@@ -732,4 +732,74 @@ public class RandomStringUtilsTest extends AbstractLangTest {
         assertNotEquals(r1, r3);
         assertNotEquals(r2, r3);
     }
+
+    /**
+     * Test {@code RandomStringUtils.random} works appropriately when letters=true
+     * and the range does not only include ASCII letters.
+     * Fails with probability less than 2^-40 (in practice this never happens).
+     */
+    @ParameterizedTest
+    @MethodSource("randomProvider")
+    void testNonASCIILetters(final RandomStringUtils rsu) {
+        // Check that the following create a string with 10 characters 0x4e00 (a non-ASCII letter)
+        String r1 = rsu.next(10, 0x4e00, 0x4e01, true, false);
+        assertEquals(10, r1.length(), "wrong length");
+        for (int i = 0; i < r1.length(); i++) {
+            assertEquals(0x4e00, r1.charAt(i), "characters not all equal to 0x4e00");
+        }
+
+        // Same with both letters=true and numbers=true
+        r1 = rsu.next(10, 0x4e00, 0x4e01, true, true);
+        assertEquals(10, r1.length(), "wrong length");
+        for (int i = 0; i < r1.length(); i++) {
+            assertEquals(0x4e00, r1.charAt(i), "characters not all equal to 0x4e00");
+        }
+
+        // Check that at least one letter is not ASCII
+        boolean found = false;
+        r1 = rsu.next(40, 'F', 0x3000, true, false);
+        assertEquals(40, r1.length(), "wrong length");
+        for (int i = 0; i < r1.length(); i++) {
+            assertTrue(Character.isLetter(r1.charAt(i)), "characters not all letters");
+            if (r1.charAt(i) > 0x7f) {
+                found = true;
+            }
+        }
+        assertTrue(found, "no non-ASCII letter generated");
+    }
+
+    /**
+     * Test {@code RandomStringUtils.random} works appropriately when numbers=true
+     * and the range does not only include ASCII numbers/digits.
+     * Fails with probability less than 2^-40 (in practice this never happens).
+     */
+    @ParameterizedTest
+    @MethodSource("randomProvider")
+    void testNonASCIINumbers(final RandomStringUtils rsu) {
+        // Check that the following create a string with 10 characters 0x0660 (a non-ASCII digit)
+        String r1 = rsu.next(10, 0x0660, 0x0661, false, true);
+        assertEquals(10, r1.length(), "wrong length");
+        for (int i = 0; i < r1.length(); i++) {
+            assertEquals(0x0660, r1.charAt(i), "characters not all equal to 0x0660");
+        }
+
+        // Same with both letters=true and numbers=true
+        r1 = rsu.next(10, 0x0660, 0x0661, true, true);
+        assertEquals(10, r1.length(), "wrong length");
+        for (int i = 0; i < r1.length(); i++) {
+            assertEquals(0x0660, r1.charAt(i), "characters not all equal to 0x0660");
+        }
+
+        // Check that at least one letter is not ASCII
+        boolean found = false;
+        r1 = rsu.next(40, 'F', 0x3000, false, true);
+        assertEquals(40, r1.length(), "wrong length");
+        for (int i = 0; i < r1.length(); i++) {
+            assertTrue(Character.isDigit(r1.charAt(i)), "characters not all numbers");
+            if (r1.charAt(i) > 0x7f) {
+                found = true;
+            }
+        }
+        assertTrue(found, "no non-ASCII number generated");
+    }
 }


### PR DESCRIPTION
An optimization introduced in commit f382d61a03778ccf838c6c051bd8692e4834dec2 incorrectly assumed that letters and numbers/digits are ASCII.

For example, `RandomStringUtils.random(1, 0x4e00, 0x4e01, true, false)` would take too long to terminate and would not output the correct answer, that is the string with a single character `0x4e00`. The issue is that `end` would be replaced by `'z' + 1 = 123` (the latest ASCII letter + 1) there: https://github.com/apache/commons-lang/blob/f382d61a03778ccf838c6c051bd8692e4834dec2/src/main/java/org/apache/commons/lang3/RandomStringUtils.java#L266-L270
 Thus, we would have `end < start` and `gap = end - start < 0`.

This PR fixes this issue by restricting the optimization to cases where only ASCII characters are requested, that is `end < 0x7f`. This PR also slightly clarifies the code, using constant variables instead of '0', '9', 'A', and 'z'.

The PR also includes two regression tests.

The Github diff does not show it very clearly, but all the PR does is

1. moving the optimization code inside a bug `if (chars == null && end <= 0x7f)`
2. using constant variables instead of '0', '9', 'A', and 'z'
3. moving the  test `(numbers && end <= zeroDigitAscii || letters && end <= firstLetterAscii)` inside the big `if (chars == null && end <= 0x7f)` and before the problematic optimization: this does not change the semantics and is just done for clarity of the resulting code.