### PR TITLE
LANG-1032 - Added overloads for joining an array of booleans with a p…

### DIFF
--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -3838,7 +3838,38 @@ public class StringUtils {
         if (array == null) {
             return null;
         }
-        return join(array, delimiter, 0, array.length);
+        return join(array, delimiter, 0, array.length, null).toString();
+    }
+
+    /**
+     * Appends the elements of the provided array into the provided StringBuilder separated by the provided delimiter. If provided StringBuilder is null, then a new one is created.
+     *
+     * <p>
+     * No delimiter is appended before or after the list. Null objects or empty strings within the array are represented by empty strings.
+     * </p>
+     *
+     * <pre>
+     * StringUtils.join(null, *, null)                      = null
+     * StringUtils.join(null, *, stringBuilder)             = stringBuilder
+     * StringUtils.join([], *, null)                        = StringUtils.join([], *)
+     * StringUtils.join([], *, stringBuilder)               = stringBuilder.append(StringUtils.join([], *)
+     * StringUtils.join([null], *, null)                    = new StringBuilder()
+     * StringUtils.join([null], *, stringBuilder)           = stringBuilder
+     * StringUtils.join([false, false], ';', null)          = new StringBuilder().append("false;false")
+     * StringUtils.join([false, false], ';', stringBuilder) = stringBuilder.append("false;false")
+     * </pre>
+     *
+     * @param array         the array of values to join together, may be null.
+     * @param delimiter     the separator character to use.
+     * @param stringBuilder the string builder to aggregate the joined String.
+     * @return Either provided or a new StringBuilder with the joined String appended to it, provided StringBuilder if null array input.
+     * @since 3.21.0
+     */
+    public static StringBuilder join(final boolean[] array, final char delimiter, StringBuilder stringBuilder) {
+        if (array == null) {
+            return stringBuilder;
+        }
+        return join(array, delimiter, 0, array.length, stringBuilder);
     }
 
     /**
@@ -3874,18 +3905,63 @@ public class StringUtils {
         if (array == null) {
             return null;
         }
+        return join(array, delimiter, startIndex, endIndex, null).toString();
+    }
+
+    /**
+     * Appends the elements of the provided array into the provided StringBuilder separated by the provided
+     * delimiter. If provided StringBuilder is null, then a new one is created.
+     *
+     * <p>
+     * No delimiter is added before or after the list. Null objects or empty strings within the array are
+     * represented by empty strings.
+     * </p>
+     *
+     * <pre>
+     * StringUtils.join(null, *, null)                      = null
+     * StringUtils.join(null, *, stringBuilder)             = stringBuilder
+     * StringUtils.join([], *, null)                        = StringUtils.join([], *)
+     * StringUtils.join([], *, stringBuilder)               = stringBuilder.append(StringUtils.join([], *)
+     * StringUtils.join([null], *, null)                    = new StringBuilder()
+     * StringUtils.join([null], *, stringBuilder)           = stringBuilder
+     * StringUtils.join([false, false], ';', null)          = new StringBuilder().append("false;false")
+     * StringUtils.join([false, false], ';', stringBuilder) = stringBuilder.append("false;false")
+     * </pre>
+     *
+     * @param array
+     *            the array of values to join together, may be null.
+     * @param delimiter
+     *            the separator character to use.
+     * @param startIndex
+     *            the first index to start joining from. It is an error to pass in a start index past the end of the
+     *            array.
+     * @param endIndex
+     *            the index to stop joining from (exclusive). It is an error to pass in an end index past the end of
+     *            the array.
+     * @param stringBuilder
+     *            the string builder to aggregate the joined String.
+     * @return Either provided or a new StringBuilder with the joined String appended to it, provided StringBuilder
+     * if null array input.
+     * @since 3.21.0
+     */
+    public static StringBuilder join(final boolean[] array, final char delimiter, final int startIndex, final int endIndex, StringBuilder stringBuilder) {
+        // See StringUtilsJoinBenchmark
+        if (array == null) {
+            return stringBuilder;
+        }
         checkFromToIndex(startIndex, endIndex, array.length);
         final int count = endIndex - startIndex;
         if (count <= 0) {
-            return EMPTY;
+            return stringBuilder != null ? stringBuilder : new StringBuilder();
         }
         final byte maxElementChars = 5; // "false"
-        final StringBuilder stringBuilder = capacity(count, maxElementChars);
-        stringBuilder.append(array[startIndex]);
+        final StringBuilder internalStringBuilder = stringBuilder != null
+            ? stringBuilder : capacity(count, maxElementChars);
+        internalStringBuilder.append(array[startIndex]);
         for (int i = startIndex + 1; i < endIndex; i++) {
-            stringBuilder.append(delimiter).append(array[i]);
+            internalStringBuilder.append(delimiter).append(array[i]);
         }
-        return stringBuilder.toString();
+        return internalStringBuilder;
     }
 
     /**

--- a/src/test/java/org/apache/commons/lang3/StringUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringUtilsTest.java
@@ -988,12 +988,29 @@ class StringUtilsTest extends AbstractLangTest {
     void testJoin_ArrayOfBooleans() {
         assertNull(StringUtils.join((boolean[]) null, COMMA_SEPARATOR_CHAR));
         assertEquals("false;false", StringUtils.join(ARRAY_FALSE_FALSE, SEPARATOR_CHAR));
-        assertEquals("", StringUtils.join(EMPTY, SEPARATOR_CHAR));
+        assertEquals(StringUtils.EMPTY, StringUtils.join(EMPTY, SEPARATOR_CHAR));
         assertEquals("false,true,false", StringUtils.join(ARRAY_FALSE_TRUE_FALSE, COMMA_SEPARATOR_CHAR));
         assertEquals("true", StringUtils.join(ARRAY_FALSE_TRUE, SEPARATOR_CHAR, 1, 2));
         assertNull(StringUtils.join((boolean[]) null, SEPARATOR_CHAR, 0, 1));
         assertEquals(StringUtils.EMPTY, StringUtils.join(ARRAY_FALSE_FALSE, SEPARATOR_CHAR, 0, 0));
         assertEquals(StringUtils.EMPTY, StringUtils.join(ARRAY_FALSE_TRUE_FALSE, SEPARATOR_CHAR, 1, 0));
+
+        assertNull(StringUtils.join((boolean[]) null, COMMA_SEPARATOR_CHAR, null));
+        assertEquals(StringUtils.EMPTY, StringUtils.join((boolean[]) null, COMMA_SEPARATOR_CHAR, new StringBuilder()).toString());
+        assertEquals("false;false", StringUtils.join(ARRAY_FALSE_FALSE, SEPARATOR_CHAR, null).toString());
+        assertEquals(SENTENCE_CAP + "false;false", StringUtils.join(ARRAY_FALSE_FALSE, SEPARATOR_CHAR, new StringBuilder(SENTENCE_CAP)).toString());
+        assertEquals(StringUtils.EMPTY, StringUtils.join(EMPTY, SEPARATOR_CHAR, null).toString());
+        assertEquals(SENTENCE_CAP, StringUtils.join(EMPTY, SEPARATOR_CHAR, new StringBuilder(SENTENCE_CAP)).toString());
+        assertEquals("false,true,false", StringUtils.join(ARRAY_FALSE_TRUE_FALSE, COMMA_SEPARATOR_CHAR, null).toString());
+        assertEquals(SENTENCE_CAP + "false,true,false", StringUtils.join(ARRAY_FALSE_TRUE_FALSE, COMMA_SEPARATOR_CHAR, new StringBuilder(SENTENCE_CAP)).toString());
+        assertEquals("true", StringUtils.join(ARRAY_FALSE_TRUE, SEPARATOR_CHAR, 1, 2, null).toString());
+        assertEquals(SENTENCE_CAP + "true", StringUtils.join(ARRAY_FALSE_TRUE, SEPARATOR_CHAR, 1, 2, new StringBuilder(SENTENCE_CAP)).toString());
+        assertNull(StringUtils.join((boolean[]) null, SEPARATOR_CHAR, 0, 1, null));
+        assertEquals(SENTENCE_CAP, StringUtils.join((boolean[]) null, SEPARATOR_CHAR, 0, 1, new StringBuilder(SENTENCE_CAP)).toString());
+        assertEquals(StringUtils.EMPTY, StringUtils.join(ARRAY_FALSE_FALSE, SEPARATOR_CHAR, 0, 0, null).toString());
+        assertEquals(SENTENCE_CAP, StringUtils.join(ARRAY_FALSE_FALSE, SEPARATOR_CHAR, 0, 0, new StringBuilder(SENTENCE_CAP)).toString());
+        assertEquals(StringUtils.EMPTY, StringUtils.join(ARRAY_FALSE_TRUE_FALSE, SEPARATOR_CHAR, 1, 0, null).toString());
+        assertEquals(SENTENCE_CAP, StringUtils.join(ARRAY_FALSE_TRUE_FALSE, SEPARATOR_CHAR, 1, 0, new StringBuilder(SENTENCE_CAP)).toString());
     }
 
     @Test


### PR DESCRIPTION
…rovided StringBuilder

<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    https://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
-->

Thanks for your contribution to [Apache Commons](https://commons.apache.org/)! Your help is appreciated!

Before you push a pull request, review this list:

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
