### PR TITLE
Fix int overflow in StringUtils.midString() and StrBuilder.midString() length handling

### DIFF
--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -5377,7 +5377,7 @@ public class StringUtils {
         if (pos < 0) {
             pos = 0;
         }
-        if (str.length() <= pos + len) {
+        if (str.length() - pos <= len) {
             return str.substring(pos);
         }
         return str.substring(pos, pos + len);

--- a/src/main/java/org/apache/commons/lang3/text/StrBuilder.java
+++ b/src/main/java/org/apache/commons/lang3/text/StrBuilder.java
@@ -2479,7 +2479,7 @@ public class StrBuilder implements CharSequence, Appendable, Serializable, Build
         if (length <= 0 || index >= size) {
             return StringUtils.EMPTY;
         }
-        if (size <= index + length) {
+        if (size - index <= length) {
             return new String(buffer, index, size - index);
         }
         return new String(buffer, index, length);

--- a/src/test/java/org/apache/commons/lang3/StringUtilsSubstringTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringUtilsSubstringTest.java
@@ -102,6 +102,9 @@ class StringUtilsSubstringTest extends AbstractLangTest {
         assertEquals(BAR, StringUtils.mid(FOOBAR, 3, 80));
         assertEquals("", StringUtils.mid(FOOBAR, 9, 3));
         assertEquals(FOO, StringUtils.mid(FOOBAR, -1, 3));
+        // LANG: a len that overflows pos + len must still return the rest
+        assertEquals(BAR, StringUtils.mid(FOOBAR, 3, Integer.MAX_VALUE));
+        assertEquals(FOOBAR, StringUtils.mid(FOOBAR, 0, Integer.MAX_VALUE));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/text/StrBuilderTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/StrBuilderTest.java
@@ -1177,6 +1177,8 @@ class StrBuilderTest extends AbstractLangTest {
         assertEquals("", sb.midString(0, -1));
         assertEquals("", sb.midString(20, 2));
         assertEquals("hello", sb.midString(14, 22));
+        // a length that overflows index + length must still return the rest
+        assertEquals("hello", sb.midString(14, Integer.MAX_VALUE));
     }
 
     @Test


### PR DESCRIPTION
Repro: `StringUtils.mid("foobar", 3, Integer.MAX_VALUE)` and `new StrBuilder("hello goodbye hello").midString(14, Integer.MAX_VALUE)`.
Expected: the tail of the string (`"bar"`, `"hello"`), per the Javadoc that says the rest is returned when the length exceeds what is available.
Actual: `StringIndexOutOfBoundsException`.
Cause: both pick the "return the rest" branch with `pos + len` / `index + length`, which overflows to a negative `int` for a length near `Integer.MAX_VALUE`, so the guard is false and the code falls through to `substring`/`new String` with an out-of-range length. `WordUtils.wrap` already widens to `long` to avoid the same overflow.
Fix: compare with subtraction (`str.length() - pos <= len`, `size - index <= length`) so the check stays in range; the `substring(pos, pos + len)` branch now runs only when `len` is smaller than the remaining characters, so it cannot overflow.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. Added overflow regressions to `StringUtilsSubstringTest` and `StrBuilderTest` (both fail before the change, pass after).
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
