### PR TITLE
added method TruncateToLength and a test case for the same

### DIFF
--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -8955,6 +8955,23 @@ public class StringUtils {
         }
         return str.substring(offset);
     }
+    
+    
+    /**
+     * Truncates a string to the specified length, returning an empty string if null.
+     * If the string is shorter than or equal to maxLength, it is returned unchanged.
+     * @param str the string to truncate, may be null
+     * @param maxLength the maximum length of the result
+     * @return the truncated string, or empty string if null
+     * @throws IllegalArgumentException if maxLength is negative
+     */
+    public static String truncateToLength(final String str, final int maxLength) {
+        if (maxLength < 0) {
+            throw new IllegalArgumentException("maxLength cannot be negative: " + maxLength);
+        }
+        return str == null ? EMPTY : str.length() <= maxLength ? str : str.substring(0, maxLength);
+    }
+    
 
     /**
      * Uncapitalizes a String, changing the first character to lower case as

--- a/src/test/java/org/apache/commons/lang3/StringUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringUtilsTest.java
@@ -26,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
@@ -3434,5 +3435,22 @@ public class StringUtilsTest extends AbstractLangTest {
 
         assertSame("ab/ab", StringUtils.wrapIfMissing("ab/ab", "ab"));
         assertSame("//x//", StringUtils.wrapIfMissing("//x//", "//"));
+    }
+    
+    
+    @Test
+    public void testTruncateToLength() {
+        assertEquals("", StringUtils.truncateToLength(null, 5));
+        assertEquals("", StringUtils.truncateToLength("", 5));
+        assertEquals("abc", StringUtils.truncateToLength("abc", 5));
+        assertEquals("abc", StringUtils.truncateToLength("abc", 3));
+        assertEquals("ab", StringUtils.truncateToLength("abc", 2));
+        assertEquals("", StringUtils.truncateToLength("abc", 0));
+        IllegalArgumentException thrown = assertThrows(
+                IllegalArgumentException.class,
+                () -> StringUtils.truncateToLength("abc", -1),
+                "Negative maxLength should throw IllegalArgumentException"
+            );
+            assertEquals("maxLength cannot be negative: -1", thrown.getMessage(), "Exception message should match");
     }
 }


### PR DESCRIPTION
Added `truncateToLength`, a null-safe method to truncate strings, returning "" for null.