### PR TITLE
[LANG-1773] Apache Commons Lang no longer builds on Android

### DIFF
--- a/src/main/java/org/apache/commons/lang3/reflect/TypeUtils.java
+++ b/src/main/java/org/apache/commons/lang3/reflect/TypeUtils.java
@@ -16,7 +16,6 @@
  */
 package org.apache.commons.lang3.reflect;
 
-import java.lang.reflect.AnnotatedType;
 import java.lang.reflect.Array;
 import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.GenericDeclaration;
@@ -1361,8 +1360,8 @@ public class TypeUtils {
      */
     private static boolean isCyclical(final Class<?> cls) {
         for (final TypeVariable<?> typeParameter : cls.getTypeParameters()) {
-            for (final AnnotatedType annotatedBound : typeParameter.getAnnotatedBounds()) {
-                if (annotatedBound.getType().getTypeName().contains(cls.getName())) {
+            for (final Type bound : typeParameter.getBounds()) {
+                if (bound.getTypeName().contains(cls.getName())) {
                     return true;
                 }
             }


### PR DESCRIPTION
Remove an unnecessary reference to `java.lang.reflect.AnnotatedType`, which does not exist on Android. We immediately call `getType()` on it, so we might just as well use the method that gives us `Type[]` directly.

<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
-->