### PR TITLE
[LANG-1801] Fix RandomStringUtils.random() does not strictly validate start/end when chars != null, causing potential IndexOutOfBoundsException

### DIFF
--- a/src/main/java/org/apache/commons/lang3/RandomStringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/RandomStringUtils.java
@@ -278,6 +278,19 @@ public class RandomStringUtils {
                     "Parameter end (" + end + ") must be greater than start (" + start + ")");
         } else if (start < 0 || end < 0) {
             throw new IllegalArgumentException("Character positions MUST be >= 0");
+        }else if (chars != null && (start >= chars.length || end > chars.length)){
+            StringBuilder errorMsg = new StringBuilder();
+            int charsLength = chars.length;
+            if (start >= charsLength) {
+                errorMsg.append("Parameter start (").append(start).append(") must be less than chars array length ").append(charsLength);
+            }
+            if (end > charsLength) {
+                if (errorMsg.length() > 0) {
+                    errorMsg.append("; ");
+                }
+                errorMsg.append("Parameter end (").append(end).append(") must be less than or equal to chars array length ").append(charsLength);
+            }
+            throw new IllegalArgumentException(errorMsg.toString());
         }
 
         if (end > Character.MAX_CODE_POINT) {

--- a/src/main/java/org/apache/commons/lang3/RandomStringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/RandomStringUtils.java
@@ -278,9 +278,9 @@ public class RandomStringUtils {
                     "Parameter end (" + end + ") must be greater than start (" + start + ")");
         } else if (start < 0 || end < 0) {
             throw new IllegalArgumentException("Character positions MUST be >= 0");
-        }else if (chars != null && (start >= chars.length || end > chars.length)){
-            StringBuilder errorMsg = new StringBuilder();
-            int charsLength = chars.length;
+        } else if (chars != null && (start >= chars.length || end > chars.length)) {
+            final StringBuilder errorMsg = new StringBuilder();
+            final int charsLength = chars.length;
             if (start >= charsLength) {
                 errorMsg.append("Parameter start (").append(start).append(") must be less than chars array length ").append(charsLength);
             }

--- a/src/test/java/org/apache/commons/lang3/RandomStringUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/RandomStringUtilsTest.java
@@ -104,7 +104,8 @@ class RandomStringUtilsTest extends AbstractLangTest {
         assertIllegalArgumentException(() -> RandomStringUtils.random(8, 32, 48, false, true));
         assertIllegalArgumentException(() -> RandomStringUtils.random(8, 32, 65, true, false));
         assertIllegalArgumentException(() -> RandomStringUtils.random(1, Integer.MIN_VALUE, -10, false, false, null));
-        assertIllegalArgumentException(() -> RandomStringUtils.random(2, 5, 6, false, false, new char[] { 'a', 'b', 'c', 'd' }, new Random()));
+        assertIllegalArgumentException(() -> RandomStringUtils.random(2, 4, 5, false, false, new char[] { 'a', 'b', 'c', 'd' }, new Random()));
+        assertIllegalArgumentException(() -> RandomStringUtils.random(2, 1, 5, false, false, new char[] { 'a', 'b', 'c', 'd' }, new Random()));
     }
 
     @ParameterizedTest

--- a/src/test/java/org/apache/commons/lang3/RandomStringUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/RandomStringUtilsTest.java
@@ -104,6 +104,7 @@ class RandomStringUtilsTest extends AbstractLangTest {
         assertIllegalArgumentException(() -> RandomStringUtils.random(8, 32, 48, false, true));
         assertIllegalArgumentException(() -> RandomStringUtils.random(8, 32, 65, true, false));
         assertIllegalArgumentException(() -> RandomStringUtils.random(1, Integer.MIN_VALUE, -10, false, false, null));
+        assertIllegalArgumentException(() -> RandomStringUtils.random(2, 5, 6, false, false, new char[] { 'a', 'b', 'c', 'd' }, new Random()));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
```
# source code 
public static String random(int count, int start, int end, final boolean letters, final boolean numbers,
final char[] chars, final Random random) {
```
When a custom character array (chars != null) is supplied to RandomStringUtils.random(), the method does not strictly check that the start and end parameters fall within the valid bounds of the chars array.

As a result, if start or end exceeds chars.length, the method may generate a random index outside the array range, leading to an unexpected ArrayIndexOutOfBoundsException.

This fails the method contract and causes unpredictable runtime errors.


```
@Test
void testStartEndOutOfRangeWithChars() {
        char[] chars = {'a', 'b', 'c'};
        assertThrows(ArrayIndexOutOfBoundsException.class, () -> {
            RandomStringUtils.random(
                    5,
                    5,         // invalid: start > chars.length
                    10,             // invalid: end > chars.length
                    false,
                    false,
                    chars,
                    new Random()
            );
        });
}

```

Actual:
Throws ArrayIndexOutOfBoundsException

Expected:
Throw IllegalArgumentException indicating invalid start/end range when chars != null
[my issue](https://issues.apache.org/jira/browse/LANG-1801) @garydgregory 