### PR TITLE
Drop trailing empty token from splitByWholeSeparator

### DIFF
--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -7447,7 +7447,11 @@ public class StringUtils {
                 }
             } else {
                 // String.substring( beg ) goes from 'beg' to the end of the String.
-                substrings.add(str.substring(beg));
+                // beg == len means the String ended on a separator, so the trailing
+                // token is empty and must be dropped unless empty tokens are preserved.
+                if (preserveAllTokens || beg < len) {
+                    substrings.add(str.substring(beg));
+                }
                 end = len;
             }
         }

--- a/src/test/java/org/apache/commons/lang3/StringUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringUtilsTest.java
@@ -2436,6 +2436,13 @@ class StringUtilsTest extends AbstractLangTest {
         for (int i = 0; i < splitWithMultipleSeparatorExpectedResults.length; i++) {
             assertEquals(splitWithMultipleSeparatorExpectedResults[i], splitWithMultipleSeparator[i]);
         }
+
+        // a trailing separator must not leak an empty token (it is dropped, like leading and adjacent ones)
+        assertArrayEquals(new String[] {"a", "b"}, StringUtils.splitByWholeSeparator("a:b:", ":"));
+        assertArrayEquals(new String[] {"a"}, StringUtils.splitByWholeSeparator("a:", ":"));
+        assertArrayEquals(new String[] {"ab", "cd"}, StringUtils.splitByWholeSeparator("ab-!-cd-!-", "-!-"));
+        // the preserve-all-tokens variant still keeps the trailing empty token
+        assertArrayEquals(new String[] {"a", "b", ""}, StringUtils.splitByWholeSeparatorPreserveAllTokens("a:b:", ":"));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/StringUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringUtilsTest.java
@@ -49,6 +49,7 @@ import org.apache.commons.lang3.text.WordUtils;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.junitpioneer.jupiter.DefaultLocale;
 import org.junitpioneer.jupiter.ReadsDefaultLocale;
@@ -2436,13 +2437,20 @@ class StringUtilsTest extends AbstractLangTest {
         for (int i = 0; i < splitWithMultipleSeparatorExpectedResults.length; i++) {
             assertEquals(splitWithMultipleSeparatorExpectedResults[i], splitWithMultipleSeparator[i]);
         }
+    }
 
+    @ParameterizedTest
+    @CsvSource({
+        "a:b:,       :,   'a,b'",
+        "a:,         :,   a",
+        "ab-!-cd-!-, -!-, 'ab,cd'",
+    })
+    void testSplitByWholeStringDropsTrailingEmpty(final String str, final String separator, final String expected) {
+        final String[] expectedTokens = expected.split(",");
         // a trailing separator must not leak an empty token (it is dropped, like leading and adjacent ones)
-        assertArrayEquals(new String[] {"a", "b"}, StringUtils.splitByWholeSeparator("a:b:", ":"));
-        assertArrayEquals(new String[] {"a"}, StringUtils.splitByWholeSeparator("a:", ":"));
-        assertArrayEquals(new String[] {"ab", "cd"}, StringUtils.splitByWholeSeparator("ab-!-cd-!-", "-!-"));
+        assertArrayEquals(expectedTokens, StringUtils.splitByWholeSeparator(str, separator));
         // the preserve-all-tokens variant still keeps the trailing empty token
-        assertArrayEquals(new String[] {"a", "b", ""}, StringUtils.splitByWholeSeparatorPreserveAllTokens("a:b:", ":"));
+        assertArrayEquals(ArrayUtils.add(expectedTokens, ""), StringUtils.splitByWholeSeparatorPreserveAllTokens(str, separator));
     }
 
     @Test


### PR DESCRIPTION
Repro: `StringUtils.splitByWholeSeparator("a:b:", ":")` returns `["a", "b", ""]`; expected `["a", "b"]`. The sibling `StringUtils.split("a:b:", ":")` already returns `["a", "b"]`.

Cause: in `splitByWholeSeparatorWorker` the no-more-separator branch adds `str.substring(beg)` unconditionally. When the input ends on a separator, `beg == len`, so an empty trailing token is appended. Leading and adjacent separators are already collapsed in non-preserve mode, so only the trailing case leaked, which disagrees with the documented "adjacent separators are treated as one separator".

Fix: in non-preserve mode only add the trailing token when it is non-empty (`beg < len`). `splitByWholeSeparatorPreserveAllTokens` keeps the trailing empty token as before.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
