### PR TITLE
Remove extra whitespace in string comparison logic

### DIFF
--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -859,7 +859,7 @@ public class StringUtils {
             return nullIsLess ? -1 : 1;
         }
         if (str2 == null) {
-            return nullIsLess ? 1 : - 1;
+            return nullIsLess ? 1 : -1;
         }
         return str1.compareTo(str2);
     }


### PR DESCRIPTION
Removed the extra space in - 1 when handling null str2, changing it to -1 for consistent syntax.