### PR TITLE
Add extractMatches() to RegExUtils

### DIFF
--- a/src/main/java/org/apache/commons/lang3/RegExUtils.java
+++ b/src/main/java/org/apache/commons/lang3/RegExUtils.java
@@ -757,62 +757,57 @@ public class RegExUtils {
     }
 
 
-    public class MatchFinder {
-
-        /**
-         * Finds all matches in the given text according to the specified pattern.
-         *
-         * @param text    the text to search for matches
-         * @param pattern the pattern to search for
-         * @return a list of found matches
-         * @throws IllegalArgumentException if text or pattern is null
-         */
-        public List<String> findMatches(CharSequence text, Pattern pattern) {
-            if (text == null)
-                throw new IllegalArgumentException("Text must not be null");
-
-            if (pattern == null)
-                throw new IllegalArgumentException("Pattern must not be null");
-
-            List<String> matches = new ArrayList<>();
-            Matcher matcher = pattern.matcher(text);
-
-            while (matcher.find()) {
-                matches.add(matcher.group());
-            }
-
-            return Collections.unmodifiableList(matches); // return an unmodifiable list
+    /**
+     * Finds all matches in the given text according to the specified pattern.
+     *
+     * @param text    the text to search for matches
+     * @param pattern the pattern to search for
+     * @return a list of found matches; returns an empty List if text or pattern is null
+     */
+    public List<String> findMatches(CharSequence text, Pattern pattern) {
+        if (text == null || pattern == null){
+            return Collections.emptyList();
         }
 
-        /**
-         * Finds all matches in the given text according to the specified pattern.
-         *
-         * @param text    the text to search for matches
-         * @param pattern the pattern to search for
-         * @return a list of found matches
-         * @throws IllegalArgumentException if text or pattern is null
-         */
-        public List<String> findMatches(String text, Pattern pattern) {
-            return findMatches((CharSequence) text, pattern);
+        List<String> matches = new ArrayList<>();
+        Matcher matcher = pattern.matcher(text);
+
+        while (matcher.find()) {
+            matches.add(matcher.group());
         }
 
-        /**
-         * Finds all matches in the given text according to the specified pattern
-         * and returns them as an array of strings.
-         *
-         * @param text  the text to search for matches (throws IllegalArgumentException if null)
-         * @param regex the regular expression pattern (throws IllegalArgumentException if null or invalid)
-         * @return an array of found matches (never null)
-         * @throws IllegalArgumentException if text or regex is null
-         * @throws PatternSyntaxException   if the regex syntax is invalid
-         */
-        public String[] findMatchesAsArray(CharSequence text, String regex) {
-            if (regex == null) {
-                throw new IllegalArgumentException("Regex must not be null");
-            }
+        return Collections.unmodifiableList(matches);
+    }
+
+    /**
+     * Finds all matches in the given text according to the specified pattern.
+     *
+     * @param text    the text to search for matches
+     * @param pattern the pattern to search for
+     * @return a list of found matches
+     */
+    public List<String> findMatches(String text, Pattern pattern) {
+        return findMatches((CharSequence) text, pattern);
+    }
+
+    /**
+     * Finds all matches in the given text according to the specified pattern
+     * and returns them as an array of strings.
+     *
+     * @param text  the text to search for matches
+     * @param regex the regular expression pattern
+     * @return an array of found matches; returns an empty array if text or regex is null
+     */
+    public String[] findMatchesAsArray(CharSequence text, String regex) {
+        if (text == null ||regex == null){
+            return new String[0];
+        }
+        try {
             Pattern pattern = Pattern.compile(regex);
             List<String> matches = findMatches(text, pattern);
             return matches.toArray(new String[0]);
+        }catch (PatternSyntaxException e){
+            return new String[0];
         }
     }
 }

--- a/src/main/java/org/apache/commons/lang3/RegExUtils.java
+++ b/src/main/java/org/apache/commons/lang3/RegExUtils.java
@@ -17,10 +17,12 @@
 package org.apache.commons.lang3;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 /**
  * Helpers to process Strings using regular expressions.
@@ -754,20 +756,63 @@ public class RegExUtils {
         // empty
     }
 
-    /**
-     * Extracts all matches of a regular expression pattern from the text.
-     *
-     * @param text    the text to search in, may be null (returns empty list)
-     * @param pattern the compiled pattern, may be null (returns empty list)
-     * @return a list of all matches, never null
-     * @since 4.1.0
-     */
-    public static List<String> extractMatches(final String text, final Pattern pattern) {
-        final Matcher matcher = pattern.matcher(text);
-        final List<String> matches = new ArrayList<>();
-        while (matcher.find()) {
-            matches.add(matcher.group());
+
+    public class MatchFinder {
+
+        /**
+         * Finds all matches in the given text according to the specified pattern.
+         *
+         * @param text    the text to search for matches
+         * @param pattern the pattern to search for
+         * @return a list of found matches
+         * @throws IllegalArgumentException if text or pattern is null
+         */
+        public List<String> findMatches(CharSequence text, Pattern pattern) {
+            if (text == null)
+                throw new IllegalArgumentException("Text must not be null");
+
+            if (pattern == null)
+                throw new IllegalArgumentException("Pattern must not be null");
+
+            List<String> matches = new ArrayList<>();
+            Matcher matcher = pattern.matcher(text);
+
+            while (matcher.find()) {
+                matches.add(matcher.group());
+            }
+
+            return Collections.unmodifiableList(matches); // return an unmodifiable list
         }
-        return matches;
+
+        /**
+         * Finds all matches in the given text according to the specified pattern.
+         *
+         * @param text    the text to search for matches
+         * @param pattern the pattern to search for
+         * @return a list of found matches
+         * @throws IllegalArgumentException if text or pattern is null
+         */
+        public List<String> findMatches(String text, Pattern pattern) {
+            return findMatches((CharSequence) text, pattern);
+        }
+
+        /**
+         * Finds all matches in the given text according to the specified pattern
+         * and returns them as an array of strings.
+         *
+         * @param text  the text to search for matches (throws IllegalArgumentException if null)
+         * @param regex the regular expression pattern (throws IllegalArgumentException if null or invalid)
+         * @return an array of found matches (never null)
+         * @throws IllegalArgumentException if text or regex is null
+         * @throws PatternSyntaxException   if the regex syntax is invalid
+         */
+        public String[] findMatchesAsArray(CharSequence text, String regex) {
+            if (regex == null) {
+                throw new IllegalArgumentException("Regex must not be null");
+            }
+            Pattern pattern = Pattern.compile(regex);
+            List<String> matches = findMatches(text, pattern);
+            return matches.toArray(new String[0]);
+        }
     }
 }

--- a/src/main/java/org/apache/commons/lang3/RegExUtils.java
+++ b/src/main/java/org/apache/commons/lang3/RegExUtils.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.lang3;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -750,5 +752,22 @@ public class RegExUtils {
     @Deprecated
     public RegExUtils() {
         // empty
+    }
+
+    /**
+     * Extracts all matches of a regular expression pattern from the text.
+     *
+     * @param text    the text to search in, may be null (returns empty list)
+     * @param pattern the compiled pattern, may be null (returns empty list)
+     * @return a list of all matches, never null
+     * @since 4.1.0
+     */
+    public static List<String> extractMatches(final String text, final Pattern pattern) {
+        final Matcher matcher = pattern.matcher(text);
+        final List<String> matches = new ArrayList<>();
+        while (matcher.find()) {
+            matches.add(matcher.group());
+        }
+        return matches;
     }
 }

--- a/src/main/java/org/apache/commons/lang3/RegExUtils.java
+++ b/src/main/java/org/apache/commons/lang3/RegExUtils.java
@@ -756,13 +756,12 @@ public class RegExUtils {
         // empty
     }
 
-
     /**
      * Finds all matches in the given text according to the specified pattern.
      *
      * @param text    the text to search for matches
      * @param pattern the pattern to search for
-     * @return a list of found matches; returns an empty List if text or pattern is null
+     * @return an unmodifiable list of found matches; returns an empty List if text or pattern is null
      */
     public List<String> findMatches(CharSequence text, Pattern pattern) {
         if (text == null || pattern == null){
@@ -777,17 +776,6 @@ public class RegExUtils {
         }
 
         return Collections.unmodifiableList(matches);
-    }
-
-    /**
-     * Finds all matches in the given text according to the specified pattern.
-     *
-     * @param text    the text to search for matches
-     * @param pattern the pattern to search for
-     * @return a list of found matches
-     */
-    public List<String> findMatches(String text, Pattern pattern) {
-        return findMatches((CharSequence) text, pattern);
     }
 
     /**
@@ -809,5 +797,25 @@ public class RegExUtils {
         }catch (PatternSyntaxException e){
             return new String[0];
         }
+    }
+
+    /**
+     * Finds all matches in the given text according to the specified pattern
+     * and returns them as a modifiable ArrayList.
+     *
+     * @param text    the text to search for matches
+     * @param pattern the pattern to search for
+     * @return a modifiable ArrayList of found matches; returns an empty List if text or pattern is null
+     */
+    public List<String> findMatchesModifiable(CharSequence text, Pattern pattern){
+        if (text == null || pattern == null){
+            return new ArrayList<>();
+        }
+        Matcher matcher = pattern.matcher(text);
+        List<String> matches = new ArrayList<>();
+        while (matcher.find()){
+            matches.add(matcher.group());
+        }
+        return matches;
     }
 }

--- a/src/test/java/org/apache/commons/lang3/RegExUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/RegExUtilsTest.java
@@ -16,12 +16,16 @@
  */
 package org.apache.commons.lang3;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import javax.annotation.RegEx;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -376,5 +380,100 @@ public class RegExUtilsTest extends AbstractLangTest {
         assertEquals("ABC_123", RegExUtils.replacePattern("ABCabc123", "[^A-Z0-9]+", "_"));
         assertEquals("ABC123", RegExUtils.replacePattern("ABCabc123", "[^A-Z0-9]+", ""));
         assertEquals("Lorem_ipsum_dolor_sit", RegExUtils.replacePattern("Lorem ipsum  dolor   sit", "( +)([a-z]+)", "_$2"));
+    }
+
+    private RegExUtils utils;
+
+    @BeforeEach
+    void setUp() {
+        utils = new RegExUtils();
+    }
+
+    @Test
+    public void testFindMultipleMatches() {
+        Pattern pattern = Pattern.compile("\\d+");
+        List<String> result = utils.findMatches("asd 123 fgd 456 zxc", pattern);
+        assertEquals(Arrays.asList("123", "456"), result);
+    }
+
+    @Test
+    public void testFindNoMatches() {
+        Pattern pattern = Pattern.compile("\\d+");
+        List<String> result = utils.findMatches("asd zxc", pattern);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testFindMatchesWhenTextIsEmpty() {
+        String[] result = utils.findMatchesAsArray("", "\\w+");
+        assertArrayEquals(new String[0], result);
+    }
+//    @Test
+//    public void testShouldReturnArrayList() {
+//        Pattern pattern = Pattern.compile("\\w+");
+//        List<String> result = utils.findMatches("test", pattern);
+//        assertEquals(Arrays.asList("test"), result);
+//        assertTrue(result instanceof ArrayList);
+//    }
+
+    @Test
+    public void testFindMatchesWhenTextIsNull() {
+        Pattern pattern = Pattern.compile("test");
+        List<String> result = utils.findMatches(null, pattern);
+        assert (result).isEmpty();
+    }
+
+    @Test
+    public void testFindMatchesWhenPatternIsNull() {
+        List<String> result = utils.findMatches("test", null);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void testFindMatchesWithEmptyText() {
+        Pattern pattern = Pattern.compile("\\d+");
+        List<String> result = utils.findMatches("", pattern);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void testFindMultipleMatchesAsArray() {
+        String[] result = utils.findMatchesAsArray("test 123 test", "\\w+");
+        assertArrayEquals(new String[]{"test", "123", "test"}, result);
+    }
+
+    @Test
+    void testFindMatchesAsArrayWhenNoMatches() {
+        String[] result = utils.findMatchesAsArray("abc", "\\d");
+        assertArrayEquals(new String[0], result);
+    }
+
+    @Test
+    void testFindMatchesAsArrayWhenTextIsNull() {
+        String[] result = utils.findMatchesAsArray(null, "\\w+");
+        assertArrayEquals(new String[0], result);
+    }
+
+    @Test
+    void testFindMatchesAsArrayWhenTextIsEmpty() {
+        String[] result = utils.findMatchesAsArray("", "\\w+");
+        assertArrayEquals(new String[0], result);
+    }
+
+    @Test
+    void testFindMatchesAsArrayWithInvalidRegex() {
+        String[] result = utils.findMatchesAsArray("text", "[a-z");
+        assertArrayEquals(new String[0], result);
+    }
+
+    @Test
+    public void testReturnedListIsUnmodifiable() {
+        Pattern pattern = Pattern.compile("\\w+");
+        List<String> result = utils.findMatches("test", pattern);
+
+        try {
+            result.add("should fail");
+            fail("Expected UnsupportedOperationException");
+        } catch (UnsupportedOperationException e) {}
     }
 }

--- a/src/test/java/org/apache/commons/lang3/RegExUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/RegExUtilsTest.java
@@ -21,6 +21,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
@@ -377,6 +379,22 @@ public class RegExUtilsTest extends AbstractLangTest {
         assertEquals("ABC_123", RegExUtils.replacePattern("ABCabc123", "[^A-Z0-9]+", "_"));
         assertEquals("ABC123", RegExUtils.replacePattern("ABCabc123", "[^A-Z0-9]+", ""));
         assertEquals("Lorem_ipsum_dolor_sit", RegExUtils.replacePattern("Lorem ipsum  dolor   sit", "( +)([a-z]+)", "_$2"));
+    }
+
+    @Test
+    public void testExtractMatches() {
+        final List<String> matches = RegExUtils.extractMatches("a1b2c3", Pattern.compile("\\d"));
+        assertEquals(Arrays.asList("1", "2", "3"), matches);
+    }
+
+    @Test
+    public void testExtractMatches_NoMatches() {
+        assertTrue(RegExUtils.extractMatches("abc", Pattern.compile("\\d")).isEmpty());
+    }
+
+    @Test
+    public void testExtractMatches_NullInput() {
+        assertTrue(RegExUtils.extractMatches(null, Pattern.compile("\\d")).isEmpty());
     }
 
 }

--- a/src/test/java/org/apache/commons/lang3/RegExUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/RegExUtilsTest.java
@@ -16,17 +16,14 @@
  */
 package org.apache.commons.lang3;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests {@link RegExUtils}.
@@ -380,21 +377,4 @@ public class RegExUtilsTest extends AbstractLangTest {
         assertEquals("ABC123", RegExUtils.replacePattern("ABCabc123", "[^A-Z0-9]+", ""));
         assertEquals("Lorem_ipsum_dolor_sit", RegExUtils.replacePattern("Lorem ipsum  dolor   sit", "( +)([a-z]+)", "_$2"));
     }
-
-    @Test
-    public void testExtractMatches() {
-        final List<String> matches = RegExUtils.extractMatches("a1b2c3", Pattern.compile("\\d"));
-        assertEquals(Arrays.asList("1", "2", "3"), matches);
-    }
-
-    @Test
-    public void testExtractMatches_NoMatches() {
-        assertTrue(RegExUtils.extractMatches("abc", Pattern.compile("\\d")).isEmpty());
-    }
-
-    @Test
-    public void testExtractMatches_NullInput() {
-        assertTrue(RegExUtils.extractMatches(null, Pattern.compile("\\d")).isEmpty());
-    }
-
 }

--- a/src/test/java/org/apache/commons/lang3/RegExUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/RegExUtilsTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.commons.lang3;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -476,4 +475,55 @@ public class RegExUtilsTest extends AbstractLangTest {
             fail("Expected UnsupportedOperationException");
         } catch (UnsupportedOperationException e) {}
     }
+
+    @Test
+    public void testFindMultipleMatchesAsArrayList(){
+        Pattern pattern = Pattern.compile("\\d+");
+        List<String> result = utils.findMatchesModifiable("asd 123 fgd 456 zxc", pattern);
+        assertEquals(Arrays.asList("123", "456"), result);
+    }
+
+    @Test
+    public void testShouldAddElementInFindMatchesModifiabale(){
+        Pattern pattern = Pattern.compile("\\w+");
+        List<String> result = utils.findMatchesModifiable("asd test 123", pattern);
+        result.add("text");
+        assertEquals(Arrays.asList("asd", "test", "123", "text"), result);
+    }
+
+    @Test
+    public void testShouldRemoveElementInFindMatchesModifiabale(){
+        Pattern pattern = Pattern.compile("\\w+");
+        List<String> result = utils.findMatchesModifiable("asd test 123", pattern);
+        result.remove("123");
+        assertEquals(Arrays.asList("asd","test"), result);
+    }
+
+    @Test
+    public void testFindNoMatchesAsArrayList() {
+        Pattern pattern = Pattern.compile("\\d+");
+        List<String> result = utils.findMatchesModifiable("asd zxc", pattern);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testFindMatchesAsArrayListWhenTextIsEmpty() {
+        Pattern pattern = Pattern.compile("\\d+");
+        List<String>result = utils.findMatchesModifiable("", pattern);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testFindMatchesAsArrayListWhenTextIsNull() {
+        Pattern pattern = Pattern.compile("\\d+");
+        List<String>result = utils.findMatchesModifiable(null, pattern);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testFindMatchesAsArrayListWhenPatternIsNull(){
+        List<String>result = utils.findMatchesModifiable("asd 123", null);
+        assertTrue(result.isEmpty());
+    }
+
 }


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
-->

Provides simple way to get all regex matches as list without manual Matcher handling.