### PR TITLE
[LANG-1776] Use GitHub URL in `project.scm.url`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
   <scm>
     <connection>scm:git:http://gitbox.apache.org/repos/asf/commons-lang.git</connection>
     <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/commons-lang.git</developerConnection>
-    <url>https://gitbox.apache.org/repos/asf?p=commons-lang.git</url>
+    <url>https://github.com/apache/commons-lang</url>
     <tag>rel/commons-lang-3.18.0</tag>
   </scm>
   <!-- Lang should depend on very little -->

--- a/pom.xml
+++ b/pom.xml
@@ -41,14 +41,18 @@
   Please ensure your build environment is up-to-date and kindly report any build issues.
   </description>
   <url>https://commons.apache.org/proper/commons-lang/</url>
+  <ciManagement>
+    <system>github</system>
+    <url>https://github.com/apache/commons-lang/actions</url>
+  </ciManagement>
   <issueManagement>
     <system>jira</system>
     <url>https://issues.apache.org/jira/browse/LANG</url>
   </issueManagement>
   <scm>
-    <connection>scm:git:http://gitbox.apache.org/repos/asf/commons-lang.git</connection>
+    <connection>scm:git:https://gitbox.apache.org/repos/asf/commons-lang.git</connection>
     <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/commons-lang.git</developerConnection>
-    <url>https://github.com/apache/commons-lang</url>
+    <url>https://gitbox.apache.org/repos/asf/commons-lang.git</url>
     <tag>rel/commons-lang-3.18.0</tag>
   </scm>
   <!-- Lang should depend on very little -->

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -156,7 +156,8 @@ The <action> type attribute can be add,update,fix,remove.
     <action                   type="update" dev="ggregory" due-to="Gary Gregory, Dependabot">Bump org.apache.commons:commons-parent from 73 to 85 #1267, #1277, #1283, #1288, #1302, #1377.</action>
     <action                   type="update" dev="ggregory" due-to="Gary Gregory, Dependabot">[site] Bump org.codehaus.mojo:taglist-maven-plugin from 3.1.0 to 3.2.1 #1300.</action>
     <action                   type="update" dev="ggregory" due-to="Gary Gregory, Dependabot">[test] Bump org.easymock:easymock from 5.4.0 to 5.6.0 #1317, #1387.</action>
-    <action                   type="update" dev="ggregory" due-to="Gary Gregory, Dependabot">[test] Bump org.apache.commons:commons-text from 1.12.0 to 1.13.1 #1336.</action> 
+    <action                   type="update" dev="ggregory" due-to="Gary Gregory, Dependabot">[test] Bump org.apache.commons:commons-text from 1.12.0 to 1.13.1 #1336.</action>
+    <action issue="LANG-1776" type="update" dev="pkarwasz">Use GitHub URL in `project.scm.url` for improved automation support.</action>
   </release>
   <release version="3.17.0" date="2024-08-24" description="This is a feature and maintenance release. Java 8 or later is required.">
     <!-- FIX -->

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -157,7 +157,7 @@ The <action> type attribute can be add,update,fix,remove.
     <action                   type="update" dev="ggregory" due-to="Gary Gregory, Dependabot">[site] Bump org.codehaus.mojo:taglist-maven-plugin from 3.1.0 to 3.2.1 #1300.</action>
     <action                   type="update" dev="ggregory" due-to="Gary Gregory, Dependabot">[test] Bump org.easymock:easymock from 5.4.0 to 5.6.0 #1317, #1387.</action>
     <action                   type="update" dev="ggregory" due-to="Gary Gregory, Dependabot">[test] Bump org.apache.commons:commons-text from 1.12.0 to 1.13.1 #1336.</action>
-    <action issue="LANG-1776" type="update" dev="pkarwasz">Use GitHub URL in `project.scm.url` for improved automation support.</action>
+    <action issue="LANG-1776" type="update" dev="pkarwasz">Use GitHub URL in POM for improved automation support.</action>
   </release>
   <release version="3.17.0" date="2024-08-24" description="This is a feature and maintenance release. Java 8 or later is required.">
     <!-- FIX -->


### PR DESCRIPTION
This PR updates the `project.scm.url` field in the Maven POM to point to the GitHub repository URL (`https://github.com/apache/commons-lang`).

While this field is not used directly by Maven during builds, it is increasingly leveraged by tools like *Dependabot* to:

* Associate the Maven artifact with its GitHub repository
* Automatically include release notes, changelogs, and commit history in pull requests for new versions

By using the GitHub URL, we improve the quality and completeness of metadata shown in automated upgrade PRs and make it easier for users to trace changes between releases.
