### PR TITLE
Fix CharSequenceUtils.lastIndexOf for supplementary code points

### DIFF
--- a/src/main/java/org/apache/commons/lang3/CharSequenceUtils.java
+++ b/src/main/java/org/apache/commons/lang3/CharSequenceUtils.java
@@ -262,11 +262,9 @@ public class CharSequenceUtils {
         //NOTE - we must do a forward traversal for this to avoid duplicating code points
         if (searchChar <= Character.MAX_CODE_POINT) {
             final char[] chars = Character.toChars(searchChar);
-            //make sure it's not the last index
-            if (start == sz - 1) {
-                return NOT_FOUND;
-            }
-            for (int i = start; i >= 0; i--) {
+            // A supplementary code point spans two chars, so its high surrogate can start no later
+            // than sz - 2; clamp the search origin instead of bailing out when start is the last index.
+            for (int i = Math.min(start, sz - 2); i >= 0; i--) {
                 final char high = cs.charAt(i);
                 final char low = cs.charAt(i + 1);
                 if (chars[0] == high && chars[1] == low) {

--- a/src/test/java/org/apache/commons/lang3/StringUtilsEqualsIndexOfTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringUtilsEqualsIndexOfTest.java
@@ -610,6 +610,13 @@ class StringUtilsEqualsIndexOfTest extends AbstractLangTest {
         assertEquals(5, StringUtils.lastIndexOf("aabaabaa", 'b'));
 
         assertEquals(5, StringUtils.lastIndexOf(new StringBuilder("aabaabaa"), 'b'));
+
+        // LANG-1300: supplementary code points searched in a non-String CharSequence must agree with String
+        final int supp = 0x2070E;
+        final String suppStr = new String(Character.toChars(supp));
+        assertEquals(suppStr.lastIndexOf(supp), StringUtils.lastIndexOf(new StringBuilder(suppStr), supp));
+        assertEquals(("x" + suppStr).lastIndexOf(supp), StringUtils.lastIndexOf(new StringBuilder("x" + suppStr), supp));
+        assertEquals((suppStr + "y").lastIndexOf(supp), StringUtils.lastIndexOf(new StringBuilder(suppStr + "y"), supp));
     }
 
     @Test


### PR DESCRIPTION
CharSequenceUtils.lastIndexOf treats a start index equal to the last char as no match for supplementary code points, so StringUtils.lastIndexOf(seq, codePoint) on a StringBuilder or other non-String CharSequence always returns -1 even when the code point is present, because the default overload passes startPos equal to the length. A supplementary code point spans two chars and its high surrogate can begin no later than sz-2, so the search origin should be clamped there rather than bailing out. With the clamp the results match java.lang.String, as the added assertions verify.