### PR TITLE
Fix NPE in ArrayUtils.toStringArray() when array contains nulls

### DIFF
--- a/src/main/java/org/apache/commons/lang3/ArrayUtils.java
+++ b/src/main/java/org/apache/commons/lang3/ArrayUtils.java
@@ -9562,6 +9562,18 @@ public class ArrayUtils {
         return map(array, String.class, e -> Objects.toString(e, valueForNullElements));
     }
 
+    public static String[] toStringArray(final Object[] array) {
+    if (array == null) {
+        return null;
+    }
+    final String[] result = new String[array.length];
+    for (int i = 0; i < array.length; i++) {
+        result[i] = (array[i] == null) ? "null" : array[i].toString();
+    }
+    return result;
+}
+
+
     /**
      * ArrayUtils instances should NOT be constructed in standard programming.
      * Instead, the class should be used as {@code ArrayUtils.clone(new int[] {2})}.

--- a/src/test/java/org/apache/commons/lang3/ArrayUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/ArrayUtilsTest.java
@@ -91,6 +91,14 @@ class ArrayUtilsTest extends AbstractLangTest {
     }
 
     @Test
+public void testToStringArrayHandlesNullElements() {
+    Object[] input = { "apple", null, 42 };
+    String[] result = ArrayUtils.toStringArray(input);
+
+    assertArrayEquals(new String[] { "apple", "null", "42" }, result);
+}
+
+    @Test
     void testArraycopySupplier() {
         final String[] arr = { "a", "b" };
         assertNullPointerException(() -> ArrayUtils.arraycopy(null, 0, 0, 1, () -> new String[3]));


### PR DESCRIPTION
This fixes an issue in ArrayUtils.toStringArray(Object[]) where passing null elements causes a NullPointerException.
The method now returns "null" for null elements, similar to how String.valueOf() behaves.