### PR TITLE
FormattableUtils.append re-parses literal output as format string

### DIFF
--- a/src/main/java/org/apache/commons/lang3/text/FormattableUtils.java
+++ b/src/main/java/org/apache/commons/lang3/text/FormattableUtils.java
@@ -104,8 +104,7 @@ public class FormattableUtils {
         for (int i = buf.length(); i < width; i++) {
             buf.insert(leftJustify ? i : 0, padChar);
         }
-        formatter.format(buf.toString());
-        return formatter;
+        return formatter.format(SIMPLEST_FORMAT, buf.toString());
     }
 
     /**

--- a/src/test/java/org/apache/commons/lang3/text/FormattableUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/FormattableUtilsTest.java
@@ -115,4 +115,14 @@ class FormattableUtilsTest extends AbstractLangTest {
         assertIllegalArgumentException(() -> FormattableUtils.append("foo", new Formatter(), 0, -1, 1, "xx"));
     }
 
+    @Test
+    void testPercentLiteral() {
+        assertEquals("100% done", FormattableUtils.append("100% done", new Formatter(), 0, -1, -1).toString());
+    }
+
+    @Test
+    void testPercentLiteralX2() {
+        assertEquals("50% off 100% items", FormattableUtils.append("50% off 100% items", new Formatter(), 0, -1, -1).toString());
+    }
+
 }


### PR DESCRIPTION
The deprecated `FormattableUtils.append()` re-parses literal output as format string

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [x] OP used AI to create the original report.
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
