### PR TITLE
[LANG-1448] StringUtils JavaDoc page wrong for containsOnly and containsNone

### DIFF
--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -1191,13 +1191,13 @@ public class StringUtils {
      * An empty CharSequence (length()=0) always returns true.</p>
      *
      * <pre>
-     * StringUtils.containsNone(null, *)       = true
-     * StringUtils.containsNone(*, null)       = true
-     * StringUtils.containsNone("", *)         = true
-     * StringUtils.containsNone("ab", '')      = true
-     * StringUtils.containsNone("abab", 'xyz') = true
-     * StringUtils.containsNone("ab1", 'xyz')  = true
-     * StringUtils.containsNone("abz", 'xyz')  = false
+     * StringUtils.containsNone(null, *)            = true
+     * StringUtils.containsNone("", *)              = true
+     * StringUtils.containsNone(*, null)            = true
+     * StringUtils.containsNone(*, [])              = true
+     * StringUtils.containsNone("abc", ['x', 'y'])  = true
+     * StringUtils.containsNone("abc", ['1', '.'])  = true
+     * StringUtils.containsNone("abc", ['b', 'z'])  = false
      * </pre>
      *
      * @param cs  the CharSequence to check, may be null
@@ -1244,12 +1244,12 @@ public class StringUtils {
      *
      * <pre>
      * StringUtils.containsNone(null, *)       = true
-     * StringUtils.containsNone(*, null)       = true
      * StringUtils.containsNone("", *)         = true
-     * StringUtils.containsNone("ab", "")      = true
-     * StringUtils.containsNone("abab", "xyz") = true
-     * StringUtils.containsNone("ab1", "xyz")  = true
-     * StringUtils.containsNone("abz", "xyz")  = false
+     * StringUtils.containsNone(*, null)       = true
+     * StringUtils.containsNone(*, "")         = true
+     * StringUtils.containsNone("abc", "xy")   = true
+     * StringUtils.containsNone("abc", "1.")   = true
+     * StringUtils.containsNone("abc", "bz")   = false
      * </pre>
      *
      * @param cs  the CharSequence to check, may be null
@@ -1273,13 +1273,13 @@ public class StringUtils {
      * An empty CharSequence (length()=0) always returns {@code true}.</p>
      *
      * <pre>
-     * StringUtils.containsOnly(null, *)       = false
-     * StringUtils.containsOnly(*, null)       = false
-     * StringUtils.containsOnly("", *)         = true
-     * StringUtils.containsOnly("ab", '')      = false
-     * StringUtils.containsOnly("abab", 'abc') = true
-     * StringUtils.containsOnly("ab1", 'abc')  = false
-     * StringUtils.containsOnly("abz", 'abc')  = false
+     * StringUtils.containsOnly(null, *)                 = false
+     * StringUtils.containsOnly("", *)                   = true
+     * StringUtils.containsOnly(*, null)                 = false
+     * StringUtils.containsOnly(*, [])                   = false
+     * StringUtils.containsOnly("abab", ['a', 'b', 'c']) = true
+     * StringUtils.containsOnly("ab1", ['a', 'b', 'c'])  = false
+     * StringUtils.containsOnly("abz", ['a', 'b', 'c'])  = false
      * </pre>
      *
      * @param cs  the String to check, may be null
@@ -1310,9 +1310,9 @@ public class StringUtils {
      *
      * <pre>
      * StringUtils.containsOnly(null, *)       = false
-     * StringUtils.containsOnly(*, null)       = false
      * StringUtils.containsOnly("", *)         = true
-     * StringUtils.containsOnly("ab", "")      = false
+     * StringUtils.containsOnly(*, null)       = false
+     * StringUtils.containsOnly(*, "")         = false
      * StringUtils.containsOnly("abab", "abc") = true
      * StringUtils.containsOnly("ab1", "abc")  = false
      * StringUtils.containsOnly("abz", "abc")  = false


### PR DESCRIPTION
https://issues.apache.org/jira/browse/LANG-1448

Update Javadoc for `StringUtils.containsOnly` and `StringUtils.containsNone` to accurately describe the use of char varargs.