### PR TITLE
Clean up pom.xml formatting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,8 +173,8 @@
   </properties>
 
   <build>
-   <defaultGoal>clean verify apache-rat:check checkstyle:check japicmp:cmp spotbugs:check pmd:check javadoc:javadoc</defaultGoal>
-   <pluginManagement>
+    <defaultGoal>clean verify apache-rat:check checkstyle:check japicmp:cmp spotbugs:check pmd:check javadoc:javadoc</defaultGoal>
+    <pluginManagement>
       <plugins>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -476,10 +476,10 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
               <excludes>
-                <exclude>org/apache/commons/lang3/time/Java15BugFastDateParserTest.java</exclude>               
+                <exclude>org/apache/commons/lang3/time/Java15BugFastDateParserTest.java</exclude>
               </excludes>
             </configuration>
-          </plugin>        
+          </plugin>
         </plugins>
       </build>
     </profile>


### PR DESCRIPTION
fix indentation and remove unnecessary whitespace

This pull request improves the formatting of `pom.xml` by fixing inconsistent indentation and removing unnecessary whitespace.  
No functional changes were made.  
This helps maintain clarity and consistency for contributors working with the build configuration.