### PR TITLE
[LANG-1597][LANG-1782] Fix getMatchingAccessibleMethod when no varargs are supplied and when the supplied varargs don't match the exact class

### DIFF
--- a/src/main/java/org/apache/commons/lang3/math/NumberUtils.java
+++ b/src/main/java/org/apache/commons/lang3/math/NumberUtils.java
@@ -152,6 +152,130 @@ public class NumberUtils {
     }
 
     /**
+     * Converts a given {@link Number} to the specified target number type, if and
+     * only if the conversion is not a narrowing conversion. Narrowing conversions
+     * (e.g., from
+     * {@link Long} to {@link Integer}) will result in an
+     * {@link IllegalArgumentException}.
+     * <p>
+     * Widening conversions are allowed in accordance with the following numeric
+     * rank:
+     *
+     * <pre>
+     * Byte &lt; Short &lt; Integer &lt; Long &lt; Float &lt; Double
+     * </pre>
+     *
+     * For example:
+     * <ul>
+     * <li>{@code Integer -> Long} is allowed</li>
+     * <li>{@code Long -> Double} is allowed</li>
+     * <li>{@code Long -> Integer} is not allowed (narrowing)</li>
+     * </ul>
+     *
+     * @param number     the source {@link Number} to convert; must not be
+     *                   {@code null}
+     * @param targetType the target number type; must not be {@code null} and must
+     *                   be one of:
+     *                   {@link Byte}, {@link Short}, {@link Integer}, {@link Long},
+     *                   {@link Float}, or {@link Double}
+     * @param <T>        the target number type parameter
+     * @return the converted value as an instance of {@code targetType}
+     * @throws IllegalArgumentException if:
+     *                                  <ul>
+     *                                  <li>{@code number} is {@code null}</li>
+     *                                  <li>{@code targetType} is {@code null}</li>
+     *                                  <li>{@code targetType} is not supported</li>
+     *                                  <li>the conversion would narrow the
+     *                                  value</li>
+     *                                  </ul>
+     */
+    public static <T extends Number> T convertIfNotNarrowing(Number number, Class<T> targetType) {
+        if (number == null || targetType == null) {
+            throw new IllegalArgumentException("Number and targetType must not be null.");
+        }
+
+        final Class<? extends Number> sourceType = number.getClass();
+
+        // Check the widening rank
+        final int sourceRank = getRank(sourceType);
+        final int targetRank = getRank(targetType);
+
+        if (sourceRank < 0 || targetRank < 0) {
+            throw new IllegalArgumentException("Unsupported number type: " + sourceType + " or " + targetType);
+        }
+
+        if (targetRank < sourceRank) {
+            throw new IllegalArgumentException(
+                    "Narrowing conversion from " + sourceType.getSimpleName() + " to " + targetType.getSimpleName()
+                            + " is not allowed.");
+        }
+
+        // Perform conversion
+        if (targetType == Byte.class) {
+            return targetType.cast(number.byteValue());
+        }
+        if (targetType == Short.class) {
+            return targetType.cast(number.shortValue());
+        }
+        if (targetType == Integer.class) {
+            return targetType.cast(number.intValue());
+        }
+        if (targetType == Long.class) {
+            return targetType.cast(number.longValue());
+        }
+        if (targetType == Float.class) {
+            return targetType.cast(number.floatValue());
+        }
+        if (targetType == Double.class) {
+            return targetType.cast(number.doubleValue());
+        }
+
+        throw new IllegalArgumentException("Unsupported target number type: " + targetType);
+    }
+
+    /**
+     * Returns a numeric rank for the specified number type to determine
+     * its position in the widening conversion hierarchy.
+     * <p>
+     * The ranks are defined as:
+     * <pre>
+     * Byte    = 1
+     * Short   = 2
+     * Integer = 3
+     * Long    = 4
+     * Float   = 5
+     * Double  = 6
+     * </pre>
+     * These ranks are used to determine whether a conversion is widening
+     * (allowed) or narrowing (disallowed) such as in the
+     * {@link #convertIfNotNarrowing(Number, Class)} method.
+     *
+     * @param type the number type class; must not be {@code null}
+     * @return the numeric rank of the type, or {@code -1} if the type is unsupported
+     */
+    private static <T extends Number> int getRank(Class<T> type) {
+        if (type == Byte.class) {
+            return 1;
+        }
+        if (type == Short.class) {
+            return 2;
+        }
+        if (type == Integer.class) {
+            return 3;
+        }
+        if (type == Long.class) {
+            return 4;
+        }
+        if (type == Float.class) {
+            return 5;
+        }
+        if (type == Double.class) {
+            return 6;
+        }
+        return -1;
+    }
+
+    /**
      * Creates a {@link BigDecimal} from a {@link String}.
      *
      * <p>Returns {@code null} if the string is {@code null}.</p>

--- a/src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java
@@ -1897,4 +1897,34 @@ class NumberUtilsTest extends AbstractLangTest {
         assertEquals(5, NumberUtils.toShort("", (short) 5));
         assertEquals(5, NumberUtils.toShort(null, (short) 5));
     }
+
+    /**
+     * Test for {@link NumberUtils#convertIfNotNarrowing}.
+     */
+    @Test
+    void testConvertIfNotNarrowing() {
+        assertEquals(42L, NumberUtils.convertIfNotNarrowing((Integer) 42, Long.class));
+        assertEquals(42.0, NumberUtils.convertIfNotNarrowing((Long) 42L, Double.class));
+        assertEquals(100, NumberUtils.convertIfNotNarrowing((Integer) 100, Integer.class));
+
+        final IllegalArgumentException exNarrowing = assertThrows(IllegalArgumentException.class,
+                () -> NumberUtils.convertIfNotNarrowing((Long) 100L, Integer.class));
+        assertTrue(exNarrowing.getMessage().contains("Narrowing conversion"));
+
+        final IllegalArgumentException exNumberNull = assertThrows(IllegalArgumentException.class,
+                () -> NumberUtils.convertIfNotNarrowing(null, Integer.class));
+        assertTrue(exNumberNull.getMessage().contains("must not be null"));
+
+        final IllegalArgumentException exTargetTypeNull = assertThrows(IllegalArgumentException.class,
+                () -> NumberUtils.convertIfNotNarrowing(42, null));
+        assertTrue(exTargetTypeNull.getMessage().contains("must not be null"));
+
+        final IllegalArgumentException exUnsupportedFromBigInteger = assertThrows(IllegalArgumentException.class,
+                () -> NumberUtils.convertIfNotNarrowing(new java.math.BigInteger("42"), Double.class));
+        assertTrue(exUnsupportedFromBigInteger.getMessage().contains("Unsupported number type"));
+
+        final IllegalArgumentException exUnsupportedToBigInteger = assertThrows(IllegalArgumentException.class,
+                () -> NumberUtils.convertIfNotNarrowing(42, java.math.BigInteger.class));
+        assertTrue(exUnsupportedToBigInteger.getMessage().contains("Unsupported number type"));
+    }
 }

