### PR TITLE
Account for duplicate values in ObjectUtils.median()

### DIFF
--- a/src/main/java/org/apache/commons/lang3/ObjectUtils.java
+++ b/src/main/java/org/apache/commons/lang3/ObjectUtils.java
@@ -21,15 +21,14 @@ import java.io.Serializable;
 import java.lang.reflect.Array;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.TreeSet;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
@@ -1058,9 +1057,9 @@ public class ObjectUtils {
         Validate.notEmpty(items, "null/empty items");
         Validate.noNullElements(items);
         Objects.requireNonNull(comparator, "comparator");
-        final TreeSet<T> treeSet = new TreeSet<>(comparator);
-        Collections.addAll(treeSet, items);
-        return (T) treeSet.toArray()[(treeSet.size() - 1) / 2];
+        final T[] sorted = items.clone();
+        Arrays.sort(sorted, comparator);
+        return sorted[(sorted.length - 1) / 2];
     }
 
     /**
@@ -1077,9 +1076,9 @@ public class ObjectUtils {
     public static <T extends Comparable<? super T>> T median(final T... items) {
         Validate.notEmpty(items);
         Validate.noNullElements(items);
-        final TreeSet<T> sort = new TreeSet<>();
-        Collections.addAll(sort, items);
-        return (T) sort.toArray()[(sort.size() - 1) / 2];
+        final T[] sorted = items.clone();
+        Arrays.sort(sorted);
+        return sorted[(sorted.length - 1) / 2];
     }
 
     /**

--- a/src/test/java/org/apache/commons/lang3/ObjectUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/ObjectUtilsTest.java
@@ -307,6 +307,8 @@ class ObjectUtilsTest extends AbstractLangTest {
         assertSame(baz, ObjectUtils.median(cmp, foo, bar, baz));
         assertSame(baz, ObjectUtils.median(cmp, foo, bar, baz, blah));
         assertSame(blah, ObjectUtils.median(cmp, foo, bar, baz, blah, wah));
+        // duplicates are counted, not collapsed
+        assertSame(foo, ObjectUtils.median(cmp, foo, foo, bar));
     }
 
     @Test
@@ -736,6 +738,12 @@ class ObjectUtilsTest extends AbstractLangTest {
                 Integer.valueOf(9)));
         assertEquals(Integer.valueOf(6),
             ObjectUtils.median(Integer.valueOf(5), Integer.valueOf(6), Integer.valueOf(7), Integer.valueOf(8)));
+        // duplicates are counted, not collapsed
+        assertEquals(Integer.valueOf(3),
+            ObjectUtils.median(Integer.valueOf(1), Integer.valueOf(2), Integer.valueOf(3), Integer.valueOf(3),
+                Integer.valueOf(3), Integer.valueOf(4)));
+        assertEquals(Integer.valueOf(5),
+            ObjectUtils.median(Integer.valueOf(5), Integer.valueOf(5), Integer.valueOf(5), Integer.valueOf(1)));
     }
 
     @Test


### PR DESCRIPTION
`ObjectUtils.median` collapses equal values before picking the middle element, so the result comes from the set of distinct values rather than from all the values passed in.

Repro: `ObjectUtils.median(5, 5, 5, 1)` returns `1`; `ObjectUtils.median(1, 2, 3, 3, 3, 4)` returns `2`.
Expected: `5` and `3` respectively, the middle of the total values (lower of the two middles for an even count) as the Javadoc states.
Cause: both overloads load the varargs into a `TreeSet`, which discards duplicates, then index it by `(size - 1) / 2`.
Fix: sort a clone of the input array with `Arrays.sort` so equal elements are kept; the index and the existing distinct-value results are unchanged.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
