### PR TITLE
Use simplified JUnit assertion methods

### DIFF
--- a/src/test/java/org/apache/commons/lang3/CharEncodingTest.java
+++ b/src/test/java/org/apache/commons/lang3/CharEncodingTest.java
@@ -28,9 +28,9 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests CharEncoding.
  *
- * @see CharEncoding
+ * @deprecated this test can be removed once the deprecated source class {@link org.apache.commons.lang3.CharEncoding} is removed.
  */
-@SuppressWarnings("deprecation")
+@Deprecated
 public class CharEncodingTest extends AbstractLangTest {
 
     private void assertSupportedEncoding(final String name) {

--- a/src/test/java/org/apache/commons/lang3/FunctionsTest.java
+++ b/src/test/java/org/apache/commons/lang3/FunctionsTest.java
@@ -45,6 +45,12 @@ import org.apache.commons.lang3.Functions.FailableSupplier;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+/**
+ * Tests Functions.
+ *
+ * @deprecated this test can be removed once the deprecated source class {@link org.apache.commons.lang3.Functions} is removed.
+ */
+@Deprecated
 public class FunctionsTest extends AbstractLangTest {
 
     public static class CloseableObject {

--- a/src/test/java/org/apache/commons/lang3/ObjectUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/ObjectUtilsTest.java
@@ -19,6 +19,7 @@ package org.apache.commons.lang3;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -792,7 +793,7 @@ public class ObjectUtilsTest extends AbstractLangTest {
     public void testNull() {
         assertNotNull(ObjectUtils.NULL);
         // 1 Check that NULL really is a Null i.e. the definition has not been changed
-        assertTrue(ObjectUtils.NULL instanceof ObjectUtils.Null);
+        assertInstanceOf(ObjectUtils.Null.class, ObjectUtils.NULL);
         assertSame(ObjectUtils.NULL, SerializationUtils.clone(ObjectUtils.NULL));
     }
 

--- a/src/test/java/org/apache/commons/lang3/RandomStringUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/RandomStringUtilsTest.java
@@ -23,7 +23,6 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -533,7 +532,7 @@ public class RandomStringUtilsTest extends AbstractLangTest {
         assertEquals(50, r1.length(), "random(50) length");
         String r2 = rsu.next(50);
         assertEquals(50, r2.length(), "random(50) length");
-        assertFalse(r1.equals(r2), "!r1.equals(r2)");
+        assertNotEquals(r1, r2, "!r1.equals(r2)");
 
         r1 = rsu.nextAscii(50);
         assertEquals(50, r1.length(), "randomAscii(50) length");
@@ -541,7 +540,7 @@ public class RandomStringUtilsTest extends AbstractLangTest {
             assertThat("char >= 32 && <= 127", (int) r1.charAt(i), allOf(greaterThanOrEqualTo(32), lessThanOrEqualTo(127)));
         }
         r2 = rsu.nextAscii(50);
-        assertFalse(r1.equals(r2), "!r1.equals(r2)");
+        assertNotEquals(r1, r2, "!r1.equals(r2)");
 
         r1 = rsu.nextAlphabetic(50);
         assertEquals(50, r1.length(), "randomAlphabetic(50)");
@@ -549,7 +548,7 @@ public class RandomStringUtilsTest extends AbstractLangTest {
             assertTrue(Character.isLetter(r1.charAt(i)) && !Character.isDigit(r1.charAt(i)), "r1 contains alphabetic");
         }
         r2 = rsu.nextAlphabetic(50);
-        assertFalse(r1.equals(r2), "!r1.equals(r2)");
+        assertNotEquals(r1, r2, "!r1.equals(r2)");
 
         r1 = rsu.nextAlphanumeric(50);
         assertEquals(50, r1.length(), "randomAlphanumeric(50)");
@@ -557,7 +556,7 @@ public class RandomStringUtilsTest extends AbstractLangTest {
             assertTrue(Character.isLetterOrDigit(r1.charAt(i)), "r1 contains alphanumeric");
         }
         r2 = rsu.nextAlphabetic(50);
-        assertFalse(r1.equals(r2), "!r1.equals(r2)");
+        assertNotEquals(r1, r2, "!r1.equals(r2)");
 
         r1 = rsu.nextGraph(50);
         assertEquals(50, r1.length(), "randomGraph(50) length");
@@ -565,7 +564,7 @@ public class RandomStringUtilsTest extends AbstractLangTest {
             assertTrue(r1.charAt(i) >= 33 && r1.charAt(i) <= 126, "char between 33 and 126");
         }
         r2 = rsu.nextGraph(50);
-        assertFalse(r1.equals(r2), "!r1.equals(r2)");
+        assertNotEquals(r1, r2, "!r1.equals(r2)");
 
         r1 = rsu.nextNumeric(50);
         assertEquals(50, r1.length(), "randomNumeric(50)");
@@ -573,7 +572,7 @@ public class RandomStringUtilsTest extends AbstractLangTest {
             assertTrue(Character.isDigit(r1.charAt(i)) && !Character.isLetter(r1.charAt(i)), "r1 contains numeric");
         }
         r2 = rsu.nextNumeric(50);
-        assertFalse(r1.equals(r2), "!r1.equals(r2)");
+        assertNotEquals(r1, r2, "!r1.equals(r2)");
 
         r1 = rsu.nextPrint(50);
         assertEquals(50, r1.length(), "randomPrint(50) length");
@@ -581,7 +580,7 @@ public class RandomStringUtilsTest extends AbstractLangTest {
             assertTrue(r1.charAt(i) >= 32 && r1.charAt(i) <= 126, "char between 32 and 126");
         }
         r2 = rsu.nextPrint(50);
-        assertFalse(r1.equals(r2), "!r1.equals(r2)");
+        assertNotEquals(r1, r2, "!r1.equals(r2)");
 
         String set = "abcdefg";
         r1 = rsu.next(50, set);
@@ -590,13 +589,13 @@ public class RandomStringUtilsTest extends AbstractLangTest {
             assertTrue(set.indexOf(r1.charAt(i)) > -1, "random char in set");
         }
         r2 = rsu.next(50, set);
-        assertFalse(r1.equals(r2), "!r1.equals(r2)");
+        assertNotEquals(r1, r2, "!r1.equals(r2)");
 
         r1 = rsu.next(50, (String) null);
         assertEquals(50, r1.length(), "random(50) length");
         r2 = rsu.next(50, (String) null);
         assertEquals(50, r2.length(), "random(50) length");
-        assertFalse(r1.equals(r2), "!r1.equals(r2)");
+        assertNotEquals(r1, r2, "!r1.equals(r2)");
 
         set = "stuvwxyz";
         r1 = rsu.next(50, set.toCharArray());
@@ -605,13 +604,13 @@ public class RandomStringUtilsTest extends AbstractLangTest {
             assertTrue(set.indexOf(r1.charAt(i)) > -1, "random char in set");
         }
         r2 = rsu.next(50, set);
-        assertFalse(r1.equals(r2), "!r1.equals(r2)");
+        assertNotEquals(r1, r2, "!r1.equals(r2)");
 
         r1 = rsu.next(50, (char[]) null);
         assertEquals(50, r1.length(), "random(50) length");
         r2 = rsu.next(50, (char[]) null);
         assertEquals(50, r2.length(), "random(50) length");
-        assertFalse(r1.equals(r2), "!r1.equals(r2)");
+        assertNotEquals(r1, r2, "!r1.equals(r2)");
 
         r1 = rsu.next(0);
         assertEquals("", r1, "random(0).equals(\"\")");

--- a/src/test/java/org/apache/commons/lang3/StreamsTest.java
+++ b/src/test/java/org/apache/commons/lang3/StreamsTest.java
@@ -41,6 +41,12 @@ import org.junit.jupiter.api.TestFactory;
 import org.junit.jupiter.api.function.Executable;
 import org.xml.sax.SAXException;
 
+/**
+ * Tests Streams.
+ *
+ * @deprecated this test can be removed once the deprecated source class {@link org.apache.commons.lang3.Streams} is removed.
+ */
+@Deprecated
 public class StreamsTest extends AbstractLangTest {
 
     protected <T extends Throwable> FailableConsumer<String, T> asIntConsumer(final T pThrowable) {

--- a/src/test/java/org/apache/commons/lang3/exception/AbstractExceptionContextTest.java
+++ b/src/test/java/org/apache/commons/lang3/exception/AbstractExceptionContextTest.java
@@ -18,6 +18,7 @@ package org.apache.commons.lang3.exception;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -164,7 +165,7 @@ public abstract class AbstractExceptionContextTest<T extends ExceptionContext & 
         assertTrue(message.contains("Crap"));
 
         assertNull(exceptionContext.getFirstContextValue("crap"));
-        assertTrue(exceptionContext.getFirstContextValue("test Poorly written obj") instanceof ObjectWithFaultyToString);
+        assertInstanceOf(ObjectWithFaultyToString.class, exceptionContext.getFirstContextValue("test Poorly written obj"));
 
         assertEquals(7, exceptionContext.getContextEntries().size());
         assertEquals(6, exceptionContext.getContextLabels().size());

--- a/src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java
@@ -18,6 +18,7 @@ package org.apache.commons.lang3.math;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -389,24 +390,24 @@ public class NumberUtilsTest extends AbstractLangTest {
     @SuppressWarnings("cast") // suppress instanceof warning check
     @Test
     public void testConstants() {
-        assertTrue(NumberUtils.LONG_ZERO instanceof Long);
-        assertTrue(NumberUtils.LONG_ONE instanceof Long);
-        assertTrue(NumberUtils.LONG_MINUS_ONE instanceof Long);
-        assertTrue(NumberUtils.INTEGER_ZERO instanceof Integer);
-        assertTrue(NumberUtils.INTEGER_ONE instanceof Integer);
-        assertTrue(NumberUtils.INTEGER_MINUS_ONE instanceof Integer);
-        assertTrue(NumberUtils.SHORT_ZERO instanceof Short);
-        assertTrue(NumberUtils.SHORT_ONE instanceof Short);
-        assertTrue(NumberUtils.SHORT_MINUS_ONE instanceof Short);
-        assertTrue(NumberUtils.BYTE_ZERO instanceof Byte);
-        assertTrue(NumberUtils.BYTE_ONE instanceof Byte);
-        assertTrue(NumberUtils.BYTE_MINUS_ONE instanceof Byte);
-        assertTrue(NumberUtils.DOUBLE_ZERO instanceof Double);
-        assertTrue(NumberUtils.DOUBLE_ONE instanceof Double);
-        assertTrue(NumberUtils.DOUBLE_MINUS_ONE instanceof Double);
-        assertTrue(NumberUtils.FLOAT_ZERO instanceof Float);
-        assertTrue(NumberUtils.FLOAT_ONE instanceof Float);
-        assertTrue(NumberUtils.FLOAT_MINUS_ONE instanceof Float);
+        assertInstanceOf(Long.class, NumberUtils.LONG_ZERO);
+        assertInstanceOf(Long.class, NumberUtils.LONG_ONE);
+        assertInstanceOf(Long.class, NumberUtils.LONG_MINUS_ONE);
+        assertInstanceOf(Integer.class, NumberUtils.INTEGER_ZERO);
+        assertInstanceOf(Integer.class, NumberUtils.INTEGER_ONE);
+        assertInstanceOf(Integer.class, NumberUtils.INTEGER_MINUS_ONE);
+        assertInstanceOf(Short.class, NumberUtils.SHORT_ZERO);
+        assertInstanceOf(Short.class, NumberUtils.SHORT_ONE);
+        assertInstanceOf(Short.class, NumberUtils.SHORT_MINUS_ONE);
+        assertInstanceOf(Byte.class, NumberUtils.BYTE_ZERO);
+        assertInstanceOf(Byte.class, NumberUtils.BYTE_ONE);
+        assertInstanceOf(Byte.class, NumberUtils.BYTE_MINUS_ONE);
+        assertInstanceOf(Double.class, NumberUtils.DOUBLE_ZERO);
+        assertInstanceOf(Double.class, NumberUtils.DOUBLE_ONE);
+        assertInstanceOf(Double.class, NumberUtils.DOUBLE_MINUS_ONE);
+        assertInstanceOf(Float.class, NumberUtils.FLOAT_ZERO);
+        assertInstanceOf(Float.class, NumberUtils.FLOAT_ONE);
+        assertInstanceOf(Float.class, NumberUtils.FLOAT_MINUS_ONE);
 
         assertEquals(0, NumberUtils.LONG_ZERO.longValue());
         assertEquals(1, NumberUtils.LONG_ONE.longValue());
@@ -1551,31 +1552,31 @@ public class NumberUtilsTest extends AbstractLangTest {
      */
     @Test
     public void testStringCreateNumberEnsureNoPrecisionLoss() {
-        assertTrue(NumberUtils.createNumber("1.23") instanceof Float);
-        assertTrue(NumberUtils.createNumber("3.40282354e+38") instanceof Double);
-        assertTrue(NumberUtils.createNumber("1.797693134862315759e+308") instanceof BigDecimal);
+        assertInstanceOf(Float.class, NumberUtils.createNumber("1.23"));
+        assertInstanceOf(Double.class, NumberUtils.createNumber("3.40282354e+38"));
+        assertInstanceOf(BigDecimal.class, NumberUtils.createNumber("1.797693134862315759e+308"));
         // LANG-1060
-        assertTrue(NumberUtils.createNumber("001.12") instanceof Float);
-        assertTrue(NumberUtils.createNumber("-001.12") instanceof Float);
-        assertTrue(NumberUtils.createNumber("+001.12") instanceof Float);
-        assertTrue(NumberUtils.createNumber("003.40282354e+38") instanceof Double);
-        assertTrue(NumberUtils.createNumber("-003.40282354e+38") instanceof Double);
-        assertTrue(NumberUtils.createNumber("+003.40282354e+38") instanceof Double);
-        assertTrue(NumberUtils.createNumber("0001.797693134862315759e+308") instanceof BigDecimal);
-        assertTrue(NumberUtils.createNumber("-001.797693134862315759e+308") instanceof BigDecimal);
-        assertTrue(NumberUtils.createNumber("+001.797693134862315759e+308") instanceof BigDecimal);
+        assertInstanceOf(Float.class, NumberUtils.createNumber("001.12"));
+        assertInstanceOf(Float.class, NumberUtils.createNumber("-001.12"));
+        assertInstanceOf(Float.class, NumberUtils.createNumber("+001.12"));
+        assertInstanceOf(Double.class, NumberUtils.createNumber("003.40282354e+38"));
+        assertInstanceOf(Double.class, NumberUtils.createNumber("-003.40282354e+38"));
+        assertInstanceOf(Double.class, NumberUtils.createNumber("+003.40282354e+38"));
+        assertInstanceOf(BigDecimal.class, NumberUtils.createNumber("0001.797693134862315759e+308"));
+        assertInstanceOf(BigDecimal.class, NumberUtils.createNumber("-001.797693134862315759e+308"));
+        assertInstanceOf(BigDecimal.class, NumberUtils.createNumber("+001.797693134862315759e+308"));
         //LANG-1613
-        assertTrue(NumberUtils.createNumber("2.2250738585072014E-308") instanceof Double);
-        assertTrue(NumberUtils.createNumber("2.2250738585072014E-308D") instanceof Double);
-        assertTrue(NumberUtils.createNumber("2.2250738585072014E-308F") instanceof Double);
-        assertTrue(NumberUtils.createNumber("4.9E-324") instanceof Double);
-        assertTrue(NumberUtils.createNumber("4.9E-324D") instanceof Double);
-        assertTrue(NumberUtils.createNumber("4.9E-324F") instanceof Double);
-        assertTrue(NumberUtils.createNumber("1.7976931348623157E308") instanceof Double);
-        assertTrue(NumberUtils.createNumber("1.7976931348623157E308D") instanceof Double);
-        assertTrue(NumberUtils.createNumber("1.7976931348623157E308F") instanceof Double);
-        assertTrue(NumberUtils.createNumber("4.9e-324D") instanceof Double);
-        assertTrue(NumberUtils.createNumber("4.9e-324F") instanceof Double);
+        assertInstanceOf(Double.class, NumberUtils.createNumber("2.2250738585072014E-308"));
+        assertInstanceOf(Double.class, NumberUtils.createNumber("2.2250738585072014E-308D"));
+        assertInstanceOf(Double.class, NumberUtils.createNumber("2.2250738585072014E-308F"));
+        assertInstanceOf(Double.class, NumberUtils.createNumber("4.9E-324"));
+        assertInstanceOf(Double.class, NumberUtils.createNumber("4.9E-324D"));
+        assertInstanceOf(Double.class, NumberUtils.createNumber("4.9E-324F"));
+        assertInstanceOf(Double.class, NumberUtils.createNumber("1.7976931348623157E308"));
+        assertInstanceOf(Double.class, NumberUtils.createNumber("1.7976931348623157E308D"));
+        assertInstanceOf(Double.class, NumberUtils.createNumber("1.7976931348623157E308F"));
+        assertInstanceOf(Double.class, NumberUtils.createNumber("4.9e-324D"));
+        assertInstanceOf(Double.class, NumberUtils.createNumber("4.9e-324F"));
     }
 
     /**

--- a/src/test/java/org/apache/commons/lang3/reflect/FieldUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/reflect/FieldUtilsTest.java
@@ -19,6 +19,7 @@ package org.apache.commons.lang3.reflect;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -83,7 +84,7 @@ public class FieldUtilsTest extends AbstractLangTest {
             FieldUtils.removeFinalModifier(field, forceAccess);
         } catch (final UnsupportedOperationException exception) {
             if (SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_12)) {
-                assertTrue(exception.getCause() instanceof NoSuchFieldException);
+                assertInstanceOf(NoSuchFieldException.class, exception.getCause());
             } else {
                 fail("No exception should be thrown for java prior to 12.0");
             }

--- a/src/test/java/org/apache/commons/lang3/text/StrMatcherTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/StrMatcherTest.java
@@ -18,8 +18,8 @@
 package org.apache.commons.lang3.text;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.commons.lang3.AbstractLangTest;
 import org.junit.jupiter.api.Test;
@@ -56,7 +56,7 @@ public class StrMatcherTest extends AbstractLangTest {
         assertEquals(0, matcher.isMatch(BUFFER2, 5));
         assertSame(StrMatcher.noneMatcher(), StrMatcher.charSetMatcher());
         assertSame(StrMatcher.noneMatcher(), StrMatcher.charSetMatcher((char[]) null));
-        assertTrue(StrMatcher.charSetMatcher("a".toCharArray()) instanceof StrMatcher.CharMatcher);
+        assertInstanceOf(StrMatcher.CharMatcher.class, StrMatcher.charSetMatcher("a".toCharArray()));
     }
 
     @Test
@@ -70,7 +70,7 @@ public class StrMatcherTest extends AbstractLangTest {
         assertEquals(0, matcher.isMatch(BUFFER2, 5));
         assertSame(StrMatcher.noneMatcher(), StrMatcher.charSetMatcher(""));
         assertSame(StrMatcher.noneMatcher(), StrMatcher.charSetMatcher((String) null));
-        assertTrue(StrMatcher.charSetMatcher("a") instanceof StrMatcher.CharMatcher);
+        assertInstanceOf(StrMatcher.CharMatcher.class, StrMatcher.charSetMatcher("a"));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/text/StrSubstitutorTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/StrSubstitutorTest.java
@@ -19,6 +19,7 @@ package org.apache.commons.lang3.text;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -266,14 +267,14 @@ public class StrSubstitutorTest extends AbstractLangTest {
     @Test
     public void testGetSetPrefix() {
         final StrSubstitutor sub = new StrSubstitutor();
-        assertTrue(sub.getVariablePrefixMatcher() instanceof StrMatcher.StringMatcher);
+        assertInstanceOf(StrMatcher.StringMatcher.class, sub.getVariablePrefixMatcher());
         sub.setVariablePrefix('<');
-        assertTrue(sub.getVariablePrefixMatcher() instanceof StrMatcher.CharMatcher);
+        assertInstanceOf(StrMatcher.CharMatcher.class, sub.getVariablePrefixMatcher());
 
         sub.setVariablePrefix("<<");
-        assertTrue(sub.getVariablePrefixMatcher() instanceof StrMatcher.StringMatcher);
+        assertInstanceOf(StrMatcher.StringMatcher.class, sub.getVariablePrefixMatcher());
         assertThrows(NullPointerException.class, () -> sub.setVariablePrefix(null));
-        assertTrue(sub.getVariablePrefixMatcher() instanceof StrMatcher.StringMatcher);
+        assertInstanceOf(StrMatcher.StringMatcher.class, sub.getVariablePrefixMatcher());
 
         final StrMatcher matcher = StrMatcher.commaMatcher();
         sub.setVariablePrefixMatcher(matcher);
@@ -288,14 +289,14 @@ public class StrSubstitutorTest extends AbstractLangTest {
     @Test
     public void testGetSetSuffix() {
         final StrSubstitutor sub = new StrSubstitutor();
-        assertTrue(sub.getVariableSuffixMatcher() instanceof StrMatcher.StringMatcher);
+        assertInstanceOf(StrMatcher.StringMatcher.class, sub.getVariableSuffixMatcher());
         sub.setVariableSuffix('<');
-        assertTrue(sub.getVariableSuffixMatcher() instanceof StrMatcher.CharMatcher);
+        assertInstanceOf(StrMatcher.CharMatcher.class, sub.getVariableSuffixMatcher());
 
         sub.setVariableSuffix("<<");
-        assertTrue(sub.getVariableSuffixMatcher() instanceof StrMatcher.StringMatcher);
+        assertInstanceOf(StrMatcher.StringMatcher.class, sub.getVariableSuffixMatcher());
         assertThrows(NullPointerException.class, () -> sub.setVariableSuffix(null));
-        assertTrue(sub.getVariableSuffixMatcher() instanceof StrMatcher.StringMatcher);
+        assertInstanceOf(StrMatcher.StringMatcher.class, sub.getVariableSuffixMatcher());
 
         final StrMatcher matcher = StrMatcher.commaMatcher();
         sub.setVariableSuffixMatcher(matcher);
@@ -310,12 +311,12 @@ public class StrSubstitutorTest extends AbstractLangTest {
     @Test
     public void testGetSetValueDelimiter() {
         final StrSubstitutor sub = new StrSubstitutor();
-        assertTrue(sub.getValueDelimiterMatcher() instanceof StrMatcher.StringMatcher);
+        assertInstanceOf(StrMatcher.StringMatcher.class, sub.getValueDelimiterMatcher());
         sub.setValueDelimiter(':');
-        assertTrue(sub.getValueDelimiterMatcher() instanceof StrMatcher.CharMatcher);
+        assertInstanceOf(StrMatcher.CharMatcher.class, sub.getValueDelimiterMatcher());
 
         sub.setValueDelimiter("||");
-        assertTrue(sub.getValueDelimiterMatcher() instanceof StrMatcher.StringMatcher);
+        assertInstanceOf(StrMatcher.StringMatcher.class, sub.getValueDelimiterMatcher());
         sub.setValueDelimiter(null);
         assertNull(sub.getValueDelimiterMatcher());
 

--- a/src/test/java/org/apache/commons/lang3/tuple/PairTest.java
+++ b/src/test/java/org/apache/commons/lang3/tuple/PairTest.java
@@ -197,17 +197,17 @@ public class PairTest extends AbstractLangTest {
                 return null;
             }
         };
-        assertTrue(pair.equals(entry));
+        assertEquals(pair, entry);
         assertEquals(pair.hashCode(), entry.hashCode());
-        assertTrue(pair.equals(entry2));
+        assertEquals(pair, entry2);
         assertEquals(pair.hashCode(), entry2.hashCode());
-        assertTrue(entry.equals(entry));
+        assertEquals(entry, entry);
         assertEquals(entry.hashCode(), entry.hashCode());
-        assertTrue(entry2.equals(entry2));
+        assertEquals(entry2, entry2);
         assertEquals(entry2.hashCode(), entry2.hashCode());
-        assertTrue(entry.equals(entry2));
+        assertEquals(entry, entry2);
         assertEquals(entry.hashCode(), entry2.hashCode());
-        assertTrue(entry.equals(pair));
+        assertEquals(entry, pair);
         assertEquals(entry.hashCode(), pair.hashCode());
 
     }
@@ -225,7 +225,7 @@ public class PairTest extends AbstractLangTest {
     }
 
     @ParameterizedTest()
-    @MethodSource("org.apache.commons.lang3.tuple.PairTest#mapClassFactory()")
+    @MethodSource("org.apache.commons.lang3.tuple.PairTest#mapClassFactory")
     public <K, V> void testMapEntries(final Class<Map<Integer, String>> clazz) throws InstantiationException, IllegalAccessException {
         testMapEntry(clazz.newInstance());
     }

--- a/src/test/java/org/apache/commons/lang3/util/FluentBitSetTest.java
+++ b/src/test/java/org/apache/commons/lang3/util/FluentBitSetTest.java
@@ -20,6 +20,7 @@ package org.apache.commons.lang3.util;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -77,7 +78,7 @@ public class FluentBitSetTest extends AbstractLangTest {
             bs.set(i);
         }
         eightFbs.and(bs);
-        assertFalse(eightFbs.equals(bs), "AND failed to clear bits");
+        assertNotEquals(eightFbs, bs, "AND failed to clear bits");
         eightFbs.set(3);
         bs.set(3);
         eightFbs.and(bs);
@@ -101,7 +102,7 @@ public class FluentBitSetTest extends AbstractLangTest {
             bs.set(i);
         }
         eightFbs.and(bs.bitSet());
-        assertFalse(eightFbs.equals(bs), "AND failed to clear bits");
+        assertNotEquals(eightFbs, bs, "AND failed to clear bits");
         eightFbs.set(3);
         bs.set(3);
         eightFbs.and(bs.bitSet());
@@ -300,7 +301,7 @@ public class FluentBitSetTest extends AbstractLangTest {
             assertFalse(bs.get(i), "Failed to clear bit " + i);
         }
         for (int i = 64; i < bs.size(); i++) {
-            assertTrue(!bs.get(i), "Shouldn't have flipped bit " + i);
+            assertFalse(bs.get(i), "Shouldn't have flipped bit " + i);
         }
         // more boundary testing
         bs = newInstance(32);
@@ -524,15 +525,15 @@ public class FluentBitSetTest extends AbstractLangTest {
         assertEquals(eightFbs, eightFbs, "Same FluentBitSet returned false");
         assertEquals(bs, eightFbs, "Identical FluentBitSet returned false");
         bs.clear(6);
-        assertFalse(eightFbs.equals(bs), "Different BitSets returned true");
+        assertNotEquals(bs, eightFbs, "Different BitSets returned true");
         assertFalse(eightFbs.equals(null), "Different BitSets returned true");
         assertFalse(eightFbs.equals(new Object()), "Different BitSets returned true");
 
         bs = (FluentBitSet) eightFbs.clone();
         bs.set(128);
-        assertFalse(eightFbs.equals(bs), "Different sized FluentBitSet with higher bit set returned true");
+        assertNotEquals(bs, eightFbs, "Different sized FluentBitSet with higher bit set returned true");
         bs.clear(128);
-        assertTrue(eightFbs.equals(bs), "Different sized FluentBitSet with higher bits not set returned false");
+        assertEquals(bs, eightFbs, "Different sized FluentBitSet with higher bits not set returned false");
     }
 
     /**
@@ -571,10 +572,10 @@ public class FluentBitSetTest extends AbstractLangTest {
             assertTrue(bs.get(i), "Test1: Incorrectly flipped bit" + i);
             assertEquals(i + 1, bs.length(), "Incorrect length");
             for (int j = bs.size(); --j > i;) {
-                assertTrue(!bs.get(j), "Test2: Incorrectly flipped bit" + j);
+                assertFalse(bs.get(j), "Test2: Incorrectly flipped bit" + j);
             }
             for (int j = i; --j >= 0;) {
-                assertTrue(!bs.get(j), "Test3: Incorrectly flipped bit" + j);
+                assertFalse(bs.get(j), "Test3: Incorrectly flipped bit" + j);
             }
             bs.flip(i);
         }
@@ -592,7 +593,7 @@ public class FluentBitSetTest extends AbstractLangTest {
         assertEquals(64, bs0.length(), "Test3: Wrong length");
 
         eightFbs.flip(7);
-        assertTrue(!eightFbs.get(7), "Failed to flip bit 7");
+        assertFalse(eightFbs.get(7), "Failed to flip bit 7");
 
         // Check to see all other bits are still set
         for (int i = 0; i < 7; i++) {
@@ -603,7 +604,7 @@ public class FluentBitSetTest extends AbstractLangTest {
         assertTrue(eightFbs.get(127), "Failed to flip bit 127");
 
         eightFbs.flip(127);
-        assertTrue(!eightFbs.get(127), "Failed to flip bit 127");
+        assertFalse(eightFbs.get(127), "Failed to flip bit 127");
     }
 
     /**
@@ -624,14 +625,14 @@ public class FluentBitSetTest extends AbstractLangTest {
         bs.set(10);
         bs.flip(7, 11);
         for (int i = 0; i < 7; i++) {
-            assertTrue(!bs.get(i), "Shouldn't have flipped bit " + i);
+            assertFalse(bs.get(i), "Shouldn't have flipped bit " + i);
         }
         assertFalse(bs.get(7), "Failed to flip bit 7");
         assertTrue(bs.get(8), "Failed to flip bit 8");
         assertTrue(bs.get(9), "Failed to flip bit 9");
         assertFalse(bs.get(10), "Failed to flip bit 10");
         for (int i = 11; i < bs.size(); i++) {
-            assertTrue(!bs.get(i), "Shouldn't have flipped bit " + i);
+            assertFalse(bs.get(i), "Shouldn't have flipped bit " + i);
         }
 
         // pos1 and pos2 is in the same bitset element, boundary testing
@@ -641,7 +642,7 @@ public class FluentBitSetTest extends AbstractLangTest {
         bs.flip(7, 64);
         assertEquals(64, bs.size(), "Failed to grow BitSet");
         for (int i = 0; i < 7; i++) {
-            assertTrue(!bs.get(i), "Shouldn't have flipped bit " + i);
+            assertFalse(bs.get(i), "Shouldn't have flipped bit " + i);
         }
         assertFalse(bs.get(7), "Failed to flip bit 7");
         assertTrue(bs.get(8), "Failed to flip bit 8");
@@ -728,7 +729,7 @@ public class FluentBitSetTest extends AbstractLangTest {
         assertFalse(bs.get(219), "Shouldn't have flipped bit 219");
         assertTrue(bs.get(220), "Shouldn't have flipped bit 220");
         for (int i = 221; i < bs.size(); i++) {
-            assertTrue(!bs.get(i), "Shouldn't have flipped bit " + i);
+            assertFalse(bs.get(i), "Shouldn't have flipped bit " + i);
         }
 
         // test illegal args


### PR DESCRIPTION
The primary objective of this PR is to start using simplified JUnit assertion methods, primarily [Assertions.assertInstanceOf()](https://junit.org/junit5/docs/5.10.0/api/org.junit.jupiter.api/org/junit/jupiter/api/Assertions.html#assertInstanceOf(java.lang.Class,java.lang.Object)), which became stable with the JUnit 5.10.0 release in July 2023.

Additionally, a few test classes that cover deprecated source classes are also marked as deprecated to simplify housekeeping in 4.0 release.