### PR TITLE
Implement a LatchUtils helper class to wrap CountDownLatch instantiation along with countDown() and await() method invocations, decoupling business logic from concurrency control for safer and cleaner thread coordination

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -90,6 +90,7 @@ The <action> type attribute can be add,update,fix,remove.
     <action                   type="fix" dev="ggregory" due-to="Gary Gregory">org.apache.commons.lang3.ClassUtils.getCanonicalName(String) now throws an IllegalArgumentException for array dimensions greater than 255.</action>
     <action                   type="fix" dev="ggregory" due-to="Sridhar Balijepalli, Piotr P. Karwasz">Fix Javadoc typo and improve clarity in defaultIfBlank method #1376.</action>
     <action issue="LANG-1773" type="fix" dev="ggregory" due-to="Éamonn McManus, Gary Gregory">Apache Commons Lang no longer builds on Android #1381.</action>
+    <action issue="LANG-1772" type="fix" dev="ggregory" due-to="James Winters, Piotr P. Karwasz, Gary Gregory">Restrict size of cache to prevent overflow errors #1379.</action>
     <!-- ADD -->
     <action                   type="add" dev="ggregory" due-to="Gary Gregory">Add Strings and refactor StringUtils.</action>
     <action issue="LANG-1747" type="add" dev="ggregory" due-to="Oliver B. Fischer, Gary Gregory">Add StopWatch.run([Failable]Runnable) and get([Failable]Supplier).</action>

