### PR TITLE
Fraction.readObject() does not re-assert denominator != 0

### DIFF
--- a/src/main/java/org/apache/commons/lang3/math/Fraction.java
+++ b/src/main/java/org/apache/commons/lang3/math/Fraction.java
@@ -121,6 +121,12 @@ public final class Fraction extends Number implements Comparable<Fraction> {
         return (int) s;
     }
 
+    private static void checkDenominator(final int denominator) {
+        if (denominator == 0) {
+            throw new ArithmeticException("The denominator must not be zero");
+        }
+    }
+
     /**
      * Creates a {@link Fraction} instance from a {@code double} value.
      * <p>
@@ -194,9 +200,7 @@ public final class Fraction extends Number implements Comparable<Fraction> {
      * @throws ArithmeticException if the denominator is {@code zero} or the denominator is {@code negative} and the numerator is {@code Integer#MIN_VALUE}
      */
     public static Fraction getFraction(int numerator, int denominator) {
-        if (denominator == 0) {
-            throw new ArithmeticException("The denominator must not be zero");
-        }
+        checkDenominator(denominator);
         if (denominator < 0) {
             if (numerator == Integer.MIN_VALUE || denominator == Integer.MIN_VALUE) {
                 throw new ArithmeticException("overflow: can't negate");
@@ -223,9 +227,7 @@ public final class Fraction extends Number implements Comparable<Fraction> {
      * @throws ArithmeticException if the resulting numerator exceeds {@code Integer.MAX_VALUE}
      */
     public static Fraction getFraction(final int whole, final int numerator, final int denominator) {
-        if (denominator == 0) {
-            throw new ArithmeticException("The denominator must not be zero");
-        }
+        checkDenominator(denominator);
         if (denominator < 0) {
             throw new ArithmeticException("The denominator must not be negative");
         }
@@ -313,9 +315,7 @@ public final class Fraction extends Number implements Comparable<Fraction> {
      * @throws ArithmeticException if the denominator is {@code zero}
      */
     public static Fraction getReducedFraction(int numerator, int denominator) {
-        if (denominator == 0) {
-            throw new ArithmeticException("The denominator must not be zero");
-        }
+        checkDenominator(denominator);
         if (numerator == 0) {
             return ZERO; // normalize zero.
         }
@@ -855,6 +855,7 @@ public final class Fraction extends Number implements Comparable<Fraction> {
      */
     private void readObject(final ObjectInputStream in) throws IOException, ClassNotFoundException {
         in.defaultReadObject();
+        checkDenominator(denominator);
         if (hashCode != hash(denominator, numerator)) {
             throw new InvalidObjectException("Fraction hashCode does not match numerator/denominator.");
         }

--- a/src/test/java/org/apache/commons/lang3/math/FractionReadObjectTest.java
+++ b/src/test/java/org/apache/commons/lang3/math/FractionReadObjectTest.java
@@ -21,9 +21,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.io.ByteArrayInputStream;
 import java.io.InvalidObjectException;
+import java.io.ObjectInputStream;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import org.apache.commons.lang3.SerializationException;
 import org.apache.commons.lang3.SerializationUtils;
@@ -36,6 +39,16 @@ import org.junit.jupiter.api.Test;
  */
 public class FractionReadObjectTest {
 
+    private static Object deserialize(final byte[] bytes) throws Exception {
+        try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(bytes))) {
+            return ois.readObject();
+        }
+    }
+
+    private static void setInt(final Object target, final String name, final int value) throws Exception {
+        FieldUtils.writeDeclaredField(target, name, value, true);
+    }
+
     @Test
     public void testBadHashCodeStreamIsRejected() throws Exception {
         final Fraction fraction = Fraction.getFraction(3, 7);
@@ -46,7 +59,22 @@ public class FractionReadObjectTest {
                 "Bad hashCode in stream must be rejected with InvalidObjectException");
         assertInstanceOf(InvalidObjectException.class, ex.getCause());
         assertEquals("java.io.InvalidObjectException: Fraction hashCode does not match numerator/denominator.", ex.getMessage());
+    }
 
+    /**
+     * Forged stream: numerator=0, denominator=0, hashCode=hash(0,0). The public factory refuses denominator 0 (negative control); readObject does not, so the
+     * forged Fraction(0,0) deserializes and divides by zero on {@code intValue()}.
+     */
+    @Test
+    void testForgedZeroDenominatorDividesByZero() throws Exception {
+        // Negative control: no public factory can build a zero-denominator Fraction.
+        assertThrows(ArithmeticException.class, () -> Fraction.getFraction(0, 0));
+        final Fraction seed = Fraction.getFraction(1, 2);
+        setInt(seed, "numerator", 0);
+        setInt(seed, "denominator", 0);
+        setInt(seed, "hashCode", Objects.hash(Integer.valueOf(0), Integer.valueOf(0)));
+        assertThrows(ArithmeticException.class, () -> deserialize(SerializationUtils.serialize(seed)));
+        assertThrows(ArithmeticException.class, () -> SerializationUtils.roundtrip(seed));
     }
 
     @Test
@@ -65,6 +93,5 @@ public class FractionReadObjectTest {
         final Fraction roundtrip = SerializationUtils.roundtrip(fraction);
         assertEquals(fraction.hashCode(), roundtrip.hashCode(), "Round-trip serialization must preserve the correct hashCode");
         assertEquals(fraction, roundtrip);
-
     }
 }


### PR DESCRIPTION
`Fraction.readObject()` does not re-assert denominator != 0.

Before you push a pull request, review this list:

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [x] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
