### PR TITLE
Fix substringAfter(Last) for supplementary code points

### DIFF
--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -8260,7 +8260,7 @@ public class StringUtils {
         if (pos == INDEX_NOT_FOUND) {
             return EMPTY;
         }
-        return str.substring(pos + 1);
+        return str.substring(pos + Character.charCount(find));
     }
 
     /**
@@ -8337,10 +8337,10 @@ public class StringUtils {
             return str;
         }
         final int pos = str.lastIndexOf(find);
-        if (pos == INDEX_NOT_FOUND || pos == str.length() - 1) {
+        if (pos == INDEX_NOT_FOUND || pos == str.length() - Character.charCount(find)) {
             return EMPTY;
         }
-        return str.substring(pos + 1);
+        return str.substring(pos + Character.charCount(find));
     }
 
     /**

--- a/src/test/java/org/apache/commons/lang3/StringUtilsSubstringTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringUtilsSubstringTest.java
@@ -175,6 +175,12 @@ class StringUtilsSubstringTest extends AbstractLangTest {
         assertEquals("cba", StringUtils.substringAfter("abcba", 'b'));
         assertEquals("", StringUtils.substringAfter("abc", 'c'));
         assertEquals("", StringUtils.substringAfter("abc", 'd'));
+
+        // a supplementary code point occupies two chars
+        final int grin = 0x1F600;
+        final String s = new String(Character.toChars(grin));
+        assertEquals("world", StringUtils.substringAfter("hello" + s + "world", grin));
+        assertEquals("", StringUtils.substringAfter("hello" + s, grin));
     }
 
     @Test
@@ -211,6 +217,13 @@ class StringUtilsSubstringTest extends AbstractLangTest {
         assertEquals("a", StringUtils.substringAfterLast("abcba", 'b'));
         assertEquals("", StringUtils.substringAfterLast("abc", 'c'));
         assertEquals("", StringUtils.substringAfterLast("", 'd'));
+
+        // a supplementary code point occupies two chars
+        final int grin = 0x1F600;
+        final String s = new String(Character.toChars(grin));
+        assertEquals("", StringUtils.substringAfterLast("hello" + s, grin));
+        assertEquals("x", StringUtils.substringAfterLast(s + "a" + s + "x", grin));
+        assertEquals("world", StringUtils.substringAfterLast("a" + s + "world", grin));
     }
 
     @Test


### PR DESCRIPTION
Repro: `StringUtils.substringAfter("a" + new String(Character.toChars(0x1F600)) + "b", 0x1F600)` returns `"\uDE00b"` (a dangling low surrogate) instead of `"b"`; `substringAfterLast(prefix + grin, 0x1F600)` returns `"\uDE00"` instead of `""`.
Cause: the code-point overloads locate `find` with `indexOf`/`lastIndexOf`, which return the index of the high surrogate for a supplementary code point, then step over the match by a fixed `+ 1`. `substringAfterLast` also tests its terminal case with `pos == length() - 1`, so when the supplementary `find` is the last code point the guard never fires.
Fix: advance by `Character.charCount(find)` and test the terminal guard against `length() - charCount`. BMP code points keep `charCount == 1` so existing behaviour is unchanged, and `substringBefore(String, int)` already slices at `pos` so it needs no change.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [ ] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
