### PR TITLE
Add StringUtils.truncateToByteLength

### DIFF
--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -8872,6 +8872,31 @@ public class StringUtils {
         return truncate(str, 0, maxWidth);
     }
 
+    public static String truncateToByteLength(String str, int maxBytes, Charset charset) {
+        if (str == null) {
+            return null;
+        }
+
+        byte[] bytes = StringUtils.getBytes(str, charset);
+        if (bytes.length <= maxBytes) {
+            return str;
+        }
+
+        // Binary search or iterative approach to find the right character length
+        int low = 0;
+        int high = str.length();
+        while (low < high) {
+            int mid = (low + high + 1) / 2;
+            if (str.substring(0, mid).getBytes(charset).length <= maxBytes) {
+                low = mid;
+            } else {
+                high = mid - 1;
+            }
+        }
+
+        return str.substring(0, low);
+    }
+
     /**
      * Truncates a String. This will turn
      * "Now is the time for all good men" into "is the time for all".

--- a/src/test/java/org/apache/commons/lang3/StringUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringUtilsTest.java
@@ -3090,6 +3090,18 @@ public class StringUtilsTest extends AbstractLangTest {
     }
 
     @Test
+    public void testTruncateToByteLength() {
+        assertNull(StringUtils.truncateToByteLength(null, 0, Charset.defaultCharset()));
+        assertEquals("abcdefghij", StringUtils.truncateToByteLength("abcdefghijklmno", 10, Charset.defaultCharset()));
+        assertEquals("abcdefghijklmno", StringUtils.truncateToByteLength("abcdefghijklmno", 15, Charset.defaultCharset()));
+        assertEquals("abcdefghijklmno", StringUtils.truncateToByteLength("abcdefghijklmno", 20, Charset.defaultCharset()));
+        assertEquals("\u4F60\u597D\u55CE", StringUtils.truncateToByteLength("\u4F60\u597D\u55CE", 10, Charset.defaultCharset()));
+        assertEquals("\u4F60", StringUtils.truncateToByteLength("\u4F60\u597D\u55CE", 5, Charset.defaultCharset()));
+        assertEquals("\u2713\u2714", StringUtils.truncateToByteLength("\u2713\u2714", 6, Charset.defaultCharset()));
+        assertEquals("", StringUtils.truncateToByteLength("\u2713\u2714", 2, Charset.defaultCharset()));
+    }
+
+    @Test
     public void testUnCapitalize() {
         assertNull(StringUtils.uncapitalize(null));
 


### PR DESCRIPTION
We sometimes need to store Unicode text in a fixed space (e.g., in a database column of type `CHARACTER(32)`). It's acceptable for the text to be truncated, but because we're dealing with Unicode, we can't simply treat the text as raw bytes and truncate it at 16 bytes — that might split a character in the middle. The function `StringUtils.truncateToByteLength(String str, int maxBytes, Charset charset)` helps handle this by safely truncating the string based on byte length while preserving valid character boundaries.
