### PR TITLE
Fix indexOfDifference splitting a surrogate pair

### DIFF
--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -3002,6 +3002,12 @@ public class StringUtils {
                 break;
             }
         }
+        if (firstDiff > 0 && Character.isLowSurrogate(css[0].charAt(firstDiff))
+                && Character.isHighSurrogate(css[0].charAt(firstDiff - 1))) {
+            // the difference splits a surrogate pair whose high half is common; report the start of the
+            // pair so getCommonPrefix never slices it in half and leaves a stray high surrogate.
+            firstDiff--;
+        }
         if (firstDiff == -1 && shortestStrLen != longestStrLen) {
             // we compared all of the characters up to the length of the
             // shortest string and didn't find a match, but the string lengths
@@ -3047,6 +3053,12 @@ public class StringUtils {
             if (cs1.charAt(i) != cs2.charAt(i)) {
                 break;
             }
+        }
+        if (i > 0 && i < cs1.length() && i < cs2.length() && Character.isHighSurrogate(cs1.charAt(i - 1))
+                && (Character.isLowSurrogate(cs1.charAt(i)) || Character.isLowSurrogate(cs2.charAt(i)))) {
+            // the difference splits a surrogate pair whose high half is common; report the start of the
+            // pair so difference does not return a string that begins with a stray low surrogate.
+            i--;
         }
         if (i < cs2.length() || i < cs1.length()) {
             return i;

--- a/src/test/java/org/apache/commons/lang3/StringUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringUtilsTest.java
@@ -542,6 +542,11 @@ class StringUtilsTest extends AbstractLangTest {
         assertEquals("robot", StringUtils.difference("i am a machine", "i am a robot"));
         assertEquals("", StringUtils.difference("abc", "abc"));
         assertEquals("you are a robot", StringUtils.difference("i am a robot", "you are a robot"));
+        // 0x10400 and 0x10401 share the same high surrogate; the difference must not begin with a lone low surrogate
+        final String cp10400 = new String(Character.toChars(0x10400));
+        final String cp10401 = new String(Character.toChars(0x10401));
+        assertEquals(cp10401, StringUtils.difference(cp10400, cp10401));
+        assertEquals("Y", StringUtils.difference(cp10400 + "X", cp10400 + "Y"));
     }
 
     @Test
@@ -563,6 +568,11 @@ class StringUtilsTest extends AbstractLangTest {
         assertEquals(0, StringUtils.indexOfDifference("abcde", "xyz"));
         assertEquals(0, StringUtils.indexOfDifference("xyz", "abcde"));
         assertEquals(7, StringUtils.indexOfDifference("i am a machine", "i am a robot"));
+        // a difference that falls inside a shared surrogate pair is reported at the start of the pair, not mid-pair
+        final String cp10400 = new String(Character.toChars(0x10400));
+        final String cp10401 = new String(Character.toChars(0x10401));
+        assertEquals(0, StringUtils.indexOfDifference(new String[] {cp10400, cp10401}));
+        assertEquals(2, StringUtils.indexOfDifference(new String[] {cp10400 + "X", cp10400 + "Y"}));
     }
 
     @Test
@@ -576,6 +586,11 @@ class StringUtilsTest extends AbstractLangTest {
         assertEquals(7, StringUtils.indexOfDifference("i am a machine", "i am a robot"));
         assertEquals(-1, StringUtils.indexOfDifference("foo", "foo"));
         assertEquals(0, StringUtils.indexOfDifference("i am a robot", "you are a robot"));
+        // a difference that falls inside a shared surrogate pair is reported at the start of the pair, not mid-pair
+        final String cp10400 = new String(Character.toChars(0x10400));
+        final String cp10401 = new String(Character.toChars(0x10401));
+        assertEquals(0, StringUtils.indexOfDifference(cp10400, cp10401));
+        assertEquals(2, StringUtils.indexOfDifference(cp10400 + "X", cp10400 + "Y"));
     }
 
     /**
@@ -679,6 +694,11 @@ class StringUtilsTest extends AbstractLangTest {
         assertEquals("", StringUtils.getCommonPrefix("abcde", "xyz"));
         assertEquals("", StringUtils.getCommonPrefix("xyz", "abcde"));
         assertEquals("i am a ", StringUtils.getCommonPrefix("i am a machine", "i am a robot"));
+        // 0x10400 and 0x10401 share the high surrogate but differ; the common prefix must not be a lone high surrogate
+        final String cp10400 = new String(Character.toChars(0x10400));
+        final String cp10401 = new String(Character.toChars(0x10401));
+        assertEquals("", StringUtils.getCommonPrefix(cp10400, cp10401));
+        assertEquals(cp10400, StringUtils.getCommonPrefix(cp10400 + "X", cp10400 + "Y"));
     }
 
     @Test


### PR DESCRIPTION
`Repro:` `getCommonPrefix("𐐀", "𐐁")` returns the lone high surrogate `\uD801`, and `difference("𐐀", "𐐁")` returns the lone low surrogate `\uDC01`. Both are malformed UTF-16.
`Cause:` both `indexOfDifference` overloads walk the inputs one `char` at a time, so when two strings share the high surrogate of a supplementary code point but differ in the low half, the reported index lands inside the pair (index `1` rather than `0`). `getCommonPrefix` then slices the pair in half and `difference` starts its result on the orphaned low half.
`Fix:` when the difference falls on a low surrogate whose preceding (common) `char` is a high surrogate, report the start of the pair. `getCommonPrefix` and `difference` follow for free. BMP inputs never hit the new branch, so existing behaviour is unchanged.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
