### PR TITLE
Add Date to LocalDateTime conversion methods to bridge legacy and modern date APIs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -452,8 +452,9 @@
       </build>
     </profile>
 
+    <!-- Profile inherited from `commmons-parent` -->
     <profile>
-      <id>java9+</id>
+      <id>java-9-up</id>
       <activation>
         <jdk>[9,)</jdk>
       </activation>
@@ -462,6 +463,32 @@
         <!-- LANG-1667: allow tests to access private fields/methods of java.base/java.util such as ArrayList via reflection -->
         <argLine>-Xmx512m --add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.time=ALL-UNNAMED --add-opens java.base/java.time.chrono=ALL-UNNAMED</argLine>
       </properties>
+      <build>
+        <plugins>
+          <!--
+            ~ Modifies the inherited Moditect configuration to add `java.sql` as `static` (optional) dependency.
+            -->
+          <plugin>
+            <groupId>org.moditect</groupId>
+            <artifactId>moditect-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>add-module-infos</id>
+                <configuration>
+                  <module>
+                    <moduleInfo>
+                      <requires>
+                        static java.sql;
+                        *;
+                      </requires>
+                    </moduleInfo>
+                  </module>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
     <profile>
       <id>java15</id>

--- a/src/main/java/org/apache/commons/lang3/time/DateUtils.java
+++ b/src/main/java/org/apache/commons/lang3/time/DateUtils.java
@@ -1688,12 +1688,12 @@ public class DateUtils {
      *             it will return 0.
      * @return The nanosecond part of the {@link java.sql.Timestamp} object.
      */
-    private static int extractNanosFromSqlTimestamp(Date date){
-        if (timestampClass==null){
+    private static int extractNanosFromSqlTimestamp(Date date) {
+        if (timestampClass == null) {
             return 0;
         }
         try {
-            return (int)timestampGetNanosMethod.invoke(date);
+            return (int) timestampGetNanosMethod.invoke(date);
         } catch (IllegalAccessException | InvocationTargetException e) {
             return 0;
         }

--- a/src/main/java/org/apache/commons/lang3/time/DateUtils.java
+++ b/src/main/java/org/apache/commons/lang3/time/DateUtils.java
@@ -18,6 +18,8 @@ package org.apache.commons.lang3.time;
 
 import java.text.ParseException;
 import java.text.ParsePosition;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Iterator;
@@ -1623,6 +1625,29 @@ public class DateUtils {
         final Calendar c = Calendar.getInstance(tz);
         c.setTime(Objects.requireNonNull(date, "date"));
         return c;
+    }
+
+    /**
+     * Converts a {@link Date} into a {@link LocalDateTime}, using the default time zone.
+     * @param date the date to convert to a LocalDateTime
+     * @return the created LocalDateTime
+     * @throws NullPointerException if {@code date} is null
+     * @since 3.18
+     */
+    public static LocalDateTime toLocalDateTime(final Date date) {
+        return toLocalDateTime(date, TimeZone.getDefault());
+    }
+
+    /**
+     * Converts a {@link Date} into a {@link LocalDateTime}
+     * @param date the date to convert to a LocalDateTime
+     * @param tz the time zone of the {@code date}
+     * @return the created LocalDateTime
+     * @throws NullPointerException if {@code date} is null
+     * @since 3.18
+     */
+    public static LocalDateTime toLocalDateTime(final Date date, final TimeZone tz) {
+        return Objects.requireNonNull(date, "date").toInstant().atZone(ZoneId.of(tz.getID())).toLocalDateTime();
     }
 
     /**

--- a/src/main/java/org/apache/commons/lang3/time/DateUtils.java
+++ b/src/main/java/org/apache/commons/lang3/time/DateUtils.java
@@ -1650,7 +1650,7 @@ public class DateUtils {
     public static LocalDateTime toLocalDateTime(final Date date, final TimeZone tz) {
         final LocalDateTime localDateTime = LocalDateTime.ofInstant(Instant.ofEpochMilli(Objects.requireNonNull(date, "date").getTime()),
                 Objects.requireNonNull(tz, "tz").toZoneId());
-        if (date instanceof java.sql.Timestamp ) {
+        if (date instanceof java.sql.Timestamp) {
             return localDateTime.withNano(((Timestamp) date).getNanos());
         }
         return localDateTime;

--- a/src/main/java/org/apache/commons/lang3/time/DateUtils.java
+++ b/src/main/java/org/apache/commons/lang3/time/DateUtils.java
@@ -1648,8 +1648,9 @@ public class DateUtils {
      * @since 3.18
      */
     public static LocalDateTime toLocalDateTime(final Date date, final TimeZone tz) {
-        final LocalDateTime localDateTime = LocalDateTime.ofInstant(Instant.ofEpochMilli(Objects.requireNonNull(date, "date").getTime()),
-                Objects.requireNonNull(tz, "tz").toZoneId());
+        Objects.requireNonNull(date, "date");
+        Objects.requireNonNull(tz, "tz");
+        final LocalDateTime localDateTime = LocalDateTime.ofInstant(Instant.ofEpochMilli(date.getTime()), tz.toZoneId());
         if (date instanceof java.sql.Timestamp) {
             return localDateTime.withNano(((Timestamp) date).getNanos());
         }

--- a/src/main/java/org/apache/commons/lang3/time/DateUtils.java
+++ b/src/main/java/org/apache/commons/lang3/time/DateUtils.java
@@ -18,8 +18,8 @@ package org.apache.commons.lang3.time;
 
 import java.text.ParseException;
 import java.text.ParsePosition;
+import java.time.Instant;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Iterator;
@@ -1647,7 +1647,8 @@ public class DateUtils {
      * @since 3.18
      */
     public static LocalDateTime toLocalDateTime(final Date date, final TimeZone tz) {
-        return Objects.requireNonNull(date, "date").toInstant().atZone(ZoneId.of(tz.getID())).toLocalDateTime();
+        return LocalDateTime.ofInstant(Instant.ofEpochMilli(Objects.requireNonNull(date, "date").getTime()),
+                Objects.requireNonNull(tz,"tz").toZoneId());
     }
 
     /**

--- a/src/main/java/org/apache/commons/lang3/time/DateUtils.java
+++ b/src/main/java/org/apache/commons/lang3/time/DateUtils.java
@@ -16,6 +16,7 @@
  */
 package org.apache.commons.lang3.time;
 
+import java.sql.Timestamp;
 import java.text.ParseException;
 import java.text.ParsePosition;
 import java.time.Instant;
@@ -1647,8 +1648,12 @@ public class DateUtils {
      * @since 3.18
      */
     public static LocalDateTime toLocalDateTime(final Date date, final TimeZone tz) {
-        return LocalDateTime.ofInstant(Instant.ofEpochMilli(Objects.requireNonNull(date, "date").getTime()),
-                Objects.requireNonNull(tz,"tz").toZoneId());
+        LocalDateTime localDateTime = LocalDateTime.ofInstant(Instant.ofEpochMilli(Objects.requireNonNull(date, "date").getTime()),
+                Objects.requireNonNull(tz, "tz").toZoneId());
+        if (date instanceof java.sql.Timestamp ) {
+            return localDateTime.withNano(((Timestamp) date).getNanos());
+        }
+        return localDateTime;
     }
 
     /**

--- a/src/main/java/org/apache/commons/lang3/time/DateUtils.java
+++ b/src/main/java/org/apache/commons/lang3/time/DateUtils.java
@@ -1648,7 +1648,7 @@ public class DateUtils {
      * @since 3.18
      */
     public static LocalDateTime toLocalDateTime(final Date date, final TimeZone tz) {
-        LocalDateTime localDateTime = LocalDateTime.ofInstant(Instant.ofEpochMilli(Objects.requireNonNull(date, "date").getTime()),
+        final LocalDateTime localDateTime = LocalDateTime.ofInstant(Instant.ofEpochMilli(Objects.requireNonNull(date, "date").getTime()),
                 Objects.requireNonNull(tz, "tz").toZoneId());
         if (date instanceof java.sql.Timestamp ) {
             return localDateTime.withNano(((Timestamp) date).getNanos());

--- a/src/test/java/org/apache/commons/lang3/time/DateUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/DateUtilsTest.java
@@ -1291,14 +1291,6 @@ public class DateUtilsTest extends AbstractLangTest {
         assertThrows(NullPointerException.class, () -> DateUtils.toCalendar(date1, null));
     }
 
-    @ParameterizedTest
-    @MethodSource("dateConversionProvider")
-    void testToLocalDateTimeWithDate(Date sqlDate, LocalDateTime expected) {
-        LocalDateTime result = DateUtils.toLocalDateTime(sqlDate);
-        assertNotNull(result);
-        assertEquals(expected, result);
-    }
-
     private static Stream<Arguments> dateConversionProvider() {
         return Stream.of(
                 Arguments.of(
@@ -1326,21 +1318,6 @@ public class DateUtilsTest extends AbstractLangTest {
                         LocalDateTime.of(2000, 1, 1, 12, 30, 45, 987_654_321)
                 )
         );
-    }
-
-    @ParameterizedTest
-    @MethodSource("dateWithTimeZoneProvider")
-    void testToLocalDateTimeWithDate(
-            Date date,
-            TimeZone timeZone,
-            LocalDateTime expected) {
-        LocalDateTime result ;
-        if (timeZone != null) {
-            result = DateUtils.toLocalDateTime(date, timeZone);
-        } else {
-            result = DateUtils.toLocalDateTime(date);
-        }
-        assertEquals(expected, result);
     }
 
     private static Stream<Arguments> dateWithTimeZoneProvider() {
@@ -1383,6 +1360,29 @@ public class DateUtilsTest extends AbstractLangTest {
                         LocalDateTime.of(2023, 1, 1, 14, 0)
                 )
         );
+    }
+
+    @ParameterizedTest
+    @MethodSource("dateConversionProvider")
+    void testToLocalDateTimeWithDate(final Date sqlDate, final LocalDateTime expected) {
+        final LocalDateTime result = DateUtils.toLocalDateTime(sqlDate);
+        assertNotNull(result);
+        assertEquals(expected, result);
+    }
+
+    @ParameterizedTest
+    @MethodSource("dateWithTimeZoneProvider")
+    void testToLocalDateTimeWithDate(
+            final Date date,
+            final TimeZone timeZone,
+            final LocalDateTime expected) {
+        final LocalDateTime result;
+        if (timeZone != null) {
+            result = DateUtils.toLocalDateTime(date, timeZone);
+        } else {
+            result = DateUtils.toLocalDateTime(date);
+        }
+        assertEquals(expected, result);
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/time/DateUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/DateUtilsTest.java
@@ -28,6 +28,9 @@ import java.lang.reflect.Modifier;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
@@ -1284,6 +1287,67 @@ public class DateUtilsTest extends AbstractLangTest {
     public void testToCalendarWithTimeZoneNull() {
         assertThrows(NullPointerException.class, () -> DateUtils.toCalendar(date1, null));
     }
+
+    @Test
+    void shouldConvertDateToLocalDateTimeUsingDefaultTimeZone() {
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Shanghai"));
+
+        Instant instant = LocalDateTime.of(2023, 1, 1, 0, 0)
+                .atOffset(ZoneOffset.UTC)
+                .toInstant();
+        Date date = Date.from(instant);
+
+        LocalDateTime expected = LocalDateTime.of(2023, 1, 1, 8, 0);
+
+        assertEquals(expected, DateUtils.toLocalDateTime(date));
+    }
+
+    @Test
+    void shouldConvertDateToLocalDateTimeUsingSpecifiedTimeZone() {
+        Instant instant = LocalDateTime.of(2023, 1, 1, 0, 0)
+                .atOffset(ZoneOffset.UTC)
+                .toInstant();
+        Date date = Date.from(instant);
+
+        TimeZone newYorkTimeZone = TimeZone.getTimeZone("America/New_York");
+        LocalDateTime expected = LocalDateTime.of(2022, 12, 31, 19, 0);
+
+        assertEquals(expected, DateUtils.toLocalDateTime(date, newYorkTimeZone));
+    }
+
+    @Test
+    void shouldThrowNullPointerExceptionWhenDateIsNull() {
+        assertThrows(NullPointerException.class, () -> DateUtils.toLocalDateTime(null));
+        assertThrows(NullPointerException.class, () -> DateUtils.toLocalDateTime(null, TimeZone.getDefault()));
+    }
+
+    @Test
+    void shouldHandleDaylightSavingTimeCorrectly() {
+        Instant instant = LocalDateTime.of(2023, 3, 12, 7, 0)
+                .atOffset(ZoneOffset.UTC)
+                .toInstant();
+        Date date = Date.from(instant);
+
+        TimeZone newYorkTimeZone = TimeZone.getTimeZone("America/New_York");
+        LocalDateTime expected = LocalDateTime.of(2023, 3, 12, 3, 0);
+
+        assertEquals(expected, DateUtils.toLocalDateTime(date, newYorkTimeZone));
+    }
+
+    @Test
+    void shouldHandleExtremeTimeZoneCorrectly() {
+        Instant instant = LocalDateTime.of(2023, 1, 1, 0, 0)
+                .atOffset(ZoneOffset.UTC)
+                .toInstant();
+        Date date = Date.from(instant);
+
+        TimeZone extremeTimeZone = TimeZone.getTimeZone("Pacific/Kiritimati");
+        LocalDateTime expected = LocalDateTime.of(2023, 1, 1, 14, 0);
+
+        assertEquals(expected, DateUtils.toLocalDateTime(date, extremeTimeZone));
+    }
+
+
 
     /**
      * Tests various values with the trunc method

--- a/src/test/java/org/apache/commons/lang3/time/DateUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/DateUtilsTest.java
@@ -1291,61 +1291,61 @@ public class DateUtilsTest extends AbstractLangTest {
 
     @Test
     void testToLocalDateTimeWithSqlDate() {
-        java.sql.Date sqlDate = java.sql.Date.valueOf("2000-01-01");
+        final java.sql.Date sqlDate = java.sql.Date.valueOf("2000-01-01");
 
-        LocalDateTime result = DateUtils.toLocalDateTime(sqlDate);
+        final LocalDateTime result = DateUtils.toLocalDateTime(sqlDate);
 
         assertNotNull(result);
 
-        LocalDateTime expected = LocalDateTime.of(2000, 1, 1, 0, 0, 0);
+        final LocalDateTime expected = LocalDateTime.of(2000, 1, 1, 0, 0, 0);
         assertEquals(expected, result);
 
-        Instant instant = Instant.ofEpochMilli(sqlDate.getTime());
-        LocalDateTime expectedWithZone = LocalDateTime.ofInstant(instant, ZoneId.systemDefault());
+        final Instant instant = Instant.ofEpochMilli(sqlDate.getTime());
+        final LocalDateTime expectedWithZone = LocalDateTime.ofInstant(instant, ZoneId.systemDefault());
         assertEquals(expectedWithZone, result);
     }
 
     @Test
     public void testToLocalDateTimeWithSqlTime() {
-        java.sql.Time sqlTime = java.sql.Time.valueOf("12:30:45");
+        final java.sql.Time sqlTime = java.sql.Time.valueOf("12:30:45");
 
-        LocalDateTime result = DateUtils.toLocalDateTime(sqlTime);
+        final LocalDateTime result = DateUtils.toLocalDateTime(sqlTime);
 
         assertNotNull(result);
 
-        LocalDateTime expected = LocalDateTime.of(1970, 1, 1, 12, 30, 45);
+        final LocalDateTime expected = LocalDateTime.of(1970, 1, 1, 12, 30, 45);
         assertEquals(expected, result);
 
-        Instant instant = Instant.ofEpochMilli(sqlTime.getTime());
-        LocalDateTime expectedWithZone = LocalDateTime.ofInstant(instant, ZoneId.systemDefault());
+        final Instant instant = Instant.ofEpochMilli(sqlTime.getTime());
+        final LocalDateTime expectedWithZone = LocalDateTime.ofInstant(instant, ZoneId.systemDefault());
         assertEquals(expectedWithZone, result);
     }
 
     @Test
     public void testToLocalDateTimeWithSqlTimestamp() {
-        java.sql.Timestamp sqlTimestamp = java.sql.Timestamp.valueOf("2000-01-01 12:30:45.123456789");
+        final java.sql.Timestamp sqlTimestamp = java.sql.Timestamp.valueOf("2000-01-01 12:30:45.123456789");
 
-        LocalDateTime result = DateUtils.toLocalDateTime(sqlTimestamp);
+        final LocalDateTime result = DateUtils.toLocalDateTime(sqlTimestamp);
 
         assertNotNull(result);
 
-        LocalDateTime expected = LocalDateTime.of(
+        final LocalDateTime expected = LocalDateTime.of(
                 2000, 1, 1, 12, 30, 45, 123_456_789
         );
         assertEquals(expected, result);
 
-        Instant instant = sqlTimestamp.toInstant();
-        LocalDateTime expectedWithZone = LocalDateTime.ofInstant(instant, ZoneId.systemDefault());
+        final Instant instant = sqlTimestamp.toInstant();
+        final LocalDateTime expectedWithZone = LocalDateTime.ofInstant(instant, ZoneId.systemDefault());
         assertEquals(expectedWithZone, result);
     }
 
     @Test
     public void testToLocalDateTimeWithSqlTimestamp_NanoPrecision() {
-        java.sql.Timestamp sqlTimestamp = java.sql.Timestamp.valueOf("2000-01-01 12:30:45.987654321");
+        final java.sql.Timestamp sqlTimestamp = java.sql.Timestamp.valueOf("2000-01-01 12:30:45.987654321");
 
-        LocalDateTime result = DateUtils.toLocalDateTime(sqlTimestamp);
+        final LocalDateTime result = DateUtils.toLocalDateTime(sqlTimestamp);
 
-        LocalDateTime expected = LocalDateTime.of(
+        final LocalDateTime expected = LocalDateTime.of(
                 2000, 1, 1, 12, 30, 45, 987_654_321
         );
         assertEquals(expected, result);
@@ -1353,45 +1353,45 @@ public class DateUtilsTest extends AbstractLangTest {
 
     @Test
     public void testToLocalDateTimeWithSqlTimestamp_WithTimeZone() {
-        java.sql.Timestamp sqlTimestamp = java.sql.Timestamp.valueOf("2000-01-01 12:30:45");
-        TimeZone timeZone = TimeZone.getTimeZone("America/New_York");
+        final java.sql.Timestamp sqlTimestamp = java.sql.Timestamp.valueOf("2000-01-01 12:30:45");
+        final TimeZone timeZone = TimeZone.getTimeZone("America/New_York");
 
-        LocalDateTime result = DateUtils.toLocalDateTime(sqlTimestamp, timeZone);
+        final LocalDateTime result = DateUtils.toLocalDateTime(sqlTimestamp, timeZone);
 
-        Instant instant = sqlTimestamp.toInstant();
-        LocalDateTime expected = LocalDateTime.ofInstant(instant, timeZone.toZoneId());
+        final Instant instant = sqlTimestamp.toInstant();
+        final LocalDateTime expected = LocalDateTime.ofInstant(instant, timeZone.toZoneId());
         assertEquals(expected, result);
     }
 
     @Test
     public void testToLocalDateTimeWithSqlDate_Epoch() {
-        java.sql.Date sqlDate = java.sql.Date.valueOf("1970-01-01");
+        final java.sql.Date sqlDate = java.sql.Date.valueOf("1970-01-01");
 
-        LocalDateTime result = DateUtils.toLocalDateTime(sqlDate);
+        final LocalDateTime result = DateUtils.toLocalDateTime(sqlDate);
 
-        LocalDateTime expected = LocalDateTime.of(1970, 1, 1, 0, 0, 0);
+        final LocalDateTime expected = LocalDateTime.of(1970, 1, 1, 0, 0, 0);
         assertEquals(expected, result);
     }
 
     @Test
     public void testToLocalDateTimeWithSqlTime_MaxValue() {
-        java.sql.Time sqlTime = java.sql.Time.valueOf("23:59:59");
+        final java.sql.Time sqlTime = java.sql.Time.valueOf("23:59:59");
 
-        LocalDateTime result = DateUtils.toLocalDateTime(sqlTime);
+        final LocalDateTime result = DateUtils.toLocalDateTime(sqlTime);
 
-        LocalDateTime expected = LocalDateTime.of(1970, 1, 1, 23, 59, 59);
+        final LocalDateTime expected = LocalDateTime.of(1970, 1, 1, 23, 59, 59);
         assertEquals(expected, result);
     }
 
     @Test
     public void testToLocalDateTimeWithSqlTimestamp_DaylightSaving() {
-        java.sql.Timestamp sqlTimestamp = java.sql.Timestamp.valueOf("2023-03-12 02:30:00");
-        TimeZone newYork = TimeZone.getTimeZone("America/New_York");
+        final java.sql.Timestamp sqlTimestamp = java.sql.Timestamp.valueOf("2023-03-12 02:30:00");
+        final TimeZone newYork = TimeZone.getTimeZone("America/New_York");
 
-        LocalDateTime result = DateUtils.toLocalDateTime(sqlTimestamp, newYork);
+        final LocalDateTime result = DateUtils.toLocalDateTime(sqlTimestamp, newYork);
 
-        Instant instant = sqlTimestamp.toInstant();
-        LocalDateTime expected = LocalDateTime.ofInstant(instant, newYork.toZoneId());
+        final Instant instant = sqlTimestamp.toInstant();
+        final LocalDateTime expected = LocalDateTime.ofInstant(instant, newYork.toZoneId());
         assertEquals(expected, result);
     }
 
@@ -1399,25 +1399,25 @@ public class DateUtilsTest extends AbstractLangTest {
     void shouldConvertDateToLocalDateTimeUsingDefaultTimeZone() {
         TimeZone.setDefault(TimeZone.getTimeZone("Asia/Shanghai"));
 
-        Instant instant = LocalDateTime.of(2023, 1, 1, 0, 0)
+        final Instant instant = LocalDateTime.of(2023, 1, 1, 0, 0)
                 .atOffset(ZoneOffset.UTC)
                 .toInstant();
-        Date date = Date.from(instant);
+        final Date date = Date.from(instant);
 
-        LocalDateTime expected = LocalDateTime.of(2023, 1, 1, 8, 0);
+        final LocalDateTime expected = LocalDateTime.of(2023, 1, 1, 8, 0);
 
         assertEquals(expected, DateUtils.toLocalDateTime(date));
     }
 
     @Test
     void shouldConvertDateToLocalDateTimeUsingSpecifiedTimeZone() {
-        Instant instant = LocalDateTime.of(2023, 1, 1, 0, 0)
+        final Instant instant = LocalDateTime.of(2023, 1, 1, 0, 0)
                 .atOffset(ZoneOffset.UTC)
                 .toInstant();
-        Date date = Date.from(instant);
+        final Date date = Date.from(instant);
 
-        TimeZone newYorkTimeZone = TimeZone.getTimeZone("America/New_York");
-        LocalDateTime expected = LocalDateTime.of(2022, 12, 31, 19, 0);
+        final TimeZone newYorkTimeZone = TimeZone.getTimeZone("America/New_York");
+        final LocalDateTime expected = LocalDateTime.of(2022, 12, 31, 19, 0);
 
         assertEquals(expected, DateUtils.toLocalDateTime(date, newYorkTimeZone));
     }
@@ -1430,26 +1430,26 @@ public class DateUtilsTest extends AbstractLangTest {
 
     @Test
     void shouldHandleDaylightSavingTimeCorrectly() {
-        Instant instant = LocalDateTime.of(2023, 3, 12, 7, 0)
+        final Instant instant = LocalDateTime.of(2023, 3, 12, 7, 0)
                 .atOffset(ZoneOffset.UTC)
                 .toInstant();
-        Date date = Date.from(instant);
+        final Date date = Date.from(instant);
 
-        TimeZone newYorkTimeZone = TimeZone.getTimeZone("America/New_York");
-        LocalDateTime expected = LocalDateTime.of(2023, 3, 12, 3, 0);
+        final TimeZone newYorkTimeZone = TimeZone.getTimeZone("America/New_York");
+        final LocalDateTime expected = LocalDateTime.of(2023, 3, 12, 3, 0);
 
         assertEquals(expected, DateUtils.toLocalDateTime(date, newYorkTimeZone));
     }
 
     @Test
     void shouldHandleExtremeTimeZoneCorrectly() {
-        Instant instant = LocalDateTime.of(2023, 1, 1, 0, 0)
+        final Instant instant = LocalDateTime.of(2023, 1, 1, 0, 0)
                 .atOffset(ZoneOffset.UTC)
                 .toInstant();
-        Date date = Date.from(instant);
+        final Date date = Date.from(instant);
 
-        TimeZone extremeTimeZone = TimeZone.getTimeZone("Pacific/Kiritimati");
-        LocalDateTime expected = LocalDateTime.of(2023, 1, 1, 14, 0);
+        final TimeZone extremeTimeZone = TimeZone.getTimeZone("Pacific/Kiritimati");
+        final LocalDateTime expected = LocalDateTime.of(2023, 1, 1, 14, 0);
 
         assertEquals(expected, DateUtils.toLocalDateTime(date, extremeTimeZone));
     }

--- a/src/test/java/org/apache/commons/lang3/time/DateUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/DateUtilsTest.java
@@ -1360,12 +1360,6 @@ public class DateUtilsTest extends AbstractLangTest {
                                 java.sql.Timestamp.valueOf("2023-03-12 02:30:00").toInstant(),
                                 TimeZone.getTimeZone("America/New_York").toZoneId()
                         )
-                ), Arguments.of(
-                        Date.from(LocalDateTime.of(2023, 1, 1, 0, 0)
-                                .atOffset(ZoneOffset.UTC)
-                                .toInstant()),
-                        null,
-                        LocalDateTime.of(2023, 1, 1, 8, 0)
                 ),
                 Arguments.of(
                         Date.from(LocalDateTime.of(2023, 1, 1, 0, 0)

--- a/src/test/java/org/apache/commons/lang3/time/DateUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/DateUtilsTest.java
@@ -28,7 +28,6 @@ import java.lang.reflect.Modifier;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.Calendar;


### PR DESCRIPTION
#### **Background and Motivation**  
With the widespread adoption of Java 8+, the project has gradually moved from the traditional `java.util.Date` to modern date-time APIs (such as `LocalDateTime`), but a large amount of existing code still relies on `Date`. To reduce migration costs and improve development efficiency, it is necessary to provide officially supported conversion tools in Apache Commons Lang to avoid developers repeating the implementation of underlying logic.

#### **Core Change Content**  
1. **New Conversion Methods**  
   - `toLocalDateTime(Date date)`：Uses the system's default time zone, simplifying common conversion scenarios.  
   - `toLocalDateTime(Date date, TimeZone tz)`：Explicitly specifies the time zone, meeting internationalization requirements (e.g., converting UTC time to local time in a specific time zone).  
   - Implementation principle: Converts using `Instant` and `ZoneId`, ensuring time zone accuracy (including daylight saving time, handling of extreme time zones).  

2. **Improve test coverage**  
   - Covers scenarios such as default time zones, specified time zones, null value validation, daylight saving time (e.g., New York in the United States), extreme time zones (e.g., Kiribati with UTC+14) to ensure code robustness.  

#### **Value Added**  
- **Smooth Migration**: Allows developers to gradually introduce `LocalDateTime` without modifying the existing `Date` interface, reducing refactoring risks.  
- **Consistency and Reliability**: Provides Apache's official conversion logic, avoiding potential bugs in third-party implementations, and enhancing project stability.  
- **Feature Extension**: Enhance `DateUtils` modern support to adapt to Java 8+ ecosystem, responding to the community's need for bridging new and old APIs.  

#### **Compatibility Note**  
- No breaking changes, new methods are independent extensions, do not affect existing `DateUtils` functionality.  
- Depends on Java 8+ (consistent with Apache Commons Lang 3.18+).