### PR TITLE
[LANG-1386] Fix BooleanUtils.and/or/xor/oneHot overload ambiguity

### DIFF
--- a/src/main/java/org/apache/commons/lang3/BooleanUtils.java
+++ b/src/main/java/org/apache/commons/lang3/BooleanUtils.java
@@ -84,12 +84,16 @@ public class BooleanUtils {
      * Performs an 'and' operation on a set of booleans.
      *
      * <pre>
-     *   BooleanUtils.and(true, true)         = true
-     *   BooleanUtils.and(false, false)       = false
-     *   BooleanUtils.and(true, false)        = false
-     *   BooleanUtils.and(true, true, false)  = false
-     *   BooleanUtils.and(true, true, true)   = true
+     *   BooleanUtils.and(new boolean[]{true, true})        = true
+     *   BooleanUtils.and(new boolean[]{false, false})      = false
+     *   BooleanUtils.and(new boolean[]{true, false})       = false
+     *   BooleanUtils.and(new boolean[]{true, true, false}) = false
+     *   BooleanUtils.and(new boolean[]{true, true, true})  = true
      * </pre>
+     *
+     * <p>
+     * Loose-argument calls like {@code BooleanUtils.and(true, false)} now resolve to {@code BooleanUtils.and(Boolean...)}.
+     * </p>
      *
      * @param array  an array of {@code boolean}s
      * @return the result of the logical 'and' operation. That is {@code false}
@@ -98,7 +102,7 @@ public class BooleanUtils {
      * @throws IllegalArgumentException if {@code array} is empty.
      * @since 3.0.1
      */
-    public static boolean and(final boolean... array) {
+    public static boolean and(final boolean[] array) {
         ObjectUtils.requireNonEmpty(array, "array");
         for (final boolean element : array) {
             if (!element) {
@@ -111,6 +115,11 @@ public class BooleanUtils {
     /**
      * Performs an 'and' operation on an array of Booleans.
      * <pre>
+     *   BooleanUtils.and(true, true)                                 = Boolean.TRUE
+     *   BooleanUtils.and(false, false)                               = Boolean.FALSE
+     *   BooleanUtils.and(true, false)                                = Boolean.FALSE
+     *   BooleanUtils.and(true, true, false)                          = Boolean.FALSE
+     *   BooleanUtils.and(true, true, true)                           = Boolean.TRUE
      *   BooleanUtils.and(Boolean.TRUE, Boolean.TRUE)                 = Boolean.TRUE
      *   BooleanUtils.and(Boolean.FALSE, Boolean.FALSE)               = Boolean.FALSE
      *   BooleanUtils.and(Boolean.TRUE, Boolean.FALSE)                = Boolean.FALSE
@@ -276,13 +285,16 @@ public class BooleanUtils {
      * <p>
      * See also <a href="https://en.wikipedia.org/wiki/One-hot">One-hot</a>.
      * </p>
+     * <p>
+     * Loose-argument calls like {@code BooleanUtils.oneHot(true, false)} now resolve to {@code BooleanUtils.oneHot(Boolean...)}.
+     * </p>
      *
      * @param array  an array of {@code boolean}s
      * @return the result of the one-hot operations
      * @throws NullPointerException if {@code array} is {@code null}
      * @throws IllegalArgumentException if {@code array} is empty.
      */
-    public static boolean oneHot(final boolean... array) {
+    public static boolean oneHot(final boolean[] array) {
         ObjectUtils.requireNonEmpty(array, "array");
         boolean result = false;
         for (final boolean element: array) {
@@ -321,13 +333,17 @@ public class BooleanUtils {
      * Performs an 'or' operation on a set of booleans.
      *
      * <pre>
-     *   BooleanUtils.or(true, true)          = true
-     *   BooleanUtils.or(false, false)        = false
-     *   BooleanUtils.or(true, false)         = true
-     *   BooleanUtils.or(true, true, false)   = true
-     *   BooleanUtils.or(true, true, true)    = true
-     *   BooleanUtils.or(false, false, false) = false
+     *   BooleanUtils.or(new boolean[]{true, true})          = true
+     *   BooleanUtils.or(new boolean[]{false, false})        = false
+     *   BooleanUtils.or(new boolean[]{true, false})         = true
+     *   BooleanUtils.or(new boolean[]{true, true, false})   = true
+     *   BooleanUtils.or(new boolean[]{true, true, true})    = true
+     *   BooleanUtils.or(new boolean[]{false, false, false}) = false
      * </pre>
+     *
+     * <p>
+     * Loose-argument calls like {@code BooleanUtils.or(true, false)} now resolve to {@code BooleanUtils.or(Boolean...)}.
+     * </p>
      *
      * @param array  an array of {@code boolean}s
      * @return {@code true} if any of the arguments is {@code true}, and it returns {@code false} otherwise.
@@ -335,7 +351,7 @@ public class BooleanUtils {
      * @throws IllegalArgumentException if {@code array} is empty.
      * @since 3.0.1
      */
-    public static boolean or(final boolean... array) {
+    public static boolean or(final boolean[] array) {
         ObjectUtils.requireNonEmpty(array, "array");
         for (final boolean element : array) {
             if (element) {
@@ -348,6 +364,12 @@ public class BooleanUtils {
     /**
      * Performs an 'or' operation on an array of Booleans.
      * <pre>
+     *   BooleanUtils.or(true, true)                                  = Boolean.TRUE
+     *   BooleanUtils.or(false, false)                                = Boolean.FALSE
+     *   BooleanUtils.or(true, false)                                 = Boolean.TRUE
+     *   BooleanUtils.or(true, true, false)                           = Boolean.TRUE
+     *   BooleanUtils.or(true, true, true)                            = Boolean.TRUE
+     *   BooleanUtils.or(false, false, false)                         = Boolean.FALSE
      *   BooleanUtils.or(Boolean.TRUE, Boolean.TRUE)                  = Boolean.TRUE
      *   BooleanUtils.or(Boolean.FALSE, Boolean.FALSE)                = Boolean.FALSE
      *   BooleanUtils.or(Boolean.TRUE, Boolean.FALSE)                 = Boolean.TRUE
@@ -1163,20 +1185,24 @@ public class BooleanUtils {
      * </p>
      *
      * <pre>
-     *   BooleanUtils.xor(true, true)             = false
-     *   BooleanUtils.xor(false, false)           = false
-     *   BooleanUtils.xor(true, false)            = true
-     *   BooleanUtils.xor(true, false, false)     = true
-     *   BooleanUtils.xor(true, true, true)       = true
-     *   BooleanUtils.xor(true, true, true, true) = false
+     *   BooleanUtils.xor(new boolean[]{true, true})             = false
+     *   BooleanUtils.xor(new boolean[]{false, false})           = false
+     *   BooleanUtils.xor(new boolean[]{true, false})            = true
+     *   BooleanUtils.xor(new boolean[]{true, false, false})     = true
+     *   BooleanUtils.xor(new boolean[]{true, true, true})       = true
+     *   BooleanUtils.xor(new boolean[]{true, true, true, true}) = false
      * </pre>
+     *
+     * <p>
+     * Loose-argument calls like {@code BooleanUtils.xor(true, false)} now resolve to {@code BooleanUtils.xor(Boolean...)}.
+     * </p>
      *
      * @param array  an array of {@code boolean}s
      * @return true if the number of true values in the array is odd; otherwise returns false.
      * @throws NullPointerException if {@code array} is {@code null}
      * @throws IllegalArgumentException if {@code array} is empty.
      */
-    public static boolean xor(final boolean... array) {
+    public static boolean xor(final boolean[] array) {
         ObjectUtils.requireNonEmpty(array, "array");
         // false if the neutral element of the xor operator
         boolean result = false;
@@ -1190,6 +1216,12 @@ public class BooleanUtils {
     /**
      * Performs an xor on an array of Booleans.
      * <pre>
+     *   BooleanUtils.xor(true, true)                                 = Boolean.FALSE
+     *   BooleanUtils.xor(false, false)                               = Boolean.FALSE
+     *   BooleanUtils.xor(true, false)                                = Boolean.TRUE
+     *   BooleanUtils.xor(true, false, false)                         = Boolean.TRUE
+     *   BooleanUtils.xor(true, true, true)                           = Boolean.TRUE
+     *   BooleanUtils.xor(true, true, true, true)                     = Boolean.FALSE
      *   BooleanUtils.xor(Boolean.TRUE, Boolean.TRUE)                 = Boolean.FALSE
      *   BooleanUtils.xor(Boolean.FALSE, Boolean.FALSE)               = Boolean.FALSE
      *   BooleanUtils.xor(Boolean.TRUE, Boolean.FALSE)                = Boolean.TRUE

--- a/src/test/java/org/apache/commons/lang3/BooleanUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/BooleanUtilsTest.java
@@ -630,6 +630,141 @@ class BooleanUtilsTest extends AbstractLangTest {
     }
 
     @Test
+    void testAnd_primitive_varargs_2items() {
+        assertTrue(
+                BooleanUtils.and(true, true),
+                "False result for (true, true)");
+
+        assertFalse(
+                BooleanUtils.and(false, false),
+                "True result for (false, false)");
+
+        assertFalse(
+                BooleanUtils.and(true, false),
+                "True result for (true, false)");
+
+        assertFalse(
+                BooleanUtils.and(false, true),
+                "True result for (false, true)");
+    }
+
+    @Test
+    void testAnd_primitive_varargs_3items() {
+        assertFalse(
+                BooleanUtils.and(false, false, true),
+                "True result for (false, false, true)");
+
+        assertFalse(
+                BooleanUtils.and(false, true, false),
+                "True result for (false, true, false)");
+
+        assertFalse(
+                BooleanUtils.and(true, false, false),
+                "True result for (true, false, false)");
+
+        assertTrue(
+                BooleanUtils.and(true, true, true),
+                "False result for (true, true, true)");
+
+        assertFalse(
+                BooleanUtils.and(false, false, false),
+                "True result for (false, false, false)");
+
+        assertFalse(
+                BooleanUtils.and(true, true, false),
+                "True result for (true, true, false)");
+
+        assertFalse(
+                BooleanUtils.and(true, false, true),
+                "True result for (true, false, true)");
+
+        assertFalse(
+                BooleanUtils.and(false, true, true),
+                "True result for (false, true, true)");
+    }
+
+    @Test
+    void testAnd_object_varargs_2items() {
+        assertTrue(
+                BooleanUtils
+                        .and(Boolean.TRUE, Boolean.TRUE)
+                        .booleanValue(),
+                "False result for (true, true)");
+
+        assertFalse(
+                BooleanUtils
+                        .and(Boolean.FALSE, Boolean.FALSE)
+                        .booleanValue(),
+                "True result for (false, false)");
+
+        assertFalse(
+                BooleanUtils
+                        .and(Boolean.TRUE, Boolean.FALSE)
+                        .booleanValue(),
+                "True result for (true, false)");
+
+        assertFalse(
+                BooleanUtils
+                        .and(Boolean.FALSE, Boolean.TRUE)
+                        .booleanValue(),
+                "True result for (false, true)");
+    }
+
+    @Test
+    void testAnd_object_varargs_3items() {
+        assertFalse(
+                BooleanUtils
+                        .and(Boolean.FALSE, Boolean.FALSE, Boolean.TRUE)
+                        .booleanValue(),
+                "True result for (false, false, true)");
+
+        assertFalse(
+                BooleanUtils
+                        .and(Boolean.FALSE, Boolean.TRUE, Boolean.FALSE)
+                        .booleanValue(),
+                "True result for (false, true, false)");
+
+        assertFalse(
+                BooleanUtils
+                        .and(Boolean.TRUE, Boolean.FALSE, Boolean.FALSE)
+                        .booleanValue(),
+                "True result for (true, false, false)");
+
+        assertTrue(
+                BooleanUtils
+                        .and(Boolean.TRUE, Boolean.TRUE, Boolean.TRUE)
+                        .booleanValue(),
+                "False result for (true, true, true)");
+
+        assertFalse(
+                BooleanUtils.and(Boolean.FALSE, Boolean.FALSE, Boolean.FALSE)
+                        .booleanValue(),
+                "True result for (false, false, false)");
+
+        assertFalse(
+                BooleanUtils.and(Boolean.TRUE, Boolean.TRUE, Boolean.FALSE)
+                        .booleanValue(),
+                "True result for (true, true, false)");
+
+        assertFalse(
+                BooleanUtils.and(Boolean.TRUE, Boolean.FALSE, Boolean.TRUE)
+                        .booleanValue(),
+                "True result for (true, false, true)");
+
+        assertFalse(
+                BooleanUtils.and(Boolean.FALSE, Boolean.TRUE, Boolean.TRUE)
+                        .booleanValue(),
+                "True result for (false, true, true)");
+    }
+
+    @Test
+    void testAnd_object_varargs_nullElement() {
+        assertFalse(
+                BooleanUtils.and(null, null).booleanValue(),
+                "True result for (null, null)");
+    }
+
+    @Test
     void testCompare() {
         assertTrue(BooleanUtils.compare(true, false) > 0);
         assertEquals(0, BooleanUtils.compare(true, true));
@@ -763,6 +898,79 @@ class BooleanUtilsTest extends AbstractLangTest {
 
         // three true
         assertFalse(BooleanUtils.oneHot(new boolean[]{true, true, true}), "all true");
+    }
+
+    @Test
+    void testOneHot_primitive_varargs_2items() {
+        assertFalse(BooleanUtils.oneHot(false, false), "all false");
+
+        assertTrue(BooleanUtils.oneHot(true, false), "first true");
+
+        assertTrue(BooleanUtils.oneHot(false, true), "last true");
+
+        assertFalse(BooleanUtils.oneHot(true, true), "all true");
+    }
+
+    @Test
+    void testOneHot_primitive_varargs_3items() {
+        // none true
+        assertFalse(BooleanUtils.oneHot(false, false, false), "all false");
+
+        // one true
+        assertTrue(BooleanUtils.oneHot(true, false, false), "first true");
+
+        assertTrue(BooleanUtils.oneHot(false, true, false), "middle true");
+
+        assertTrue(BooleanUtils.oneHot(false, false, true), "last true");
+
+        // two true
+        assertFalse(BooleanUtils.oneHot(false, true, true), "first false");
+
+        assertFalse(BooleanUtils.oneHot(true, false, true), "middle false");
+
+        assertFalse(BooleanUtils.oneHot(true, true, false), "last false");
+
+        // three true
+        assertFalse(BooleanUtils.oneHot(true, true, true), "all true");
+    }
+
+    @Test
+    void testOneHot_object_varargs_2items() {
+        assertFalse(BooleanUtils.oneHot(Boolean.FALSE, Boolean.FALSE), "all false");
+
+        assertTrue(BooleanUtils.oneHot(Boolean.TRUE, Boolean.FALSE), "first true");
+
+        assertTrue(BooleanUtils.oneHot(Boolean.FALSE, Boolean.TRUE), "last true");
+
+        assertFalse(BooleanUtils.oneHot(Boolean.TRUE, Boolean.TRUE), "all true");
+    }
+
+    @Test
+    void testOneHot_object_varargs_3items() {
+        // none true
+        assertFalse(BooleanUtils.oneHot(Boolean.FALSE, Boolean.FALSE, Boolean.FALSE), "all false");
+
+        // one true
+        assertTrue(BooleanUtils.oneHot(Boolean.TRUE, Boolean.FALSE, Boolean.FALSE), "first true");
+
+        assertTrue(BooleanUtils.oneHot(Boolean.FALSE, Boolean.TRUE, Boolean.FALSE), "middle true");
+
+        assertTrue(BooleanUtils.oneHot(Boolean.FALSE, Boolean.FALSE, Boolean.TRUE), "last true");
+
+        // two true
+        assertFalse(BooleanUtils.oneHot(Boolean.FALSE, Boolean.TRUE, Boolean.TRUE), "first false");
+
+        assertFalse(BooleanUtils.oneHot(Boolean.TRUE, Boolean.FALSE, Boolean.TRUE), "middle false");
+
+        assertFalse(BooleanUtils.oneHot(Boolean.TRUE, Boolean.TRUE, Boolean.FALSE), "last false");
+
+        // three true
+        assertFalse(BooleanUtils.oneHot(Boolean.TRUE, Boolean.TRUE, Boolean.TRUE), "all true");
+    }
+
+    @Test
+    void testOneHot_object_varargs_nullElement() {
+        assertFalse(BooleanUtils.oneHot(null, null), "True result for (null, null)");
     }
 
     @Test
@@ -944,6 +1152,141 @@ class BooleanUtilsTest extends AbstractLangTest {
         assertTrue(
                 BooleanUtils.or(new boolean[] { false, true, true }),
                 "False result for (false, true, true)");
+    }
+
+    @Test
+    void testOr_primitive_varargs_2items() {
+        assertTrue(
+                BooleanUtils.or(true, true),
+                "False result for (true, true)");
+
+        assertFalse(
+                BooleanUtils.or(false, false),
+                "True result for (false, false)");
+
+        assertTrue(
+                BooleanUtils.or(true, false),
+                "False result for (true, false)");
+
+        assertTrue(
+                BooleanUtils.or(false, true),
+                "False result for (false, true)");
+    }
+
+    @Test
+    void testOr_primitive_varargs_3items() {
+        assertTrue(
+                BooleanUtils.or(false, false, true),
+                "False result for (false, false, true)");
+
+        assertTrue(
+                BooleanUtils.or(false, true, false),
+                "False result for (false, true, false)");
+
+        assertTrue(
+                BooleanUtils.or(true, false, false),
+                "False result for (true, false, false)");
+
+        assertTrue(
+                BooleanUtils.or(true, true, true),
+                "False result for (true, true, true)");
+
+        assertFalse(
+                BooleanUtils.or(false, false, false),
+                "True result for (false, false, false)");
+
+        assertTrue(
+                BooleanUtils.or(true, true, false),
+                "False result for (true, true, false)");
+
+        assertTrue(
+                BooleanUtils.or(true, false, true),
+                "False result for (true, false, true)");
+
+        assertTrue(
+                BooleanUtils.or(false, true, true),
+                "False result for (false, true, true)");
+    }
+
+    @Test
+    void testOr_object_varargs_2items() {
+        assertTrue(
+                BooleanUtils
+                        .or(Boolean.TRUE, Boolean.TRUE)
+                        .booleanValue(),
+                "False result for (true, true)");
+
+        assertFalse(
+                BooleanUtils
+                        .or(Boolean.FALSE, Boolean.FALSE)
+                        .booleanValue(),
+                "True result for (false, false)");
+
+        assertTrue(
+                BooleanUtils
+                        .or(Boolean.TRUE, Boolean.FALSE)
+                        .booleanValue(),
+                "False result for (true, false)");
+
+        assertTrue(
+                BooleanUtils
+                        .or(Boolean.FALSE, Boolean.TRUE)
+                        .booleanValue(),
+                "False result for (false, true)");
+    }
+
+    @Test
+    void testOr_object_varargs_3items() {
+        assertTrue(
+                BooleanUtils
+                        .or(Boolean.FALSE, Boolean.FALSE, Boolean.TRUE)
+                        .booleanValue(),
+                "False result for (false, false, true)");
+
+        assertTrue(
+                BooleanUtils
+                        .or(Boolean.FALSE, Boolean.TRUE, Boolean.FALSE)
+                        .booleanValue(),
+                "False result for (false, true, false)");
+
+        assertTrue(
+                BooleanUtils
+                        .or(Boolean.TRUE, Boolean.FALSE, Boolean.FALSE)
+                        .booleanValue(),
+                "False result for (true, false, false)");
+
+        assertTrue(
+                BooleanUtils
+                        .or(Boolean.TRUE, Boolean.TRUE, Boolean.TRUE)
+                        .booleanValue(),
+                "False result for (true, true, true)");
+
+        assertFalse(
+                BooleanUtils.or(Boolean.FALSE, Boolean.FALSE, Boolean.FALSE)
+                        .booleanValue(),
+                "True result for (false, false, false)");
+
+        assertTrue(
+                BooleanUtils.or(Boolean.TRUE, Boolean.TRUE, Boolean.FALSE)
+                        .booleanValue(),
+                "False result for (true, true, false)");
+
+        assertTrue(
+                BooleanUtils.or(Boolean.TRUE, Boolean.FALSE, Boolean.TRUE)
+                        .booleanValue(),
+                "False result for (true, false, true)");
+
+        assertTrue(
+                BooleanUtils.or(Boolean.FALSE, Boolean.TRUE, Boolean.TRUE)
+                        .booleanValue(),
+                "False result for (false, true, true)");
+    }
+
+    @Test
+    void testOr_object_varargs_nullElement() {
+        assertFalse(
+                BooleanUtils.or(null, null).booleanValue(),
+                "True result for (null, null)");
     }
 
     @Test
@@ -1170,5 +1513,145 @@ class BooleanUtilsTest extends AbstractLangTest {
                 true ^ true ^ true,
                 BooleanUtils.xor(new boolean[] { true, true, true }),
                 "true ^ true ^ true");
+    }
+
+    @Test
+    void testXor_primitive_varargs_2items() {
+        assertEquals(
+                false ^ false,
+                BooleanUtils.xor(false, false),
+                "false ^ false");
+
+        assertEquals(
+                false ^ true,
+                BooleanUtils.xor(false, true),
+                "false ^ true");
+
+        assertEquals(
+                true ^ false,
+                BooleanUtils.xor(true, false),
+                "true ^ false");
+
+        assertEquals(
+                true ^ true,
+                BooleanUtils.xor(true, true),
+                "true ^ true");
+    }
+
+    @Test
+    void testXor_primitive_varargs_3items() {
+        assertEquals(
+                false ^ false ^ false,
+                BooleanUtils.xor(false, false, false),
+                "false ^ false ^ false");
+
+        assertEquals(
+                false ^ false ^ true,
+                BooleanUtils.xor(false, false, true),
+                "false ^ false ^ true");
+
+        assertEquals(
+                false ^ true ^ false,
+                BooleanUtils.xor(false, true, false),
+                "false ^ true ^ false");
+
+        assertEquals(
+                false ^ true ^ true,
+                BooleanUtils.xor(false, true, true),
+                "false ^ true ^ true");
+
+        assertEquals(
+                true ^ false ^ false,
+                BooleanUtils.xor(true, false, false),
+                "true ^ false ^ false");
+
+        assertEquals(
+                true ^ false ^ true,
+                BooleanUtils.xor(true, false, true),
+                "true ^ false ^ true");
+
+        assertEquals(
+                true ^ true ^ false,
+                BooleanUtils.xor(true, true, false),
+                "true ^ true ^ false");
+
+        assertEquals(
+                true ^ true ^ true,
+                BooleanUtils.xor(true, true, true),
+                "true ^ true ^ true");
+    }
+
+    @Test
+    void testXor_object_varargs_2items() {
+        assertEquals(
+                false ^ false,
+                BooleanUtils.xor(Boolean.FALSE, Boolean.FALSE).booleanValue(),
+                "FALSE ^ FALSE");
+
+        assertEquals(
+                false ^ true,
+                BooleanUtils.xor(Boolean.FALSE, Boolean.TRUE).booleanValue(),
+                "FALSE ^ TRUE");
+
+        assertEquals(
+                true ^ false,
+                BooleanUtils.xor(Boolean.TRUE, Boolean.FALSE).booleanValue(),
+                "TRUE ^ FALSE");
+
+        assertEquals(
+                true ^ true,
+                BooleanUtils.xor(Boolean.TRUE, Boolean.TRUE).booleanValue(),
+                "TRUE ^ TRUE");
+    }
+
+    @Test
+    void testXor_object_varargs_3items() {
+        assertEquals(
+                false ^ false ^ false,
+                BooleanUtils.xor(Boolean.FALSE, Boolean.FALSE, Boolean.FALSE).booleanValue(),
+                "FALSE ^ FALSE ^ FALSE");
+
+        assertEquals(
+                false ^ false ^ true,
+                BooleanUtils.xor(Boolean.FALSE, Boolean.FALSE, Boolean.TRUE).booleanValue(),
+                "FALSE ^ FALSE ^ TRUE");
+
+        assertEquals(
+                false ^ true ^ false,
+                BooleanUtils.xor(Boolean.FALSE, Boolean.TRUE, Boolean.FALSE).booleanValue(),
+                "FALSE ^ TRUE ^ FALSE");
+
+        assertEquals(
+                false ^ true ^ true,
+                BooleanUtils.xor(Boolean.FALSE, Boolean.TRUE, Boolean.TRUE).booleanValue(),
+                "FALSE ^ TRUE ^ TRUE");
+
+        assertEquals(
+                true ^ false ^ false,
+                BooleanUtils.xor(Boolean.TRUE, Boolean.FALSE, Boolean.FALSE).booleanValue(),
+                "TRUE ^ FALSE ^ FALSE");
+
+        assertEquals(
+                true ^ false ^ true,
+                BooleanUtils.xor(Boolean.TRUE, Boolean.FALSE, Boolean.TRUE).booleanValue(),
+                "TRUE ^ FALSE ^ TRUE");
+
+        assertEquals(
+                true ^ true ^ false,
+                BooleanUtils.xor(Boolean.TRUE, Boolean.TRUE, Boolean.FALSE).booleanValue(),
+                "TRUE ^ TRUE ^ FALSE");
+
+        assertEquals(
+                true ^ true ^ true,
+                BooleanUtils.xor(Boolean.TRUE, Boolean.TRUE, Boolean.TRUE).booleanValue(),
+                "TRUE ^ TRUE ^ TRUE");
+    }
+
+    @Test
+    void testXor_object_varargs_nullElement() {
+        assertEquals(
+                Boolean.FALSE,
+                BooleanUtils.xor(null, null),
+                "True result for (null, null)");
     }
 }


### PR DESCRIPTION
This issue is tracked as [LANG-1386](https://issues.apache.org/jira/browse/LANG-1386).

**Repro:** `BooleanUtils.and(Boolean.TRUE, Boolean.FALSE)` — the call form shown in the `and(Boolean...)` Javadoc — fails to compile on Java 8 with `error: reference to and is ambiguous, both method and(boolean...) and method and(Boolean...) match`. The same ambiguity affects the loose-argument form of `or`, `xor`, and `oneHot`.

**Cause:** Both overloads accept loose arguments via varargs, and the compiler can't prefer one — `boolean` and `Boolean` aren't subtype-related, and overload resolution doesn't consider autoboxing as a tie-breaker.

**Fix:** convert the primitive overloads from `boolean...` to `boolean[]` for `and`, `or`, `xor`, `oneHot`, leaving the `Boolean...` overloads untouched. With only one variable-arity overload remaining, loose-argument calls resolve unambiguously to `Boolean...` via autoboxing. Direction chosen over the mirror fix (`Boolean...` → `Boolean[]`) because routing loose-arg calls through the boxed overload preserves the documented null-tolerance contract — `and((Boolean) null, Boolean.TRUE)` returns `Boolean.FALSE` rather than NPE-ing on unbox. 

<details>
<summary><b>Compatibility report</b> (<code>mvn package japicmp:cmp</code> against 3.20.0)</summary>

### `org.apache.commons.lang3.BooleanUtils`

- [X] Binary-compatible
- [ ] Source-compatible
- [X] Serialization-compatible

| Status   | Modifiers | Type  | Name           | Extends    | JDK   | Serialization     | Compatibility Changes |
|----------|-----------|-------|----------------|------------|-------|-------------------|-----------------------|
| Modified | `public`  | Class | `BooleanUtils` | [`Object`] | JDK 8 | Not serializable  | No changes            |

#### Methods

| Status   | Modifiers         | Generics | Type      | Method                                            | Annotations | Throws | Compatibility Changes      |
|----------|-------------------|----------|-----------|---------------------------------------------------|-------------|--------|----------------------------|
| Modified | `static` `public` |          | `boolean` | `and`(~~`boolean...`~~ &rarr; **`boolean[]`**)    |             |        | Method no longer varargs   |
| Modified | `static` `public` |          | `boolean` | `oneHot`(~~`boolean...`~~ &rarr; **`boolean[]`**) |             |        | Method no longer varargs   |
| Modified | `static` `public` |          | `boolean` | `or`(~~`boolean...`~~ &rarr; **`boolean[]`**)     |             |        | Method no longer varargs   |
| Modified | `static` `public` |          | `boolean` | `xor`(~~`boolean...`~~ &rarr; **`boolean[]`**)    |             |        | Method no longer varargs   |

Source-compat is flagged solely due to the `ACC_VARARGS` flag removal. In practice no real-world caller is expected to lose the ability to compile — loose-argument calls are absorbed by the `Boolean...` overload via autoboxing, and this fix **adds** more compilable forms than it removes (the previously ambiguous calls now compile). Callers that need the primitive path explicitly can continue to use the array form: `BooleanUtils.and(new boolean[]{true, false})`.

</details>

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [x] AI used: Claude (Anthropic, `claude-opus-4-7`) via the Claude Code CLI. Assisted with JLS analysis, Javadoc rewrites, and the `or`/`xor`/`oneHot` test additions (the `and` tests were written by me directly). I reviewed every line, validated the truth tables, and ran the local build. Per ASF guidance: Anthropic's terms place no restrictions inconsistent with the OSD; no third-party material is reproduced in the output.
- [x] Run a successful build using the default [Maven](https://maven.apache.org/).
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.