### PR TITLE
[LANG-1801] RandomStringUtils.random() does not strictly validate start and end

### DIFF
--- a/src/main/java/org/apache/commons/lang3/RandomStringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/RandomStringUtils.java
@@ -276,6 +276,10 @@ public class RandomStringUtils {
             throw new IllegalArgumentException(String.format("Parameter end (%,d) must be greater than start (%,d)", end, start));
         } else if (start < 0 || end < 0) {
             throw new IllegalArgumentException("Character positions MUST be >= 0");
+        } else if (chars != null && start >= chars.length) {
+            throw new IllegalArgumentException("start >= chars.length");
+        } else if (chars != null && end > chars.length) {
+            throw new IllegalArgumentException("end > chars.length");
         }
         if (end > Character.MAX_CODE_POINT) {
             // Technically, it should be `Character.MAX_CODE_POINT+1` as `end` is excluded

--- a/src/test/java/org/apache/commons/lang3/RandomStringUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/RandomStringUtilsTest.java
@@ -134,7 +134,8 @@ class RandomStringUtilsTest extends AbstractLangTest {
         assertIllegalArgumentException(() -> RandomStringUtils.random(8, 32, 48, false, true));
         assertIllegalArgumentException(() -> RandomStringUtils.random(8, 32, 65, true, false));
         assertIllegalArgumentException(() -> RandomStringUtils.random(1, Integer.MIN_VALUE, -10, false, false, null));
-    }
+        assertIllegalArgumentException(() -> RandomStringUtils.random(2, 4, 5, false, false, new char[] { 'a', 'b', 'c', 'd' }, new Random()));
+        assertIllegalArgumentException(() -> RandomStringUtils.random(2, 1, 5, false, false, new char[] { 'a', 'b', 'c', 'd' }, new Random()));    }
 
     @ParameterizedTest
     @MethodSource("randomProvider")


### PR DESCRIPTION
[[LANG-1801]](https://issues.apache.org/jira/browse/LANG-1801) `RandomStringUtils.random()` does not strictly validate `start`/`end` when chars isn't null, causing potential `IndexOutOfBoundsException`

Before you push a pull request, review this list:

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] ~~I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?~~
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
