### PR TITLE
Improve container detection if current process is pid 1

### DIFF
--- a/src/main/java/org/apache/commons/lang3/RuntimeEnvironment.java
+++ b/src/main/java/org/apache/commons/lang3/RuntimeEnvironment.java
@@ -18,6 +18,7 @@
 package org.apache.commons.lang3;
 
 import java.io.IOException;
+import java.lang.management.ManagementFactory;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.stream.Stream;
@@ -76,7 +77,15 @@ public class RuntimeEnvironment {
      */
     // Could be public at a later time.
     static Boolean inPodman() {
+        if (isPid1()) {
+            return "podman".equals(System.getenv("container"));
+        }
         return containsLine("/proc/1/environ", "container=podman");
+    }
+
+    private static boolean isPid1() {
+        String name = ManagementFactory.getRuntimeMXBean().getName();
+        return name.startsWith("1@");
     }
 
     /**
@@ -89,6 +98,9 @@ public class RuntimeEnvironment {
      */
     // Could be public at a later time.
     static Boolean inWsl() {
+        if (isPid1()) {
+            return "wslcontainer_host_id".equals(System.getenv("container"));
+        }
         return containsLine("/proc/1/environ", "container=wslcontainer_host_id");
     }
 


### PR DESCRIPTION
If current process is pid 1, read directly from `System.getenv()` instead of performing file i/o on `/proc/1/environ`

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible but is a best-practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that commits might be squashed by a maintainer on merge.
