### PR TITLE
[LANG-1772] Restrict size of cache to prevent overflow errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,10 @@
   </distributionManagement>
 
   <properties>
-    <argLine>-Xmx512m</argLine>
+    <heapSize>-Xmx512m</heapSize>
+    <extraArgs/>
+    <systemProperties/>
+    <argLine>${heapSize} ${extraArgs} ${systemProperties}</argLine>
     <project.build.sourceEncoding>ISO-8859-1</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <!-- project.build.outputTimestamp is managed by Maven plugins, see https://maven.apache.org/guides/mini/guide-reproducible-builds.html -->
@@ -460,7 +463,7 @@
       <properties>
         <!-- LANG-1265: allow tests to access private fields/methods of java.base classes via reflection -->
         <!-- LANG-1667: allow tests to access private fields/methods of java.base/java.util such as ArrayList via reflection -->
-        <argLine>-Xmx512m --add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.time=ALL-UNNAMED --add-opens java.base/java.time.chrono=ALL-UNNAMED</argLine>
+        <extraArgs>--add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.time=ALL-UNNAMED --add-opens java.base/java.time.chrono=ALL-UNNAMED</extraArgs>
       </properties>
     </profile>
     <profile>
@@ -521,6 +524,13 @@
           </plugin>
         </plugins>
       </build>
+    </profile>
+    <profile>
+      <id>largeheap</id>
+      <properties>
+        <heapSize>-Xmx1024m</heapSize>
+        <systemProperties>-Dtest.large.heap=true</systemProperties>
+      </properties>
     </profile>
   </profiles>
   <developers>

