### PR TITLE
[LANG-1825] EqualsBuilder.reflectionAppend tries to set visibility on excluded fields

### DIFF
--- a/src/main/java/org/apache/commons/lang3/builder/AbstractReflection.java
+++ b/src/main/java/org/apache/commons/lang3/builder/AbstractReflection.java
@@ -112,24 +112,39 @@ public abstract class AbstractReflection {
     }
 
     /**
-     * If {@code forceAccessible} flag is true, each field in the given array is made accessible by calling {@link AccessibleObject#setAccessible(boolean)
+     * If {@code forceAccessible} flag is true, then the field is made accessible by calling {@link AccessibleObject#setAccessible(boolean)
      * AccessibleObject#setAccessible(true)} but <em>only</em> if a field is not already accessible.
      *
      * @param forceAccessible Whether to call {@link AccessibleObject#setAccessible(boolean)} if a field is not already accessible.
-     * @param fields          The fields to set.
+     * @param field          The field to set.
+     * @return true if the field is accessible, false otherwise.
      * @throws SecurityException Thrown if {@code forceAccessible} flag is true and the request is denied.
      * @see AccessibleObject#setAccessible(boolean)
      * @see SecurityManager#checkPermission
      */
-    static void setAccessible(final boolean forceAccessible, final Field... fields) {
-        if (forceAccessible) {
-            for (final Field field : fields) {
-                // Test to avoid the permission check if there is a security manager.
-                if (field != null && !field.isAccessible()) {
-                    field.setAccessible(true);
-                }
+    static boolean setAccessible(final boolean forceAccessible, final Field field) {
+        return !field.isAccessible() && forceAccessible && setAccessibleTrue(field);
+    }
+
+    /**
+     * Sets the field as accessible by calling {@link AccessibleObject#setAccessible(boolean) AccessibleObject#setAccessible(true)} but <em>only</em> if a field
+     * is not already accessible.
+     *
+     * @param field The field to set, may be null.
+     * @return true if the field is accessible, false otherwise.
+     * @throws SecurityException Thrown if {@code forceAccessible} flag is true and the request is denied.
+     * @see AccessibleObject#setAccessible(boolean)
+     * @see SecurityManager#checkPermission
+     */
+    private static boolean setAccessibleTrue(final Field field) {
+        if (field != null) {
+            // Test isAccessible() to avoid the permission check.
+            if (!field.isAccessible()) {
+                field.setAccessible(true);
             }
+            return field.isAccessible();
         }
+        return false;
     }
 
     /**
@@ -160,12 +175,13 @@ public abstract class AbstractReflection {
      * If {@code forceAccessible} flag is true, each field in the given array is made accessible by calling {@link AccessibleObject#setAccessible(boolean)
      * AccessibleObject#setAccessible(true)} but <em>only</em> if a field is not already accessible.
      *
-     * @param fields The fields to set.
+     * @param field The fields to set.
      * @throws SecurityException Thrown if {@code forceAccessible} flag is true and the request is denied.
+     * @return true if the field is accessible, false otherwise.
      * @see AccessibleObject#setAccessible(boolean)
      * @see SecurityManager#checkPermission
      */
-    void setAccessible(final Field... fields) {
-        setAccessible(isForceAccessible(), fields);
+    boolean setAccessible(final Field field) {
+        return setAccessible(isForceAccessible(), field);
     }
 }

--- a/src/main/java/org/apache/commons/lang3/builder/CompareToBuilder.java
+++ b/src/main/java/org/apache/commons/lang3/builder/CompareToBuilder.java
@@ -24,6 +24,7 @@ import java.util.Objects;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.ObjectUtils;
+import org.apache.commons.lang3.builder.AbstractReflection.AbstractBuilder;
 
 /**
  * Assists in implementing {@link Comparable#compareTo(Object)} methods.
@@ -72,7 +73,9 @@ import org.apache.commons.lang3.ObjectUtils;
  * bypass normal access control checks. This will fail under a security manager,
  * unless the appropriate permissions are set up correctly. It is also
  * slower than appending explicitly.</p>
- *
+ * <p>
+ * See also {@link AbstractBuilder#setForceAccessible(boolean)}
+ * </p>
  * <p>A typical implementation of {@code compareTo(Object)} using
  * {@code reflectionCompare} looks like:</p>
 
@@ -91,6 +94,7 @@ import org.apache.commons.lang3.ObjectUtils;
  * @see Object#hashCode()
  * @see EqualsBuilder
  * @see HashCodeBuilder
+ * @see AbstractBuilder#setForceAccessible(boolean)
  * @since 1.0
  */
 public class CompareToBuilder extends AbstractReflection implements Builder<Integer> {
@@ -145,18 +149,18 @@ public class CompareToBuilder extends AbstractReflection implements Builder<Inte
         final boolean forceAccessible) {
 
         final Field[] fields = clazz.getDeclaredFields();
-        setAccessible(forceAccessible, fields);
         for (int i = 0; i < fields.length && builder.comparison == 0; i++) {
             final Field field = fields[i];
             final String name = field.getName();
             if (!ArrayUtils.contains(excludeFields, name)
                 && !name.contains("$")
                 && (useTransients || !Modifier.isTransient(field.getModifiers()))
-                && !Modifier.isStatic(field.getModifiers())
-                && field.isAccessible()) {
-                // IllegalAccessException can't happen. Would get a Security exception instead.
-                // Throw a runtime exception in case the impossible happens.
-                builder.append(Reflection.getUnchecked(field, lhs), Reflection.getUnchecked(field, rhs));
+                && !Modifier.isStatic(field.getModifiers())) {
+                if (setAccessible(forceAccessible, field)) {
+                    // IllegalAccessException can't happen. Would get a Security exception instead.
+                    // Throw a runtime exception in case the impossible happens.
+                    builder.append(Reflection.getUnchecked(field, lhs), Reflection.getUnchecked(field, rhs));
+                }
             }
         }
     }

--- a/src/main/java/org/apache/commons/lang3/builder/EqualsBuilder.java
+++ b/src/main/java/org/apache/commons/lang3/builder/EqualsBuilder.java
@@ -26,6 +26,7 @@ import java.util.Set;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.ClassUtils;
+import org.apache.commons.lang3.builder.AbstractReflection.AbstractBuilder;
 import org.apache.commons.lang3.tuple.Pair;
 
 /**
@@ -72,6 +73,9 @@ import org.apache.commons.lang3.tuple.Pair;
  * manager, unless the appropriate permissions are set up correctly. It is
  * also slower than testing explicitly.  Non-primitive fields are compared using
  * {@code equals()}.</p>
+ * <p>
+ * See also {@link AbstractBuilder#setForceAccessible(boolean)}
+ * </p>
  *
  * <p>A typical invocation for this method would look like:</p>
  * <pre>
@@ -84,6 +88,7 @@ import org.apache.commons.lang3.tuple.Pair;
  * used by the {@code reflectionEquals} methods.</p>
  *
  * @since 1.0
+ * @see AbstractBuilder#setForceAccessible(boolean)
  */
 public class EqualsBuilder extends AbstractReflection implements Builder<Boolean> {
 
@@ -107,6 +112,13 @@ public class EqualsBuilder extends AbstractReflection implements Builder<Boolean
     }
 
     /**
+     * A registry of objects used by reflection methods to detect cyclical object references and avoid infinite loops.
+     *
+     * @since 3.0
+     */
+    private static final ThreadLocal<Set<Pair<IDKey, IDKey>>> REGISTRY = ThreadLocal.withInitial(HashSet::new);
+
+    /**
      * Constructs a new Builder.
      *
      * @return a new Builder.
@@ -114,13 +126,6 @@ public class EqualsBuilder extends AbstractReflection implements Builder<Boolean
     public static Builder builder() {
         return new Builder();
     }
-
-    /**
-     * A registry of objects used by reflection methods to detect cyclical object references and avoid infinite loops.
-     *
-     * @since 3.0
-     */
-    private static final ThreadLocal<Set<Pair<IDKey, IDKey>>> REGISTRY = ThreadLocal.withInitial(HashSet::new);
 
     /*
      * NOTE: we cannot store the actual objects in a HashSet, as that would use the very hashCode()
@@ -964,7 +969,6 @@ public class EqualsBuilder extends AbstractReflection implements Builder<Boolean
             isEquals = false;
             return this;
         }
-
         // Find the leaf class since there may be transients in the leaf
         // class or in classes between the leaf and root.
         // If we are not testing transients or a subclass has no ivars,
@@ -989,7 +993,6 @@ public class EqualsBuilder extends AbstractReflection implements Builder<Boolean
             isEquals = false;
             return this;
         }
-
         try {
             if (testClass.isArray()) {
                 append(lhs, rhs);
@@ -1018,9 +1021,9 @@ public class EqualsBuilder extends AbstractReflection implements Builder<Boolean
      * Appends the fields and values defined by the given object of the
      * given Class.
      *
-     * @param lhs  the left-hand side object
-     * @param rhs  the right-hand side object
-     * @param clazz  the class to append details of
+     * @param lhs  the left-hand side object.
+     * @param rhs  the right-hand side object.
+     * @param clazz  the class to append details of.
      */
     private void reflectionAppend(final Object lhs, final Object rhs, final Class<?> clazz) {
         if (isRegistered(lhs, rhs)) {
@@ -1029,7 +1032,6 @@ public class EqualsBuilder extends AbstractReflection implements Builder<Boolean
         try {
             register(lhs, rhs);
             final Field[] fields = clazz.getDeclaredFields();
-            setAccessible(fields);
             for (int i = 0; i < fields.length && isEquals; i++) {
                 final Field field = fields[i];
                 if (!ArrayUtils.contains(excludeFields, field.getName())
@@ -1037,7 +1039,9 @@ public class EqualsBuilder extends AbstractReflection implements Builder<Boolean
                     && (testTransients || !Modifier.isTransient(field.getModifiers()))
                     && !Modifier.isStatic(field.getModifiers())
                     && !field.isAnnotationPresent(EqualsExclude.class)) {
-                    append(Reflection.getUnchecked(field, lhs), Reflection.getUnchecked(field, rhs));
+                    if (setAccessible(field)) {
+                        append(Reflection.getUnchecked(field, lhs), Reflection.getUnchecked(field, rhs));
+                    }
                 }
             }
         } finally {

--- a/src/main/java/org/apache/commons/lang3/builder/HashCodeBuilder.java
+++ b/src/main/java/org/apache/commons/lang3/builder/HashCodeBuilder.java
@@ -29,6 +29,7 @@ import org.apache.commons.lang3.ArraySorter;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.Validate;
+import org.apache.commons.lang3.builder.AbstractReflection.AbstractBuilder;
 
 /**
  * Assists in implementing {@link Object#hashCode()} methods.
@@ -85,6 +86,9 @@ import org.apache.commons.lang3.Validate;
  * to change the visibility of the fields. This will fail under a security manager, unless the appropriate permissions
  * are set up correctly. It is also slower than testing explicitly.
  * </p>
+ * <p>
+ * See also {@link AbstractBuilder#setForceAccessible(boolean)}
+ * </p>
  *
  * <p>
  * A typical invocation for this method would look like:
@@ -99,6 +103,7 @@ import org.apache.commons.lang3.Validate;
  * <p>The {@link HashCodeExclude} annotation can be used to exclude fields from being
  * used by the {@code reflectionHashCode} methods.</p>
  *
+ * @see AbstractBuilder#setForceAccessible(boolean)
  * @since 1.0
  */
 public class HashCodeBuilder extends AbstractReflection implements Builder<Integer> {
@@ -229,10 +234,10 @@ public class HashCodeBuilder extends AbstractReflection implements Builder<Integ
      *            whether to use transient fields
      * @param excludeFields
      *            Collection of String field names to exclude from use in calculation of hash code
-     * @param setAccessible Whether to set fields' accessible flags
+     * @param forceAccessible Whether to set fields' accessible flags
      */
     private static void reflectionAppend(final Object object, final Class<?> clazz, final HashCodeBuilder builder, final boolean useTransients,
-            final String[] excludeFields, final boolean setAccessible) {
+            final String[] excludeFields, final boolean forceAccessible) {
         if (isRegistered(object)) {
             return;
         }
@@ -240,14 +245,15 @@ public class HashCodeBuilder extends AbstractReflection implements Builder<Integ
             register(object);
             // The elements in the returned array are not sorted and are not in any particular order.
             final Field[] fields = ArraySorter.sort(clazz.getDeclaredFields(), Comparator.comparing(Field::getName));
-            setAccessible(setAccessible, fields);
             for (final Field field : fields) {
                 if (!ArrayUtils.contains(excludeFields, field.getName())
                     && !field.getName().contains("$")
                     && (useTransients || !Modifier.isTransient(field.getModifiers()))
                     && !Modifier.isStatic(field.getModifiers())
                     && !field.isAnnotationPresent(HashCodeExclude.class)) {
-                    builder.append(Reflection.getUnchecked(field, object));
+                    if (setAccessible(forceAccessible, field)) {
+                        builder.append(Reflection.getUnchecked(field, object));
+                    }
                 }
             }
         } finally {

--- a/src/main/java/org/apache/commons/lang3/builder/ReflectionToStringBuilder.java
+++ b/src/main/java/org/apache/commons/lang3/builder/ReflectionToStringBuilder.java
@@ -612,18 +612,14 @@ public class ReflectionToStringBuilder extends ToStringBuilder {
             // Reject static fields.
             return false;
         }
-
-        if (this.excludeFieldNames != null
-            && Arrays.binarySearch(this.excludeFieldNames, field.getName()) >= 0) {
+        if (this.excludeFieldNames != null && Arrays.binarySearch(this.excludeFieldNames, field.getName()) >= 0) {
             // Reject fields from the getExcludeFieldNames list.
             return false;
         }
-
         if (ArrayUtils.isNotEmpty(includeFieldNames)) {
             // Accept fields from the getIncludeFieldNames list. {@code null} or empty means all fields are included. All fields are included by default.
             return Arrays.binarySearch(this.includeFieldNames, field.getName()) >= 0;
         }
-
         return !field.isAnnotationPresent(ToStringExclude.class);
     }
 
@@ -645,10 +641,10 @@ public class ReflectionToStringBuilder extends ToStringBuilder {
         }
         // The elements in the returned array are not sorted and are not in any particular order.
         final Field[] fields = ArraySorter.sort(clazz.getDeclaredFields(), Comparator.comparing(Field::getName));
-        setAccessible(fields);
         for (final Field field : fields) {
             final String fieldName = field.getName();
             if (accept(field)) {
+                setAccessible(field);
                 try {
                     // Warning: Field.get(Object) creates wrappers objects
                     // for primitive types.

--- a/src/main/java/org/apache/commons/lang3/builder/ToStringBuilder.java
+++ b/src/main/java/org/apache/commons/lang3/builder/ToStringBuilder.java
@@ -19,6 +19,7 @@ package org.apache.commons.lang3.builder;
 import java.util.Objects;
 
 import org.apache.commons.lang3.ObjectUtils;
+import org.apache.commons.lang3.builder.AbstractReflection.AbstractBuilder;
 
 /**
  * Assists in implementing {@link Object#toString()} methods.
@@ -67,6 +68,9 @@ import org.apache.commons.lang3.ObjectUtils;
  * change the visibility of the fields. This will fail under a security manager,
  * unless the appropriate permissions are set up correctly. It is also
  * slower than testing explicitly.</p>
+ * <p>
+ * See also {@link AbstractBuilder#setForceAccessible(boolean)}
+ * </p>
  *
  * <p>A typical invocation for this method would look like:</p>
  *
@@ -85,6 +89,7 @@ import org.apache.commons.lang3.ObjectUtils;
  * <p>The exact format of the {@code toString} is determined by
  * the {@link ToStringStyle} passed into the constructor.</p>
  *
+ * @see AbstractBuilder#setForceAccessible(boolean)
  * @since 1.0
  */
 public class ToStringBuilder extends AbstractReflection implements Builder<String> {

--- a/src/test/java/org/apache/commons/lang3/builder/AbstractBuilderTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/AbstractBuilderTest.java
@@ -18,6 +18,7 @@
 package org.apache.commons.lang3.builder;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.util.Objects;
 import java.util.function.Supplier;
@@ -30,33 +31,41 @@ import org.apache.commons.lang3.AbstractLangTest;
 class AbstractBuilderTest extends AbstractLangTest {
 
     /**
-     * Delegates to {@link AbstractReflection#getForceAccessible()}.
-     *
-     * @return {@link AbstractReflection#getForceAccessible()}.
-     */
-    protected static boolean accessibleFlag() {
-        return AbstractReflection.getForceAccessible();
-    }
-
-    /**
      * Helps test reflection classes.
      *
      * @param string An input string.
      * @return The given string or "<null>".
      */
     protected static String accessibleString(final String string) {
-        return accessibleFlag() ? string : "<null>";
+        return isForceAccessible() ? string : "<null>";
     }
 
     protected static void assertEqualsIfAccessible(final Object expected, final Object actual) {
-        assertEquals(accessibleFlag(), Objects.equals(expected, actual));
+        assertEquals(isForceAccessible(), Objects.equals(expected, actual));
+    }
+
+    protected static void assertFalseIfAccessible(final boolean test) {
+        assertNotEquals(isForceAccessible(), test);
+    }
+
+    protected static void assertNotEqualsIfAccessible(final Object expected, final Object actual) {
+        assertNotEquals(isForceAccessible(), Objects.equals(expected, actual));
     }
 
     protected static void assertTrueIfAccessible(final boolean test) {
-        assertEquals(accessibleFlag(), test);
+        assertEquals(isForceAccessible(), test);
     }
 
     protected static void assertTrueIfAccessible(final boolean test, final Supplier<String> messageSupplier) {
-        assertEquals(accessibleFlag(), test, messageSupplier);
+        assertEquals(isForceAccessible(), test, messageSupplier);
+    }
+
+    /**
+     * Delegates to {@link AbstractReflection#getForceAccessible()}.
+     *
+     * @return {@link AbstractReflection#getForceAccessible()}.
+     */
+    protected static boolean isForceAccessible() {
+        return AbstractReflection.getForceAccessible();
     }
 }

--- a/src/test/java/org/apache/commons/lang3/builder/CompareToBuilderTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/CompareToBuilderTest.java
@@ -135,10 +135,10 @@ class CompareToBuilderTest extends AbstractBuilderTest {
         // assertTrue(CompareToBuilder.reflectionCompare(x, y, testTransients) == 0 == EqualsBuilder.reflectionEquals(x, y, testTransients));
         //assertTrueIfAccessible(CompareToBuilder.reflectionCompare(x, y, testTransients) == 0 == EqualsBuilder.reflectionEquals(x, y, testTransients));
         final boolean actual = CompareToBuilder.reflectionCompare(x, y, testTransients) == 0 == EqualsBuilder.reflectionEquals(x, y, testTransients);
-        if (accessibleFlag()) {
+        if (isForceAccessible()) {
             assertEqualsIfAccessible(expectAccessibleFactor, actual);
         } else {
-            assertEqualsIfAccessible(accessibleFlag() || expectAccessibleFactor, actual);
+            assertEqualsIfAccessible(isForceAccessible() || expectAccessibleFactor, actual);
         }
     }
 
@@ -1059,10 +1059,10 @@ class CompareToBuilderTest extends AbstractBuilderTest {
         final TestSubObject tso2 = new TestSubObject(2, 2);
         final TestSubObject tso3 = new TestSubObject(3, 3);
 
-        assertReflectionCompareContract(to1, to1, to1, false, excludeFields, accessibleFlag());
-        assertReflectionCompareContract(to1, to2, to3, false, excludeFields, true);
-        assertReflectionCompareContract(tso1, tso1, tso1, false, excludeFields, accessibleFlag());
-        assertReflectionCompareContract(tso1, tso2, tso3, false, excludeFields, true);
+        assertReflectionCompareContract(to1, to1, to1, false, excludeFields, isForceAccessible());
+        assertReflectionCompareContract(to1, to2, to3, false, excludeFields, isForceAccessible());
+        assertReflectionCompareContract(tso1, tso1, tso1, false, excludeFields, isForceAccessible());
+        assertReflectionCompareContract(tso1, tso2, tso3, false, excludeFields, isForceAccessible());
         assertReflectionCompareContract("1", "2", "3", false, excludeFields, true);
 
         assertTrueIfAccessible(0 != CompareToBuilder.reflectionCompare(tso1, new TestSubObject(1, 0), testTransients));

--- a/src/test/java/org/apache/commons/lang3/builder/DiffBuilderTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/DiffBuilderTest.java
@@ -128,17 +128,24 @@ class DiffBuilderTest extends AbstractBuilderTest {
 
     private static final ToStringStyle SHORT_STYLE = ToStringStyle.SHORT_PREFIX_STYLE;
 
+    private boolean assertSingleAccessibleDiff(final DiffResult<TypeTestClass> list) {
+        final boolean forceAccessible = isForceAccessible();
+        assertEquals(forceAccessible ? 1 : 0, list.getNumberOfDiffs());
+        return forceAccessible;
+    }
+
     @Test
     void testBoolean() {
         final TypeTestClass class1 = new TypeTestClass();
         final TypeTestClass class2 = new TypeTestClass();
         class2.booleanField = false;
         final DiffResult<TypeTestClass> list = class1.diff(class2);
-        assertEquals(1, list.getNumberOfDiffs());
-        final Diff<?> diff = list.getDiffs().get(0);
-        assertEquals(Boolean.class, diff.getType(), () -> diff.getType().getClass().toString());
-        assertEquals(Boolean.TRUE, diff.getLeft());
-        assertEquals(Boolean.FALSE, diff.getRight());
+        if (assertSingleAccessibleDiff(list)) {
+            final Diff<?> diff = list.getDiffs().get(0);
+            assertEquals(Boolean.class, diff.getType(), () -> diff.getType().getClass().toString());
+            assertEquals(Boolean.TRUE, diff.getLeft());
+            assertEquals(Boolean.FALSE, diff.getRight());
+        }
     }
 
     @Test
@@ -147,10 +154,11 @@ class DiffBuilderTest extends AbstractBuilderTest {
         final TypeTestClass class2 = new TypeTestClass();
         class2.booleanArrayField = new boolean[] { false, false };
         final DiffResult<TypeTestClass> list = class1.diff(class2);
-        assertEquals(1, list.getNumberOfDiffs());
-        final Diff<?> diff = list.getDiffs().get(0);
-        assertArrayEquals(ArrayUtils.toObject(class1.booleanArrayField), (Object[]) diff.getLeft());
-        assertArrayEquals(ArrayUtils.toObject(class2.booleanArrayField), (Object[]) diff.getRight());
+        if (assertSingleAccessibleDiff(list)) {
+            final Diff<?> diff = list.getDiffs().get(0);
+            assertArrayEquals(ArrayUtils.toObject(class1.booleanArrayField), (Object[]) diff.getLeft());
+            assertArrayEquals(ArrayUtils.toObject(class2.booleanArrayField), (Object[]) diff.getRight());
+        }
     }
 
     @Test
@@ -159,11 +167,12 @@ class DiffBuilderTest extends AbstractBuilderTest {
         final TypeTestClass class2 = new TypeTestClass();
         class2.byteField = 0x01;
         final DiffResult<TypeTestClass> list = class1.diff(class2);
-        assertEquals(1, list.getNumberOfDiffs());
-        final Diff<?> diff = list.getDiffs().get(0);
-        assertEquals(Byte.class, diff.getType(), () -> diff.getType().getClass().toString());
-        assertEquals(Byte.valueOf(class1.byteField), diff.getLeft());
-        assertEquals(Byte.valueOf(class2.byteField), diff.getRight());
+        if (assertSingleAccessibleDiff(list)) {
+            final Diff<?> diff = list.getDiffs().get(0);
+            assertEquals(Byte.class, diff.getType(), () -> diff.getType().getClass().toString());
+            assertEquals(Byte.valueOf(class1.byteField), diff.getLeft());
+            assertEquals(Byte.valueOf(class2.byteField), diff.getRight());
+        }
     }
 
     @Test
@@ -172,10 +181,11 @@ class DiffBuilderTest extends AbstractBuilderTest {
         final TypeTestClass class2 = new TypeTestClass();
         class2.byteArrayField = new byte[] { 0x01, 0x02 };
         final DiffResult<TypeTestClass> list = class1.diff(class2);
-        assertEquals(1, list.getNumberOfDiffs());
-        final Diff<?> diff = list.getDiffs().get(0);
-        assertArrayEquals(ArrayUtils.toObject(class1.byteArrayField), (Object[]) diff.getLeft());
-        assertArrayEquals(ArrayUtils.toObject(class2.byteArrayField), (Object[]) diff.getRight());
+        if (assertSingleAccessibleDiff(list)) {
+            final Diff<?> diff = list.getDiffs().get(0);
+            assertArrayEquals(ArrayUtils.toObject(class1.byteArrayField), (Object[]) diff.getLeft());
+            assertArrayEquals(ArrayUtils.toObject(class2.byteArrayField), (Object[]) diff.getRight());
+        }
     }
 
     @Test
@@ -220,10 +230,11 @@ class DiffBuilderTest extends AbstractBuilderTest {
         final TypeTestClass class2 = new TypeTestClass();
         class2.charField = 'z';
         final DiffResult<TypeTestClass> list = class1.diff(class2);
-        assertEquals(1, list.getNumberOfDiffs());
-        final Diff<?> diff = list.getDiffs().get(0);
-        assertEquals(Character.valueOf(class1.charField), diff.getLeft());
-        assertEquals(Character.valueOf(class2.charField), diff.getRight());
+        if (assertSingleAccessibleDiff(list)) {
+            final Diff<?> diff = list.getDiffs().get(0);
+            assertEquals(Character.valueOf(class1.charField), diff.getLeft());
+            assertEquals(Character.valueOf(class2.charField), diff.getRight());
+        }
     }
 
     @Test
@@ -232,10 +243,11 @@ class DiffBuilderTest extends AbstractBuilderTest {
         final TypeTestClass class2 = new TypeTestClass();
         class2.charArrayField = new char[] { 'f', 'o', 'o' };
         final DiffResult<TypeTestClass> list = class1.diff(class2);
-        assertEquals(1, list.getNumberOfDiffs());
-        final Diff<?> diff = list.getDiffs().get(0);
-        assertArrayEquals(ArrayUtils.toObject(class1.charArrayField), (Object[]) diff.getLeft());
-        assertArrayEquals(ArrayUtils.toObject(class2.charArrayField), (Object[]) diff.getRight());
+        if (assertSingleAccessibleDiff(list)) {
+            final Diff<?> diff = list.getDiffs().get(0);
+            assertArrayEquals(ArrayUtils.toObject(class1.charArrayField), (Object[]) diff.getLeft());
+            assertArrayEquals(ArrayUtils.toObject(class2.charArrayField), (Object[]) diff.getRight());
+        }
     }
 
     @Test
@@ -243,10 +255,10 @@ class DiffBuilderTest extends AbstractBuilderTest {
         final TypeTestClass class1 = new TypeTestClass();
         final TypeTestClass class2 = new TypeTestClass();
         class2.intField = 2;
-
         final DiffResult<TypeTestClass> list = new DiffBuilder<>(class1, class2, SHORT_STYLE).append("prop1", class1.diff(class2)).build();
-        assertEquals(1, list.getNumberOfDiffs());
-        assertEquals("prop1.int", list.getDiffs().get(0).getFieldName());
+        if (assertSingleAccessibleDiff(list)) {
+            assertEquals("prop1.int", list.getDiffs().get(0).getFieldName());
+        }
     }
 
     @Test
@@ -265,10 +277,11 @@ class DiffBuilderTest extends AbstractBuilderTest {
         final TypeTestClass class2 = new TypeTestClass();
         class2.doubleField = 99.99;
         final DiffResult<TypeTestClass> list = class1.diff(class2);
-        assertEquals(1, list.getNumberOfDiffs());
-        final Diff<?> diff = list.getDiffs().get(0);
-        assertEquals(Double.valueOf(class1.doubleField), diff.getLeft());
-        assertEquals(Double.valueOf(class2.doubleField), diff.getRight());
+        if (assertSingleAccessibleDiff(list)) {
+            final Diff<?> diff = list.getDiffs().get(0);
+            assertEquals(Double.valueOf(class1.doubleField), diff.getLeft());
+            assertEquals(Double.valueOf(class2.doubleField), diff.getRight());
+        }
     }
 
     @Test
@@ -277,10 +290,11 @@ class DiffBuilderTest extends AbstractBuilderTest {
         final TypeTestClass class2 = new TypeTestClass();
         class2.doubleArrayField = new double[] { 3.0, 2.9, 2.8 };
         final DiffResult<TypeTestClass> list = class1.diff(class2);
-        assertEquals(1, list.getNumberOfDiffs());
-        final Diff<?> diff = list.getDiffs().get(0);
-        assertArrayEquals(ArrayUtils.toObject(class1.doubleArrayField), (Object[]) diff.getLeft());
-        assertArrayEquals(ArrayUtils.toObject(class2.doubleArrayField), (Object[]) diff.getRight());
+        if (assertSingleAccessibleDiff(list)) {
+            final Diff<?> diff = list.getDiffs().get(0);
+            assertArrayEquals(ArrayUtils.toObject(class1.doubleArrayField), (Object[]) diff.getLeft());
+            assertArrayEquals(ArrayUtils.toObject(class2.doubleArrayField), (Object[]) diff.getRight());
+        }
     }
 
     @Test
@@ -289,10 +303,11 @@ class DiffBuilderTest extends AbstractBuilderTest {
         final TypeTestClass class2 = new TypeTestClass();
         class2.floatField = 99.99F;
         final DiffResult<TypeTestClass> list = class1.diff(class2);
-        assertEquals(1, list.getNumberOfDiffs());
-        final Diff<?> diff = list.getDiffs().get(0);
-        assertEquals(Float.valueOf(class1.floatField), diff.getLeft());
-        assertEquals(Float.valueOf(class2.floatField), diff.getRight());
+        if (assertSingleAccessibleDiff(list)) {
+            final Diff<?> diff = list.getDiffs().get(0);
+            assertEquals(Float.valueOf(class1.floatField), diff.getLeft());
+            assertEquals(Float.valueOf(class2.floatField), diff.getRight());
+        }
     }
 
     @Test
@@ -301,10 +316,11 @@ class DiffBuilderTest extends AbstractBuilderTest {
         final TypeTestClass class2 = new TypeTestClass();
         class2.floatArrayField = new float[] { 3.0F, 2.9F, 2.8F };
         final DiffResult<TypeTestClass> list = class1.diff(class2);
-        assertEquals(1, list.getNumberOfDiffs());
-        final Diff<?> diff = list.getDiffs().get(0);
-        assertArrayEquals(ArrayUtils.toObject(class1.floatArrayField), (Object[]) diff.getLeft());
-        assertArrayEquals(ArrayUtils.toObject(class2.floatArrayField), (Object[]) diff.getRight());
+        if (assertSingleAccessibleDiff(list)) {
+            final Diff<?> diff = list.getDiffs().get(0);
+            assertArrayEquals(ArrayUtils.toObject(class1.floatArrayField), (Object[]) diff.getLeft());
+            assertArrayEquals(ArrayUtils.toObject(class2.floatArrayField), (Object[]) diff.getRight());
+        }
     }
 
     @Test
@@ -313,10 +329,11 @@ class DiffBuilderTest extends AbstractBuilderTest {
         final TypeTestClass class2 = new TypeTestClass();
         class2.intField = 42;
         final DiffResult<TypeTestClass> list = class1.diff(class2);
-        assertEquals(1, list.getNumberOfDiffs());
-        final Diff<?> diff = list.getDiffs().get(0);
-        assertEquals(Integer.valueOf(class1.intField), diff.getLeft());
-        assertEquals(Integer.valueOf(class2.intField), diff.getRight());
+        if (assertSingleAccessibleDiff(list)) {
+            final Diff<?> diff = list.getDiffs().get(0);
+            assertEquals(Integer.valueOf(class1.intField), diff.getLeft());
+            assertEquals(Integer.valueOf(class2.intField), diff.getRight());
+        }
     }
 
     @Test
@@ -325,10 +342,11 @@ class DiffBuilderTest extends AbstractBuilderTest {
         final TypeTestClass class2 = new TypeTestClass();
         class2.intArrayField = new int[] { 3, 2, 1 };
         final DiffResult<TypeTestClass> list = class1.diff(class2);
-        assertEquals(1, list.getNumberOfDiffs());
-        final Diff<?> diff = list.getDiffs().get(0);
-        assertArrayEquals(ArrayUtils.toObject(class1.intArrayField), (Object[]) diff.getLeft());
-        assertArrayEquals(ArrayUtils.toObject(class2.intArrayField), (Object[]) diff.getRight());
+        if (assertSingleAccessibleDiff(list)) {
+            final Diff<?> diff = list.getDiffs().get(0);
+            assertArrayEquals(ArrayUtils.toObject(class1.intArrayField), (Object[]) diff.getLeft());
+            assertArrayEquals(ArrayUtils.toObject(class2.intArrayField), (Object[]) diff.getRight());
+        }
     }
 
     @Test
@@ -337,10 +355,11 @@ class DiffBuilderTest extends AbstractBuilderTest {
         final TypeTestClass class2 = new TypeTestClass();
         class2.longField = 42L;
         final DiffResult<TypeTestClass> list = class1.diff(class2);
-        assertEquals(1, list.getNumberOfDiffs());
-        final Diff<?> diff = list.getDiffs().get(0);
-        assertEquals(Long.valueOf(class1.longField), diff.getLeft());
-        assertEquals(Long.valueOf(class2.longField), diff.getRight());
+        if (assertSingleAccessibleDiff(list)) {
+            final Diff<?> diff = list.getDiffs().get(0);
+            assertEquals(Long.valueOf(class1.longField), diff.getLeft());
+            assertEquals(Long.valueOf(class2.longField), diff.getRight());
+        }
     }
 
     @Test
@@ -349,10 +368,11 @@ class DiffBuilderTest extends AbstractBuilderTest {
         final TypeTestClass class2 = new TypeTestClass();
         class2.longArrayField = new long[] { 3L, 2L, 1L };
         final DiffResult<TypeTestClass> list = class1.diff(class2);
-        assertEquals(1, list.getNumberOfDiffs());
-        final Diff<?> diff = list.getDiffs().get(0);
-        assertArrayEquals(ArrayUtils.toObject(class1.longArrayField), (Object[]) diff.getLeft());
-        assertArrayEquals(ArrayUtils.toObject(class2.longArrayField), (Object[]) diff.getRight());
+        if (assertSingleAccessibleDiff(list)) {
+            final Diff<?> diff = list.getDiffs().get(0);
+            assertArrayEquals(ArrayUtils.toObject(class1.longArrayField), (Object[]) diff.getLeft());
+            assertArrayEquals(ArrayUtils.toObject(class2.longArrayField), (Object[]) diff.getRight());
+        }
     }
 
     @Test
@@ -371,11 +391,12 @@ class DiffBuilderTest extends AbstractBuilderTest {
         final TypeTestClass class2 = new TypeTestClass();
         class2.intField = 9;
         final DiffResult<TypeTestClass> list = class1.diff(class2);
-        assertEquals(1, list.getNumberOfDiffs());
-        final Diff<?> diff = list.getDiffs().get(0);
-        assertEquals(Integer.class, diff.getType());
-        assertEquals(1, diff.getLeft());
-        assertEquals(9, diff.getRight());
+        if (assertSingleAccessibleDiff(list)) {
+            final Diff<?> diff = list.getDiffs().get(0);
+            assertEquals(Integer.class, diff.getType());
+            assertEquals(1, diff.getLeft());
+            assertEquals(9, diff.getRight());
+        }
     }
 
     @Test
@@ -384,11 +405,12 @@ class DiffBuilderTest extends AbstractBuilderTest {
         final TypeTestClass class2 = new TypeTestClass();
         class2.nestedDiffableField.booleanField = false;
         final DiffResult<TypeTestClass> list = class1.diff(class2);
-        assertEquals(1, list.getNumberOfDiffs());
-        final Diff<?> diff = list.getDiffs().get(0);
-        assertEquals(Object.class, diff.getType());
-        assertEquals(Boolean.TRUE, diff.getLeft());
-        assertEquals(Boolean.FALSE, diff.getRight());
+        if (assertSingleAccessibleDiff(list)) {
+            final Diff<?> diff = list.getDiffs().get(0);
+            assertEquals(Object.class, diff.getType());
+            assertEquals(Boolean.TRUE, diff.getLeft());
+            assertEquals(Boolean.FALSE, diff.getRight());
+        }
     }
 
     @Test
@@ -398,15 +420,17 @@ class DiffBuilderTest extends AbstractBuilderTest {
         class2.intField = 9;
         class2.nestedDiffableField.booleanField = false;
         final DiffResult<TypeTestClass> list = class1.diff(class2);
-        assertEquals(2, list.getNumberOfDiffs());
-        final Diff<?> diff0 = list.getDiffs().get(0);
-        assertEquals(Integer.class, diff0.getType());
-        assertEquals(1, diff0.getLeft());
-        assertEquals(9, diff0.getRight());
-        final Diff<?> diff1 = list.getDiffs().get(1);
-        assertEquals(Object.class, diff1.getType());
-        assertEquals(Boolean.TRUE, diff1.getLeft());
-        assertEquals(Boolean.FALSE, diff1.getRight());
+        assertEquals(isForceAccessible() ? 2 : 0, list.getNumberOfDiffs());
+        if (isForceAccessible()) {
+            final Diff<?> diff0 = list.getDiffs().get(0);
+            assertEquals(Integer.class, diff0.getType());
+            assertEquals(1, diff0.getLeft());
+            assertEquals(9, diff0.getRight());
+            final Diff<?> diff1 = list.getDiffs().get(1);
+            assertEquals(Object.class, diff1.getType());
+            assertEquals(Boolean.TRUE, diff1.getLeft());
+            assertEquals(Boolean.FALSE, diff1.getRight());
+        }
     }
 
     @Test
@@ -435,10 +459,11 @@ class DiffBuilderTest extends AbstractBuilderTest {
         final TypeTestClass class2 = new TypeTestClass();
         class2.objectField = "Some string";
         final DiffResult<TypeTestClass> list = class1.diff(class2);
-        assertEquals(1, list.getNumberOfDiffs());
-        final Diff<?> diff = list.getDiffs().get(0);
-        assertEquals(class1.objectField, diff.getLeft());
-        assertEquals(class2.objectField, diff.getRight());
+        if (assertSingleAccessibleDiff(list)) {
+            final Diff<?> diff = list.getDiffs().get(0);
+            assertEquals(class1.objectField, diff.getLeft());
+            assertEquals(class2.objectField, diff.getRight());
+        }
     }
 
     @Test
@@ -447,10 +472,11 @@ class DiffBuilderTest extends AbstractBuilderTest {
         final TypeTestClass class2 = new TypeTestClass();
         class2.objectArrayField = new Object[] { "string", 1, 2 };
         final DiffResult<TypeTestClass> list = class1.diff(class2);
-        assertEquals(1, list.getNumberOfDiffs());
-        final Diff<?> diff = list.getDiffs().get(0);
-        assertArrayEquals(class1.objectArrayField, (Object[]) diff.getLeft());
-        assertArrayEquals(class2.objectArrayField, (Object[]) diff.getRight());
+        if (assertSingleAccessibleDiff(list)) {
+            final Diff<?> diff = list.getDiffs().get(0);
+            assertArrayEquals(class1.objectArrayField, (Object[]) diff.getLeft());
+            assertArrayEquals(class2.objectArrayField, (Object[]) diff.getRight());
+        }
     }
 
     @Test
@@ -492,7 +518,8 @@ class DiffBuilderTest extends AbstractBuilderTest {
         assertNotEquals(left.objectField, right.objectField);
 
         final DiffResult<TypeTestClass> list = left.diff(right);
-        assertEquals(1, list.getNumberOfDiffs());
+        assertSingleAccessibleDiff(list);
+
     }
 
     /**
@@ -525,10 +552,11 @@ class DiffBuilderTest extends AbstractBuilderTest {
         final TypeTestClass class2 = new TypeTestClass();
         class2.shortField = 42;
         final DiffResult<TypeTestClass> list = class1.diff(class2);
-        assertEquals(1, list.getNumberOfDiffs());
-        final Diff<?> diff = list.getDiffs().get(0);
-        assertEquals(Short.valueOf(class1.shortField), diff.getLeft());
-        assertEquals(Short.valueOf(class2.shortField), diff.getRight());
+        if (assertSingleAccessibleDiff(list)) {
+            final Diff<?> diff = list.getDiffs().get(0);
+            assertEquals(Short.valueOf(class1.shortField), diff.getLeft());
+            assertEquals(Short.valueOf(class2.shortField), diff.getRight());
+        }
     }
 
     @Test
@@ -537,10 +565,11 @@ class DiffBuilderTest extends AbstractBuilderTest {
         final TypeTestClass class2 = new TypeTestClass();
         class2.shortArrayField = new short[] { 3, 2, 1 };
         final DiffResult<TypeTestClass> list = class1.diff(class2);
-        assertEquals(1, list.getNumberOfDiffs());
-        final Diff<?> diff = list.getDiffs().get(0);
-        assertArrayEquals(ArrayUtils.toObject(class1.shortArrayField), (Object[]) diff.getLeft());
-        assertArrayEquals(ArrayUtils.toObject(class2.shortArrayField), (Object[]) diff.getRight());
+        if (assertSingleAccessibleDiff(list)) {
+            final Diff<?> diff = list.getDiffs().get(0);
+            assertArrayEquals(ArrayUtils.toObject(class1.shortArrayField), (Object[]) diff.getLeft());
+            assertArrayEquals(ArrayUtils.toObject(class2.shortArrayField), (Object[]) diff.getRight());
+        }
     }
 
     @Test
@@ -548,7 +577,7 @@ class DiffBuilderTest extends AbstractBuilderTest {
         final TypeTestClass testClass1 = new TypeTestClass();
         final TypeTestClass testClass2 = new TypeTestClass();
         final DiffResult<TypeTestClass> list = new DiffBuilder<>(testClass1, testClass2, SHORT_STYLE).append("ignored", false, true).build();
-        assertEquals(accessibleFlag() ? 0 : 1, list.getNumberOfDiffs());
+        assertEquals(0, list.getNumberOfDiffs());
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/builder/EqualsBuilderNoForceTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/EqualsBuilderNoForceTest.java
@@ -17,8 +17,6 @@
 
 package org.apache.commons.lang3.builder;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-
 import java.util.HashMap;
 
 import org.junit.jupiter.api.Test;
@@ -32,13 +30,13 @@ public class EqualsBuilderNoForceTest extends EqualsBuilderTest {
 
     @Test
     void testReflectionOnCustomArrayList() {
-        assertFalse(EqualsBuilder.reflectionEquals(new TestArrayList(1, "2", "3", "4"), new TestArrayList(1, "2", "3", "4")));
-        assertFalse(EqualsBuilder.reflectionEquals(new TestArrayList(1, "2", "3", "4"), new TestArrayList(2, "2", "3", "4")));
+        assertFalseIfAccessible(EqualsBuilder.reflectionEquals(new TestArrayList(1, "2", "3", "4"), new TestArrayList(1, "2", "3", "4")));
+        assertFalseIfAccessible(EqualsBuilder.reflectionEquals(new TestArrayList(1, "2", "3", "4"), new TestArrayList(2, "2", "3", "4")));
     }
 
     @Test
     void testReflectionOnCustomHashMap() {
-        assertFalse(EqualsBuilder.reflectionEquals(new TestHashMap(1, new HashMap<>()), new TestHashMap(1, new HashMap<>())));
-        assertFalse(EqualsBuilder.reflectionEquals(new TestHashMap(1, new HashMap<>()), new TestHashMap(2, new HashMap<>())));
+        assertFalseIfAccessible(EqualsBuilder.reflectionEquals(new TestHashMap(1, new HashMap<>()), new TestHashMap(1, new HashMap<>())));
+        assertFalseIfAccessible(EqualsBuilder.reflectionEquals(new TestHashMap(1, new HashMap<>()), new TestHashMap(2, new HashMap<>())));
     }
 }

--- a/src/test/java/org/apache/commons/lang3/builder/EqualsBuilderReflectJreImplementationTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/EqualsBuilderReflectJreImplementationTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.commons.lang3.builder;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Duration;
@@ -259,26 +259,45 @@ class EqualsBuilderReflectJreImplementationTest extends AbstractBuilderTest {
 
     }
 
+    private EqualsBuilder newRecursive() {
+        return new EqualsBuilder().setTestRecursive(true);
+    }
+
     @Test
     void testRecursive() {
+        // assertions are tricky to to the subclass
         final MyClass o1 = new MyClass(new MyCharSequence("1"), new MyTemporal("2"), new MyTemporalAccessor("3"), new MyTemporalAmount("4"));
         // This gives you different instances of MyTemporalAccessor for 1 (and 2) that should be equals by reflection.
         final MyClass o1Bis = new MyClass(new MyCharSequence("1"), new MyTemporal("2"), new MyTemporalAccessor("3"), new MyTemporalAmount("4"));
         final MyClass o2 = new MyClass(new MyCharSequence("5"), new MyTemporal("6"), new MyTemporalAccessor("7"), new MyTemporalAmount("8"));
         final MyClass o2Bis = new MyClass(new MyCharSequence("5"), new MyTemporal("6"), new MyTemporalAccessor("7"), new MyTemporalAmount("8"));
         // MyTemporal
-        assertTrueIfAccessible(new EqualsBuilder().setTestRecursive(true).append(new MyTemporal("1"), new MyTemporal("1")).isEquals());
+        final EqualsBuilder builder1 = newRecursive();
+        boolean defaultEq = builder1.isEquals();
+        assertEquals(defaultEq, builder1.append(new MyTemporal("1"), new MyTemporal("1")).isEquals());
         // MyTemporalAccessor
-        assertTrueIfAccessible(new EqualsBuilder().setTestRecursive(true).append(new MyTemporalAccessor("1"), new MyTemporalAccessor("1")).isEquals());
+        final EqualsBuilder builder2 = newRecursive();
+        defaultEq = builder2.isEquals();
+        assertEquals(defaultEq, builder2.append(new MyTemporalAccessor("1"), new MyTemporalAccessor("1")).isEquals());
         // MyCharSequence
-        assertTrueIfAccessible(new EqualsBuilder().setTestRecursive(true).append(new MyCharSequence("1"), new MyCharSequence("1")).isEquals());
+        final EqualsBuilder builder3 = newRecursive();
+        defaultEq = builder3.isEquals();
+        assertEquals(defaultEq, builder3.append(new MyCharSequence("1"), new MyCharSequence("1")).isEquals());
         // MyClass
-        assertTrue(new EqualsBuilder().setTestRecursive(true).append(o1, o1).isEquals(), o1::toString);
-        assertTrueIfAccessible(new EqualsBuilder().setTestRecursive(true).append(o1, o1Bis).isEquals(), o1::toString);
-        assertTrue(new EqualsBuilder().setTestRecursive(true).append(o2, o2).isEquals(), o2::toString);
-        assertTrueIfAccessible(new EqualsBuilder().setTestRecursive(true).append(o2, o2Bis).isEquals(), o2::toString);
-        assertFalse(new EqualsBuilder().setTestRecursive(true).append(o1, o2).isEquals());
-        assertFalse(new EqualsBuilder().setTestRecursive(true).append(o2, o1).isEquals());
+        assertTrue(newRecursive().append(o1, o1).isEquals(), o1::toString);
+        final EqualsBuilder builder4 = newRecursive();
+        defaultEq = builder4.isEquals();
+        assertEquals(defaultEq, builder4.append(o1, o1Bis).isEquals(), o1::toString);
+        assertTrue(newRecursive().append(o2, o2).isEquals(), o2::toString);
+        final EqualsBuilder builder5 = newRecursive();
+        defaultEq = builder5.isEquals();
+        assertEquals(defaultEq, builder5.append(o2, o2Bis).isEquals(), o2::toString);
+        // not equal normally (see subclass)
+        final EqualsBuilder builder6 = newRecursive();
+        defaultEq = !isForceAccessible();
+        assertEquals(defaultEq, builder6.append(o1, o2).isEquals());
+        final EqualsBuilder builder7 = newRecursive();
+        assertEquals(defaultEq, builder7.append(o2, o1).isEquals());
     }
 
     @Test
@@ -286,7 +305,7 @@ class EqualsBuilderReflectJreImplementationTest extends AbstractBuilderTest {
         // The following should not retain memory.
         for (int i = 0; i < Integer.getInteger("testRetention", 10_000); i++) {
             final Class<?> clazz = TestClassBuilder.defineSimpleClass(getClass().getPackage().getName(), i);
-            assertTrue(new EqualsBuilder().setTestRecursive(true).append(clazz.newInstance(), clazz.newInstance()).isEquals());
+            assertTrue(newRecursive().append(clazz.newInstance(), clazz.newInstance()).isEquals());
         }
         // some retention is checked in super's after().
     }

--- a/src/test/java/org/apache/commons/lang3/builder/EqualsBuilderTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/EqualsBuilderTest.java
@@ -606,9 +606,9 @@ class EqualsBuilderTest extends AbstractBuilderTest {
         x3.setObjectReference(refX3);
         refX3.setObjectReference(x3);
 
-        assertTrueIfAccessible(x1.equals(x2));
-        assertNotEquals(x1, x3);
-        assertNotEquals(x2, x3);
+        assertTrue(x1.equals(x2));
+        assertNotEqualsIfAccessible(x1, x3);
+        assertNotEqualsIfAccessible(x2, x3);
     }
 
     @Test
@@ -1096,12 +1096,12 @@ class EqualsBuilderTest extends AbstractBuilderTest {
         final TestRecursiveObject oNull = new TestRecursiveObject(null, null, 2);
 
         assertTrue(new EqualsBuilder().setTestRecursive(true).append(o1A, o1A).isEquals());
-        assertTrueIfAccessible(new EqualsBuilder().setTestRecursive(true).append(o1A, o1B).isEquals());
+        assertTrue(new EqualsBuilder().setTestRecursive(true).append(o1A, o1B).isEquals());
 
-        assertFalse(new EqualsBuilder().setTestRecursive(true).append(o1A, o2).isEquals());
+        assertFalseIfAccessible(new EqualsBuilder().setTestRecursive(true).append(o1A, o2).isEquals());
 
         assertTrue(new EqualsBuilder().setTestRecursive(true).append(oNull, oNull).isEquals());
-        assertFalse(new EqualsBuilder().setTestRecursive(true).append(o1A, oNull).isEquals());
+        assertFalseIfAccessible(new EqualsBuilder().setTestRecursive(true).append(o1A, oNull).isEquals());
     }
 
     @Test
@@ -1119,11 +1119,11 @@ class EqualsBuilderTest extends AbstractBuilderTest {
         o2.setCycle(i2);
 
         assertTrue(new EqualsBuilder().setTestRecursive(true).append(o1A, o1A).isEquals());
-        assertTrueIfAccessible(new EqualsBuilder().setTestRecursive(true).append(o1A, o1B).isEquals());
-        assertFalse(new EqualsBuilder().setTestRecursive(true).append(o1A, o2).isEquals());
+        assertTrue(new EqualsBuilder().setTestRecursive(true).append(o1A, o1B).isEquals());
+        assertFalseIfAccessible(new EqualsBuilder().setTestRecursive(true).append(o1A, o2).isEquals());
 
-        assertTrueIfAccessible(EqualsBuilder.reflectionEquals(o1A, o1B, false, null, true));
-        assertFalse(EqualsBuilder.reflectionEquals(o1A, o2, false, null, true));
+        assertTrue(EqualsBuilder.reflectionEquals(o1A, o1B, false, null, true));
+        assertFalseIfAccessible(EqualsBuilder.reflectionEquals(o1A, o2, false, null, true));
     }
 
     @Test
@@ -1133,8 +1133,8 @@ class EqualsBuilderTest extends AbstractBuilderTest {
         final TestRecursiveCycleObject o2 = new TestRecursiveCycleObject(2);
 
         assertTrue(new EqualsBuilder().setTestRecursive(true).append(o1A, o1A).isEquals());
-        assertTrueIfAccessible(new EqualsBuilder().setTestRecursive(true).append(o1A, o1B).isEquals());
-        assertFalse(new EqualsBuilder().setTestRecursive(true).append(o1A, o2).isEquals());
+        assertTrue(new EqualsBuilder().setTestRecursive(true).append(o1A, o1B).isEquals());
+        assertFalseIfAccessible(new EqualsBuilder().setTestRecursive(true).append(o1A, o2).isEquals());
     }
 
     @Test
@@ -1143,10 +1143,10 @@ class EqualsBuilderTest extends AbstractBuilderTest {
         final TestRecursiveGenericObject<Integer> o1B = new TestRecursiveGenericObject<>(1);
         final TestRecursiveGenericObject<Integer> o2 = new TestRecursiveGenericObject<>(2);
 
-        assertTrueIfAccessible(new EqualsBuilder().setTestRecursive(true).append(o1A, o1B).isEquals());
-        assertTrueIfAccessible(new EqualsBuilder().setTestRecursive(true).append(o1B, o1A).isEquals());
+        assertTrue(new EqualsBuilder().setTestRecursive(true).append(o1A, o1B).isEquals());
+        assertTrue(new EqualsBuilder().setTestRecursive(true).append(o1B, o1A).isEquals());
 
-        assertFalse(new EqualsBuilder().setTestRecursive(true).append(o1B, o2).isEquals());
+        assertFalseIfAccessible(new EqualsBuilder().setTestRecursive(true).append(o1B, o2).isEquals());
     }
 
     @Test
@@ -1160,10 +1160,10 @@ class EqualsBuilderTest extends AbstractBuilderTest {
         // To trigger bug reported in LANG-1356, call hashCode only on string in instance o1_a
         s1A.hashCode();
 
-        assertTrueIfAccessible(new EqualsBuilder().setTestRecursive(true).append(o1A, o1B).isEquals());
-        assertTrueIfAccessible(new EqualsBuilder().setTestRecursive(true).append(o1B, o1A).isEquals());
+        assertTrue(new EqualsBuilder().setTestRecursive(true).append(o1A, o1B).isEquals());
+        assertTrue(new EqualsBuilder().setTestRecursive(true).append(o1B, o1A).isEquals());
 
-        assertFalse(new EqualsBuilder().setTestRecursive(true).append(o1B, o2).isEquals());
+        assertFalseIfAccessible(new EqualsBuilder().setTestRecursive(true).append(o1B, o2).isEquals());
     }
 
     @Test
@@ -1199,11 +1199,11 @@ class EqualsBuilderTest extends AbstractBuilderTest {
         final TestObject o1 = new TestObject(4);
         final TestObject o2 = new TestObject(5);
         assertTrue(new EqualsBuilder().reflectionAppend(o1, o1).build());
-        assertFalse(new EqualsBuilder().reflectionAppend(o1, o2).build());
-        assertFalse(new EqualsBuilder().reflectionAppend(o1, o2).reflectionAppend(o1, o1).build());
+        assertFalseIfAccessible(new EqualsBuilder().reflectionAppend(o1, o2).build());
+        assertFalseIfAccessible(new EqualsBuilder().reflectionAppend(o1, o2).reflectionAppend(o1, o1).build());
 
         o2.setA(4);
-        assertTrueIfAccessible(new EqualsBuilder().reflectionAppend(o1, o2).build());
+        assertTrue(new EqualsBuilder().reflectionAppend(o1, o2).build());
 
         assertFalse(new EqualsBuilder().reflectionAppend(o1, this).build());
 
@@ -1239,9 +1239,9 @@ class EqualsBuilderTest extends AbstractBuilderTest {
         final TestObject o1 = new TestObject(4);
         final TestObject o2 = new TestObject(5);
         assertTrue(EqualsBuilder.reflectionEquals(o1, o1));
-        assertFalse(EqualsBuilder.reflectionEquals(o1, o2));
+        assertFalseIfAccessible(EqualsBuilder.reflectionEquals(o1, o2));
         o2.setA(4);
-        assertTrueIfAccessible(EqualsBuilder.reflectionEquals(o1, o2));
+        assertTrue(EqualsBuilder.reflectionEquals(o1, o2));
 
         assertFalse(EqualsBuilder.reflectionEquals(o1, this));
 
@@ -1274,32 +1274,28 @@ class EqualsBuilderTest extends AbstractBuilderTest {
             final TestObject to2,
             final TestObject oToChange,
             final boolean testTransients) {
-
         // reflection test
         assertTrue(EqualsBuilder.reflectionEquals(to, to, testTransients));
         assertTrue(EqualsBuilder.reflectionEquals(to2, to2, testTransients));
         // symmetry test
-        assertTrueIfAccessible(EqualsBuilder.reflectionEquals(to, toBis, testTransients) && EqualsBuilder.reflectionEquals(toBis, to, testTransients));
+        assertTrue(EqualsBuilder.reflectionEquals(to, toBis, testTransients) && EqualsBuilder.reflectionEquals(toBis, to, testTransients));
         // transitive test
-        assertEquals(accessibleFlag(),
-                EqualsBuilder.reflectionEquals(to, toBis, testTransients)
-                        && EqualsBuilder.reflectionEquals(toBis, toTer, testTransients)
-                        && EqualsBuilder.reflectionEquals(to, toTer, testTransients));
-
+        assertTrue(EqualsBuilder.reflectionEquals(to, toBis, testTransients)
+                && EqualsBuilder.reflectionEquals(toBis, toTer, testTransients)
+                && EqualsBuilder.reflectionEquals(to, toTer, testTransients));
         // consistency test
         oToChange.setA(to.getA());
         if (oToChange instanceof TestSubObject) {
             ((TestSubObject) oToChange).setB(((TestSubObject) to).getB());
         }
-        assertTrueIfAccessible(EqualsBuilder.reflectionEquals(oToChange, to, testTransients));
-        assertTrueIfAccessible(EqualsBuilder.reflectionEquals(oToChange, to, testTransients));
+        assertTrue(EqualsBuilder.reflectionEquals(oToChange, to, testTransients));
+        assertTrue(EqualsBuilder.reflectionEquals(oToChange, to, testTransients));
         oToChange.setA(to.getA() + 1);
         if (oToChange instanceof TestSubObject) {
             ((TestSubObject) oToChange).setB(((TestSubObject) to).getB() + 1);
         }
-        assertFalse(EqualsBuilder.reflectionEquals(oToChange, to, testTransients));
-        assertFalse(EqualsBuilder.reflectionEquals(oToChange, to, testTransients));
-
+        assertFalseIfAccessible(EqualsBuilder.reflectionEquals(oToChange, to, testTransients));
+        assertFalseIfAccessible(EqualsBuilder.reflectionEquals(oToChange, to, testTransients));
         // non-null reference test
         assertFalse(EqualsBuilder.reflectionEquals(to, null, testTransients));
         assertFalse(EqualsBuilder.reflectionEquals(to2, null, testTransients));
@@ -1314,19 +1310,19 @@ class EqualsBuilderTest extends AbstractBuilderTest {
         final TestObjectWithMultipleFields x2 = new TestObjectWithMultipleFields(1, 3, 4);
 
         // not equal when including all fields
-        assertFalse(EqualsBuilder.reflectionEquals(x1, x2));
+        assertFalseIfAccessible(EqualsBuilder.reflectionEquals(x1, x2));
 
         // doesn't barf on null, empty array, or non-existent field, but still tests as not equal
-        assertFalse(EqualsBuilder.reflectionEquals(x1, x2, (String[]) null));
-        assertFalse(EqualsBuilder.reflectionEquals(x1, x2));
-        assertFalse(EqualsBuilder.reflectionEquals(x1, x2, "xxx"));
+        assertFalseIfAccessible(EqualsBuilder.reflectionEquals(x1, x2, (String[]) null));
+        assertFalseIfAccessible(EqualsBuilder.reflectionEquals(x1, x2));
+        assertFalseIfAccessible(EqualsBuilder.reflectionEquals(x1, x2, "xxx"));
 
         // not equal if only one of the differing fields excluded
-        assertFalse(EqualsBuilder.reflectionEquals(x1, x2, "two"));
-        assertFalse(EqualsBuilder.reflectionEquals(x1, x2, "three"));
+        assertFalseIfAccessible(EqualsBuilder.reflectionEquals(x1, x2, "two"));
+        assertFalseIfAccessible(EqualsBuilder.reflectionEquals(x1, x2, "three"));
 
         // equal if both differing fields excluded
-        assertTrueIfAccessible(EqualsBuilder.reflectionEquals(x1, x2, "two", "three"));
+        assertTrue(EqualsBuilder.reflectionEquals(x1, x2, "two", "three"));
 
         // still equal as long as both differing fields are among excluded
         assertTrue(EqualsBuilder.reflectionEquals(x1, x2, "one", "two", "three"));
@@ -1343,11 +1339,11 @@ class EqualsBuilderTest extends AbstractBuilderTest {
         testReflectionHierarchyEquals(false);
         testReflectionHierarchyEquals(true);
         // Transients
-        assertTrueIfAccessible(EqualsBuilder.reflectionEquals(new TestTTLeafObject(1, 2, 3, 4), new TestTTLeafObject(1, 2, 3, 4), true));
-        assertTrueIfAccessible(EqualsBuilder.reflectionEquals(new TestTTLeafObject(1, 2, 3, 4), new TestTTLeafObject(1, 2, 3, 4), false));
-        assertFalse(EqualsBuilder.reflectionEquals(new TestTTLeafObject(1, 0, 0, 4), new TestTTLeafObject(1, 2, 3, 4), true));
-        assertFalse(EqualsBuilder.reflectionEquals(new TestTTLeafObject(1, 2, 3, 4), new TestTTLeafObject(1, 2, 3, 0), true));
-        assertFalse(EqualsBuilder.reflectionEquals(new TestTTLeafObject(0, 2, 3, 4), new TestTTLeafObject(1, 2, 3, 4), true));
+        assertTrue(EqualsBuilder.reflectionEquals(new TestTTLeafObject(1, 2, 3, 4), new TestTTLeafObject(1, 2, 3, 4), true));
+        assertTrue(EqualsBuilder.reflectionEquals(new TestTTLeafObject(1, 2, 3, 4), new TestTTLeafObject(1, 2, 3, 4), false));
+        assertFalseIfAccessible(EqualsBuilder.reflectionEquals(new TestTTLeafObject(1, 0, 0, 4), new TestTTLeafObject(1, 2, 3, 4), true));
+        assertFalseIfAccessible(EqualsBuilder.reflectionEquals(new TestTTLeafObject(1, 2, 3, 4), new TestTTLeafObject(1, 2, 3, 0), true));
+        assertFalseIfAccessible(EqualsBuilder.reflectionEquals(new TestTTLeafObject(0, 2, 3, 4), new TestTTLeafObject(1, 2, 3, 4), true));
     }
 
     private void testReflectionHierarchyEquals(final boolean testTransients) {
@@ -1371,38 +1367,38 @@ class EqualsBuilderTest extends AbstractBuilderTest {
 
         // same values
         assertTrue(EqualsBuilder.reflectionEquals(ttlo, ttlo, testTransients));
-        assertTrueIfAccessible(EqualsBuilder.reflectionEquals(new TestSubObject(1, 10), new TestSubObject(1, 10), testTransients));
+        assertTrue(EqualsBuilder.reflectionEquals(new TestSubObject(1, 10), new TestSubObject(1, 10), testTransients));
         // same super values, diff sub values
-        assertFalse(EqualsBuilder.reflectionEquals(new TestSubObject(1, 10), new TestSubObject(1, 11), testTransients));
-        assertFalse(EqualsBuilder.reflectionEquals(new TestSubObject(1, 11), new TestSubObject(1, 10), testTransients));
+        assertFalseIfAccessible(EqualsBuilder.reflectionEquals(new TestSubObject(1, 10), new TestSubObject(1, 11), testTransients));
+        assertFalseIfAccessible(EqualsBuilder.reflectionEquals(new TestSubObject(1, 11), new TestSubObject(1, 10), testTransients));
         // diff super values, same sub values
-        assertFalse(EqualsBuilder.reflectionEquals(new TestSubObject(0, 10), new TestSubObject(1, 10), testTransients));
-        assertFalse(EqualsBuilder.reflectionEquals(new TestSubObject(1, 10), new TestSubObject(0, 10), testTransients));
+        assertFalseIfAccessible(EqualsBuilder.reflectionEquals(new TestSubObject(0, 10), new TestSubObject(1, 10), testTransients));
+        assertFalseIfAccessible(EqualsBuilder.reflectionEquals(new TestSubObject(1, 10), new TestSubObject(0, 10), testTransients));
 
         // mix super and sub types: equals
-        assertTrueIfAccessible(EqualsBuilder.reflectionEquals(to1, teso, testTransients));
-        assertTrueIfAccessible(EqualsBuilder.reflectionEquals(teso, to1, testTransients));
+        assertTrue(EqualsBuilder.reflectionEquals(to1, teso, testTransients));
+        assertTrue(EqualsBuilder.reflectionEquals(teso, to1, testTransients));
 
-        assertTrueIfAccessible(EqualsBuilder.reflectionEquals(to1, ttso, false)); // Force testTransients = false for this assert
-        assertTrueIfAccessible(EqualsBuilder.reflectionEquals(ttso, to1, false)); // Force testTransients = false for this assert
+        assertTrue(EqualsBuilder.reflectionEquals(to1, ttso, false)); // Force testTransients = false for this assert
+        assertTrue(EqualsBuilder.reflectionEquals(ttso, to1, false)); // Force testTransients = false for this assert
 
-        assertTrueIfAccessible(EqualsBuilder.reflectionEquals(to1, tttso, false)); // Force testTransients = false for this assert
-        assertTrueIfAccessible(EqualsBuilder.reflectionEquals(tttso, to1, false)); // Force testTransients = false for this assert
+        assertTrue(EqualsBuilder.reflectionEquals(to1, tttso, false)); // Force testTransients = false for this assert
+        assertTrue(EqualsBuilder.reflectionEquals(tttso, to1, false)); // Force testTransients = false for this assert
 
-        assertTrueIfAccessible(EqualsBuilder.reflectionEquals(ttso, tttso, false)); // Force testTransients = false for this assert
-        assertTrueIfAccessible(EqualsBuilder.reflectionEquals(tttso, ttso, false)); // Force testTransients = false for this assert
+        assertTrue(EqualsBuilder.reflectionEquals(ttso, tttso, false)); // Force testTransients = false for this assert
+        assertTrue(EqualsBuilder.reflectionEquals(tttso, ttso, false)); // Force testTransients = false for this assert
 
         // mix super and sub types: NOT equals
-        assertFalse(EqualsBuilder.reflectionEquals(new TestObject(0), new TestEmptySubObject(1), testTransients));
-        assertFalse(EqualsBuilder.reflectionEquals(new TestEmptySubObject(1), new TestObject(0), testTransients));
+        assertFalseIfAccessible(EqualsBuilder.reflectionEquals(new TestObject(0), new TestEmptySubObject(1), testTransients));
+        assertFalseIfAccessible(EqualsBuilder.reflectionEquals(new TestEmptySubObject(1), new TestObject(0), testTransients));
 
-        assertFalse(EqualsBuilder.reflectionEquals(new TestObject(0), new TestTSubObject(1, 1), testTransients));
-        assertFalse(EqualsBuilder.reflectionEquals(new TestTSubObject(1, 1), new TestObject(0), testTransients));
+        assertFalseIfAccessible(EqualsBuilder.reflectionEquals(new TestObject(0), new TestTSubObject(1, 1), testTransients));
+        assertFalseIfAccessible(EqualsBuilder.reflectionEquals(new TestTSubObject(1, 1), new TestObject(0), testTransients));
 
-        assertFalse(EqualsBuilder.reflectionEquals(new TestObject(1), new TestSubObject(0, 10), testTransients));
-        assertFalse(EqualsBuilder.reflectionEquals(new TestSubObject(0, 10), new TestObject(1), testTransients));
+        assertFalseIfAccessible(EqualsBuilder.reflectionEquals(new TestObject(1), new TestSubObject(0, 10), testTransients));
+        assertFalseIfAccessible(EqualsBuilder.reflectionEquals(new TestSubObject(0, 10), new TestObject(1), testTransients));
 
-        assertFalse(EqualsBuilder.reflectionEquals(to1, ttlo));
+        assertFalseIfAccessible(EqualsBuilder.reflectionEquals(to1, ttlo));
         assertFalse(EqualsBuilder.reflectionEquals(tso1, this));
     }
 
@@ -1494,12 +1490,12 @@ class EqualsBuilderTest extends AbstractBuilderTest {
         TestObjectEqualsExclude one = new TestObjectEqualsExclude(1, 2);
         TestObjectEqualsExclude two = new TestObjectEqualsExclude(1, 3);
 
-        assertFalse(EqualsBuilder.reflectionEquals(one, two));
+        assertFalseIfAccessible(EqualsBuilder.reflectionEquals(one, two));
 
         one = new TestObjectEqualsExclude(1, 2);
         two = new TestObjectEqualsExclude(2, 2);
 
-        assertTrueIfAccessible(EqualsBuilder.reflectionEquals(one, two));
+        assertTrue(EqualsBuilder.reflectionEquals(one, two));
     }
 
     /**

--- a/src/test/java/org/apache/commons/lang3/time/StopWatchTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/StopWatchTest.java
@@ -267,6 +267,12 @@ class StopWatchTest extends AbstractLangTest {
         assertThrows(IllegalStateException.class, watch::getStartTime, "Calling getStartTime on a reset, but unstarted StopWatch should throw an exception");
     }
 
+    @Test
+    void testGetStopTime() throws InterruptedException {
+        final StopWatch watch = StopWatch.createStarted();
+        assertEquals(0, watch.getStopTime());
+    }
+
     @RepeatedTest(10)
     void testGetTime() throws InterruptedException {
         final StopWatch watch = new StopWatch();
@@ -443,12 +449,6 @@ class StopWatchTest extends AbstractLangTest {
     void testStatic() {
         final StopWatch watch = StopWatch.createStarted();
         assertTrue(watch.isStarted());
-    }
-
-    @Test
-    void testGetStopTime() throws InterruptedException {
-        final StopWatch watch = StopWatch.createStarted();
-        assertEquals(0, watch.getStopTime());
     }
 
     @Test


### PR DESCRIPTION
[[LANG-1825]](https://issues.apache.org/jira/browse/LANG-1825) EqualsBuilder.reflectionAppend tries to set visibility on excluded fields.

Don't force fields to be accessible when excluded.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] ~~I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?~~
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
