### PR TITLE
LANG-1711: Skip inaccessible fields in ReflectionDiffBuilder

### DIFF
--- a/src/main/java/org/apache/commons/lang3/builder/ReflectionDiffBuilder.java
+++ b/src/main/java/org/apache/commons/lang3/builder/ReflectionDiffBuilder.java
@@ -204,11 +204,18 @@ public class ReflectionDiffBuilder<T> implements Builder<DiffResult<T>> {
         for (final Field field : FieldUtils.getAllFields(clazz)) {
             if (accept(field)) {
                 try {
-                    diffBuilder.append(field.getName(), readField(field, getLeft()), readField(field, getRight()));
-                } catch (final IllegalAccessException e) {
+                    final Object leftValue = readField(field,getLeft());
+                    final Object rightValue = readField(field,getRight());
+                    diffBuilder.append(field.getName(), leftValue, rightValue);
+                } catch (final IllegalAccessException | RuntimeException ex) {
                     // this can't happen. Would get a Security exception instead
                     // throw a runtime exception in case the impossible happens.
-                    throw new IllegalArgumentException("Unexpected IllegalAccessException: " + e.getMessage(), e);
+                    //throw new IllegalArgumentException("Unexpected IllegalAccessException: " + e.getMessage(), e);
+
+
+                    // Skip inaccessible fields (best-effort reflection)
+                    // IllegalAccessException: Java 8
+                    // RuntimeException: Java 9+ (InaccessibleObjectException)
                 }
             }
         }


### PR DESCRIPTION
This change makes ReflectionDiffBuilder skip fields that cannot be accessed via reflection
instead of failing fast with an exception.

Previously, if reflective access to a field was denied (for example due to Java 9+ module
restrictions or security constraints), the diff process would abort entirely. This prevented
producing a partial diff even when most fields were accessible.

The implementation is limited to appendFields(...), where reflection access failures are
caught and ignored. This covers IllegalAccessException on Java 8 as well as runtime reflection
failures on newer Java versions. No public APIs were changed.

This keeps full Java 8 compatibility while improving robustness on restricted environments.

Related issue: LANG-1711
