### PR TITLE
Fix broken URL to project location in Maven Central

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Apache Commons Lang
 ===================
 
 [![Java CI](https://github.com/apache/commons-lang/actions/workflows/maven.yml/badge.svg)](https://github.com/apache/commons-lang/actions/workflows/maven.yml)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.apache.commons/commons-lang3/badge.svg?gav=true)](https://maven-badges.herokuapp.com/maven-central/org.apache.commons/commons-lang3/?gav=true)
+[![Maven Central](https://img.shields.io/maven-central/v/org.apache.commons/commons-lang3?label=Maven%20Central)](https://search.maven.org/artifact/org.apache.commons/commons-lang3)
 [![Javadocs](https://javadoc.io/badge/org.apache.commons/commons-lang3/3.17.0.svg)](https://javadoc.io/doc/org.apache.commons/commons-lang3/3.17.0)
 [![CodeQL](https://github.com/apache/commons-lang/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/apache/commons-lang/actions/workflows/codeql-analysis.yml)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/apache/commons-lang/badge)](https://api.securityscorecards.dev/projects/github.com/apache/commons-lang)


### PR DESCRIPTION
Ahoy @garydgregory, 👋

It appears that [https://maven-badges.herokuapp.com ](https://maven-badges.herokuapp.com/)is no longer functioning, resulting in a broken Maven Central badge in the README. I've noticed that other Apache projects (e.g., [maven-stage-plugin](https://github.com/apache/maven-stage-plugin/blob/master/README.md)) use [shields.io ](https://shields.io/badges/maven-central-version) as an alternative. If there are no plans to restore the maven-badges app, this is a trivial patch to fix it. If you find it appropriate, I can raise similar PRs for other repositories in the Apache group affected by this issue.

<img width="800" alt="image" src="https://github.com/user-attachments/assets/80097927-981b-4147-b318-5417becf0cc3">