### PR TITLE
Fix case-insensitive Strings.replace dropping length-changing matches

### DIFF
--- a/src/main/java/org/apache/commons/lang3/Strings.java
+++ b/src/main/java/org/apache/commons/lang3/Strings.java
@@ -1288,12 +1288,9 @@ public abstract class Strings {
      * @param max          maximum number of values to replace, or {@code -1} if no maximum
      * @return the text with any replacements processed, {@code null} if null String input
      */
-    public String replace(final String text, String searchString, final String replacement, int max) {
+    public String replace(final String text, final String searchString, final String replacement, int max) {
         if (StringUtils.isEmpty(text) || StringUtils.isEmpty(searchString) || replacement == null || max == 0) {
             return text;
-        }
-        if (ignoreCase) {
-            searchString = searchString.toLowerCase();
         }
         int start = 0;
         int end = indexOf(text, searchString, start);

--- a/src/test/java/org/apache/commons/lang3/StringsTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringsTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.commons.lang3;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -26,6 +27,7 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junitpioneer.jupiter.DefaultLocale;
 
 /**
  * Tests {@link Strings}.
@@ -76,6 +78,19 @@ class StringsTest extends AbstractLangTest {
 
         assertTrue(Strings.CI.startsWithAny("AbCxYz", new StringBuilder("XyZ"), new StringBuffer("aBc")));
         assertTrue(Strings.CI.startsWithAny(new StringBuffer("AbCxYz"), new StringBuilder("XyZ"), new StringBuffer("abc")));
+    }
+
+    /**
+     * {@code U+0130} lower-cases to the two-char sequence {@code "i̇"} outside Turkish locales, so pre-lower-casing the
+     * search argument made the case-insensitive replace look for a two-char needle that no longer matches the single source
+     * character.
+     */
+    @Test
+    @DefaultLocale("en")
+    void testCaseInsensitiveReplaceLengthChangingLowerCase() {
+        assertEquals("aXb", Strings.CI.replace("aİb", "İ", "X", -1));
+        assertEquals("x_y_z", Strings.CI.replace("xİyİz", "İ", "_", -1));
+        assertEquals("X", Strings.CI.replaceOnce("İ", "İ", "X"));
     }
 
     @Test


### PR DESCRIPTION
Repro: `Strings.CI.replace("aİb", "İ", "X", -1)` returns `aİb` instead of `aXb` under any non-Turkish locale (`StringUtils.replaceIgnoreCase`/`replaceOnceIgnoreCase` delegate here, so they are affected too).
Cause: `replace` lower-cases the search argument up front, but the case-insensitive `indexOf` it calls already matches case-insensitively through `CharSequenceUtils.regionMatches`. `'İ'` (`U+0130`) lower-cases to the two-char `"i̇"`, so both the needle and the derived `replLength` grow to length 2 and stop lining up with the single source character, so the match is silently dropped.
Fix: remove the redundant lower-casing and let the case-insensitive `indexOf` do the matching. The case-sensitive path never lower-cased, so it is unchanged.

The regression test pins the locale with `@DefaultLocale("en")` so the lower-case expansion is deterministic; it fails on the current code and passes with the fix.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
