### PR TITLE
[LANG-1682] Javadoc and test: Use Strings.CI.startsWithAny method instead

### DIFF
--- a/src/main/java/org/apache/commons/lang3/Strings.java
+++ b/src/main/java/org/apache/commons/lang3/Strings.java
@@ -607,7 +607,7 @@ public abstract class Strings {
     }
 
     /**
-     * Tests if a CharSequence ends with any of the provided case-sensitive suffixes.
+     * Tests if a CharSequence ends with any of the provided suffixes.
      *
      * <p>
      * Case-sensitive examples
@@ -625,10 +625,10 @@ public abstract class Strings {
      * </pre>
      *
      * @param sequence      the CharSequence to check, may be null
-     * @param searchStrings the case-sensitive CharSequences to find, may be empty or contain {@code null}
-     * @see StringUtils#endsWith(CharSequence, CharSequence)
+     * @param searchStrings the CharSequence suffixes to find, may be empty or contain {@code null}
+     * @see Strings#endsWith(CharSequence, CharSequence)
      * @return {@code true} if the input {@code sequence} is {@code null} AND no {@code searchStrings} are provided, or the input {@code sequence} ends in any
-     *         of the provided case-sensitive {@code searchStrings}.
+     *         of the provided {@code searchStrings}.
      */
     public boolean endsWithAny(final CharSequence sequence, final CharSequence... searchStrings) {
         if (StringUtils.isEmpty(sequence) || ArrayUtils.isEmpty(searchStrings)) {
@@ -1412,28 +1412,43 @@ public abstract class Strings {
     }
 
     /**
-     * Tests if a CharSequence starts with any of the provided case-sensitive prefixes.
+     * Tests if a CharSequence starts with any of the provided prefixes.
      *
      * <p>
      * Case-sensitive examples
      * </p>
      *
      * <pre>
-     * StringUtils.startsWithAny(null, null)      = false
-     * StringUtils.startsWithAny(null, new String[] {"abc"})  = false
-     * StringUtils.startsWithAny("abcxyz", null)     = false
-     * StringUtils.startsWithAny("abcxyz", new String[] {""}) = true
-     * StringUtils.startsWithAny("abcxyz", new String[] {"abc"}) = true
-     * StringUtils.startsWithAny("abcxyz", new String[] {null, "xyz", "abc"}) = true
-     * StringUtils.startsWithAny("abcxyz", null, "xyz", "ABCX") = false
-     * StringUtils.startsWithAny("ABCXYZ", null, "xyz", "abc") = false
+     * Strings.CS.startsWithAny(null, null)      = false
+     * Strings.CS.startsWithAny(null, new String[] {"abc"})  = false
+     * Strings.CS.startsWithAny("abcxyz", null)     = false
+     * Strings.CS.startsWithAny("abcxyz", new String[] {""}) = true
+     * Strings.CS.startsWithAny("abcxyz", new String[] {"abc"}) = true
+     * Strings.CS.startsWithAny("abcxyz", new String[] {null, "xyz", "abc"}) = true
+     * Strings.CS.startsWithAny("abcxyz", null, "xyz", "ABCX") = false
+     * Strings.CS.startsWithAny("ABCXYZ", null, "xyz", "abc") = false
+     * </pre>
+     *
+     * <p>
+     * Case-insensitive examples
+     * </p>
+     *
+     * <pre>
+     * Strings.CI.startsWithAny(null, null)      = false
+     * Strings.CI.startsWithAny(null, new String[] {"aBc"})  = false
+     * Strings.CI.startsWithAny("AbCxYz", null)     = false
+     * Strings.CI.startsWithAny("AbCxYz", new String[] {""}) = true
+     * Strings.CI.startsWithAny("AbCxYz", new String[] {"aBc"}) = true
+     * Strings.CI.startsWithAny("AbCxYz", new String[] {null, "XyZ", "aBc"}) = true
+     * Strings.CI.startsWithAny("abcxyz", null, "xyz", "ABCX") = true
+     * Strings.CI.startsWithAny("ABCXYZ", null, "xyz", "abc") = true
      * </pre>
      *
      * @param sequence      the CharSequence to check, may be null
-     * @param searchStrings the case-sensitive CharSequence prefixes, may be empty or contain {@code null}
-     * @see StringUtils#startsWith(CharSequence, CharSequence)
+     * @param searchStrings the CharSequence prefixes, may be empty or contain {@code null}
+     * @see Strings#startsWith(CharSequence, CharSequence)
      * @return {@code true} if the input {@code sequence} is {@code null} AND no {@code searchStrings} are provided, or the input {@code sequence} begins with
-     *         any of the provided case-sensitive {@code searchStrings}.
+     *         any of the provided {@code searchStrings}.
      */
     public boolean startsWithAny(final CharSequence sequence, final CharSequence... searchStrings) {
         if (StringUtils.isEmpty(sequence) || ArrayUtils.isEmpty(searchStrings)) {

--- a/src/test/java/org/apache/commons/lang3/StringsTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringsTest.java
@@ -63,6 +63,27 @@ public class StringsTest {
         assertTrue(Strings.CS.isCaseSensitive());
     }
 
+    /**
+     * Expanding the existing test group {@link StringUtilsStartsEndsWithTest#testStartsWithAny()} to include case-insensitive cases
+     */
+    @Test
+    public void testCaseInsensitiveStartsWithAny() {
+        // LANG-1682
+        assertFalse(Strings.CI.startsWithAny(null, (String[]) null));
+        assertFalse(Strings.CI.startsWithAny(null, "aBc"));
+        assertFalse(Strings.CI.startsWithAny("AbCxYz", (String[]) null));
+        assertFalse(Strings.CI.startsWithAny("AbCxYz"));
+        assertTrue(Strings.CI.startsWithAny("AbCxYz", "aBc"));
+        assertTrue(Strings.CI.startsWithAny("AbCxYz", null, "XyZ", "aBc"));
+        assertFalse(Strings.CI.startsWithAny("AbCxYz", null, "XyZ", "aBcD"));
+        assertTrue(Strings.CI.startsWithAny("AbCxYz", ""));
+        assertTrue(Strings.CI.startsWithAny("abcxyz", null, "XyZ", "ABCX"));
+        assertTrue(Strings.CI.startsWithAny("ABCXYZ", null, "XyZ", "abc"));
+
+        assertTrue(Strings.CI.startsWithAny("AbCxYz", new StringBuilder("XyZ"), new StringBuffer("aBc")));
+        assertTrue(Strings.CI.startsWithAny(new StringBuffer("AbCxYz"), new StringBuilder("XyZ"), new StringBuffer("abc")));
+    }
+
     @ParameterizedTest
     @MethodSource("stringsFactory")
     public void testEqualsStrings(final Strings strings) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/LANG-1682

There have been several attempts ([PR #848](https://github.com/apache/commons-lang/pull/848), [PR #1040](https://github.com/apache/commons-lang/pull/1040)) to introduce the `startsWithAnyIgnoreCase` method to the already overcrowded `StringUtils` class. This discussion led to the creation of the `Strings` class (which supersedes `StringUtils`), providing similar functionality but managing case-sensitivity through:
 - Case-sensitive (`Strings.CS`) instance
 - Case-insensitive (`Strings.CI`) instance

In the recent [commit](https://github.com/apache/commons-lang/commit/479532b83db2d7b228e4128f2db02233f91e6e91), the `Strings` class now supports the requested `startsWithAny` functionality. This PR adds a test group to cover case-insensitive scenarios and adjusts the javadoc to accurately describe its behavior.