### PR TITLE
ClassUtils.toCleanName(String) resolves malformed array suffixes

### DIFF
--- a/src/main/java/org/apache/commons/lang3/ClassUtils.java
+++ b/src/main/java/org/apache/commons/lang3/ClassUtils.java
@@ -1643,6 +1643,13 @@ public class ClassUtils {
             throw new IllegalArgumentException(String.format("Class name greater than maxium length %,d", MAX_CLASS_NAME_LENGTH));
         }
         if (canonicalName.endsWith(arrayMarker)) {
+            // Reject malformed inputs like "java.lang.String[]junk[]" or
+            // "java.lang.String[]][]" where the suffix is not composed of
+            // repeated "[]" pairs.
+            final String tail = canonicalName.substring(arrIdx);
+            if (!tail.matches("(?:\\[\\])+")) {
+                throw new IllegalArgumentException("Malformed array name: " + canonicalName);
+            }
             final int dims =  (canonicalName.length() - arrIdx) / 2;
             if (dims > MAX_JVM_ARRAY_DIMENSION) {
                 throw new IllegalArgumentException("Array dimension greater than JVM specification maximum of 255.");

--- a/src/test/java/org/apache/commons/lang3/ClassUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/ClassUtilsTest.java
@@ -1320,6 +1320,34 @@ class ClassUtilsTest extends AbstractLangTest {
         assertEquals(void.class, ClassUtils.getClass("void"));
     }
 
+    /**
+     * Pre-patch: getClass("java.lang.String[]junk[]") silently returns String[][][][] (4 dims, because (24 - 16)/2 = 4 — junk is 4 chars). Post-patch: must
+     * throw IllegalArgumentException.
+     */
+    @Test
+    public void testGetClassStringMalformedMiddleJunkRejected() {
+        assertThrows(IllegalArgumentException.class, () -> ClassUtils.getClass("java.lang.String[]junk[]"));
+    }
+
+    /**
+     * Mutation control: suffix ends with "[]" so the array-branch is entered, and the suffix from arrIdx contains only '[' and ']' chars but NOT as well-formed
+     * pairs ("[]][]"). A char-class-only patch would accept this; the correct pair-validating patch must reject. Without this case, a weaker patch would still
+     * pass.
+     */
+    @Test
+    public void testGetClassStringMalformedUnpairedBracketsRejected() {
+        assertThrows(IllegalArgumentException.class, () -> ClassUtils.getClass("java.lang.String[]][]"));
+    }
+
+    /**
+     * Negative control: well-formed multi-dim array still resolves. Confirms the fix is minimal and does not over-reject.
+     */
+    @Test
+    public void testGetClassStringWellFormedArrayStillResolves() throws Exception {
+        assertNotNull(ClassUtils.getClass("java.lang.String[]"));
+        assertNotNull(ClassUtils.getClass("java.lang.String[][]"));
+    }
+
     @Test
     void testGetClassWithArrayClasses() throws Exception {
         assertGetClassReturnsClass(String[].class);


### PR DESCRIPTION
`ClassUtils.toCleanName(String)` resolves malformed array suffixes instead of throwing.

Called by `ClassUtils.getClass(ClassLoader, String, boolean)`.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [x] OP used AI to create the original report.
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