--- a/src/main/java/org/apache/commons/lang3/concurrent/LatchUtils.java
+++ b/src/main/java/org/apache/commons/lang3/concurrent/LatchUtils.java
@@ -1,0 +1,83 @@
+package org.apache.commons.lang3.concurrent;
+
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * the utility class for {@link CountDownLatch}
+ * Provide a safer, more user-friendly, and concise wrapper for CountDownLatch's creation, countDown(), and await() operations
+ * To achieve separation between business logic and CountDownLatch
+ */
+public class LatchUtils {
+
+    private static final ThreadLocal<List<TaskInfo>> THREADLOCAL = ThreadLocal.withInitial(LinkedList::new);
+
+    private static final class TaskInfo {
+        private Executor executor;
+        private Runnable runnable;
+
+        public TaskInfo(Executor executor, Runnable runnable) {
+            this.executor = executor;
+            this.runnable = runnable;
+        }
+    }
+
+    /**
+     * @param executor the threadpool for the task will run in
+     * @param runnable the task
+     */
+    public static void submitTask(Executor executor, Runnable runnable) {
+        THREADLOCAL.get().add(new TaskInfo(executor, runnable));
+    }
+
+    private static List<TaskInfo> popTask() {
+        List<TaskInfo> taskInfos = THREADLOCAL.get();
+        THREADLOCAL.remove();
+        return taskInfos;
+    }
+
+    /**
+     * start task and wait for task finish
+     *
+     * @param timeout
+     * @return
+     */
+    public static boolean waitFor(Long timeout, TimeUnit timeUnit) {
+        List<TaskInfo> taskInfos = popTask();
+        if (taskInfos.isEmpty()) {
+            return true;
+        }
+
+        CountDownLatch latch = new CountDownLatch(taskInfos.size());
+        for (TaskInfo taskInfo : taskInfos) {
+            Executor executor = taskInfo.executor;
+            Runnable runnable = taskInfo.runnable;
+            executor.execute(() -> {
+                try {
+                    runnable.run();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        boolean await = false;
+        try {
+            if (timeout != null) {
+                await = latch.await(timeout, timeUnit != null ? timeUnit : TimeUnit.SECONDS);
+            } else {
+                latch.await();
+                await = true;
+            }
+        } catch (Exception e) {
+
+        }
+
+        return await;
+    }
+
+}

--- a/src/main/java/org/apache/commons/lang3/concurrent/locks/LockUtils.java
+++ b/src/main/java/org/apache/commons/lang3/concurrent/locks/LockUtils.java
@@ -1,0 +1,164 @@
+package org.apache.commons.lang3.concurrent.locks;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
+
+/**
+ * Utility class providing convenient methods for working with {@link Lock} objects.
+ * <p>
+ * This class offers simplified lock management with automatic resource cleanup using 
+ * try-with-resources syntax. It wraps lock operations and provides a {@link LockStat} 
+ * object that implements {@link AutoCloseable} for automatic unlocking.
+ * </p>
+ * 
+ * <p>Example usage:</p>
+ * <pre>
+ * Lock myLock = new ReentrantLock();
+ * 
+ * // Try to acquire lock with timeout
+ * try (LockStat lockStat = LockUtils.tryLock(myLock, 5, TimeUnit.SECONDS)) {
+ *     if (lockStat.isLocked()) {
+ *         // Critical section - lock acquired successfully
+ *         doSomethingCritical();
+ *     } else {
+ *         // Handle case where lock was not acquired
+ *         handleLockTimeout();
+ *     }
+ * } // Lock is automatically released here
+ * 
+ * // Or acquire lock without timeout
+ * try (LockStat lockStat = LockUtils.lock(myLock)) {
+ *     // Critical section - lock is guaranteed to be acquired
+ *     doSomethingCritical();
+ * } // Lock is automatically released here
+ * </pre>
+ *
+ */
+public class LockUtils {
+
+    /**
+     * Attempts to acquire the specified lock within the given timeout period.
+     * <p>
+     * This method tries to acquire the lock and waits for the specified timeout
+     * if the lock is not immediately available. If the thread is interrupted
+     * while waiting, the method returns a {@link LockStat} indicating that the
+     * lock was not acquired.
+     * </p>
+     * 
+     * @param lock the lock to acquire, must not be null
+     * @param timeout the maximum time to wait for the lock
+     * @param timeUnit the time unit of the timeout argument, must not be null
+     * @return a {@link LockStat} object that can be used with try-with-resources
+     *         to automatically release the lock. Use {@code isLocked()} to check
+     *         if the lock was successfully acquired.
+     * @throws NullPointerException if lock or timeUnit is null
+     */
+    public static LockStat tryLock(Lock lock, long timeout, TimeUnit timeUnit) {
+        boolean tryLock = false;
+        try {
+            tryLock = lock.tryLock(timeout, timeUnit);
+        } catch (InterruptedException e) {
+            tryLock = false;
+        }
+        return new LockStat(lock, tryLock);
+    }
+
+    /**
+     * Attempts to acquire the specified lock immediately without waiting.
+     * <p>
+     * This method tries to acquire the lock immediately. If the lock is not
+     * available, it returns immediately without waiting.
+     * </p>
+     * 
+     * @param lock the lock to acquire, must not be null
+     * @return a {@link LockStat} object that can be used with try-with-resources
+     *         to automatically release the lock. Use {@code isLocked()} to check
+     *         if the lock was successfully acquired.
+     * @throws NullPointerException if lock is null
+     */
+    public static LockStat tryLock(Lock lock) {
+        boolean tryLock = lock.tryLock();
+        return new LockStat(lock, tryLock);
+    }
+
+    /**
+     * Acquires the specified lock, blocking if necessary until the lock is available.
+     * <p>
+     * This method blocks the current thread until the lock is acquired. Unlike
+     * the {@code tryLock} methods, this method guarantees that the lock will be
+     * acquired (unless the thread is interrupted).
+     * </p>
+     * 
+     * @param lock the lock to acquire, must not be null
+     * @return a {@link LockStat} object that can be used with try-with-resources
+     *         to automatically release the lock. The returned {@code LockStat}
+     *         will always have {@code isLocked()} return {@code true}.
+     * @throws NullPointerException if lock is null
+     */
+    public static LockStat lock(Lock lock) {
+        lock.lock();
+        return new LockStat(lock, true);
+    }
+
+    /**
+     * A container class that holds a {@link Lock} and its acquisition status.
+     * <p>
+     * This class implements {@link AutoCloseable} to enable automatic resource
+     * management with try-with-resources statements. When used in a try-with-resources
+     * block, the lock will be automatically released when the block is exited,
+     * but only if the lock was successfully acquired.
+     * </p>
+     * 
+     * <p>This class is immutable and thread-safe.</p>
+     */
+    public static class LockStat implements AutoCloseable {
+        private final Lock lock;
+        private final boolean isLocked;
+
+        /**
+         * Constructs a new LockStat with the specified lock and acquisition status.
+         * 
+         * @param lock the lock object, must not be null
+         * @param isLocked {@code true} if the lock was successfully acquired,
+         *                 {@code false} otherwise
+         * @throws NullPointerException if lock is null
+         */
+        public LockStat(Lock lock, boolean isLocked) {
+            this.lock = lock;
+            this.isLocked = isLocked;
+        }
+
+        /**
+         * Returns the lock associated with this LockStat.
+         * 
+         * @return the lock object, never null
+         */
+        public Lock getLock() {
+            return lock;
+        }
+
+        /**
+         * Returns whether the lock was successfully acquired.
+         * 
+         * @return {@code true} if the lock was acquired, {@code false} otherwise
+         */
+        public boolean isLocked() {
+            return isLocked;
+        }
+
+        /**
+         * Releases the lock if it was successfully acquired.
+         * <p>
+         * This method is called automatically when used in a try-with-resources
+         * statement. It only releases the lock if {@code isLocked()} returns
+         * {@code true}, preventing attempts to unlock a lock that was never acquired.
+         * </p>
+         */
+        @Override
+        public void close() {
+            if (isLocked) {
+                lock.unlock();
+            }
+        }
+    }
+}

--- a/src/test/java/org/apache/commons/lang3/concurrent/LatchUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/concurrent/LatchUtilsTest.java
@@ -1,0 +1,35 @@
+package org.apache.commons.lang3.concurrent;
+
+import org.apache.commons.lang3.AbstractLangTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests {@link LatchUtils}.
+ */
+class LatchUtilsTest extends AbstractLangTest {
+
+    private ExecutorService executorService = Executors.newFixedThreadPool(2);
+
+    @Test
+    void testSubmitTask1() {
+        LatchUtils.submitTask(executorService, () -> {
+            System.out.println("task1");
+        });
+        LatchUtils.submitTask(executorService, () -> {
+            System.out.println("task2");
+
+        });
+        LatchUtils.submitTask(executorService, () -> {
+            System.out.println("task3");
+
+        });
+        assertTrue(LatchUtils.waitFor(1L, TimeUnit.SECONDS
+        ));
+    }
+}

--- a/src/test/java/org/apache/commons/lang3/concurrent/locks/LockUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/concurrent/locks/LockUtilsTest.java
@@ -1,0 +1,451 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.lang3.concurrent.locks;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import org.apache.commons.lang3.AbstractLangTest;
+import org.apache.commons.lang3.ThreadUtils;
+import org.apache.commons.lang3.concurrent.locks.LockUtils.LockStat;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests {@link LockUtils}.
+ */
+public class LockUtilsTest extends AbstractLangTest {
+
+    /**
+     * Test {@link LockUtils#lock(Lock)} with successful lock acquisition.
+     */
+    @Test
+    public void testLock_Success() {
+        final Lock lock = new ReentrantLock();
+        
+        try (LockStat lockStat = LockUtils.lock(lock)) {
+            assertNotNull(lockStat);
+            assertSame(lock, lockStat.getLock());
+            assertTrue(lockStat.isLocked());
+        }
+    }
+
+    /**
+     * Test {@link LockUtils#lock(Lock)} with null lock throws NPE.
+     */
+    @Test
+    public void testLock_NullLock() {
+        assertThrows(NullPointerException.class, () -> LockUtils.lock(null));
+    }
+
+    /**
+     * Test {@link LockUtils#lock(Lock)} with already held lock (reentrant).
+     */
+    @Test
+    public void testLock_Reentrant() {
+        final ReentrantLock lock = new ReentrantLock();
+        
+        try (LockStat lockStat1 = LockUtils.lock(lock)) {
+            assertTrue(lockStat1.isLocked());
+            assertEquals(1, lock.getHoldCount());
+            
+            try (LockStat lockStat2 = LockUtils.lock(lock)) {
+                assertTrue(lockStat2.isLocked());
+                assertEquals(2, lock.getHoldCount());
+            }
+            assertEquals(1, lock.getHoldCount());
+        }
+        assertEquals(0, lock.getHoldCount());
+    }
+
+    /**
+     * Test {@link LockUtils#tryLock(Lock)} with successful immediate lock acquisition.
+     */
+    @Test
+    public void testTryLock_Success() {
+        final Lock lock = new ReentrantLock();
+        
+        try (LockStat lockStat = LockUtils.tryLock(lock)) {
+            assertNotNull(lockStat);
+            assertSame(lock, lockStat.getLock());
+            assertTrue(lockStat.isLocked());
+        }
+    }
+
+    /**
+     * Test {@link LockUtils#tryLock(Lock)} with lock held by another thread.
+     */
+    @Test
+    public void testTryLock_LockHeld() throws InterruptedException {
+        final Lock lock = new ReentrantLock();
+        final CountDownLatch latch1 = new CountDownLatch(1);
+        final CountDownLatch latch2 = new CountDownLatch(1);
+        final AtomicBoolean lockAcquired = new AtomicBoolean(false);
+
+        // Thread 1 acquires the lock
+        final Thread thread1 = new Thread(() -> {
+            try (LockStat lockStat = LockUtils.lock(lock)) {
+                latch1.countDown(); // Signal that lock is acquired
+                assertTrue(lockStat.isLocked());
+                ThreadUtils.sleep(Duration.ofMillis(100)); // Hold the lock
+                latch2.await(); // Wait for signal to proceed
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+
+        // Thread 2 tries to acquire the lock
+        final Thread thread2 = new Thread(() -> {
+            try {
+                latch1.await(); // Wait for thread1 to acquire lock
+                try (LockStat lockStat = LockUtils.tryLock(lock)) {
+                    lockAcquired.set(lockStat.isLocked());
+                }
+                latch2.countDown(); // Signal thread1 to proceed
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+
+        thread1.start();
+        thread2.start();
+        thread1.join();
+        thread2.join();
+
+        assertFalse(lockAcquired.get());
+    }
+
+    /**
+     * Test {@link LockUtils#tryLock(Lock)} with null lock throws NPE.
+     */
+    @Test
+    public void testTryLock_NullLock() {
+        assertThrows(NullPointerException.class, () -> LockUtils.tryLock(null));
+    }
+
+    /**
+     * Test {@link LockUtils#tryLock(Lock, long, TimeUnit)} with successful lock acquisition.
+     */
+    @Test
+    public void testTryLockWithTimeout_Success() {
+        final Lock lock = new ReentrantLock();
+        
+        try (LockStat lockStat = LockUtils.tryLock(lock, 1, TimeUnit.SECONDS)) {
+            assertNotNull(lockStat);
+            assertSame(lock, lockStat.getLock());
+            assertTrue(lockStat.isLocked());
+        }
+    }
+
+    /**
+     * Test {@link LockUtils#tryLock(Lock, long, TimeUnit)} with timeout.
+     */
+    @Test
+    public void testTryLockWithTimeout_Timeout() throws InterruptedException {
+        final Lock lock = new ReentrantLock();
+        final CountDownLatch latch1 = new CountDownLatch(1);
+        final CountDownLatch latch2 = new CountDownLatch(1);
+        final AtomicBoolean lockAcquired = new AtomicBoolean(false);
+
+        // Thread 1 acquires the lock and holds it
+        final Thread thread1 = new Thread(() -> {
+            try (LockStat lockStat = LockUtils.lock(lock)) {
+                latch1.countDown(); // Signal that lock is acquired
+                assertTrue(lockStat.isLocked());
+                latch2.await(); // Wait for signal to proceed
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+
+        // Thread 2 tries to acquire the lock with timeout
+        final Thread thread2 = new Thread(() -> {
+            try {
+                latch1.await(); // Wait for thread1 to acquire lock
+                try (LockStat lockStat = LockUtils.tryLock(lock, 50, TimeUnit.MILLISECONDS)) {
+                    lockAcquired.set(lockStat.isLocked());
+                }
+                latch2.countDown(); // Signal thread1 to proceed
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+
+        thread1.start();
+        thread2.start();
+        thread1.join();
+        thread2.join();
+
+        assertFalse(lockAcquired.get());
+    }
+
+    /**
+     * Test {@link LockUtils#tryLock(Lock, long, TimeUnit)} with thread interruption.
+     */
+    @Test
+    public void testTryLockWithTimeout_Interrupted() throws InterruptedException {
+        final Lock lock = new ReentrantLock();
+        final CountDownLatch latch1 = new CountDownLatch(1);
+        final CountDownLatch latch2 = new CountDownLatch(1);
+        final AtomicBoolean lockAcquired = new AtomicBoolean(false);
+
+        // Thread 1 acquires the lock and holds it
+        final Thread thread1 = new Thread(() -> {
+            try (LockStat lockStat = LockUtils.lock(lock)) {
+                latch1.countDown(); // Signal that lock is acquired
+                assertTrue(lockStat.isLocked());
+                latch2.await(); // Wait for signal to proceed
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+
+        // Thread 2 tries to acquire the lock with timeout and gets interrupted
+        final Thread thread2 = new Thread(() -> {
+            try {
+                latch1.await(); // Wait for thread1 to acquire lock
+                try (LockStat lockStat = LockUtils.tryLock(lock, 5, TimeUnit.SECONDS)) {
+                    lockAcquired.set(lockStat.isLocked());
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+
+        thread1.start();
+        thread2.start();
+        
+        // Interrupt thread2 while it's waiting for the lock
+        ThreadUtils.sleep(Duration.ofMillis(50));
+        thread2.interrupt();
+        
+        thread1.join();
+        thread2.join();
+        
+        latch2.countDown(); // Clean up
+
+        assertFalse(lockAcquired.get());
+    }
+
+    /**
+     * Test {@link LockUtils#tryLock(Lock, long, TimeUnit)} with null lock throws NPE.
+     */
+    @Test
+    public void testTryLockWithTimeout_NullLock() {
+        assertThrows(NullPointerException.class, () -> LockUtils.tryLock(null, 1, TimeUnit.SECONDS));
+    }
+
+    /**
+     * Test {@link LockUtils#tryLock(Lock, long, TimeUnit)} with null TimeUnit throws NPE.
+     */
+    @Test
+    public void testTryLockWithTimeout_NullTimeUnit() {
+        final Lock lock = new ReentrantLock();
+        assertThrows(NullPointerException.class, () -> LockUtils.tryLock(lock, 1, null));
+    }
+
+    /**
+     * Test try-with-resources automatic unlocking.
+     */
+    @Test
+    public void testTryWithResources_AutoUnlock() {
+        final ReentrantLock lock = new ReentrantLock();
+        
+        // Acquire and release lock
+        try (LockStat lockStat = LockUtils.lock(lock)) {
+            assertTrue(lockStat.isLocked());
+            assertEquals(1, lock.getHoldCount());
+        }
+        
+        // Lock should be released
+        assertEquals(0, lock.getHoldCount());
+        assertFalse(lock.isLocked());
+    }
+
+    /**
+     * Test try-with-resources with failed lock acquisition.
+     */
+    @Test
+    public void testTryWithResources_FailedAcquisition() throws InterruptedException {
+        final Lock lock = new ReentrantLock();
+        final CountDownLatch latch1 = new CountDownLatch(1);
+        final CountDownLatch latch2 = new CountDownLatch(1);
+
+        // Thread 1 acquires the lock
+        final Thread thread1 = new Thread(() -> {
+            try (LockStat lockStat = LockUtils.lock(lock)) {
+                latch1.countDown(); // Signal that lock is acquired
+                assertTrue(lockStat.isLocked());
+                latch2.await(); // Wait for signal to proceed
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+
+        // Thread 2 fails to acquire the lock
+        final Thread thread2 = new Thread(() -> {
+            try {
+                latch1.await(); // Wait for thread1 to acquire lock
+                try (LockStat lockStat = LockUtils.tryLock(lock)) {
+                    assertFalse(lockStat.isLocked());
+                    // close() should not attempt to unlock since lock was not acquired
+                }
+                latch2.countDown(); // Signal thread1 to proceed
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+
+        thread1.start();
+        thread2.start();
+        thread1.join();
+        thread2.join();
+    }
+
+    /**
+     * Test concurrent access with multiple threads.
+     */
+    @Test
+    public void testConcurrentAccess() throws InterruptedException {
+        final Lock lock = new ReentrantLock();
+        final AtomicInteger counter = new AtomicInteger(0);
+        final int numThreads = 10;
+        final CountDownLatch startLatch = new CountDownLatch(1);
+        final CountDownLatch endLatch = new CountDownLatch(numThreads);
+
+        for (int i = 0; i < numThreads; i++) {
+            new Thread(() -> {
+                try {
+                    startLatch.await();
+                    try (LockStat lockStat = LockUtils.lock(lock)) {
+                        if (lockStat.isLocked()) {
+                            final int current = counter.get();
+                            ThreadUtils.sleep(Duration.ofMillis(1)); // Simulate work
+                            counter.set(current + 1);
+                        }
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    endLatch.countDown();
+                }
+            }).start();
+        }
+
+        startLatch.countDown();
+        endLatch.await();
+
+        assertEquals(numThreads, counter.get());
+    }
+
+    /**
+     * Test {@link LockStat} constructor.
+     */
+    @Test
+    public void testLockStat_Constructor() {
+        final Lock lock = new ReentrantLock();
+        final LockStat lockStat = new LockStat(lock, true);
+        
+        assertSame(lock, lockStat.getLock());
+        assertTrue(lockStat.isLocked());
+        
+        final LockStat lockStat2 = new LockStat(lock, false);
+        assertSame(lock, lockStat2.getLock());
+        assertFalse(lockStat2.isLocked());
+    }
+
+    /**
+     * Test {@link LockStat} constructor with null lock throws NPE.
+     */
+    @Test
+    public void testLockStat_NullLock() {
+        assertThrows(NullPointerException.class, () -> new LockStat(null, true));
+    }
+
+    /**
+     * Test {@link LockStat#close()} method directly.
+     */
+    @Test
+    public void testLockStat_CloseMethod() {
+        final ReentrantLock lock = new ReentrantLock();
+        
+        // Test close with acquired lock
+        final LockStat lockStat1 = new LockStat(lock, true);
+        lock.lock(); // Manually acquire lock
+        assertEquals(1, lock.getHoldCount());
+        
+        lockStat1.close();
+        assertEquals(0, lock.getHoldCount());
+        
+        // Test close with non-acquired lock
+        final LockStat lockStat2 = new LockStat(lock, false);
+        lockStat2.close(); // Should not throw exception
+        assertEquals(0, lock.getHoldCount());
+    }
+
+    /**
+     * Test that LockStat is immutable.
+     */
+    @Test
+    public void testLockStat_Immutability() {
+        final Lock lock = new ReentrantLock();
+        final LockStat lockStat = new LockStat(lock, true);
+        
+        // Verify that the state cannot be changed after construction
+        assertSame(lock, lockStat.getLock());
+        assertTrue(lockStat.isLocked());
+        
+        // The lock and status should remain the same
+        assertSame(lock, lockStat.getLock());
+        assertTrue(lockStat.isLocked());
+    }
+
+    /**
+     * Test edge case with zero timeout.
+     */
+    @Test
+    public void testTryLockWithTimeout_ZeroTimeout() {
+        final Lock lock = new ReentrantLock();
+        
+        try (LockStat lockStat = LockUtils.tryLock(lock, 0, TimeUnit.SECONDS)) {
+            assertTrue(lockStat.isLocked()); // Should still acquire if available
+        }
+    }
+
+    /**
+     * Test edge case with negative timeout.
+     */
+    @Test
+    public void testTryLockWithTimeout_NegativeTimeout() {
+        final Lock lock = new ReentrantLock();
+        
+        try (LockStat lockStat = LockUtils.tryLock(lock, -1, TimeUnit.SECONDS)) {
+            assertTrue(lockStat.isLocked()); // Should still acquire if available
+        }
+    }
+} 


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    https://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
-->

Thanks for your contribution to [Apache Commons](https://commons.apache.org/)! Your help is appreciated!

Before you push a pull request, review this list:

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible but is a best-practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that commits might be squashed by a maintainer on merge.
