### PR TITLE
Fix RandomStringUtils.random() false rejection of letters and digits

### DIFF
--- a/src/main/java/org/apache/commons/lang3/RandomStringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/RandomStringUtils.java
@@ -296,7 +296,9 @@ public class RandomStringUtils {
             if (letters && digits && start <= ASCII_0 && end >= ASCII_z + 1) {
                 return random(count, 0, 0, false, false, ALPHANUMERICAL_CHARS, random);
             }
-            if (digits && end <= ASCII_0 || letters && end <= ASCII_A) {
+            // Only reject when none of the requested categories is reachable; otherwise a letters && digits
+            // request would throw on a range that holds one category but not the other (e.g. [ASCII_0, ASCII_A)).
+            if ((!digits || end <= ASCII_0) && (!letters || end <= ASCII_A) && (digits || letters)) {
                 throw new IllegalArgumentException(
                         String.format("Parameter end (%,d) must be greater than (%,d) for generating digits or greater than (%,d) for generating letters.", end,
                                 ASCII_0, ASCII_A));

--- a/src/main/java/org/apache/commons/lang3/RandomStringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/RandomStringUtils.java
@@ -314,6 +314,12 @@ public class RandomStringUtils {
             if (letters && digits) {
                 start = Math.max(ASCII_0, start);
                 end = Math.min(ASCII_z + 1, end);
+                // The clamp can empty the range when it sits above the alphanumerics (e.g. [ASCII_z + 1, 0x7f)),
+                // unlike the single-category branches below which are validated by the reachability loops further
+                // down. Reject here so the caller gets a clear range error instead of nextBits(0) failing later.
+                if (start >= end) {
+                    throw new IllegalArgumentException(String.format("No letters or digits exist between start %,d and end %,d.", start, end));
+                }
             } else if (digits) {
                 // just numbers, no letters
                 start = Math.max(ASCII_0, start);

--- a/src/test/java/org/apache/commons/lang3/RandomStringUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/RandomStringUtilsTest.java
@@ -135,6 +135,20 @@ class RandomStringUtilsTest extends AbstractLangTest {
         assertDoesNotThrow(() -> RandomStringUtils.random(100, '0', 'A', false, true, null, new Random(42)));
     }
 
+    /**
+     * The {@code letters && digits} ASCII fast path clamps {@code start} up to {@code '0'} and {@code end} down to
+     * {@code 'z' + 1}. A range sitting entirely above the alphanumerics, e.g. {@code ['z' + 1, 0x7f)}, collapses to
+     * {@code start >= end} after that clamp. It must throw a clear range IllegalArgumentException, not fall through to
+     * {@code nextBits(0)} which reports the unrelated "number of bits must be between 1 and 32".
+     */
+    @Test
+    void testLettersAndDigitsOverEmptyAsciiRange() {
+        final IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                () -> RandomStringUtils.random(10, 'z' + 1, 0x7f, true, true, null, new Random(42)));
+        assertTrue(e.getMessage() != null && !e.getMessage().contains("number of bits"),
+                () -> "Expected a range-validation message but got: " + e.getMessage());
+    }
+
     @Test
     void testExceptionsRandom() {
         assertIllegalArgumentException(() -> RandomStringUtils.random(-1));

--- a/src/test/java/org/apache/commons/lang3/RandomStringUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/RandomStringUtilsTest.java
@@ -119,6 +119,22 @@ class RandomStringUtilsTest extends AbstractLangTest {
         }, "RandomStringUtils.random() threw IAE for valid letter chars array - pre-patch behavior");
     }
 
+    /**
+     * Asking for {@code letters && digits} must never be stricter than asking for {@code digits} alone. The range
+     * {@code ['0', 'A')} holds the digits but no letters, so {@code random(count, '0', 'A', true, true, ...)} must
+     * generate digits like the digits-only call over the same range, not throw IllegalArgumentException.
+     */
+    @Test
+    void testLettersAndDigitsOverDigitOnlyRange() {
+        final String both = RandomStringUtils.random(100, '0', 'A', true, true, null, new Random(42));
+        assertEquals(100, both.length());
+        for (final char c : both.toCharArray()) {
+            assertTrue(c >= '0' && c <= '9', () -> "Expected a digit but got: " + c);
+        }
+        // digits alone already works over this range, so letters && digits must not reject it
+        assertDoesNotThrow(() -> RandomStringUtils.random(100, '0', 'A', false, true, null, new Random(42)));
+    }
+
     @Test
     void testExceptionsRandom() {
         assertIllegalArgumentException(() -> RandomStringUtils.random(-1));


### PR DESCRIPTION
Repro: `RandomStringUtils.random(10, '0', 'A', true, true, null, rng)` throws `IllegalArgumentException`.
Expected: a string of digits, the same as the digits-only call over that range.
Actual: it throws, even though `RandomStringUtils.random(10, '0', 'A', false, true, null, rng)` succeeds on the identical range.
Cause: the ASCII fast-path guard rejects with `digits && end <= '0' || letters && end <= 'A'`, so a `letters && digits` request trips whenever either category is missing. The range `['0', 'A')` holds the digits but no letters, so the `letters` clause fires. Adding `letters` to a `digits` request can only widen the accepted set, never empty it.
Fix: reject only when none of the requested categories is reachable. A range holding neither still rejects through the existing rejection cap.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
