### PR TITLE
Reject doubled leading sign in NumberUtils.createBigInteger

### DIFF
--- a/src/main/java/org/apache/commons/lang3/math/NumberUtils.java
+++ b/src/main/java/org/apache/commons/lang3/math/NumberUtils.java
@@ -232,6 +232,11 @@ public class NumberUtils {
             radix = 8;
             pos++;
         } // default is to treat as decimal
+        if (str.startsWith("-", pos) || str.startsWith("+", pos)) {
+            // a second sign here (e.g. "--1") is not a number; new BigInteger(String) would otherwise
+            // consume it and silently flip the sign. Integer.decode/Long.decode reject this the same way.
+            throw new NumberFormatException("Sign character in wrong position");
+        }
         final BigInteger value = new BigInteger(str.substring(pos), radix);
         return negate ? value.negate() : value;
     }

--- a/src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java
@@ -483,6 +483,13 @@ class NumberUtilsTest extends AbstractLangTest {
         assertEquals(new BigInteger("+FFFFFFFFFFFFFFFF", 16), NumberUtils.createBigInteger("+0xFFFFFFFFFFFFFFFF"));
         assertEquals(new BigInteger("+FFFFFFFFFFFFFFFF", 16), NumberUtils.createBigInteger("+#FFFFFFFFFFFFFFFF"));
         assertEquals(new BigInteger("+1234567", 8), NumberUtils.createBigInteger("+01234567"));
+        // a doubled sign is not a valid number
+        testCreateBigIntegerFailure("--1");
+        testCreateBigIntegerFailure("-+1");
+        testCreateBigIntegerFailure("+-1");
+        testCreateBigIntegerFailure("++1");
+        testCreateBigIntegerFailure("--010");
+        testCreateBigIntegerFailure("-0x-1");
     }
 
     protected void testCreateBigIntegerFailure(final String str) {
@@ -790,6 +797,10 @@ class NumberUtilsTest extends AbstractLangTest {
         compareIsCreatableWithCreateNumber(" ", false);
         compareIsCreatableWithCreateNumber("\r\n\t", false);
         compareIsCreatableWithCreateNumber("--2.3", false);
+        compareIsCreatableWithCreateNumber("--2", false);
+        compareIsCreatableWithCreateNumber("-+2", false);
+        compareIsCreatableWithCreateNumber("+-2", false);
+        compareIsCreatableWithCreateNumber("++2", false);
         compareIsCreatableWithCreateNumber(".12.3", false);
         compareIsCreatableWithCreateNumber("-123E", false);
         compareIsCreatableWithCreateNumber("-123E+-212", false);


### PR DESCRIPTION
`NumberUtils.createBigInteger` peels off one optional leading `+`/`-` (into a `negate` flag) and an optional `0x`/`#`/`0` radix prefix, then passes the rest to `new BigInteger(String)`, which parses a sign of its own. A doubled sign slips through and is silently mis-valued: `createBigInteger("--1")` returns `1`, `"-+1"` and `"+-1"` return `-1`, `"+-10"` returns `-10`, `"--010"` returns `10`. Since `createNumber` falls back to `createBigInteger` for plain integer tokens, `createNumber("--1")` returns `1` and `isCreatable("--1")` reports `true`, even though `isParsable("--1")` is `false` and the sibling `createInteger`/`createLong` reject the input via `Integer.decode`/`Long.decode`.

`Integer.decode`/`Long.decode` already throw `Sign character in wrong position` when a sign is not at the start, so the same check goes into `createBigInteger` once the leading sign and radix prefix are consumed. Putting it in the parser lets `createNumber`, `isCreatable` and the deprecated `isNumber` agree without each adding its own guard; `createBigDecimal` already rejects these through `new BigDecimal`. The added assertions cover the `createBigInteger` failures and the `isCreatable`/`createNumber` chain, and they fail on the current code. The `math` unit tests pass with the patch applied.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [ ] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
