### PR TITLE
[LANG-1815] AnnotationUtils.equals fails for package-private annotations

### DIFF
--- a/src/main/java/org/apache/commons/lang3/AnnotationUtils.java
+++ b/src/main/java/org/apache/commons/lang3/AnnotationUtils.java
@@ -212,7 +212,9 @@ public class AnnotationUtils {
             for (final Method m : type1.getDeclaredMethods()) {
                 if (m.getParameterTypes().length == 0
                         && isValidAnnotationMemberType(m.getReturnType())) {
-                    m.setAccessible(true);
+                    if (!m.isAccessible()) {
+                        m.setAccessible(true);
+                    }
                     final Object v1 = m.invoke(a1);
                     final Object v2 = m.invoke(a2);
                     if (!memberEquals(m.getReturnType(), v1, v2)) {

--- a/src/main/java/org/apache/commons/lang3/AnnotationUtils.java
+++ b/src/main/java/org/apache/commons/lang3/AnnotationUtils.java
@@ -212,6 +212,7 @@ public class AnnotationUtils {
             for (final Method m : type1.getDeclaredMethods()) {
                 if (m.getParameterTypes().length == 0
                         && isValidAnnotationMemberType(m.getReturnType())) {
+                    m.setAccessible(true);
                     final Object v1 = m.invoke(a1);
                     final Object v2 = m.invoke(a2);
                     if (!memberEquals(m.getReturnType(), v1, v2)) {
@@ -220,7 +221,7 @@ public class AnnotationUtils {
                 }
             }
         } catch (final ReflectiveOperationException ex) {
-            return false;
+            throw new IllegalStateException(ex);
         }
         return true;
     }

--- a/src/test/java/org/apache/commons/lang3/external/AnnotationEqualsTest.java
+++ b/src/test/java/org/apache/commons/lang3/external/AnnotationEqualsTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.lang3.external;
+
+import org.apache.commons.lang3.AnnotationUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+// CAUTION: in order to reproduce https://issues.apache.org/jira/browse/LANG-1815,
+// this test MUST be located OUTSIDE org.apache.commons.lang3 package.
+// Do NOT move it to the org.apache.commons.lang3 package!
+public class AnnotationEqualsTest {
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface Tag {
+        String value();
+    }
+
+    @Tag("value")
+    private final Object a = new Object();
+    @Tag("value")
+    private final Object b = new Object();
+
+    @Test
+    void equalsWorksOnPackagePrivateAnnotations() throws Exception {
+        Tag tagA = getClass().getDeclaredField("a").getAnnotation(Tag.class);
+        Tag tagB = getClass().getDeclaredField("b").getAnnotation(Tag.class);
+        Assertions.assertTrue(AnnotationUtils.equals(tagA, tagB));
+    }
+}

--- a/src/test/java/org/apache/commons/lang3/external/AnnotationEqualsTest.java
+++ b/src/test/java/org/apache/commons/lang3/external/AnnotationEqualsTest.java
@@ -17,19 +17,52 @@
 package org.apache.commons.lang3.external;
 
 import org.apache.commons.lang3.AnnotationUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.lang.annotation.Annotation;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.lang.reflect.InvocationTargetException;
 
-// CAUTION: in order to reproduce https://issues.apache.org/jira/browse/LANG-1815,
-// this test MUST be located OUTSIDE org.apache.commons.lang3 package.
-// Do NOT move it to the org.apache.commons.lang3 package!
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression test for <a href="https://issues.apache.org/jira/browse/LANG-1815">LANG-1815</a>.
+ * <p>
+ * Verifies that {@code AnnotationUtils.equals(Annotation, Annotation)} treats two equal
+ * package-private annotations as equal, and also wraps a possible ReflectiveOperationException.
+ * </p>
+ *
+ * <h2>Important</h2>
+ * <p>
+ * This test relies on reflective access rules that differ depending on the caller's package.
+ * To reproduce the original bug, this class <strong>must remain outside</strong> the
+ * {@code org.apache.commons.lang3} package.
+ * </p>
+ * <p>
+ * Do <strong>not</strong> move this class into {@code org.apache.commons.lang3},
+ * otherwise the test may no longer exercise the failing scenario from LANG-1815.
+ * </p>
+ */
 public class AnnotationEqualsTest {
     @Retention(RetentionPolicy.RUNTIME)
     @interface Tag {
         String value();
+    }
+
+    static class ThrowingTag implements Tag {
+        @Override
+        public String value() {
+            throw new IllegalArgumentException("boom");
+        }
+
+        @Override
+        public Class<? extends Annotation> annotationType() {
+            return Tag.class;
+        }
     }
 
     @Tag("value")
@@ -41,6 +74,19 @@ public class AnnotationEqualsTest {
     void equalsWorksOnPackagePrivateAnnotations() throws Exception {
         Tag tagA = getClass().getDeclaredField("a").getAnnotation(Tag.class);
         Tag tagB = getClass().getDeclaredField("b").getAnnotation(Tag.class);
-        Assertions.assertTrue(AnnotationUtils.equals(tagA, tagB));
+        assertTrue(AnnotationUtils.equals(tagA, tagB));
     }
+
+    @Test
+    void equalsWrapsReflectiveOperationException() throws Exception {
+        // Proxy annotation instances: calling Tag#value() will throw at runtime
+        final Tag tagA = new ThrowingTag();
+        final Tag tagB = getClass().getDeclaredField("b").getAnnotation(Tag.class);
+
+        final IllegalStateException ex =
+                assertThrows(IllegalStateException.class, () -> AnnotationUtils.equals(tagA, tagB));
+        assertInstanceOf(InvocationTargetException.class, ex.getCause());
+        assertEquals("boom", ((InvocationTargetException) ex.getCause()).getTargetException().getMessage());
+    }
+
 }


### PR DESCRIPTION
# Problem

AnnotationUtils.equals(Annotation, Annotation) may incorrectly return false for equal annotations when the annotation type or its members are not reflectively accessible from the caller’s package.

The root cause is twofold:

* Annotation member methods are invoked reflectively without ensuring accessibility, which can trigger access-related ReflectiveOperationExceptions (e.g. for package-private annotations accessed from outside their package).
* `ReflectiveOperationExceptions` are swallowed and treated as “not equal” by returning `false`, which hides reflection failure.

This behavior violates the method’s documented intent to implement the equality semantics defined by `Annotation.equals(Object)` and makes the result depend on reflective accessibility rather than annotation content.

This issue is tracked as [LANG-1815](https://issues.apache.org/jira/browse/LANG-1815).


Before you push a pull request, review this list:

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [ ] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
