### PR TITLE
[LANG-1769] Support lenient mode in FastDateFormat and FastDateParser like SimpleDateFormat

### DIFF
--- a/src/main/java/org/apache/commons/lang3/time/FastDateFormat.java
+++ b/src/main/java/org/apache/commons/lang3/time/FastDateFormat.java
@@ -103,6 +103,13 @@ public class FastDateFormat extends Format implements DateParser, DatePrinter {
 
     private static final AbstractFormatCache<FastDateFormat> CACHE = new AbstractFormatCache<FastDateFormat>() {
         @Override
+        public FastDateFormat getInstance(String pattern, TimeZone timeZone, Locale locale) {
+            final FastDateFormat instance = super.getInstance(pattern, timeZone, locale);
+            instance.reset();
+            return instance;
+        }
+
+        @Override
         protected FastDateFormat createInstance(final String pattern, final TimeZone timeZone, final Locale locale) {
             return new FastDateFormat(pattern, timeZone, locale);
         }
@@ -664,6 +671,33 @@ public class FastDateFormat extends Format implements DateParser, DatePrinter {
     @Override
     public Object parseObject(final String source, final ParsePosition pos) {
         return parser.parseObject(source, pos);
+    }
+
+    /**
+     * Tell whether date/time parsing is to be lenient.
+     * @return {@code true} if the {@link #parser} is lenient;
+     *         {@code false} otherwise.
+     */
+    public boolean isLenient() {
+        return parser.isLenient();
+    }
+
+    /**
+     * Support lenient mode, same like {@link java.text.SimpleDateFormat}.
+     * Modifies the lenient mode of the {@link #parser}.
+     * @param lenient <code>true</code> if the lenient mode is
+     * to be turned on; <code>false</code> if it is to be turned off.
+     */
+    public void setLenient(boolean lenient) {
+        parser.setLenient(lenient);
+    }
+
+    /**
+     * Reset the current state of the cached instance.
+     * Resetting the lenient mode of the {@link #parser}.
+     */
+    private void reset() {
+        parser.reset();
     }
 
     /**


### PR DESCRIPTION
This PR extended `FastDateFormat` to support a strict (lenient) mode, following the same pattern as `SimpleDateFormat`: 
Thanks @ppkarwasz  for the direction. 

- Added methods: `isLenient`, `setLenient` and `reset`. 
- Throws an exception for invalid input data and lenient is false. 
- Added tests for new scenarios and confirmed all existing and new test cases pass with `mvn`. 

`reset()` method resets the object's state because the instance is cached and reused. 

There is support for serialization and deserialization of the `FastDateParser`. 
However, retaining the lenient value after serialization is not added. It currently resets to the default value. 
This helps avoid unintentional exceptions when lenient is set to false. Users can explicitly set the value if needed.