--- a/src/test/java/org/apache/commons/lang3/reflect/MethodUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/reflect/MethodUtilsTest.java
@@ -72,6 +72,16 @@ class MethodUtilsTest extends AbstractLangTest {
         @Override
         public void testMethod6() { }
     }
+
+    interface VarArgInterface {
+    }
+
+    public static class VarArgInterfaceImpl1 implements VarArgInterface {
+    }
+
+    public static class VarArgInterfaceImpl2 implements VarArgInterface {
+    }
+
     interface ChildInterface {
     }
 
@@ -287,6 +297,14 @@ class MethodUtilsTest extends AbstractLangTest {
 
         public static String varOverload(final String... args) {
             return "String...";
+        }
+
+        public static String varargsWithOtherArg(final int firstArg, final String... args) {
+            return "int, String...";
+        }
+
+        public static String varargsInterface(final VarArgInterface... args) {
+            return "VarArgInterface...";
         }
 
         public static ImmutablePair<String, Object[]> varOverloadEchoStatic(final Number... args) {
@@ -995,6 +1013,16 @@ class MethodUtilsTest extends AbstractLangTest {
     }
 
     @Test
+    void testInvokeJavaVarargsResolution() throws Exception {
+        assertEquals("int, String...", MethodUtils.invokeStaticMethod(TestBean.class, "varargsWithOtherArg", 1));
+        assertEquals("int, String...", MethodUtils.invokeStaticMethod(TestBean.class, "varargsWithOtherArg", 1, "s"));
+        assertEquals("int, String...", MethodUtils.invokeStaticMethod(TestBean.class, "varargsWithOtherArg", 1, "s1", "s2"));
+        assertThrows(NoSuchMethodException.class, () -> MethodUtils.invokeStaticMethod(TestBean.class, "varargsWithOtherArg", 1, "s1", 5));
+        assertEquals("VarArgInterface...", MethodUtils.invokeStaticMethod(TestBean.class, "varargsInterface",
+            new VarArgInterfaceImpl1(), new VarArgInterfaceImpl2()));
+    }
+
+    @Test
     void testInvokeMethod() throws Exception {
         assertEquals("foo()", MethodUtils.invokeMethod(testBean, "foo", (Object[]) ArrayUtils.EMPTY_CLASS_ARRAY));
         assertEquals("foo()", MethodUtils.invokeMethod(testBean, "foo"));
@@ -1011,7 +1039,7 @@ class MethodUtilsTest extends AbstractLangTest {
         assertEquals("foo(String...)", MethodUtils.invokeMethod(testBean, "foo", "a", "b", "c"));
         assertEquals("foo(int, String...)", MethodUtils.invokeMethod(testBean, "foo", 5, "a", "b", "c"));
         assertEquals("foo(long...)", MethodUtils.invokeMethod(testBean, "foo", 1L, 2L));
-        assertThrows(NoSuchMethodException.class, () -> MethodUtils.invokeMethod(testBean, "foo", 1, 2));
+        assertEquals("foo(long...)", MethodUtils.invokeMethod(testBean, "foo", 1, 2));
         TestBean.verify(new ImmutablePair<>("String...", new String[] { "x", "y" }), MethodUtils.invokeMethod(testBean, "varOverloadEcho", "x", "y"));
         TestBean.verify(new ImmutablePair<>("Number...", new Number[] { 17, 23, 42 }), MethodUtils.invokeMethod(testBean, "varOverloadEcho", 17, 23, 42));
         TestBean.verify(new ImmutablePair<>("String...", new String[] { "x", "y" }), MethodUtils.invokeMethod(testBean, "varOverloadEcho", "x", "y"));
@@ -1129,5 +1157,9 @@ class MethodUtilsTest extends AbstractLangTest {
         assertEquals("Number...", TestBean.varOverload((short) 1, (byte) 1));
         assertEquals("Object...", TestBean.varOverload(1, 'c'));
         assertEquals("Object...", TestBean.varOverload('c', "s"));
+        assertEquals("VarArgInterface...", TestBean.varargsInterface(
+            new VarArgInterfaceImpl1(),
+            new VarArgInterfaceImpl2()
+        ));
     }
 }


### PR DESCRIPTION
Fixes [LANG-1597](https://issues.apache.org/jira/browse/LANG-1597) and [LANG-1782](https://issues.apache.org/jira/browse/LANG-1782)

The current implementation discarded methods which could be potential matches because the matching was way to strict. This change loosens the check to allow any assignable values. The change also checks all variable arguments instead of just the last argument.

To facilitate various number types and conversion
NumberUtils.convertIfNotNarrowing was also introduced. This allows integers to be passed to methods which take Long... varargs

