### PR TITLE
Fix spurious overflow in Fraction.add/subtract for coprime denominators

### DIFF
--- a/src/main/java/org/apache/commons/lang3/math/Fraction.java
+++ b/src/main/java/org/apache/commons/lang3/math/Fraction.java
@@ -528,15 +528,12 @@ public final class Fraction extends Number implements Comparable<Fraction> {
         final int d1 = greatestCommonDivisor(denominator, fraction.denominator);
         if (d1 == 1) {
             // result is ((u*v' +/- u'v) / u'v')
-            // both denominators are positive and below 2^31, so the cross products and their
-            // sum stay within long range; only the reduced numerator has to fit in an int.
-            final long uvp = (long) numerator * (long) fraction.denominator;
-            final long upv = (long) fraction.numerator * (long) denominator;
-            final long t = isAdd ? uvp + upv : uvp - upv;
-            if (t < Integer.MIN_VALUE || t > Integer.MAX_VALUE) {
-                throw new ArithmeticException("overflow: numerator too large after multiply");
-            }
-            return new Fraction((int) t, mulPosAndCheck(denominator, fraction.denominator));
+            // the int cross products u*v' and u'*v can overflow even when the reduced result
+            // fits an int, so widen to long and let Math narrow the final numerator back.
+            final long uvp = (long) numerator * fraction.denominator;
+            final long upv = (long) fraction.numerator * denominator;
+            final long t = isAdd ? Math.addExact(uvp, upv) : Math.subtractExact(uvp, upv);
+            return new Fraction(Math.toIntExact(t), mulPosAndCheck(denominator, fraction.denominator));
         }
         // the quantity 't' requires 65 bits of precision; see knuth 4.5.1
         // exercise 7. we're going to use a BigInteger.

--- a/src/main/java/org/apache/commons/lang3/math/Fraction.java
+++ b/src/main/java/org/apache/commons/lang3/math/Fraction.java
@@ -105,22 +105,11 @@ public final class Fraction extends Number implements Comparable<Fraction> {
     public static final Fraction FOUR_FIFTHS = new Fraction(4, 5);
 
     /**
-     * Adds two integers, checking for overflow.
+     * Checks that a denominator is not zero.
      *
-     * @param x an addend
-     * @param y an addend
-     * @return the sum {@code x+y}
-     * @throws ArithmeticException if the result cannot be represented as
-     * an int
+     * @param denominator the denominator to check
+     * @throws ArithmeticException if the denominator is zero
      */
-    private static int addAndCheck(final int x, final int y) {
-        final long s = (long) x + (long) y;
-        if (s < Integer.MIN_VALUE || s > Integer.MAX_VALUE) {
-            throw new ArithmeticException("overflow: add");
-        }
-        return (int) s;
-    }
-
     private static void checkDenominator(final int denominator) {
         if (denominator == 0) {
             throw new ArithmeticException("The denominator must not be zero");
@@ -445,23 +434,6 @@ public final class Fraction extends Number implements Comparable<Fraction> {
     }
 
     /**
-     * Subtracts two integers, checking for overflow.
-     *
-     * @param x the minuend
-     * @param y the subtrahend
-     * @return the difference {@code x-y}
-     * @throws ArithmeticException if the result cannot be represented as
-     * an int
-     */
-    private static int subAndCheck(final int x, final int y) {
-        final long s = (long) x - (long) y;
-        if (s < Integer.MIN_VALUE || s > Integer.MAX_VALUE) {
-            throw new ArithmeticException("overflow: add");
-        }
-        return (int) s;
-    }
-
-    /**
      * The numerator number part of the fraction (the three in three sevenths).
      */
     private final int numerator;
@@ -556,10 +528,15 @@ public final class Fraction extends Number implements Comparable<Fraction> {
         final int d1 = greatestCommonDivisor(denominator, fraction.denominator);
         if (d1 == 1) {
             // result is ((u*v' +/- u'v) / u'v')
-            final int uvp = mulAndCheck(numerator, fraction.denominator);
-            final int upv = mulAndCheck(fraction.numerator, denominator);
-            return new Fraction(isAdd ? addAndCheck(uvp, upv) : subAndCheck(uvp, upv), mulPosAndCheck(denominator,
-                    fraction.denominator));
+            // both denominators are positive and below 2^31, so the cross products and their
+            // sum stay within long range; only the reduced numerator has to fit in an int.
+            final long uvp = (long) numerator * (long) fraction.denominator;
+            final long upv = (long) fraction.numerator * (long) denominator;
+            final long t = isAdd ? uvp + upv : uvp - upv;
+            if (t < Integer.MIN_VALUE || t > Integer.MAX_VALUE) {
+                throw new ArithmeticException("overflow: numerator too large after multiply");
+            }
+            return new Fraction((int) t, mulPosAndCheck(denominator, fraction.denominator));
         }
         // the quantity 't' requires 65 bits of precision; see knuth 4.5.1
         // exercise 7. we're going to use a BigInteger.

--- a/src/test/java/org/apache/commons/lang3/math/FractionTest.java
+++ b/src/test/java/org/apache/commons/lang3/math/FractionTest.java
@@ -162,6 +162,19 @@ class FractionTest extends AbstractLangTest {
         final Fraction f3 = Fraction.getFraction(3, 327680);
         final Fraction f4 = Fraction.getFraction(2, 59049);
         assertThrows(ArithmeticException.class, () -> f3.add(f4)); // should overflow
+
+        // the cross products u*v' and u'*v overflow an int, but the reduced result fits.
+        f1 = Fraction.getFraction(Integer.MAX_VALUE, 2);
+        f2 = Fraction.getFraction(-Integer.MAX_VALUE, 1);
+        f = f1.add(f2);
+        assertEquals(-Integer.MAX_VALUE, f.getNumerator());
+        assertEquals(2, f.getDenominator());
+
+        f1 = Fraction.getFraction(2, 1);
+        f2 = Fraction.getFraction(-Integer.MAX_VALUE, 2114962910);
+        f = f1.add(f2);
+        assertEquals(2082442173, f.getNumerator());
+        assertEquals(2114962910, f.getDenominator());
     }
 
     @Test
@@ -1065,6 +1078,13 @@ class FractionTest extends AbstractLangTest {
 
         // Should overflow
         assertThrows(ArithmeticException.class, () -> Fraction.getFraction(3, 327680).subtract(Fraction.getFraction(2, 59049)));
+
+        // the cross products u*v' and u'*v overflow an int, but the reduced result fits.
+        f1 = Fraction.getFraction(Integer.MAX_VALUE, 2);
+        f2 = Fraction.getFraction(Integer.MAX_VALUE, 1);
+        f = f1.subtract(f2);
+        assertEquals(-Integer.MAX_VALUE, f.getNumerator());
+        assertEquals(2, f.getDenominator());
     }
 
     @Test


### PR DESCRIPTION
Thanks for your contribution to [Apache Commons](https://commons.apache.org/)! Your help is appreciated!

Before you push a pull request, review this list:

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.

---

`Fraction.add`/`subtract` go through `addSub`, whose `d1 == 1` fast path (coprime denominators) builds the result numerator with `mulAndCheck(numerator, fraction.denominator)` and `mulAndCheck(fraction.numerator, denominator)`. Those cross products overflow an `int` even when the reduced result is comfortably in range, so `Fraction.getFraction(Integer.MAX_VALUE, 2).add(Fraction.getFraction(-Integer.MAX_VALUE, 1))` throws `ArithmeticException: overflow: mul`. Expected `-2147483647/2`, actual an exception. The sibling `d1 != 1` branch already computes the numerator in wider precision and only rejects the final reduced value.

Compute the two cross products and their sum/difference in `long` (both denominators are positive and below `2^31`, so the intermediate values cannot overflow `long`) and reject only when the resulting numerator does not fit an `int`, matching the wider branch. Keeping it inside `addSub` covers `add`, `subtract` and `divideBy`. The two helpers `addAndCheck`/`subAndCheck` were only used by this branch and are removed. Regression cases added to `FractionTest` fail with `overflow: mul` before the change.