--- a/src/main/java/org/apache/commons/lang3/CachedRandomBits.java
+++ b/src/main/java/org/apache/commons/lang3/CachedRandomBits.java
@@ -57,6 +57,7 @@ final class CachedRandomBits {
      *
      * <p>
      * This is to prevent the possibility of overflow in the {@code if (bitIndex >> 3 >= cache.length)} in the {@link #nextBits(int)} method.
+     * </p>
      */
     private static final int MAX_CACHE_SIZE = Integer.MAX_VALUE >> 3;
 

--- a/src/main/java/org/apache/commons/lang3/CachedRandomBits.java
+++ b/src/main/java/org/apache/commons/lang3/CachedRandomBits.java
@@ -57,10 +57,8 @@ final class CachedRandomBits {
      *
      * <p>
      * This is dictated by the {@code if (bitIndex >> 3 >= cache.length)} in the {@link #nextBits(int)} method.
-     * Essentially {@code 63_913_202 << 3 } will overflow so this line will never evaluate to true.
-     * At some point the {@code bitIndex += generatedBitsInIteration} will overflow and cause an exception.
      */
-    private static final int MAX_CACHE_SIZE = 63_913_200;
+    private static final int MAX_CACHE_SIZE = 0x7FFF_FFFF >> 3;
 
     /**
      * Creates a new instance.
@@ -72,7 +70,7 @@ final class CachedRandomBits {
         if (cacheSize <= 0) {
             throw new IllegalArgumentException("cacheSize must be positive");
         }
-        this.cache = cacheSize <= MAX_CACHE_SIZE ? new byte[cacheSize]: new byte[MAX_CACHE_SIZE];
+        this.cache = cacheSize <= MAX_CACHE_SIZE ? new byte[cacheSize] : new byte[MAX_CACHE_SIZE];
         this.random = Objects.requireNonNull(random, "random");
         this.random.nextBytes(this.cache);
         this.bitIndex = 0;

--- a/src/main/java/org/apache/commons/lang3/CachedRandomBits.java
+++ b/src/main/java/org/apache/commons/lang3/CachedRandomBits.java
@@ -56,9 +56,9 @@ final class CachedRandomBits {
      * The maximum size of the cache.
      *
      * <p>
-     * This is dictated by the {@code if (bitIndex >> 3 >= cache.length)} in the {@link #nextBits(int)} method.
+     * This is to prevent the possibility of overflow in the {@code if (bitIndex >> 3 >= cache.length)} in the {@link #nextBits(int)} method.
      */
-    private static final int MAX_CACHE_SIZE = 0x7FFF_FFFF >> 3;
+    private static final int MAX_CACHE_SIZE = Integer.MAX_VALUE >> 3;
 
     /**
      * Creates a new instance.

--- a/src/main/java/org/apache/commons/lang3/CachedRandomBits.java
+++ b/src/main/java/org/apache/commons/lang3/CachedRandomBits.java
@@ -53,6 +53,16 @@ final class CachedRandomBits {
     private int bitIndex;
 
     /**
+     * The maximum size of the cache.
+     *
+     * <p>
+     * This is dictated by the {@code if (bitIndex >> 3 >= cache.length)} in the {@link #nextBits(int)} method.
+     * Essentially {@code 63_913_202 << 3 } will overflow so this line will never evaluate to true.
+     * At some point the {@code bitIndex += generatedBitsInIteration} will overflow and cause an exception.
+     */
+    private static final int MAX_CACHE_SIZE = 63_913_200;
+
+    /**
      * Creates a new instance.
      *
      * @param cacheSize number of bytes cached (only affects performance)
@@ -62,7 +72,7 @@ final class CachedRandomBits {
         if (cacheSize <= 0) {
             throw new IllegalArgumentException("cacheSize must be positive");
         }
-        this.cache = new byte[cacheSize];
+        this.cache = cacheSize <= MAX_CACHE_SIZE ? new byte[cacheSize]: new byte[MAX_CACHE_SIZE];
         this.random = Objects.requireNonNull(random, "random");
         this.random.nextBytes(this.cache);
         this.bitIndex = 0;

--- a/src/main/java/org/apache/commons/lang3/RandomStringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/RandomStringUtils.java
@@ -97,7 +97,6 @@ public class RandomStringUtils {
     private static final int ASCII_9 = '9';
     private static final int ASCII_A = 'A';
     private static final int ASCII_z = 'z';
-    private static final int MAX_CACHE_SIZE = 60_000_000;
 
     /**
      * Gets the singleton instance based on {@link ThreadLocalRandom#current()}; <b>which is not cryptographically
@@ -330,8 +329,8 @@ public class RandomStringUtils {
         // Ideally the cache size depends on multiple factor, including the cost of generating x bytes
         // of randomness as well as the probability of rejection. It is however not easy to know
         // those values programmatically for the general case.
-        // To prevent overflow restrict the cache size to 60M entries (
-        final int cacheSize = Math.min ((count * gapBits + 3) / 5 + 10, MAX_CACHE_SIZE);
+        // For huge strings the padding required can cause an overflow
+        final int cacheSize = (count * gapBits + 3) / 5 + 10 > 0 ? (count * gapBits + 3) / 5 + 10 : Integer.MAX_VALUE;
         final CachedRandomBits arb = new CachedRandomBits(cacheSize, random);
 
         while (count-- != 0) {

--- a/src/main/java/org/apache/commons/lang3/RandomStringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/RandomStringUtils.java
@@ -341,7 +341,7 @@ public class RandomStringUtils {
         // 5. Ensure we don't exceed Integer.MAX_VALUE / 5 + 10 to provide a good balance between overflow prevention and
         //    making the cache extremely large
         final long desiredCacheSize = ((long) count * gapBits + CACHE_PADDING_BITS) / BITS_TO_BYTES_DIVISOR + BASE_CACHE_SIZE_PADDING;
-        final int cacheSize = Math.min((int) desiredCacheSize, Integer.MAX_VALUE / BITS_TO_BYTES_DIVISOR + BASE_CACHE_SIZE_PADDING);
+        final int cacheSize = (int) Math.min(desiredCacheSize, Integer.MAX_VALUE / BITS_TO_BYTES_DIVISOR + BASE_CACHE_SIZE_PADDING);
         final CachedRandomBits arb = new CachedRandomBits(cacheSize, random);
 
         while (count-- != 0) {

--- a/src/main/java/org/apache/commons/lang3/RandomStringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/RandomStringUtils.java
@@ -330,9 +330,9 @@ public class RandomStringUtils {
         // of randomness as well as the probability of rejection. It is however not easy to know
         // those values programmatically for the general case.
         // For huge strings the padding required can cause an overflow
-        // 63_913_201 is the highest x such that (21x + 3) / 5 + 10 ? 0x0FFF_FFFF.
-        final int cacheSize = (count * gapBits + 3) > 0 ? (count * gapBits + 3) / 5 + 10 : 63_913_201;
-        final CachedRandomBits arb = new CachedRandomBits(cacheSize, random);
+        // 63_913_201 is the highest x such that (21x + 3) / 5 + 10 < 0x0FFF_FFFF.
+        final long cacheSize = Math.min((count * gapBits + 3) / 5 + 10, Integer.MAX_VALUE / 5);
+        final CachedRandomBits arb = new CachedRandomBits((int) cacheSize, random);
 
         while (count-- != 0) {
             // Generate a random value between start (included) and end (excluded)

--- a/src/main/java/org/apache/commons/lang3/RandomStringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/RandomStringUtils.java
@@ -330,7 +330,8 @@ public class RandomStringUtils {
         // of randomness as well as the probability of rejection. It is however not easy to know
         // those values programmatically for the general case.
         // For huge strings the padding required can cause an overflow
-        final int cacheSize = (count * gapBits + 3) / 5 + 10 > 0 ? (count * gapBits + 3) / 5 + 10 : Integer.MAX_VALUE;
+        // 63_913_201 is the highest x such that (21x + 3) / 5 + 10 ? 0x0FFF_FFFF.
+        final int cacheSize = (count * gapBits + 3) > 0 ? (count * gapBits + 3) / 5 + 10 : 63_913_201;
         final CachedRandomBits arb = new CachedRandomBits(cacheSize, random);
 
         while (count-- != 0) {

--- a/src/main/java/org/apache/commons/lang3/RandomStringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/RandomStringUtils.java
@@ -97,6 +97,7 @@ public class RandomStringUtils {
     private static final int ASCII_9 = '9';
     private static final int ASCII_A = 'A';
     private static final int ASCII_z = 'z';
+    private static final int MAX_CACHE_SIZE = 60_000_000;
 
     /**
      * Gets the singleton instance based on {@link ThreadLocalRandom#current()}; <b>which is not cryptographically
@@ -329,7 +330,9 @@ public class RandomStringUtils {
         // Ideally the cache size depends on multiple factor, including the cost of generating x bytes
         // of randomness as well as the probability of rejection. It is however not easy to know
         // those values programmatically for the general case.
-        final CachedRandomBits arb = new CachedRandomBits((count * gapBits + 3) / 5 + 10, random);
+        // To prevent overflow restrict the cache size to 60M entries (
+        final int cacheSize = Math.min ((count * gapBits + 3) / 5 + 10, MAX_CACHE_SIZE);
+        final CachedRandomBits arb = new CachedRandomBits(cacheSize, random);
 
         while (count-- != 0) {
             // Generate a random value between start (included) and end (excluded)

--- a/src/main/java/org/apache/commons/lang3/RandomStringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/RandomStringUtils.java
@@ -98,6 +98,10 @@ public class RandomStringUtils {
     private static final int ASCII_A = 'A';
     private static final int ASCII_z = 'z';
 
+    private static final int CACHE_PADDING_BITS = 3;
+    private static final int BITS_TO_BYTES_DIVISOR = 5;
+    private static final int BASE_CACHE_SIZE_PADDING = 10;
+
     /**
      * Gets the singleton instance based on {@link ThreadLocalRandom#current()}; <b>which is not cryptographically
      * secure</b>; use {@link #secure()} to use an algorithms/providers specified in the
@@ -329,10 +333,16 @@ public class RandomStringUtils {
         // Ideally the cache size depends on multiple factor, including the cost of generating x bytes
         // of randomness as well as the probability of rejection. It is however not easy to know
         // those values programmatically for the general case.
-        // For huge strings the padding required can cause an overflow
-        // 63_913_201 is the highest x such that (21x + 3) / 5 + 10 < 0x0FFF_FFFF.
-        final long cacheSize = Math.min((count * gapBits + 3) / 5 + 10, Integer.MAX_VALUE / 5);
-        final CachedRandomBits arb = new CachedRandomBits((int) cacheSize, random);
+        // Calculate cache size:
+        // 1. Multiply count by bits needed per character (gapBits)
+        // 2. Add padding bits (3) to handle partial bytes
+        // 3. Divide by 5 to convert to bytes (normally this would be by 8, dividing by 5 allows for about 60% extra space)
+        // 4. Add base padding (10) to handle small counts efficiently
+        // 5. Ensure we don't exceed Integer.MAX_VALUE / 5 + 10 to provide a good balance between overflow prevention and
+        //    making the cache extremely large
+        final long desiredCacheSize = ((long) count * gapBits + CACHE_PADDING_BITS) / BITS_TO_BYTES_DIVISOR + BASE_CACHE_SIZE_PADDING;
+        final int cacheSize = Math.min((int) desiredCacheSize, Integer.MAX_VALUE / BITS_TO_BYTES_DIVISOR + BASE_CACHE_SIZE_PADDING);
+        final CachedRandomBits arb = new CachedRandomBits(cacheSize, random);
 
         while (count-- != 0) {
             // Generate a random value between start (included) and end (excluded)

--- a/src/test/java/org/apache/commons/lang3/RandomStringUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/RandomStringUtilsTest.java
@@ -802,4 +802,11 @@ public class RandomStringUtilsTest extends AbstractLangTest {
         assertNotEquals(r1, r3);
         assertNotEquals(r2, r3);
     }
+
+    @Test
+    public void testHugeStrings() {
+        final int expectedLength = 64_000_000;
+        final String hugeString = RandomStringUtils.random(expectedLength);
+        assertEquals(expectedLength, hugeString.length(), "hugeString.length() == expectedLength");
+    }
 }

--- a/src/test/java/org/apache/commons/lang3/RandomStringUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/RandomStringUtilsTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Tests {@link RandomStringUtils}.
@@ -804,10 +805,10 @@ public class RandomStringUtilsTest extends AbstractLangTest {
         assertNotEquals(r2, r3);
     }
 
-    @Test
+    @ParameterizedTest
+    @ValueSource(ints = {63_913_201, 63_913_202})
     @EnabledIfSystemProperty(named = "test.large.heap", matches = "true")
-    public void testHugeStrings() {
-        final int expectedLength = 64_000_000;
+    public void testHugeStrings(final int expectedLength) {
         final String hugeString = RandomStringUtils.random(expectedLength);
         assertEquals(expectedLength, hugeString.length(), "hugeString.length() == expectedLength");
     }

--- a/src/test/java/org/apache/commons/lang3/RandomStringUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/RandomStringUtilsTest.java
@@ -29,6 +29,7 @@ import java.util.Random;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -804,6 +805,7 @@ public class RandomStringUtilsTest extends AbstractLangTest {
     }
 
     @Test
+    @EnabledIfSystemProperty(named = "test.large.heap", matches = "true")
     public void testHugeStrings() {
         final int expectedLength = 64_000_000;
         final String hugeString = RandomStringUtils.random(expectedLength);

--- a/src/test/java/org/apache/commons/lang3/RandomStringUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/RandomStringUtilsTest.java
@@ -40,6 +40,9 @@ import org.junit.jupiter.params.provider.ValueSource;
 public class RandomStringUtilsTest extends AbstractLangTest {
 
     private static final int LOOP_COUNT = 1_000;
+    /** Maximum safe value for count to avoid overflow: (21x + 3) / 5 + 10 < 0x0FFF_FFFF */
+    private static final int MAX_SAFE_COUNT = 63_913_201;
+
 
     static Stream<RandomStringUtils> randomProvider() {
         return Stream.of(RandomStringUtils.secure(), RandomStringUtils.secureStrong(), RandomStringUtils.insecure());
@@ -806,7 +809,7 @@ public class RandomStringUtilsTest extends AbstractLangTest {
     }
 
     @ParameterizedTest
-    @ValueSource(ints = {63_913_201, 63_913_202})
+    @ValueSource(ints = {MAX_SAFE_COUNT, MAX_SAFE_COUNT + 1})
     @EnabledIfSystemProperty(named = "test.large.heap", matches = "true")
     public void testHugeStrings(final int expectedLength) {
         final String hugeString = RandomStringUtils.random(expectedLength);


### PR DESCRIPTION
Added a length restriction to `RandomStringutils`, limiting the cache to 60M entries.  Because of rejections the bitIndex in the underling cache can overflow when right shifting.   Also added a test to verify the fix.

This test takes quite a while to run, so if necessary I can create a profile for slow tests to exclude the test from the normal build.  
