### PR TITLE
[LANG-927] Add method convert a iterator to array in ArrayUtils

### DIFF
--- a/src/main/java/org/apache/commons/lang3/ArrayUtils.java
+++ b/src/main/java/org/apache/commons/lang3/ArrayUtils.java
@@ -21,11 +21,14 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.security.SecureRandom;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.BitSet;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Random;
@@ -8860,6 +8863,63 @@ public class ArrayUtils {
      */
     public static <T> T[] toArray(@SuppressWarnings("unchecked") final T... items) {
         return items;
+    }
+
+    /**
+     * Converts an {@link Iterator} into an array.
+     * <p>
+     * Returns {@code null} if the input iterator is {@code null}.
+     * If the iterator has no elements, an empty {@code Object[]} is returned.
+     * </p>
+     * <p>
+     * Note: The returned array has runtime type {@code Object[]}, and requires that all elements
+     * in the iterator are of the same type. If a type-safe array is needed, use
+     * {@link #iteratorToArray(Iterator, Class)} instead.
+     * </p>
+     *
+     * @param iterator the iterator to convert, may be {@code null}
+     * @param <T> the element type
+     * @return the array containing elements from the iterator,
+     *         or {@code null} if the input is {@code null}
+     * @since 3.18
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> T[] iteratorToArray(Iterator<T> iterator) {
+        if (iterator == null) {
+            return null;
+        }
+
+        if (!iterator.hasNext()) {
+            return (T[]) ArrayUtils.EMPTY_OBJECT_ARRAY;
+        }
+
+        return (T[]) Streams.of(iterator).toArray();
+    }
+
+    /**
+     * Converts an {@link Iterator} into a typed array.
+     * <p>
+     * Returns {@code null} if the input iterator or class is {@code null}.
+     * If the iterator has no elements, an empty array of the specified type is returned.
+     * </p>
+     *
+     * @param iterator the iterator to convert, may be {@code null}
+     * @param clazz    the class of the array component type, must not be {@code null}
+     * @param <T>      the element type
+     * @return the array containing elements from the iterator, or {@code null} if the input is {@code null}
+     * @since 3.18
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> T[] iteratorToArray(Iterator<T> iterator, Class<T> clazz) {
+        if (iterator == null || clazz == null) {
+            return null;
+        }
+
+        List<T> list = new ArrayList<>();
+        iterator.forEachRemaining(list::add);
+
+        T[] array = (T[]) Array.newInstance(clazz, list.size());
+        return list.toArray(array);
     }
 
     /**

--- a/src/main/java/org/apache/commons/lang3/ArrayUtils.java
+++ b/src/main/java/org/apache/commons/lang3/ArrayUtils.java
@@ -8915,10 +8915,10 @@ public class ArrayUtils {
             return null;
         }
 
-        List<T> list = new ArrayList<>();
+        final List<T> list = new ArrayList<>();
         iterator.forEachRemaining(list::add);
 
-        T[] array = (T[]) Array.newInstance(clazz, list.size());
+        final T[] array = (T[]) Array.newInstance(clazz, list.size());
         return list.toArray(array);
     }
 

--- a/src/test/java/org/apache/commons/lang3/ArrayUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/ArrayUtilsTest.java
@@ -6454,50 +6454,50 @@ class ArrayUtilsTest extends AbstractLangTest {
     }
 
     @Test
-    void testIteratorToArray(){
-        Iterator<String> iterator = Arrays.asList("one", "two", "three").iterator();
-        Object[] normalResult = ArrayUtils.iteratorToArray(iterator);
+    void testIteratorToArray() {
+        final Iterator<String> iterator = Arrays.asList("one", "two", "three").iterator();
+        final Object[] normalResult = ArrayUtils.iteratorToArray(iterator);
 
         assertArrayEquals(new Object[]{"one", "two", "three"}, normalResult);
 
-        Iterator<Object> emptyIterator = Collections.emptyIterator();
-        Object[] emptyArray = ArrayUtils.iteratorToArray(emptyIterator);
+        final Iterator<Object> emptyIterator = Collections.emptyIterator();
+        final Object[] emptyArray = ArrayUtils.iteratorToArray(emptyIterator);
 
         assertEquals(0, emptyArray.length);
         assertNull(ArrayUtils.iteratorToArray(null));
 
-        Iterator<Integer> singletonIterator = Collections.singletonList(42).iterator();
-        Object[] result = ArrayUtils.iteratorToArray(singletonIterator);
+        final Iterator<Integer> singletonIterator = Collections.singletonList(42).iterator();
+        final Object[] result = ArrayUtils.iteratorToArray(singletonIterator);
 
         assertEquals(1, result.length);
         assertEquals(42, result[0]);
 
-        Iterator<?> mixed = Arrays.asList(1, "two", 3.0).iterator();
-        Object[] mixedResult = ArrayUtils.iteratorToArray(mixed);
+        final Iterator<?> mixed = Arrays.asList(1, "two", 3.0).iterator();
+        final Object[] mixedResult = ArrayUtils.iteratorToArray(mixed);
 
         assertArrayEquals(new Object[]{1, "two", 3.0}, mixedResult);
     }
 
     @Test
-    void testIteratorToArrayWithClazz(){
-        Iterator<String> it1 = Arrays.asList("a", "b", "c").iterator();
-        String[] result1 = ArrayUtils.iteratorToArray(it1, String.class);
+    void testIteratorToArrayWithClazz() {
+        final Iterator<String> it1 = Arrays.asList("a", "b", "c").iterator();
+        final String[] result1 = ArrayUtils.iteratorToArray(it1, String.class);
         assertArrayEquals(new String[] {"a", "b", "c"}, result1);
 
-        Iterator<Integer> it2 = Collections.<Integer>emptyList().iterator();
-        Integer[] result2 = ArrayUtils.iteratorToArray(it2, Integer.class);
+        final Iterator<Integer> it2 = Collections.<Integer>emptyList().iterator();
+        final Integer[] result2 = ArrayUtils.iteratorToArray(it2, Integer.class);
         assertNotNull(result2);
         assertEquals(0, result2.length);
 
-        String[] result3 = ArrayUtils.iteratorToArray(null, String.class);
+        final String[] result3 = ArrayUtils.iteratorToArray(null, String.class);
         assertNull(result3);
 
-        Iterator<Double> it4 = Arrays.asList(1.1, 2.2).iterator();
-        Double[] result4 = ArrayUtils.iteratorToArray(it4, null);
+        final Iterator<Double> it4 = Arrays.asList(1.1, 2.2).iterator();
+        final Double[] result4 = ArrayUtils.iteratorToArray(it4, null);
         assertNull(result4);
 
-        Iterator<String> it5 = Arrays.asList("x", null, "z").iterator();
-        String[] result5 = ArrayUtils.iteratorToArray(it5, String.class);
+        final Iterator<String> it5 = Arrays.asList("x", null, "z").iterator();
+        final String[] result5 = ArrayUtils.iteratorToArray(it5, String.class);
         assertArrayEquals(new String[] {"x", null, "z"}, result5);
     }
 

--- a/src/test/java/org/apache/commons/lang3/ArrayUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/ArrayUtilsTest.java
@@ -40,6 +40,7 @@ import java.util.BitSet;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Random;
 import java.util.function.Function;
@@ -6451,6 +6452,55 @@ class ArrayUtilsTest extends AbstractLangTest {
         assertEquals(testSet, ArrayUtils.indexesOf(array, 3));
         assertEquals(emptySet, ArrayUtils.indexesOf(array, 99));
     }
+
+    @Test
+    void testIteratorToArray(){
+        Iterator<String> iterator = Arrays.asList("one", "two", "three").iterator();
+        Object[] normalResult = ArrayUtils.iteratorToArray(iterator);
+
+        assertArrayEquals(new Object[]{"one", "two", "three"}, normalResult);
+
+        Iterator<Object> emptyIterator = Collections.emptyIterator();
+        Object[] emptyArray = ArrayUtils.iteratorToArray(emptyIterator);
+
+        assertEquals(0, emptyArray.length);
+        assertNull(ArrayUtils.iteratorToArray(null));
+
+        Iterator<Integer> singletonIterator = Collections.singletonList(42).iterator();
+        Object[] result = ArrayUtils.iteratorToArray(singletonIterator);
+
+        assertEquals(1, result.length);
+        assertEquals(42, result[0]);
+
+        Iterator<?> mixed = Arrays.asList(1, "two", 3.0).iterator();
+        Object[] mixedResult = ArrayUtils.iteratorToArray(mixed);
+
+        assertArrayEquals(new Object[]{1, "two", 3.0}, mixedResult);
+    }
+
+    @Test
+    void testIteratorToArrayWithClazz(){
+        Iterator<String> it1 = Arrays.asList("a", "b", "c").iterator();
+        String[] result1 = ArrayUtils.iteratorToArray(it1, String.class);
+        assertArrayEquals(new String[] {"a", "b", "c"}, result1);
+
+        Iterator<Integer> it2 = Collections.<Integer>emptyList().iterator();
+        Integer[] result2 = ArrayUtils.iteratorToArray(it2, Integer.class);
+        assertNotNull(result2);
+        assertEquals(0, result2.length);
+
+        String[] result3 = ArrayUtils.iteratorToArray(null, String.class);
+        assertNull(result3);
+
+        Iterator<Double> it4 = Arrays.asList(1.1, 2.2).iterator();
+        Double[] result4 = ArrayUtils.iteratorToArray(it4, null);
+        assertNull(result4);
+
+        Iterator<String> it5 = Arrays.asList("x", null, "z").iterator();
+        String[] result5 = ArrayUtils.iteratorToArray(it5, String.class);
+        assertArrayEquals(new String[] {"x", null, "z"}, result5);
+    }
+
 
     @Test
     void testToMap() {


### PR DESCRIPTION
This PR fixes issue LANG-927 which ask to "Create Iterable APIs"

✅ Improvement:
Create Iterable APIs, add two methods in `ArrayUtils`.

- `T[] iteratorToArray(Iterator<T> iterator)`
-  `T[] iteratorToArray(Iterator<T> iterator, Class<T> clazz)`

✅ Tests:

Added two test methods in `ArrayUtilsTest` and All other tests pass

- `testIteratorToArrayWithClazz`
- `testIteratorToArray`
