### PR TITLE
Fix PA_PUBLIC_PRIMITIVE_ATTRIBUT of MuttablePair class with attribute encapsulation

### DIFF
--- a/src/main/java/org/apache/commons/lang3/tuple/MutablePair.java
+++ b/src/main/java/org/apache/commons/lang3/tuple/MutablePair.java
@@ -117,10 +117,10 @@ public class MutablePair<L, R> extends Pair<L, R> {
     }
 
     /** Left object */
-    public L left;
+    private L left;
 
     /** Right object */
-    public R right;
+    private R right;
 
     /**
      * Create a new pair instance of two nulls.

--- a/src/test/java/org/apache/commons/lang3/tuple/MutablePairTest.java
+++ b/src/test/java/org/apache/commons/lang3/tuple/MutablePairTest.java
@@ -39,9 +39,9 @@ public class MutablePairTest extends AbstractLangTest {
         MutablePair<Integer, String> nowPair;
         for (int i = 0; i < 4; i++) {
             nowPair = MutablePair.of(oldPair);
-            assertEquals(0, nowPair.left.intValue());
             assertEquals(0, nowPair.getLeft().intValue());
-            assertEquals("foo", nowPair.right);
+            assertEquals(0, nowPair.getLeft().intValue());
+            assertEquals("foo", nowPair.getRight());
             assertEquals("foo", nowPair.getRight());
             assertEquals(oldPair, nowPair);
             oldPair = nowPair;
@@ -51,9 +51,9 @@ public class MutablePairTest extends AbstractLangTest {
         MutablePair<Object, String> nowPair2;
         for (int i = 0; i < 4; i++) {
             nowPair2 = MutablePair.of(oldPair2);
-            assertNull(nowPair2.left);
             assertNull(nowPair2.getLeft());
-            assertEquals("bar", nowPair2.right);
+            assertNull(nowPair2.getLeft());
+            assertEquals("bar", nowPair2.getRight());
             assertEquals("bar", nowPair2.getRight());
             oldPair2 = nowPair2;
         }
@@ -110,8 +110,8 @@ public class MutablePairTest extends AbstractLangTest {
         assertThrows(NullPointerException.class, () -> MutablePair.ofNonNull(null, "x"));
         assertThrows(NullPointerException.class, () -> MutablePair.ofNonNull("x", null));
         final MutablePair<String, String> pair = MutablePair.ofNonNull("x", "y");
-        assertEquals("x", pair.left);
-        assertEquals("y", pair.right);
+        assertEquals("x", pair.getLeft());
+        assertEquals("y", pair.getRight());
     }
 
     @Test
@@ -133,8 +133,8 @@ public class MutablePairTest extends AbstractLangTest {
         assertNull(pair2.getLeft());
         assertEquals("bar", pair2.getRight());
         final MutablePair<?, ?> pair3 = MutablePair.of(null, null);
-        assertNull(pair3.left);
-        assertNull(pair3.right);
+        assertNull(pair3.getLeft());
+        assertNull(pair3.getRight());
     }
 
     @Test


### PR DESCRIPTION
### Encapsulate fields left and right in MutablePair to improve data integrity

**Description:**
This pull request addresses the issue identified by SpotBugs (PA_PUBLIC_PRIMITIVE_ATTRIBUTE) regarding the "left" and "right" fields in the MutablePair class. These fields were publicly accessible, which exposed them to potential unintended modification, violating the principle of encapsulation.

**Changes made:**

1. Encapsulation: The fields "left" and "right" in MutablePair were changed from public to private to improve data integrity.
2. Getter methods: The getLeft() and getRight() methods were already present, so no additional getters were created.
3. Test class update: Updated MutablePairTest to use the getLeft() and getRight() methods instead of accessing the fields directly.

**SpotBugs Reference:** 
This change resolves the SpotBugs warning: PA_PUBLIC_PRIMITIVE_ATTRIBUTE
Reference: MutablePair.java:[line 138]

**Why this change is important:**
Encapsulating fields ensures better control over the internal state of the MutablePair object, preventing potential misuse and maintaining consistency within the class.