### PR TITLE
Fix CT_CONSTRUCTOR_THROW: move validation from constructor to factory…

### DIFF
--- a/src/main/java/org/apache/commons/lang3/Range.java
+++ b/src/main/java/org/apache/commons/lang3/Range.java
@@ -189,6 +189,8 @@ public class Range<T> implements Serializable {
      * @since 3.13.0
      */
     public static <T> Range<T> of(final T fromInclusive, final T toInclusive, final Comparator<T> comparator) {
+        Objects.requireNonNull(fromInclusive, "fromInclusive");
+        Objects.requireNonNull(toInclusive, "toInclusive");
         return new Range<>(fromInclusive, toInclusive, comparator);
     }
 
@@ -228,8 +230,7 @@ public class Range<T> implements Serializable {
      */
     @SuppressWarnings("unchecked")
     Range(final T element1, final T element2, final Comparator<T> comp) {
-        Objects.requireNonNull(element1, "element1");
-        Objects.requireNonNull(element2, "element2");
+       
         if (comp == null) {
             this.comparator = ComparableComparator.INSTANCE;
         } else {

--- a/src/test/java/org/apache/commons/lang3/RangeTest.java
+++ b/src/test/java/org/apache/commons/lang3/RangeTest.java
@@ -404,4 +404,21 @@ class RangeTest extends AbstractLangTest {
         final String str = intRange.toString("From %1$s to %2$s");
         assertEquals("From 10 to 20", str);
     }
+
+    @Test
+    void testOfNullFromInclusive() {
+        assertNullPointerException(() -> Range.of(null, "b"));
+    }
+
+    @Test
+    void testOfNullToInclusive() {
+        assertNullPointerException(() -> Range.of("a", null));
+    }
+
+    @Test
+    void testOfNullBothWithComparator() {
+        final Comparator<String> c = Comparator.comparingInt(String::length);
+        assertNullPointerException(() -> Range.of(null, "b", c));
+        assertNullPointerException(() -> Range.of("a", null, c));
+    }
 }


### PR DESCRIPTION
Fix CT_CONSTRUCTOR_THROW (BAD_PRACTICE) in Range constructor

SpotBugs detected CT_CONSTRUCTOR_THROW in Range: when a constructor
throws an exception before completing initialization, the partially
constructed object may be exploited via finalizer attacks.

This fix moves the null validation of fromInclusive and toInclusive
from the Range constructor to the static factory method
of(T, T, Comparator), which is the single entry point for all other
factory methods (of, is, between). The constructor no longer throws
exceptions.

Unit tests were added to RangeTest to verify that NullPointerException
is thrown from the factory method for null arguments.

- [x] Read the contribution guidelines.
- [x] Read the ASF Generative Tooling Guidance.
- [x] I used AI (Claude by Anthropic) to assist in identifying and implementing this fix.
- [x] Run a successful build with `mvn`.
- [x] Unit tests added to RangeTest.
- [x] Pull request description written above.