### PR TITLE
CompareToBuilder lacks cycle guard on Object[] recursion.

### DIFF
--- a/src/main/java/org/apache/commons/lang3/builder/AbstractReflection.java
+++ b/src/main/java/org/apache/commons/lang3/builder/AbstractReflection.java
@@ -19,9 +19,11 @@ package org.apache.commons.lang3.builder;
 
 import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Field;
+import java.util.Set;
 import java.util.function.Supplier;
 
 import org.apache.commons.lang3.SystemProperties;
+import org.apache.commons.lang3.tuple.Pair;
 
 /**
  * Abstracts reflection access for reflection-based classes in this package.
@@ -111,6 +113,16 @@ public abstract class AbstractReflection {
         return SystemProperties.getBoolean(AbstractReflection.class, "forceAccessible", () -> true);
     }
 
+    static boolean isRegistered(final Object lhs, final Object rhs, final Set<Pair<IDKey, IDKey>> registry) {
+        final Pair<IDKey, IDKey> pair = toRegisterPair(lhs, rhs);
+        final Pair<IDKey, IDKey> swappedPair = Pair.of(pair.getRight(), pair.getLeft());
+        return registry != null && (registry.contains(pair) || registry.contains(swappedPair));
+    }
+
+    static void register(final Object lhs, final Object rhs, final Set<Pair<IDKey, IDKey>> registry) {
+        registry.add(toRegisterPair(lhs, rhs));
+    }
+
     /**
      * If {@code forceAccessible} flag is true, then the field is made accessible by calling {@link AccessibleObject#setAccessible(boolean)
      * AccessibleObject#setAccessible(true)} but <em>only</em> if a field is not already accessible.
@@ -145,6 +157,24 @@ public abstract class AbstractReflection {
             return field.isAccessible();
         }
         return false;
+    }
+
+    /**
+     * Converters value pair into a register pair.
+     *
+     * @param lhs {@code this} object.
+     * @param rhs the other object.
+     * @return the pair.
+     */
+    static Pair<IDKey, IDKey> toRegisterPair(final Object lhs, final Object rhs) {
+        return Pair.of(new IDKey(lhs), new IDKey(rhs));
+    }
+
+    static void unregister(final Object lhs, final Object rhs, final Set<Pair<IDKey, IDKey>> registry, final ThreadLocal<Set<Pair<IDKey, IDKey>>> registryTL) {
+        registry.remove(toRegisterPair(lhs, rhs));
+        if (registry.isEmpty()) {
+            registryTL.remove();
+        }
     }
 
     /**

--- a/src/main/java/org/apache/commons/lang3/builder/CompareToBuilder.java
+++ b/src/main/java/org/apache/commons/lang3/builder/CompareToBuilder.java
@@ -20,11 +20,14 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.Objects;
+import java.util.Set;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.builder.AbstractReflection.AbstractBuilder;
+import org.apache.commons.lang3.tuple.Pair;
 
 /**
  * Assists in implementing {@link Comparable#compareTo(Object)} methods.
@@ -119,12 +122,43 @@ public class CompareToBuilder extends AbstractReflection implements Builder<Inte
     }
 
     /**
+     * A registry of objects to detect cyclical object references, avoid infinite loops, and stack overflows.
+     */
+    private static final ThreadLocal<Set<Pair<IDKey, IDKey>>> REGISTRY = ThreadLocal.withInitial(HashSet::new);
+
+    /**
      * Constructs a new Builder.
      *
      * @return a new Builder.
      */
     public static Builder builder() {
         return new Builder();
+    }
+
+    /**
+     * Gets the registry of object pairs being traversed by the reflection
+     * methods in the current thread.
+     *
+     * @return Set the registry of objects being traversed
+     */
+    static Set<Pair<IDKey, IDKey>> getRegistry() {
+        return REGISTRY.get();
+    }
+
+    /**
+     * Tests whether the registry contains the given object pair.
+     * <p>
+     * Used by the reflection methods to avoid infinite loops.
+     * Objects might be swapped therefore a check is needed if the object pair
+     * is registered in the given or swapped order.
+     * </p>
+     *
+     * @param lhs {@code this} object to lookup in registry
+     * @param rhs the other object to lookup on registry
+     * @return boolean {@code true} if the registry contains the given object.
+     */
+    static boolean isRegistered(final Object lhs, final Object rhs) {
+        return isRegistered(lhs, rhs, getRegistry());
     }
 
     /**
@@ -347,6 +381,31 @@ public class CompareToBuilder extends AbstractReflection implements Builder<Inte
      */
     public static int reflectionCompare(final Object lhs, final Object rhs, final String... excludeFields) {
         return reflectionCompare(lhs, rhs, false, null, excludeFields);
+    }
+
+    /**
+     * Registers the given object pair.
+     * Used by the reflection methods to avoid infinite loops.
+     *
+     * @param lhs {@code this} object to register
+     * @param rhs the other object to register
+     */
+    private static void register(final Object lhs, final Object rhs) {
+        register(lhs, rhs, getRegistry());
+    }
+
+    /**
+     * Unregisters the given object pair.
+     *
+     * <p>
+     * Used by the reflection methods to avoid infinite loops.
+     * </p>
+     *
+     * @param lhs {@code this} object to unregister
+     * @param rhs the other object to unregister
+     */
+    private static void unregister(final Object lhs, final Object rhs) {
+        unregister(lhs, rhs, getRegistry(), REGISTRY);
     }
 
     /**
@@ -842,20 +901,28 @@ public class CompareToBuilder extends AbstractReflection implements Builder<Inte
             comparison = 1;
             return this;
         }
-        if (ObjectUtils.isArray(lhs)) {
-            // factor out array case in order to keep method small enough to be inlined
-            appendArray(lhs, rhs, comparator);
-        } else // the simple case, not an array, just test the element
-        if (comparator == null) {
-            @SuppressWarnings("unchecked") // assume this can be done; if not throw CCE as per Javadoc
-            final Comparable<Object> comparable = (Comparable<Object>) lhs;
-            comparison = comparable.compareTo(rhs);
-        } else {
-            @SuppressWarnings("unchecked") // assume this can be done; if not throw CCE as per Javadoc
-            final Comparator<Object> comparator2 = (Comparator<Object>) comparator;
-            comparison = comparator2.compare(lhs, rhs);
+        if (isRegistered(lhs, rhs)) {
+            return this;
         }
-        return this;
+        try {
+            register(lhs, rhs);
+            if (ObjectUtils.isArray(lhs)) {
+                // factor out array case in order to keep method small enough to be inlined
+                appendArray(lhs, rhs, comparator);
+            } else // the simple case, not an array, just test the element
+            if (comparator == null) {
+                @SuppressWarnings("unchecked") // assume this can be done; if not throw CCE as per Javadoc
+                final Comparable<Object> comparable = (Comparable<Object>) lhs;
+                comparison = comparable.compareTo(rhs);
+            } else {
+                @SuppressWarnings("unchecked") // assume this can be done; if not throw CCE as per Javadoc
+                final Comparator<Object> comparator2 = (Comparator<Object>) comparator;
+                comparison = comparator2.compare(lhs, rhs);
+            }
+            return this;
+        } finally {
+            unregister(lhs, rhs);
+        }
     }
 
     /**

--- a/src/main/java/org/apache/commons/lang3/builder/EqualsBuilder.java
+++ b/src/main/java/org/apache/commons/lang3/builder/EqualsBuilder.java
@@ -142,17 +142,6 @@ public class EqualsBuilder extends AbstractReflection implements Builder<Boolean
      */
 
     /**
-     * Converters value pair into a register pair.
-     *
-     * @param lhs {@code this} object
-     * @param rhs the other object
-     * @return the pair
-     */
-    static Pair<IDKey, IDKey> getRegisterPair(final Object lhs, final Object rhs) {
-        return Pair.of(new IDKey(lhs), new IDKey(rhs));
-    }
-
-    /**
      * Gets the registry of object pairs being traversed by the reflection
      * methods in the current thread.
      *
@@ -173,13 +162,9 @@ public class EqualsBuilder extends AbstractReflection implements Builder<Boolean
      * @param lhs {@code this} object to lookup in registry
      * @param rhs the other object to lookup on registry
      * @return boolean {@code true} if the registry contains the given object.
-     * @since 3.0
      */
     static boolean isRegistered(final Object lhs, final Object rhs) {
-        final Set<Pair<IDKey, IDKey>> registry = getRegistry();
-        final Pair<IDKey, IDKey> pair = getRegisterPair(lhs, rhs);
-        final Pair<IDKey, IDKey> swappedPair = Pair.of(pair.getRight(), pair.getLeft());
-        return registry != null && (registry.contains(pair) || registry.contains(swappedPair));
+        return isRegistered(lhs, rhs, getRegistry());
     }
 
     /**
@@ -353,7 +338,7 @@ public class EqualsBuilder extends AbstractReflection implements Builder<Boolean
      * @param rhs the other object to register
      */
     private static void register(final Object lhs, final Object rhs) {
-        getRegistry().add(getRegisterPair(lhs, rhs));
+        register(lhs, rhs, getRegistry());
     }
 
     /**
@@ -367,11 +352,7 @@ public class EqualsBuilder extends AbstractReflection implements Builder<Boolean
      * @param rhs the other object to unregister
      */
     private static void unregister(final Object lhs, final Object rhs) {
-        final Set<Pair<IDKey, IDKey>> registry = getRegistry();
-        registry.remove(getRegisterPair(lhs, rhs));
-        if (registry.isEmpty()) {
-            REGISTRY.remove();
-        }
+        unregister(lhs, rhs, getRegistry(), REGISTRY);
     }
 
     /**

--- a/src/test/java/org/apache/commons/lang3/builder/CompareToBuilderTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/CompareToBuilderTest.java
@@ -96,6 +96,35 @@ class CompareToBuilderTest extends AbstractBuilderTest {
         }
     }
 
+    /**
+     * Mutually-referential {@code Object[]}s: {@code a[0] = b}, {@code b[0] = a}, with {@code a != b}. The recursion is
+     * {@code append(a,b) -> append(a[0]=b, b[0]=a) -> append(b,a) ->
+     * append(b[0]=a, a[0]=b) -> append(a,b)}, never terminating.
+     */
+    @Test
+    void testCycleMutuallyReferentialObjectArrays() {
+        final Object[] a = new Object[1];
+        final Object[] b = new Object[1];
+        a[0] = b;
+        b[0] = a;
+        assertEquals(0, new CompareToBuilder().append(a, b, null).toComparison());
+        assertEquals(0, new CompareToBuilder().append((Object) a, (Object) b, null).toComparison());
+    }
+
+    /**
+     * Two distinct self-referential {@code Object[]}s: {@code a[0] = a}, {@code b[0] = b}, with {@code a != b}. The recursion is
+     * {@code append(a,b) -> append(a[0]=a, b[0]=b) -> append(a,b)}, never terminating.
+     */
+    @Test
+    void testCycleTwoDistinctSelfReferentialObjectArrays() {
+        final Object[] a = new Object[1];
+        final Object[] b = new Object[1];
+        a[0] = a;
+        b[0] = b;
+        assertEquals(0, new CompareToBuilder().append(a, b, null).toComparison());
+        assertEquals(0, new CompareToBuilder().append((Object) a, (Object) b, null).toComparison());
+    }
+
     static class TestTransientSubObject extends TestObject {
         @SuppressWarnings("unused")
         private final transient int t;


### PR DESCRIPTION
`CompareToBuilder` lacks cycle guard on `Object[]` recursion.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [x] OP used AI to create the original report.
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
