### PR TITLE
[LANG-1774] Improve handling of ClassUtils.getShortCanonicalName for invalid input data

### DIFF
--- a/src/main/java/org/apache/commons/lang3/ClassUtils.java
+++ b/src/main/java/org/apache/commons/lang3/ClassUtils.java
@@ -504,7 +504,7 @@ public class ClassUtils {
             }
             className = className.substring(1, className.length() - 1);
         } else if (className.length() == 1) {
-            String primitive = REVERSE_ABBREVIATION_MAP.get(className.substring(0, 1));
+            final String primitive = REVERSE_ABBREVIATION_MAP.get(className.substring(0, 1));
             if (primitive == null) {
                 throw new IllegalArgumentException(String.format("Invalid class name %s", name));
             }

--- a/src/main/java/org/apache/commons/lang3/ClassUtils.java
+++ b/src/main/java/org/apache/commons/lang3/ClassUtils.java
@@ -476,6 +476,7 @@ public class ClassUtils {
      *
      * @param name the name of class.
      * @return canonical form of class name.
+     * @throws IllegalArgumentException if the class name is invalid
      */
     private static String getCanonicalName(final String name) {
         String className = StringUtils.deleteWhitespace(name);
@@ -483,20 +484,33 @@ public class ClassUtils {
             return null;
         }
         int dim = 0;
-        while (className.charAt(dim) == '[') {
+        final int len = className.length();
+        while (dim < len && className.charAt(dim) == '[') {
             dim++;
             if (dim > MAX_DIMENSIONS) {
                 throw new IllegalArgumentException(String.format("Maximum array dimension %d exceeded", MAX_DIMENSIONS));
             }
+        }
+        if (dim >= len) {
+            throw new IllegalArgumentException(String.format("Invalid class name %s", name));
         }
         if (dim < 1) {
             return className;
         }
         className = className.substring(dim);
         if (className.startsWith("L")) {
-            className = className.substring(1, className.endsWith(";") ? className.length() - 1 : className.length());
-        } else if (!className.isEmpty()) {
-            className = REVERSE_ABBREVIATION_MAP.get(className.substring(0, 1));
+            if (!className.endsWith(";") || className.length() < 3) {
+                throw new IllegalArgumentException(String.format("Invalid class name %s", name));
+            }
+            className = className.substring(1, className.length() - 1);
+        } else if (className.length() == 1) {
+            String primitive = REVERSE_ABBREVIATION_MAP.get(className.substring(0, 1));
+            if (primitive == null) {
+                throw new IllegalArgumentException(String.format("Invalid class name %s", name));
+            }
+            className = primitive;
+        } else {
+            throw new IllegalArgumentException(String.format("Invalid class name %s", name));
         }
         final StringBuilder canonicalClassNameBuffer = new StringBuilder(className.length() + dim * 2);
         canonicalClassNameBuffer.append(className);

--- a/src/test/java/org/apache/commons/lang3/ClassUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/ClassUtilsTest.java
@@ -585,15 +585,19 @@ class ClassUtilsTest extends AbstractLangTest {
         assertEquals("String[]", ClassUtils.getShortCanonicalName(String[].class.getName()));
         assertEquals("String[]", ClassUtils.getShortCanonicalName(String[].class.getCanonicalName()));
         assertEquals("String[]", ClassUtils.getShortCanonicalName("String[]"));
-        // Note that we throw RuntimeException (but not which one) for the following bad inputs:
-        assertThrows(RuntimeException.class, () -> ClassUtils.getShortCanonicalName(""));
-        assertThrows(RuntimeException.class, () -> ClassUtils.getShortCanonicalName("["));
-        assertThrows(RuntimeException.class, () -> ClassUtils.getShortCanonicalName("[]"));
-        assertThrows(RuntimeException.class, () -> ClassUtils.getShortCanonicalName("[;"));
-        assertThrows(RuntimeException.class, () -> ClassUtils.getShortCanonicalName("[];"));
-        assertThrows(RuntimeException.class, () -> ClassUtils.getShortCanonicalName(" "));
-        assertThrows(RuntimeException.class, () -> ClassUtils.getShortCanonicalName("[$"));
-        assertThrows(RuntimeException.class, () -> ClassUtils.getShortCanonicalName("[$a"));
+        // Note that we throw IllegalArgumentException for the following bad inputs:
+        assertThrows(IllegalArgumentException.class, () -> ClassUtils.getShortCanonicalName(""));
+        assertThrows(IllegalArgumentException.class, () -> ClassUtils.getShortCanonicalName("["));
+        assertThrows(IllegalArgumentException.class, () -> ClassUtils.getShortCanonicalName("[]"));
+        assertThrows(IllegalArgumentException.class, () -> ClassUtils.getShortCanonicalName("[;"));
+        assertThrows(IllegalArgumentException.class, () -> ClassUtils.getShortCanonicalName("[];"));
+        assertThrows(IllegalArgumentException.class, () -> ClassUtils.getShortCanonicalName(" "));
+        assertThrows(IllegalArgumentException.class, () -> ClassUtils.getShortCanonicalName("[$"));
+        assertThrows(IllegalArgumentException.class, () -> ClassUtils.getShortCanonicalName("[$a"));
+        assertThrows(IllegalArgumentException.class, () -> ClassUtils.getShortCanonicalName("[["));
+        assertThrows(IllegalArgumentException.class, () -> ClassUtils.getShortCanonicalName("[[L"));
+        assertThrows(IllegalArgumentException.class, () -> ClassUtils.getShortCanonicalName("[org.apache.commons.lang3.ClassUtilsTest"));
+        assertThrows(IllegalArgumentException.class, () -> ClassUtils.getShortCanonicalName("[Lorg.apache.commons.lang3.ClassUtilsTest"));
     }
 
     @Test


### PR DESCRIPTION
This PR improves handling of invalid class name inputs to `ClassUtils.getShortCanonicalName(String name)`

- Added checks for the invalid class names, and replaced `RuntimeException `with descriptive `IllegalArgumentException`.
- Added tests for invalid input scenarios and confirmed all existing and new test cases pass with `mvn`.