### PR TITLE
Make the StopWatch more reliable for tracking nanos, adjust suspend test

### DIFF
--- a/src/test/java/org/apache/commons/lang3/time/StopWatchTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/StopWatchTest.java
@@ -69,12 +69,12 @@ class StopWatchTest extends AbstractLangTest {
         return set(watch, nanos);
     }
 
-    private StopWatch set(final StopWatch watch, final long nanos) {
+    private StopWatch set(final StopWatch watch, final long elapsed) {
         try {
             final long currentNanos = System.nanoTime();
             final List<StopWatch.Split> splits = new ArrayList<>();
-            splits.add(new StopWatch.Split(String.valueOf(0), Duration.ofNanos(nanos)));
-            FieldUtils.writeField(watch, "startTimeNanos", currentNanos - nanos, true);
+            splits.add(new StopWatch.Split(String.valueOf(0), Duration.ofNanos(elapsed)));
+            FieldUtils.writeField(watch, "startTimeNanos", currentNanos - elapsed, true);
             FieldUtils.writeField(watch, "stopTimeNanos", currentNanos, true);
             FieldUtils.writeField(watch, "splits", splits, true);
         } catch (final IllegalAccessException e) {
@@ -488,9 +488,9 @@ class StopWatchTest extends AbstractLangTest {
         final Duration sleepDuration = MIN_DURATION;
         final long sleepMillis = sleepDuration.toMillis();
         sleepPlus1(sleepDuration);
-        watch.suspend();
         final long testSuspendMillis = System.currentTimeMillis();
         final long testSuspendNanos = System.nanoTime();
+        watch.suspend();
         final long testSuspendTimeNanos = testSuspendNanos - testStartNanos;
         // See sleepPlus1
         final Duration testSuspendDuration = Duration.ofNanos(testSuspendTimeNanos).plusMillis(1);


### PR DESCRIPTION
Make the StopWatch more reliable for tracking nanos, adjust suspend test

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [x] I used GitHub Copilot to diagnose the issue.
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
