### PR TITLE
Fix indexOfAny matching an unpaired trailing high surrogate

### DIFF
--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -2815,8 +2815,7 @@ public class StringUtils {
             final char ch = cs.charAt(i);
             for (int j = 0; j < searchLen; j++) {
                 if (searchChars[j] == ch) {
-                    // ch is a supplementary character
-                    if (i >= csLast || j >= searchLast || !Character.isHighSurrogate(ch) || searchChars[j + 1] == cs.charAt(i + 1)) {
+                    if (!Character.isHighSurrogate(ch) || j == searchLast || i < csLast && searchChars[j + 1] == cs.charAt(i + 1)) {
                         return i;
                     }
                 }

--- a/src/test/java/org/apache/commons/lang3/StringUtilsEqualsIndexOfTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringUtilsEqualsIndexOfTest.java
@@ -411,6 +411,10 @@ class StringUtilsEqualsIndexOfTest extends AbstractLangTest {
         assertEquals(2, StringUtils.indexOfAny(CharU20000 + CharU20001, CharU20001.toCharArray()));
         assertEquals(0, StringUtils.indexOfAny(CharU20000, CharU20000.toCharArray()));
         assertEquals(-1, StringUtils.indexOfAny(CharU20000, CharU20001.toCharArray()));
+        // An unpaired trailing high surrogate must not match a supplementary code point, matching containsAny.
+        assertEquals(-1, StringUtils.indexOfAny(CharUSuppCharHigh, CharU20001.toCharArray()));
+        assertFalse(StringUtils.containsAny(CharUSuppCharHigh, CharU20001.toCharArray()));
+        assertEquals(-1, StringUtils.indexOfAny("abc" + CharUSuppCharHigh, CharU20000.toCharArray()));
     }
 
     @Test


### PR DESCRIPTION
indexOfAny(CharSequence, int, char...) reports a hit when the last char of the input is a lone high surrogate that equals the high half of a supplementary code point in searchChars: the surrogate guard short-circuits on `i >= csLast` and returns that index without ever matching the low half. So `indexOfAny("\uD840", new char[] {'\uD840', '\uDC01'})` returns 0 while `containsAny`/`containsNone` return false on the same input, even though the StringUtilsContainsTest cases pin that lone-half behavior. Reused the existing containsAny condition so the three methods agree.