### PR TITLE
TimeZones.GMT is a mutable public static final field

### DIFF
--- a/src/main/java/org/apache/commons/lang3/time/ImmutableTimeZone.java
+++ b/src/main/java/org/apache/commons/lang3/time/ImmutableTimeZone.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.lang3.time;
+
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.TimeZone;
+
+/**
+ * An immutable {@link TimeZone}.
+ */
+final class ImmutableTimeZone extends TimeZone {
+
+    private static final long serialVersionUID = 1L;
+    private final TimeZone timeZone;
+
+    ImmutableTimeZone(final TimeZone timeZone) {
+        this.timeZone = Objects.requireNonNull(timeZone, "timeZone");
+    }
+
+    @Override
+    public Object clone() {
+        // Immutable, so return this.
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getDisplayName(final boolean daylight, final int style, final Locale locale) {
+        return timeZone.getDisplayName(daylight, style, locale);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getDSTSavings() {
+        return timeZone.getDSTSavings();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getID() {
+        return timeZone.getID();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getOffset(final int era, final int year, final int month, final int day, final int dayOfWeek, final int milliseconds) {
+        return timeZone.getOffset(era, year, month, day, dayOfWeek, milliseconds);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getOffset(final long date) {
+        return timeZone.getOffset(date);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getRawOffset() {
+        return timeZone.getRawOffset();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean hasSameRules(final TimeZone other) {
+        return timeZone.hasSameRules(other);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean inDaylightTime(final Date date) {
+        return timeZone.inDaylightTime(date);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean observesDaylightTime() {
+        return timeZone.observesDaylightTime();
+    }
+
+    /**
+     * Always throws {@link UnsupportedOperationException}.
+     */
+    @Override
+    public void setID(final String ID) {
+        throw new UnsupportedOperationException("This class is immutable.");
+    }
+
+    /**
+     * Always throws {@link UnsupportedOperationException}.
+     */
+    @Override
+    public void setRawOffset(final int offsetMillis) {
+        throw new UnsupportedOperationException("This class is immutable.");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toString() {
+        return timeZone.toString();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ZoneId toZoneId() {
+        return timeZone.toZoneId();
+    }
+
+    TimeZone unwrap() {
+        return timeZone;
+    }
+
+    @Override
+    public boolean useDaylightTime() {
+        return timeZone.useDaylightTime();
+    }
+}

--- a/src/main/java/org/apache/commons/lang3/time/TimeZones.java
+++ b/src/main/java/org/apache/commons/lang3/time/TimeZones.java
@@ -27,7 +27,7 @@ import org.apache.commons.lang3.SystemProperties;
 import org.apache.commons.lang3.SystemUtils;
 
 /**
- * Helps dealing with {@link java.util.TimeZone}s.
+ * Helps work with {@link java.util.TimeZone}s.
  *
  * @since 3.7
  */
@@ -43,7 +43,7 @@ public class TimeZones {
      *
      * @since 3.13.0
      */
-    public static final TimeZone GMT = TimeZones.getTimeZone(GMT_ID);
+    public static final TimeZone GMT = new ImmutableTimeZone(TimeZones.getTimeZone(GMT_ID));
 
     private static final boolean JAVA_25 = SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_25);
 

--- a/src/test/java/org/apache/commons/lang3/time/ImmutableTimeZoneTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/ImmutableTimeZoneTest.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.lang3.time;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
+
+import org.apache.commons.lang3.AbstractLangTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link ImmutableTimeZone}.
+ */
+class ImmutableTimeZoneTest extends AbstractLangTest {
+
+    private static final TimeZone NEW_YORK = TimeZone.getTimeZone("America/New_York");
+    private static final TimeZone UTC = TimeZone.getTimeZone("UTC");
+    private ImmutableTimeZone newYorkImmutable;
+    private ImmutableTimeZone utcImmutable;
+
+    @BeforeEach
+    void setUp() {
+        utcImmutable = new ImmutableTimeZone(UTC);
+        newYorkImmutable = new ImmutableTimeZone(NEW_YORK);
+    }
+
+    @Test
+    void testCloneReturnsSameInstance() {
+        // Immutable singleton: clone() must return 'this'
+        assertSame(utcImmutable, utcImmutable.clone());
+        assertSame(newYorkImmutable, newYorkImmutable.clone());
+    }
+
+    @Test
+    void testConstructorNullThrowsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new ImmutableTimeZone(null));
+    }
+
+    @Test
+    void testGetDisplayNameDelegatesToWrappedTimeZone() {
+        assertEquals(UTC.getDisplayName(false, TimeZone.LONG, Locale.US), utcImmutable.getDisplayName(false, TimeZone.LONG, Locale.US));
+        assertEquals(NEW_YORK.getDisplayName(true, TimeZone.SHORT, Locale.US), newYorkImmutable.getDisplayName(true, TimeZone.SHORT, Locale.US));
+    }
+
+    @Test
+    void testGetDSTSavingsDelegatesToWrappedTimeZone() {
+        assertEquals(UTC.getDSTSavings(), utcImmutable.getDSTSavings());
+        assertEquals(NEW_YORK.getDSTSavings(), newYorkImmutable.getDSTSavings());
+    }
+
+    @Test
+    void testGetIDDelegatesToWrappedTimeZone() {
+        assertEquals(UTC.getID(), utcImmutable.getID());
+        assertEquals(NEW_YORK.getID(), newYorkImmutable.getID());
+    }
+
+    @Test
+    void testGetOffsetEraYearMonthDayDelegatesToWrappedTimeZone() {
+        // era=1 (AD), year=2024, month=0 (Jan), day=1, dayOfWeek=2 (Mon), milliseconds=0
+        assertEquals(UTC.getOffset(1, 2024, 0, 1, 2, 0), utcImmutable.getOffset(1, 2024, 0, 1, 2, 0));
+        assertEquals(NEW_YORK.getOffset(1, 2024, 0, 1, 2, 0), newYorkImmutable.getOffset(1, 2024, 0, 1, 2, 0));
+    }
+
+    @Test
+    void testGetOffsetLongDelegatesToWrappedTimeZone() {
+        final long now = System.currentTimeMillis();
+        assertEquals(UTC.getOffset(now), utcImmutable.getOffset(now));
+        assertEquals(NEW_YORK.getOffset(now), newYorkImmutable.getOffset(now));
+    }
+
+    @Test
+    void testGetRawOffsetDelegatesToWrappedTimeZone() {
+        assertEquals(UTC.getRawOffset(), utcImmutable.getRawOffset());
+        assertEquals(NEW_YORK.getRawOffset(), newYorkImmutable.getRawOffset());
+    }
+
+    @Test
+    void testHasSameRulesDelegatesToWrappedTimeZone() {
+        assertTrue(utcImmutable.hasSameRules(UTC));
+        assertTrue(newYorkImmutable.hasSameRules(NEW_YORK));
+    }
+
+    @Test
+    void testInDaylightTimeDelegatesToWrappedTimeZone() {
+        final Date date = new Date();
+        assertEquals(UTC.inDaylightTime(date), utcImmutable.inDaylightTime(date));
+        assertEquals(NEW_YORK.inDaylightTime(date), newYorkImmutable.inDaylightTime(date));
+    }
+
+    @Test
+    void testObservesDaylightTimeDelegatesToWrappedTimeZone() {
+        assertEquals(UTC.observesDaylightTime(), utcImmutable.observesDaylightTime());
+        assertEquals(NEW_YORK.observesDaylightTime(), newYorkImmutable.observesDaylightTime());
+    }
+
+    @Test
+    void testSetIDThrowsUnsupportedOperationException() {
+        assertThrows(UnsupportedOperationException.class, () -> utcImmutable.setID("GMT"));
+    }
+
+    @Test
+    void testSetRawOffsetThrowsUnsupportedOperationException() {
+        assertThrows(UnsupportedOperationException.class, () -> utcImmutable.setRawOffset(0));
+    }
+
+    @Test
+    void testToStringDelegatesToWrappedTimeZone() {
+        assertEquals(UTC.toString(), utcImmutable.toString());
+        assertEquals(NEW_YORK.toString(), newYorkImmutable.toString());
+    }
+
+    @Test
+    void testToZoneIdDelegatesToWrappedTimeZone() {
+        assertEquals(UTC.toZoneId(), utcImmutable.toZoneId());
+        assertEquals(NEW_YORK.toZoneId(), newYorkImmutable.toZoneId());
+    }
+
+    @Test
+    void testToZoneIdNotNull() {
+        assertNotNull(utcImmutable.toZoneId());
+        assertNotNull(newYorkImmutable.toZoneId());
+    }
+
+    @Test
+    void testUseDaylightTimeDelegatesToWrappedTimeZone() {
+        assertEquals(UTC.useDaylightTime(), utcImmutable.useDaylightTime());
+        assertEquals(NEW_YORK.useDaylightTime(), newYorkImmutable.useDaylightTime());
+    }
+}

--- a/src/test/java/org/apache/commons/lang3/time/TimeZonesGmtTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/TimeZonesGmtTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.lang3.time;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.TimeZone;
+
+import org.apache.commons.lang3.SerializationUtils;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests {@link ImmutableTimeZone} and {@link TimeZones#GMT}.
+ * <p>
+ * TimeZones.GMT is a public static final mutable TimeZone. Callers can call setRawOffset() / setID() to globally corrupt time zone behavior.
+ * </p>
+ * <p>
+ * Pre-patch: setRawOffset() / setID() succeed silently and mutate the shared singleton.
+ * </p>
+ * <p>
+ * Post-patch: setRawOffset() / setID() throw UnsupportedOperationException.
+ * </p>
+ */
+public class TimeZonesGmtTest {
+
+    @Test
+    public void testGmtTimeZoneIsImmutableSetRawOffset() {
+        assertThrows(UnsupportedOperationException.class, () -> TimeZones.GMT.setRawOffset(3600000));
+    }
+
+    @Test
+    public void testGmtTimeZoneIsImmutableSetId() {
+        assertThrows(UnsupportedOperationException.class, () -> TimeZones.GMT.setID("Etc/UTC"));
+    }
+
+    @Test
+    public void testGmtOffsetRemainsZeroAfterAttemptedMutation() {
+        assertThrows(UnsupportedOperationException.class, () -> TimeZones.GMT.setRawOffset(3600000));
+        assertEquals(0, TimeZones.GMT.getRawOffset());
+    }
+
+    @Test
+    public void testGmtIdRemainsGmtAfterAttemptedMutation() {
+        assertThrows(UnsupportedOperationException.class, () -> TimeZones.GMT.setID("Etc/UTC"));
+        assertEquals("GMT", TimeZones.GMT.getID());
+    }
+
+    @Test
+    public void testCloneReturnsSelfForImmutableSingleton() {
+        // For an immutable singleton, clone() should return the same instance,
+        // and there must be no need to defensively copy the value.
+        final Object copy = TimeZones.GMT.clone();
+        assertSame(TimeZones.GMT, copy, "clone() of an immutable singleton should return the same instance");
+    }
+
+    @Test
+    public void testSerializedFormUsesNamedClass() throws Exception {
+        // Wire-format hazard guard: ensure the implementation class is a named static
+        // nested type, not an anonymous inner class whose synthetic name (TimeZones$1)
+        // is brittle across non-functional code reorderings.
+        assertEquals(ImmutableTimeZone.class.getName(), TimeZones.GMT.getClass().getName());
+    }
+
+    @Test
+    public void testSerializationRoundTripPreservesId() throws Exception {
+        // Round-trip via Serializable to confirm the type is wire-format friendly.
+        final TimeZone roundtrip = SerializationUtils.roundtrip(TimeZones.GMT);
+        assertNotNull(roundtrip, "Round-tripped TimeZone must not be null");
+        assertEquals("GMT", roundtrip.getID(), "Round-tripped TimeZone id must remain \"GMT\"");
+        assertEquals(0, roundtrip.getRawOffset(), "Round-tripped TimeZone offset must remain 0");
+    }
+}

--- a/src/test/java/org/apache/commons/lang3/time/TimeZonesTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/TimeZonesTest.java
@@ -36,5 +36,11 @@ class TimeZonesTest extends AbstractLangTest {
         assertEquals(TimeZone.getDefault(), TimeZones.toTimeZone(null));
         assertEquals(TimeZone.getDefault(), TimeZones.toTimeZone(TimeZone.getDefault()));
         assertEquals(TimeZones.GMT, TimeZones.toTimeZone(TimeZones.GMT));
+        final TimeZone timeZone = TimeZones.toTimeZone(TimeZones.GMT);
+        assertEquals(TimeZones.GMT.getID(), timeZone.getID());
+        assertEquals(TimeZones.GMT.toString(), timeZone.toString());
+        final TimeZone unwrap = ((ImmutableTimeZone) TimeZones.GMT).unwrap();
+        assertEquals(unwrap.getID(), timeZone.getID());
+        assertEquals(unwrap.toString(), timeZone.toString());
     }
 }


### PR DESCRIPTION
`TimeZones.GMT` is a mutable `public` `static` `final` field, `setRawOffset()` and `setID()` can globally corrupt time zone behavior.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [x] OP used AI to the original report. I used Claude Sonet 4.6 to create the first cut of the new test class ImmutableTimeZoneTest.
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
