### PR TITLE
StrBuilder.deleteImpl(int, int, int) doesn't clear its unused bytes.

### DIFF
--- a/src/main/java/org/apache/commons/lang3/text/StrBuilder.java
+++ b/src/main/java/org/apache/commons/lang3/text/StrBuilder.java
@@ -1614,7 +1614,7 @@ public class StrBuilder implements CharSequence, Appendable, Serializable, Build
      */
     public StrBuilder clear() {
         size = 0;
-        Arrays.fill(buffer, '0');
+        Arrays.fill(buffer, CharUtils.NUL);
         return this;
     }
 
@@ -1810,6 +1810,7 @@ public class StrBuilder implements CharSequence, Appendable, Serializable, Build
     private void deleteImpl(final int startIndex, final int endIndex, final int len) {
         System.arraycopy(buffer, endIndex, buffer, startIndex, size - endIndex);
         size -= len;
+        Arrays.fill(buffer, size, size + len, CharUtils.NUL);
     }
 
     /**

--- a/src/test/java/org/apache/commons/lang3/text/StrBuilderClearTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/StrBuilderClearTest.java
@@ -19,9 +19,14 @@ package org.apache.commons.lang3.text;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.ObjectInputStream;
 import java.io.Reader;
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
 
+import org.apache.commons.lang3.SerializationUtils;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -86,6 +91,40 @@ public class StrBuilderClearTest {
         }
     }
 
+    /** Search for a string encoded as UTF-16BE (2 bytes per char) in a byte array. */
+    private static boolean containsUtf16Be(final byte[] haystack, final String needle) throws IOException {
+        final byte[] needleBytes = needle.getBytes(StandardCharsets.UTF_16BE);
+        outer: for (int i = 0; i <= haystack.length - needleBytes.length; i++) {
+            for (int j = 0; j < needleBytes.length; j++) {
+                if (haystack[i + j] != needleBytes[j]) {
+                    continue outer;
+                }
+            }
+            return true;
+        }
+        return false;
+    }
+
+    @Test
+    public void testDeserializedStrBuilderHasNoStaleBufferContent() throws Exception {
+        final StrBuilder sb = new StrBuilder("secret_password_xyzzy");
+        sb.clear();
+        sb.append("safe");
+        final byte[] serialized = SerializationUtils.serialize(sb);
+        final StrBuilder sb2;
+        // Deserialize and inspect the buffer
+        try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(serialized))) {
+            sb2 = (StrBuilder) ois.readObject();
+        }
+        final Field bufField = StrBuilder.class.getDeclaredField("buffer");
+        bufField.setAccessible(true);
+        final Field sizeField = StrBuilder.class.getDeclaredField("size");
+        sizeField.setAccessible(true);
+        final char[] buf2 = (char[]) bufField.get(sb2);
+        final String bufContent = new String(buf2);
+        assertFalse(bufContent.contains("secret_password"), "Deserialized StrBuilder buffer must not contain stale chars: " + bufContent);
+    }
+
     @Test
     public void testReadFromReaderDoesNotExposeStaleInternalBuffer() throws IOException {
         final StrBuilder sb = new StrBuilder();
@@ -103,5 +142,26 @@ public class StrBuilderClearTest {
             // Post-patch: stale chars must NOT be visible to the Reader
             assertFalse(spy.observedStaleChars("_DATA_SHOULD_NOT_LEAK"));
         }
+    }
+
+    @Test
+    public void testStaleCharsNotLeakedAfterClear() throws Exception {
+        final StrBuilder sb = new StrBuilder("secret_password_xyzzy_leak");
+        // clear() resets logical size to 0 but leaves chars in buffer
+        sb.clear();
+        // append something shorter than the original
+        sb.append("ok");
+        // Stale content is serialized as UTF-16BE char[] data.
+        // "xyzzy_leak" was at positions 15+, well beyond "ok" (len=2), so must not appear.
+        assertFalse(containsUtf16Be(SerializationUtils.serialize(sb), "xyzzy_leak"));
+    }
+
+    @Test
+    public void testStaleCharsNotLeakedAfterTruncate() throws Exception {
+        final StrBuilder sb = new StrBuilder("top_secret_key_material");
+        // truncate to a short length – tail remains in buffer
+        sb.delete(6, sb.length());
+        // sb now logically contains "top_se"
+        assertFalse(containsUtf16Be(SerializationUtils.serialize(sb), "secret_key_material"));
     }
 }

--- a/src/test/java/org/apache/commons/lang3/text/StrBuilderClearTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/StrBuilderClearTest.java
@@ -23,7 +23,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.Reader;
-import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.lang3.SerializationUtils;
@@ -116,11 +115,7 @@ public class StrBuilderClearTest {
         try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(serialized))) {
             sb2 = (StrBuilder) ois.readObject();
         }
-        final Field bufField = StrBuilder.class.getDeclaredField("buffer");
-        bufField.setAccessible(true);
-        final Field sizeField = StrBuilder.class.getDeclaredField("size");
-        sizeField.setAccessible(true);
-        final char[] buf2 = (char[]) bufField.get(sb2);
+        final char[] buf2 = sb2.buffer;
         final String bufContent = new String(buf2);
         assertFalse(bufContent.contains("secret_password"), "Deserialized StrBuilder buffer must not contain stale chars: " + bufContent);
     }


### PR DESCRIPTION
`StrBuilder.deleteImpl(int, int, int)` doesn't clear its unused bytes.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [x] OP used AI to create the original report.
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
