### PR TITLE
WordUtils.wrap() zero-width wrapOn regex match causes infinite loop

### DIFF
--- a/src/main/java/org/apache/commons/lang3/text/WordUtils.java
+++ b/src/main/java/org/apache/commons/lang3/text/WordUtils.java
@@ -652,21 +652,19 @@ public class WordUtils {
                 str.substring(offset, Math.min((int) Math.min(Integer.MAX_VALUE, offset + wrapLength + 1L), inputLineLength)));
             if (matcher.find()) {
                 if (matcher.start() == 0) {
-                    offset += matcher.end();
+                    // If the match is zero-width, advance by at least 1 to avoid infinite loop.
+                    offset += matcher.end() > 0 ? matcher.end() : 1;
                     continue;
                 }
                 spaceToWrapAt = matcher.start() + offset;
             }
-
             // only last line without leading spaces is left
             if (inputLineLength - offset <= wrapLength) {
                 break;
             }
-
             while (matcher.find()) {
                 spaceToWrapAt = matcher.start() + offset;
             }
-
             if (spaceToWrapAt >= offset) {
                 // normal case
                 wrappedLine.append(str, offset, spaceToWrapAt);
@@ -696,10 +694,8 @@ public class WordUtils {
                 }
             }
         }
-
         // Whatever is left in line is short enough to just pass through
         wrappedLine.append(str, offset, str.length());
-
         return wrappedLine.toString();
     }
 

--- a/src/test/java/org/apache/commons/lang3/text/WordUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/WordUtilsTest.java
@@ -20,10 +20,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTimeout;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
+import java.time.Duration;
 
 import org.apache.commons.lang3.AbstractLangTest;
 import org.junit.jupiter.api.Test;
@@ -428,5 +430,10 @@ class WordUtilsTest extends AbstractLangTest {
         input = "flammableinflammable";
         expected = "flammableinflam\nmable";
         assertEquals(expected, WordUtils.wrap(input, 15, "\n", true, "/"));
+    }
+
+    @Test
+    void testZeroWidthWrapOnRegex() {
+        assertTimeout(Duration.ofSeconds(2), () -> assertNotNull(WordUtils.wrap("abcdef", 3, "\n", false, "(?=a)")));
     }
 }


### PR DESCRIPTION
Calling the deprecated method `WordUtils.wrap(String, int, String, boolean, String)` with zero-width wrapOn regex match causes infinite loop

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [x] OP used AI to create the original report.
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
