### PR TITLE
EqualsBuilder.reflectionEquals() array branch missing cycle guard causes stack overflow on self-referential Object arrays

### DIFF
--- a/src/main/java/org/apache/commons/lang3/builder/EqualsBuilder.java
+++ b/src/main/java/org/apache/commons/lang3/builder/EqualsBuilder.java
@@ -26,7 +26,6 @@ import java.util.Set;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.ClassUtils;
-import org.apache.commons.lang3.builder.AbstractReflection.AbstractBuilder;
 import org.apache.commons.lang3.tuple.Pair;
 
 /**
@@ -171,7 +170,7 @@ public class EqualsBuilder extends AbstractReflection implements Builder<Boolean
      * <p>
      * Used by the reflection methods to avoid infinite loops.
      * Objects might be swapped therefore a check is needed if the object pair
-     * is registered in given or swapped order.
+     * is registered in the given or swapped order.
      * </p>
      *
      * @param lhs {@code this} object to lookup in registry
@@ -409,7 +408,7 @@ public class EqualsBuilder extends AbstractReflection implements Builder<Boolean
         bypassReflectionClasses.add(String.class); //hashCode field being lazy but not transient
     }
 
-    private EqualsBuilder(Builder builder) {
+    private EqualsBuilder(final Builder builder) {
         super(builder);
     }
 
@@ -793,24 +792,29 @@ public class EqualsBuilder extends AbstractReflection implements Builder<Boolean
      * @return {@code this} instance.
      */
     public EqualsBuilder append(final Object[] lhs, final Object[] rhs) {
-        if (!isEquals) {
+        if (!isEquals || isRegistered(lhs, rhs)) {
             return this;
         }
-        if (lhs == rhs) {
+        try {
+            register(lhs, rhs);
+            if (lhs == rhs) {
+                return this;
+            }
+            if (lhs == null || rhs == null) {
+                setEquals(false);
+                return this;
+            }
+            if (lhs.length != rhs.length) {
+                setEquals(false);
+                return this;
+            }
+            for (int i = 0; i < lhs.length && isEquals; ++i) {
+                append(lhs[i], rhs[i]);
+            }
             return this;
+        } finally {
+            unregister(lhs, rhs);
         }
-        if (lhs == null || rhs == null) {
-            setEquals(false);
-            return this;
-        }
-        if (lhs.length != rhs.length) {
-            setEquals(false);
-            return this;
-        }
-        for (int i = 0; i < lhs.length && isEquals; ++i) {
-            append(lhs[i], rhs[i]);
-        }
-        return this;
     }
 
     /**

--- a/src/test/java/org/apache/commons/lang3/builder/EqualsBuilderReflectionEqualsCycleTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/EqualsBuilderReflectionEqualsCycleTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.lang3.builder;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests {@link EqualsBuilder#reflectionEquals(Object, Object, String...)}.
+ * <p>
+ * reflectionEquals array fix enables cyclic-array.
+ * </p>
+ * <p>
+ * Pre-patch: Object[] elements containing themselves cause StackOverflowError when compared via EqualsBuilder.reflectionEquals because the array branch in
+ * reflectionAppend calls append(lhs, rhs) which recurses without cycle check.
+ * </p>
+ * <p>
+ * Post-patch: the arrays are registered before recursing so cycles are detected and the comparison terminates (returning false).
+ * </p>
+ */
+class EqualsBuilderReflectionEqualsCycleTest {
+
+    @Test
+    void testSelfReferentialObjectArrays() {
+        final Object[] a = new Object[1];
+        final Object[] b = new Object[1];
+        a[0] = a;
+        b[0] = b;
+        // Pre-patch: StackOverflowError; Post-patch: terminates without error.
+        // With cycle detection, comparing a[0]=a vs b[0]=b sees (a,b) already registered
+        // and treats the cycle as equal, so the overall result is true (structurally isomorphic).
+        // The key assertion is that NO StackOverflowError is thrown.
+        assertTrue(EqualsBuilder.reflectionEquals(a, b));
+    }
+
+    @Test
+    void testCrossReferentialObjectArrays() {
+        final Object[] a = new Object[1];
+        final Object[] b = new Object[1];
+        // a[0] -> b, b[0] -> a: mutual cycle
+        a[0] = b;
+        b[0] = a;
+        assertTrue(EqualsBuilder.reflectionEquals(a, b));
+    }
+}


### PR DESCRIPTION
`EqualsBuilder.reflectionEquals(Object, Object, String...)` array branch missing cycle guard causes stack overflow on self-referential Object arrays.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [x] OP used AI to create the original report.
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
