### PR TITLE
[javadoc] Fix typo in Javadoc of Strings instances

### DIFF
--- a/src/main/java/org/apache/commons/lang3/Strings.java
+++ b/src/main/java/org/apache/commons/lang3/Strings.java
@@ -268,7 +268,7 @@ public abstract class Strings {
     public static final Strings CI = new CiStrings(true);
 
     /**
-     * The <strong>C</strong>ase-<strong>S</strong>nsensitive singleton instance.
+     * The <strong>C</strong>ase-<strong>S</strong>ensitive singleton instance.
      */
     public static final Strings CS = new CsStrings(true);
 


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    https://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
-->

Hi everybody,

I found and fixed a small (if fun) typo in the Javadoc of Strings.java - if it's intentional to have it, feel free to ignore this PR