### PR TITLE
Fix int mask sign extension in BitField long methods

### DIFF
--- a/src/main/java/org/apache/commons/lang3/BitField.java
+++ b/src/main/java/org/apache/commons/lang3/BitField.java
@@ -82,7 +82,7 @@ public class BitField {
      * @param mask the mask specifying which bits apply to this BitField. Bits that are set in this mask are the bits that this BitField operates on.
      */
     public BitField(final int mask) {
-        this.mask = mask;
+        this.mask = Integer.toUnsignedLong(mask);
         this.shiftCount = mask == 0 ? 0 : Integer.numberOfTrailingZeros(mask);
     }
 

--- a/src/main/java/org/apache/commons/lang3/BitField.java
+++ b/src/main/java/org/apache/commons/lang3/BitField.java
@@ -83,7 +83,7 @@ public class BitField {
      */
     public BitField(final int mask) {
         this.mask = Integer.toUnsignedLong(mask);
-        this.shiftCount = mask == 0 ? 0 : Integer.numberOfTrailingZeros(mask);
+        this.shiftCount = this.mask == 0 ? 0 : Long.numberOfTrailingZeros(this.mask);
     }
 
     /**

--- a/src/test/java/org/apache/commons/lang3/BitFieldTest.java
+++ b/src/test/java/org/apache/commons/lang3/BitFieldTest.java
@@ -153,6 +153,25 @@ class BitFieldTest extends AbstractLangTest {
     }
 
     /**
+     * Tests that an int mask with the high bit set is treated as 32 unsigned bits on the long methods, instead of being sign-extended into bits 32-63.
+     */
+    @Test
+    void testIntMaskHighBitOnLongHolder() {
+        final BitField bit31 = new BitField(0x80000000);
+        assertEquals(bit31.getRawValue(-1L), 0x80000000L);
+        assertEquals(bit31.getValue(-1L), 1L);
+        assertEquals(bit31.clear(-1L), 0xFFFFFFFF7FFFFFFFL);
+        assertEquals(bit31.set(0L), 0x80000000L);
+        assertTrue(bit31.isSet(0x80000000L));
+        assertTrue(bit31.isAllSet(0x80000000L));
+
+        final BitField topByte = new BitField(0xFF000000);
+        assertEquals(topByte.getRawValue(-1L), 0xFF000000L);
+        assertEquals(topByte.getValue(-1L), 0xFFL);
+        assertEquals(topByte.clear(-1L), 0xFFFFFFFF00FFFFFFL);
+    }
+
+    /**
      * test the isSet() method.
      */
     @Test


### PR DESCRIPTION
Repro: `new BitField(0x80000000)`, then `getRawValue(-1L)` / `clear(-1L)`.
Expected: `getRawValue(-1L)` == `0x80000000` and `clear(-1L)` == `0xFFFFFFFF7FFFFFFF`, since only bit 31 belongs to the field.
Actual: `getRawValue(-1L)` == `0xFFFFFFFF80000000` and `clear(-1L)` == `0x7FFFFFFF`, so bits 32-63 leak into the field.
Cause: the `long mask` field and the long-typed methods arrived in 3.21.0, but `BitField(int)` still assigns the int mask straight into the `long` field, so any mask with bit 31 set is sign-extended across bits 32-63. The int-typed methods cast back to `int` and hide it, the long ones do not.
Fix: build the field with `Integer.toUnsignedLong(mask)` so the int mask only occupies the low 32 bits.