### PR TITLE
[LANG-1685] reflectionToString falls back to toString if reflective access is not permitted.

### DIFF
--- a/src/main/java/org/apache/commons/lang3/builder/ReflectionToStringBuilder.java
+++ b/src/main/java/org/apache/commons/lang3/builder/ReflectionToStringBuilder.java
@@ -849,6 +849,12 @@ public class ReflectionToStringBuilder extends ToStringBuilder {
         validate();
 
         Class<?> clazz = getObject().getClass();
+
+        if (!reflectiveAccess.isAllowed(clazz)) {
+          appendToString(getStyle().getContentStart() + getObject().toString() + getStyle().getContentEnd());
+          return super.toString();
+        }
+
         appendFieldsIn(clazz);
         while (clazz.getSuperclass() != null && clazz != getUpToClass()) {
             clazz = clazz.getSuperclass();
@@ -856,6 +862,8 @@ public class ReflectionToStringBuilder extends ToStringBuilder {
         }
         return super.toString();
     }
+
+    ReflectiveAccessUtil reflectiveAccess = new ReflectiveAccessUtil();
 
     /**
      * Validates that include and exclude names do not intersect.

--- a/src/main/java/org/apache/commons/lang3/builder/ReflectiveAccessUtil.java
+++ b/src/main/java/org/apache/commons/lang3/builder/ReflectiveAccessUtil.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.lang3.builder;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+/**
+ * Utility class to determine whether reflective access to a target module is permitted from the current module.
+ * This class assumes all reflective accesses are allowed in JVM where JPMS is not supported (i.e. JDK8 or earlier).
+ */
+class ReflectiveAccessUtil {
+
+    /**
+     * Determines whether {@code targetClass} is accessible via reflection from the module that defines this class.
+     * On JVMs that do not support the Java Platform Module System, the method always returns {@code true}.
+     * Otherwise, it checks whether the module that declares {@code targetClass} is open to the module containing
+     * this class at runtime.
+     *
+     * @param targetClass the {@link Class} object to inspect.
+     * @return {@code true} if {@code targetClass} can be reflected on from this module,
+     *         {@code false} otherwise.
+     */
+    boolean isAllowed(Class<?> targetClass) {
+        if (!isJpmsSupported()) {
+            return true;
+        }
+        if (targetClass.isArray()) {
+            return true;
+        }
+        try {
+            final Object targetModule = getModule.invoke(targetClass);
+            return (Boolean) isOpen.invoke(targetModule, targetClass.getPackage().getName(), selfModule);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Indicates whether the current JVM supports the Java Platform Module System (JPMS).
+     * @return {@code true} if JPMS is available.
+     */
+    boolean isJpmsSupported() {
+        return getModule != null;
+    }
+
+    // Cache the following methods and object in static fields to minimize performance impact.
+    private static final Method getModule = initializeGetModuleMethod();
+    private static final Object selfModule = initializeSelfModule();
+    private static final Method isOpen = initializeIsOpenMethod();
+
+    private static Method initializeGetModuleMethod() {
+        try {
+            return Class.class.getMethod("getModule");
+        } catch (NoSuchMethodException e) {
+            return null;
+        }
+    }
+
+    private static Object initializeSelfModule() {
+        if (getModule == null) {
+            return null;
+        }
+        try {
+            return getModule.invoke(ReflectiveAccessUtil.class);
+        } catch (InvocationTargetException | IllegalAccessException e) {
+            return null;
+        }
+    }
+
+    private static Method initializeIsOpenMethod() {
+        if (selfModule == null) {
+            return null;
+        }
+        try {
+            final Class<?> moduleClass = selfModule.getClass();
+            return moduleClass.getMethod("isOpen", String.class, moduleClass);
+        } catch (NoSuchMethodException e) {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
### Description
The `ToStringBuilder.reflectionToString()` implementation previously threw an exception when access to a field was prohibited by JPMS.  This patch adds defensive handling so that, when reflective access is not permitted, the method falls back to invoking the target object's native `toString()`.
Additionally, the change is implemented to work on JVMs that do not support JPMS (JDK 8).

----

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request.
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
