### PR TITLE
Fix LookupTranslator code point consumption for supplementary keys

### DIFF
--- a/src/main/java/org/apache/commons/lang3/text/translate/LookupTranslator.java
+++ b/src/main/java/org/apache/commons/lang3/text/translate/LookupTranslator.java
@@ -86,7 +86,7 @@ public class LookupTranslator extends CharSequenceTranslator {
 
                 if (result != null) {
                     out.write(result);
-                    return i;
+                    return Character.codePointCount(input, index, index + i);
                 }
             }
         }

--- a/src/test/java/org/apache/commons/lang3/text/translate/LookupTranslatorTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/translate/LookupTranslatorTest.java
@@ -50,4 +50,16 @@ class LookupTranslatorTest extends AbstractLangTest {
         assertEquals("two", out.toString(), "Incorrect value");
     }
 
+    @Test
+    void testSupplementaryKey() throws IOException {
+        final String key = new String(Character.toChars(0x1D54F)); // a single supplementary code point
+        final LookupTranslator lt = new LookupTranslator(new CharSequence[][] { { key, "X" } });
+        final StringWriter out = new StringWriter();
+        final int result = lt.translate(key, 0, out);
+        assertEquals(1, result, "Incorrect code point consumption");
+        assertEquals("X", out.toString(), "Incorrect value");
+        // the matched key must not over-consume the following character
+        assertEquals("XY", lt.translate(key + "Y"), "Trailing character must be preserved");
+    }
+
 }


### PR DESCRIPTION
Repro: build a `LookupTranslator` whose key is a single supplementary code point, e.g. `U+1D54F` mapped to `X`, then `translate("𝕏Y")`.
Expected: `XY`. Actual: `X` — the trailing `Y` is silently dropped (likewise `a𝕏b` becomes `aX`).
Cause: `translate` returns the matched key length counted in `char`s (`i`), but `CharSequenceTranslator` documents the return value as a count of code points and advances the cursor by `Character.charCount` per unit. A supplementary key is two `char`s but one code point, so the loop steps twice and over-consumes the following character.
Fix: return `Character.codePointCount(input, index, index + i)` so the count matches the framework's code-point stepping. The other translators in the package already return code-point counts, so this is the only affected site.