### PR TITLE
Strip L suffix for oversized hex literals in createNumber

### DIFF
--- a/src/main/java/org/apache/commons/lang3/math/NumberUtils.java
+++ b/src/main/java/org/apache/commons/lang3/math/NumberUtils.java
@@ -386,7 +386,7 @@ public class NumberUtils {
                 hexDigits--;
             }
             if (hexDigits > 16 || hexDigits == 16 && firstSigDigit > '7') { // too many for Long
-                return createBigInteger(str);
+                return createBigInteger(isLongCh ? str.substring(0, length - 1) : str);
             }
             if (isLongCh) {
                 return createLong(str.substring(0, str.length() - 1));

--- a/src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java
@@ -661,6 +661,13 @@ class NumberUtilsTest extends AbstractLangTest {
         assertEquals(Integer.decode("+0xF"), NumberUtils.createNumber("+0xF"), "createNumber(String) LANG-1645a failed");
         assertEquals(Long.decode("+0xFFFFFFFF"), NumberUtils.createNumber("+0xFFFFFFFF"), "createNumber(String) LANG-1645b failed");
         assertEquals(new BigInteger("+FFFFFFFFFFFFFFFF", 16), NumberUtils.createNumber("+0xFFFFFFFFFFFFFFFF"), "createNumber(String) LANG-1645c failed");
+        // A hex literal too large for a Long but carrying an explicit 'L'/'l' type suffix must drop the suffix
+        // before falling back to BigInteger, matching the decimal path (e.g. "12345678901234567890L").
+        assertEquals(new BigInteger("FFFFFFFFFFFFFFFF", 16), NumberUtils.createNumber("0xFFFFFFFFFFFFFFFFL"));
+        assertEquals(new BigInteger("FFFFFFFFFFFFFFFF", 16), NumberUtils.createNumber("0xFFFFFFFFFFFFFFFFl"));
+        assertEquals(new BigInteger("8000000000000000", 16), NumberUtils.createNumber("0x8000000000000000L"));
+        assertEquals(new BigInteger("-FFFFFFFFFFFFFFFF", 16), NumberUtils.createNumber("-0xFFFFFFFFFFFFFFFFL"));
+        assertEquals(new BigInteger("FFFFFFFFFFFFFFFF", 16), NumberUtils.createNumber("#FFFFFFFFFFFFFFFFL"));
         // Map to a BigDecimal, not a Float.
         assertEquals(new BigDecimal("0.100000001490116121"), NumberUtils.createNumber("0.100000001490116121"));
     }


### PR DESCRIPTION
Repro: `NumberUtils.createNumber("0xFFFFFFFFFFFFFFFFL")` throws `NumberFormatException: For input string: "FFFFFFL"`.
Expected: a `BigInteger` of `0xFFFFFFFFFFFFFFFF`, the same result as `createNumber("0xFFFFFFFFFFFFFFFF")` (no suffix) and the decimal path `createNumber("9223372036854775808L")`.
Cause: the hex branch that is too large for a `Long` calls `createBigInteger(str)` with the `L`/`l` type suffix still attached. `createBigInteger` strips only the radix prefix and then runs `new BigInteger(substring, 16)`, so the trailing `L` reaches the hex parser and is rejected. The decimal branch already drops the suffix before its `BigInteger` fallback, which is why only the hex form throws.
Fix: drop the trailing type char before the `createBigInteger` fallback when the literal carries one, so an over-long hex literal with a suffix parses the same as the unsuffixed form.

Covers the `0x`/`0X`/`#` prefixes, signed and unsigned. Regression assertions added to `NumberUtilsTest.testCreateNumber`; they fail with `NumberFormatException` before the change and pass after.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [ ] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
