### PR TITLE
LocaleUtils.parseLocale(String) operator precedence bug allows invalid language with numeric country

### DIFF
--- a/src/main/java/org/apache/commons/lang3/LocaleUtils.java
+++ b/src/main/java/org/apache/commons/lang3/LocaleUtils.java
@@ -338,7 +338,7 @@ public class LocaleUtils {
         final String language = segments[0];
         if (segments.length == 2) {
             final String country = segments[1];
-            if (isISO639LanguageCode(language) && isISO3166CountryCode(country) || isNumericAreaCode(country)) {
+            if (isISO639LanguageCode(language) && (isISO3166CountryCode(country) || isNumericAreaCode(country))) {
                 return new Locale(language, country);
             }
         } else if (segments.length == limit) {

--- a/src/test/java/org/apache/commons/lang3/LocaleUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/LocaleUtilsTest.java
@@ -256,6 +256,16 @@ class LocaleUtilsTest extends AbstractLangTest {
         assertCountriesByLanguage("it", new String[]{"IT", "CH"});
     }
 
+    @Test
+    void testIllegalLanguageWithNumericCountry() {
+        assertIllegalArgumentException(() -> LocaleUtils.toLocale("../../unexpected_001"));
+    }
+
+    @Test
+    void testIllegalSingleCharLanguageWithNumericCountry() {
+        assertIllegalArgumentException(() -> LocaleUtils.toLocale("x_001"));
+    }
+
     /**
      * Test availableLocaleSet() method.
      */


### PR DESCRIPTION
`LocaleUtils.parseLocale(String)` operator precedence bug allows invalid language with numeric country.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [x] OP used AI to create the original report.
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
