### PR TITLE
Add fill method for boolean arrays in ArrayFill utility class

### DIFF
--- a/src/main/java/org/apache/commons/lang3/ArrayFill.java
+++ b/src/main/java/org/apache/commons/lang3/ArrayFill.java
@@ -45,6 +45,21 @@ public final class ArrayFill {
     }
 
     /**
+     * Fills and returns the given array, assigning the given {@code boolean} value to each element of the array.
+     *
+     * @param a   the array to be filled (may be null).
+     * @param val the value to be stored in all elements of the array.
+     * @return the given array.
+     * @see Arrays#fill(boolean[],boolean)
+     */
+    public static boolean[] fill(final boolean[] a, final boolean val) {
+        if (a != null) {
+            Arrays.fill(a, val);
+        }
+        return a;
+    }
+
+    /**
      * Fills and returns the given array, assigning the given {@code char} value to each element of the array.
      *
      * @param a   the array to be filled (may be null).

--- a/src/test/java/org/apache/commons/lang3/ArrayFillTest.java
+++ b/src/test/java/org/apache/commons/lang3/ArrayFillTest.java
@@ -50,6 +50,25 @@ public class ArrayFillTest extends AbstractLangTest {
     }
 
     @Test
+    public void testFillBooleanArray() {
+        final boolean[] array = new boolean[3];
+        final boolean val = true;
+        final boolean[] actual = ArrayFill.fill(array, val);
+        assertSame(array, actual);
+        for (final boolean v : actual) {
+            assertEquals(val, v);
+        }
+    }
+
+    @Test
+    public void testFillBooleanArrayNull() {
+        final boolean[] array = null;
+        final boolean val = true;
+        final boolean[] actual = ArrayFill.fill(array, val);
+        assertSame(array, actual);
+    }
+
+    @Test
     public void testFillCharArray() {
         final char[] array = new char[3];
         final char val = 1;


### PR DESCRIPTION
- Completes the fill methods for all primitive array types
#### Summary
This PR adds support for filling `boolean[]` arrays in the `ArrayFill` utility class, completing coverage for all primitive array types.

#### Changes
- Introduced `public static boolean[] fill(boolean[] a, boolean val)` method
- Consistent with existing `fill` methods for other primitive types like `int`, `double`, etc.
- Ensures fluent API style by returning the input array

#### Motivation
This method complements the existing API by supporting `boolean[]`, which was missing. It helps users initialize boolean arrays in a fluent and consistent way across all primitive types.

#### Checklist
- [x] Code compiles successfully
- [x] All existing and unit tests pass
- [x] Ran mvn command and verified build is successful.