### PR TITLE
Add ObjectUtils.ifNotNull helper method

### DIFF
--- a/src/main/java/org/apache/commons/lang3/ObjectUtils.java
+++ b/src/main/java/org/apache/commons/lang3/ObjectUtils.java
@@ -30,6 +30,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.TreeSet;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
@@ -213,6 +215,67 @@ public class ObjectUtils {
      */
     public static boolean anyNull(final Object... values) {
         return !allNotNull(values);
+    }
+
+
+    /**
+     * Invokes the consumer on the given object if it is not {@code null}.
+     * <p>This method is intended as a replacement to common antipatterns, such as
+     * <ul>
+     *   <li>accessing a getter twice, just for the sake of null-checking
+     *   <pre>{@code
+     *     if (obj.getProperty() != null) {
+     *       consume(obj.getProperty());
+     *     }
+     *   }</pre>
+     *   </li>
+     *   <li>creating useless {@link Optional}s
+     *   <pre>{@code
+     *     Optional.ofNullable(obj.getProperty())
+     *       .ifPresent(c -> consume(c));
+     *   }</pre>
+     *   </li>
+     * </ul>
+     * </p>
+     * <pre>
+     *   ObjectUtils.ifNotNull(obj.getProperty(), prop -> doSomethingWith(prop));
+     * </pre>
+     *
+     * @param maybeNull the object to possibly consume
+     * @param consumer the {@link Consumer} to invoke if the object is not {@code null}
+     * @param <T> the type of the object to consume
+     * @see #ifNotNull(Object, Object, BiConsumer)
+     * @throws RuntimeException if the {@link Consumer} does
+     */
+    public static <T> void ifNotNull(final T maybeNull, final Consumer<T> consumer) {
+        if (maybeNull != null) {
+            consumer.accept(maybeNull);
+        }
+    }
+
+    /**
+     * Invokes the consumer on the given object if it is not {@code null}, passing a possible context
+     * as an argument (for performance reasons), to avoid generating capturing lambdas that can
+     * pollute the heap and causes pressure on the garbage collector.
+     * <p>
+     * A common use case can be to consume the current instance:
+     * <pre>
+     *   ObjectUtils.ifNotNull(obj.getProperty(), this, (prop, ctx) -> prop.setContext(ctx));
+     * </pre>
+     * </p>
+     *
+     * @param maybeNull  the object to possibly consume
+     * @param context    a context, to be consumed together with the object, may be {@code null}
+     * @param biConsumer a {@link BiConsumer} that accepts the object and the context
+     * @param <T>        the type of the object to consume
+     * @param <CTX>      the type of the context to consume
+     * @see #ifNotNull(Object, Consumer)
+     * @throws RuntimeException if the {@link BiConsumer} does
+     */
+    public static <T, CTX> void ifNotNull(final T maybeNull, final CTX context, final BiConsumer<T, CTX> biConsumer) {
+        if (maybeNull != null) {
+            biConsumer.accept(maybeNull, context);
+        }
     }
 
     /**

--- a/src/test/java/org/apache/commons/lang3/ObjectUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/ObjectUtilsTest.java
@@ -50,6 +50,7 @@ import java.util.Set;
 import java.util.function.Supplier;
 
 import org.apache.commons.lang3.exception.CloneFailedException;
+import org.apache.commons.lang3.exception.CustomUncheckedException;
 import org.apache.commons.lang3.function.Suppliers;
 import org.apache.commons.lang3.mutable.MutableInt;
 import org.apache.commons.lang3.mutable.MutableObject;
@@ -207,6 +208,44 @@ class ObjectUtilsTest extends AbstractLangTest {
         assertFalse(ObjectUtils.anyNull());
         assertFalse(ObjectUtils.anyNull(FOO));
         assertFalse(ObjectUtils.anyNull(FOO, BAR, 1, Boolean.TRUE, new Object(), new Object[]{}));
+    }
+
+    /**
+     * Test {@link ObjectUtils#ifNotNull(Object, java.util.function.Consumer)}
+     */
+    @Test
+    void testIfNotNullConsumer() {
+        ObjectUtils.ifNotNull(null, unused -> fail());
+        ObjectUtils.ifNotNull(FOO, foo -> assertEquals(FOO, foo));
+
+        // check that the exception produced inside the consumer is rethrown
+        final CustomUncheckedException expectedException = new CustomUncheckedException("TEST exception Consumer");
+        final CustomUncheckedException thrown = assertThrows(CustomUncheckedException.class,
+            () -> ObjectUtils.ifNotNull(FOO, unused -> { throw expectedException; })
+        );
+
+        assertEquals(expectedException, thrown);
+    }
+
+    /**
+     * Test {@link ObjectUtils#ifNotNull(Object, Object, java.util.function.BiConsumer)}
+     */
+    @Test
+    void testIfNotNullBiConsumer() {
+        ObjectUtils.ifNotNull(null, BAR, (unusedObj, unusedCtx) -> fail());
+        ObjectUtils.ifNotNull(FOO, BAR, (foo, bar) -> {
+            assertEquals(FOO, foo);
+            assertEquals(BAR, bar);
+        });
+
+        // check that the exception produced inside the BiConsumer is rethrown
+        final CustomUncheckedException expectedException = new CustomUncheckedException("TEST exception BiConsumer");
+        final CustomUncheckedException thrown = assertThrows(CustomUncheckedException.class,
+            () -> ObjectUtils.ifNotNull(FOO, BAR, (unusedObj, unusedCtx) -> {
+                throw expectedException;
+            })
+        );
+        assertEquals(expectedException, thrown);
     }
 
     /**


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    https://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
-->

Thanks for your contribution to [Apache Commons](https://commons.apache.org/)! Your help is appreciated!

This PR introduces two new utility methods in `ObjectUtils` to reduce boilerplate 
when executing an action only if an object is not null.

### Rationale
- Currently, developers either write explicit null checks or use 
  `Optional.ofNullable(obj).ifPresent(...)`.
- `Optional` adds readability but creates an extra object which is unnecessary 
  for simple null-guarded operations.
- Usual null check is prone to the error of calling a getter method twice, (like `if (obj.getX() != null) consume(obj.getX())`), a pattern seen many times in a lot of projects, which is an error in many ways:
   - causes twice the access to the property
   - potentially doubles the side effects
   - can be a partial guard as it actually does not prevent the getter to return null in the second call
- A static utility method in `ObjectUtils` makes the intent clearer and avoids 
  extra allocations.

### Proposed API
```java
public static <T> void ifNotNull(T obj, Consumer<? super T> action) {
    if (obj != null) {
        action.accept(obj);
    }
}
```

The proposed API could then be used like `ifNotNull(obj.getX(), x -> consume(x))` preventing the creation of an unnecessary Optional and avoiding the possibility of accessing a property twice.

Also, to accomplish the task of not allocating extra objects, we need to take care of injecting some context as a parameter (to avoid capturing lambdas):

``` java
public static <T, C> void ifNotNull(T obj, C ctx, BiConsumer<? super T, ? super C> action) {
    if (obj != null) {
        action.accept(obj, ctx);
    }
}
```

So that it becomes possible to write `ifNotNull(obj.getX(), this, (x, ctx) -> XType::setContext)`

-----------------------------------------
Before you push a pull request, review this list:

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request.
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best-practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.