### PR TITLE
Fix AnnotationUtils equals access handling

### DIFF
--- a/src/main/java/org/apache/commons/lang3/AnnotationUtils.java
+++ b/src/main/java/org/apache/commons/lang3/AnnotationUtils.java
@@ -193,6 +193,7 @@ public class AnnotationUtils {
      * {@code false} unless both are {@code null}
      * @return {@code true} if the two annotations are {@code equal} or both
      * {@code null}
+     * @throws IllegalStateException if an annotation member cannot be accessed
      */
     public static boolean equals(final Annotation a1, final Annotation a2) {
         if (a1 == a2) {
@@ -212,6 +213,12 @@ public class AnnotationUtils {
             for (final Method m : type1.getDeclaredMethods()) {
                 if (m.getParameterTypes().length == 0
                         && isValidAnnotationMemberType(m.getReturnType())) {
+                    try {
+                        m.setAccessible(true);
+                    } catch (final RuntimeException ex) {
+                        throw new IllegalStateException(
+                                String.format("Could not make annotation method %s accessible", m), ex);
+                    }
                     final Object v1 = m.invoke(a1);
                     final Object v2 = m.invoke(a2);
                     if (!memberEquals(m.getReturnType(), v1, v2)) {
@@ -220,7 +227,7 @@ public class AnnotationUtils {
                 }
             }
         } catch (final ReflectiveOperationException ex) {
-            return false;
+            throw new IllegalStateException("Could not read annotation member value", ex);
         }
         return true;
     }

--- a/src/test/java/org/apache/commons/lang3/external/AnnotationUtilsExternalTest.java
+++ b/src/test/java/org/apache/commons/lang3/external/AnnotationUtilsExternalTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.lang3.external;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import org.apache.commons.lang3.AnnotationUtils;
+import org.junit.jupiter.api.Test;
+
+/**
+ * This test must stay outside the {@code org.apache.commons.lang3} package.
+ */
+class AnnotationUtilsExternalTest {
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface Tag {
+        String value();
+    }
+
+    @Tag("value")
+    private final Object a = new Object();
+
+    @Tag("value")
+    private final Object b = new Object();
+
+    @Test
+    void testEqualsOnPackagePrivateAnnotations() throws ReflectiveOperationException {
+        final Tag tagA = getClass().getDeclaredField("a").getAnnotation(Tag.class);
+        final Tag tagB = getClass().getDeclaredField("b").getAnnotation(Tag.class);
+
+        assertTrue(AnnotationUtils.equals(tagA, tagB));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes `AnnotationUtils.equals(Annotation, Annotation)` so reflective annotation member access failures are not silently treated as inequality.

## Root Cause

`AnnotationUtils.equals` invoked annotation member methods reflectively and returned `false` for any `ReflectiveOperationException`. For package-private annotation types accessed from outside `org.apache.commons.lang3`, member invocation can fail due to Java access checks even when the annotation values are equal.

## Changes

- Makes annotation member methods accessible before invoking them.
- Throws `IllegalStateException` when member access fails instead of returning `false`.
- Adds an external-package regression test covering package-private runtime annotations.

## Validation

- `mvn -Dtest=AnnotationUtilsTest,AnnotationUtilsExternalTest test`
- `mvn -DskipTests checkstyle:check`