### PR TITLE
FastDatePrinter WeekYear rule calls Calendar.getWeekYear() may throw UnsupportedOperationException

### DIFF
--- a/src/main/java/org/apache/commons/lang3/time/FastDatePrinter.java
+++ b/src/main/java/org/apache/commons/lang3/time/FastDatePrinter.java
@@ -862,7 +862,9 @@ public class FastDatePrinter implements DatePrinter, Serializable {
 
         @Override
         public void appendTo(final Appendable buffer, final Calendar calendar) throws IOException {
-            rule.appendTo(buffer, calendar.getWeekYear());
+            // Some Calendar implementations (JapaneseImperialCalendar) do not support week-dates.
+            // Fall back to Calendar.YEAR in that case.
+            rule.appendTo(buffer, calendar.isWeekDateSupported() ? calendar.getWeekYear() : calendar.get(Calendar.YEAR));
         }
 
         @Override

--- a/src/test/java/org/apache/commons/lang3/time/FastDateFormatTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/FastDateFormatTest.java
@@ -110,6 +110,36 @@ class FastDateFormatTest extends AbstractLangTest {
         return totalElapsed;
     }
 
+    /**
+     * Pre-patch: UnsupportedOperationException when formatting a Japanese Imperial Calendar with 'Y' (week-year) pattern.
+     * <p>
+     * Post-patch: falls back to Calendar.YEAR and formats successfully.
+     * </p>
+     */
+    @Test
+    void testJapaneseImperialCalendarWeekYearDoesNotThrow() {
+        final Locale japaneseImperial = new Locale("ja", "JP", "JP");
+        final Calendar japaneseCal = Calendar.getInstance(japaneseImperial);
+        final FastDateFormat fdp = FastDateFormat.getInstance("YYYY-MM-dd");
+        assertNotNull(fdp.format(japaneseCal), "Formatting JapaneseImperialCalendar with YYYY pattern must not throw UnsupportedOperationException");
+    }
+
+    /**
+     * Pre-patch: UnsupportedOperationException when formatting a Japanese Imperial
+     * <p>
+     * Calendar with 'Y' (week-year) pattern. Post-patch: falls back to Calendar.YEAR and formats successfully.
+     * </p>
+     * <p>
+     * Also test that a regular Gregorian calendar works fine with YYYY.
+     * </p>
+     */
+    @Test
+    void testGregorianCalendarWeekYearWorks() {
+        final Calendar cal = Calendar.getInstance();
+        final FastDateFormat fdp = FastDateFormat.getInstance("YYYY-MM-dd");
+        assertNotNull(fdp.format(cal), "Formatting Gregorian Calendar with YYYY pattern should always work");
+    }
+
     @DefaultLocale(language = "en", country = "US")
     @Test
     void test_changeDefault_Locale_DateInstance() {


### PR DESCRIPTION
`FastDatePrinter` `WeekYear` rule calls `Calendar.getWeekYear()` without checking `isWeekDateSupported()`

The method would throw `UnsupportedOperationException`.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [x] OP used AI to create the original report.
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
