### PR TITLE
[LANG-1824] Fix Strings.replace overflow on large replacements

### DIFF
--- a/src/main/java/org/apache/commons/lang3/Strings.java
+++ b/src/main/java/org/apache/commons/lang3/Strings.java
@@ -1298,9 +1298,8 @@ public abstract class Strings {
             return text;
         }
         final int replLength = searchString.length();
-        int increase = Math.max(replacement.length() - replLength, 0);
-        increase *= max < 0 ? 16 : Math.min(max, 64);
-        final StringBuilder buf = new StringBuilder(text.length() + increase);
+        final int initialCapacity = computeInitialCapacity(text.length(), replLength, replacement.length(), max);
+        final StringBuilder buf = new StringBuilder(initialCapacity);
         while (end != INDEX_NOT_FOUND) {
             buf.append(text, start, end).append(replacement);
             start = end + replLength;
@@ -1311,6 +1310,37 @@ public abstract class Strings {
         }
         buf.append(text, start, text.length());
         return buf.toString();
+    }
+
+    /**
+     * Computes a safe initial capacity for the {@link StringBuilder} used by
+     * {@link #replace(String, String, String, int)}.
+     *
+     * <p>
+     * Uses {@code long} arithmetic so that the estimated growth cannot overflow
+     * {@code int} when {@code replacementLength} is much greater than
+     * {@code searchLength}, and clamps the result to
+     * {@link ArrayUtils#SAFE_MAX_ARRAY_LENGTH} so that
+     * {@code new StringBuilder(int)} is never invoked with a value that exceeds
+     * the VM's array-size limit.
+     * </p>
+     *
+     * <p>
+     * The estimated number of matches is {@code 16} when {@code max} is negative
+     * (unbounded), otherwise {@code Math.min(max, 64)}. These multipliers
+     * preserve the historical behavior of the inlined estimate.
+     * </p>
+     *
+     * @param textLength        the length of the input text, in characters.
+     * @param searchLength      the length of the search string, in characters.
+     * @param replacementLength the length of the replacement string, in characters.
+     * @param max               the maximum number of replacements, or {@code -1} for no maximum.
+     * @return a non-negative initial capacity, never greater than {@link ArrayUtils#SAFE_MAX_ARRAY_LENGTH}.
+     */
+    static int computeInitialCapacity(final int textLength, final int searchLength, final int replacementLength, final int max) {
+        final long perReplacementGrowth = Math.max((long) replacementLength - searchLength, 0L);
+        final long totalGrowth = perReplacementGrowth * (max < 0 ? 16 : Math.min(max, 64));
+        return (int) Math.min((long) textLength + totalGrowth, ArrayUtils.SAFE_MAX_ARRAY_LENGTH);
     }
 
     /**

--- a/src/test/java/org/apache/commons/lang3/StringsTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringsTest.java
@@ -72,6 +72,18 @@ class StringsTest extends AbstractLangTest {
         assertEquals("X", Strings.CI.replaceOnce("İ", "İ", "X"));
     }
 
+    @Test
+    void testComputeInitialCapacityReplacementGrowthDoesNotOverflowInt() {
+        final int capacity = Strings.computeInitialCapacity(0, 0, 50_000_000, 64);
+        assertEquals(ArrayUtils.SAFE_MAX_ARRAY_LENGTH, capacity);
+    }
+
+    @Test
+    void testComputeInitialCapacityNeverOverflowsForMaxValueInputs() {
+        final int capacity = Strings.computeInitialCapacity(Integer.MAX_VALUE, 0, Integer.MAX_VALUE, 64);
+        assertEquals(ArrayUtils.SAFE_MAX_ARRAY_LENGTH, capacity);
+    }
+
     /**
      * Expanding the existing test group {@link StringUtilsStartsEndsWithTest#testStartsWithAny()} to include case-insensitive cases
      */


### PR DESCRIPTION
This issue is tracked as [LANG-1824](https://issues.apache.org/jira/browse/LANG-1824).

**Repro:** 
```java
final String text        = "axb";
final String search      = "x";
final String replacement = StringUtils.repeat('y', 33_554_433);

Strings.CS.replace(text, search, replacement, 64);   // → NegativeArraySizeException
```
The pre-allocation estimate inside replace is (replacement.length() - search.length()) * multiplier, where multiplier is Math.min(max, 64) for non-negative max and 16 otherwise. With the inputs above, that product is exactly Integer.MAX_VALUE + 1, wraps negative in int, and the subsequent new StringBuilder(text.length() + increase) is handed a negative capacity.

**Cause:** The pre-allocation estimate runs entirely in `int`:
```java
int increase = Math.max(replacement.length() - replLength, 0);
increase *= max < 0 ? 16 : Math.min(max, 64);
final StringBuilder buf = new StringBuilder(text.length() + increase);
```
The × multiplier step alone can exceed Integer.MAX_VALUE. Once increase wraps negative, text.length() + increase produces a value new StringBuilder(int) rejects. There was no clamp against the JVM's array-size limit either, so even a correctly-computed int capacity could exceed what the constructor accepts on some JVMs.

**Fix:** Compute the capacity in `long` instead of `int`, and clamp the result to `ArrayUtils.SAFE_MAX_ARRAY_LENGTH` before casting back. The math moves into a small package-private helper, `computeInitialCapacity`, so the overflow paths are directly unit-testable. The multipliers (`16` when `max < 0`, otherwise `Math.min(max, 64)`) are unchanged — any input that didn't overflow before allocates the same capacity as before.

<details>
<summary><b>Compatibility report</b> (<code>mvn package japicmp:cmp</code> against 3.20.0)</summary>

### `org.apache.commons.lang3.Strings`

- [X] Binary-compatible
- [X] Source-compatible
- [X] Serialization-compatible

| Status   | Modifiers           | Type  | Name      | Extends    | JDK   | Serialization       | Compatibility Changes |
|----------|---------------------|-------|-----------|------------|-------|---------------------|-----------------------|
| Modified | `public` `abstract` | Class | `Strings` | [`Object`] | JDK 8 | ![Not serializable] | ![No changes]         |

The class is reported as Modified only because of the internal refactor — no method signatures, fields, or supertypes changed. All three compatibility axes are clean.
</details>

**Regression Test**
```java
import org.apache.commons.lang3.StringUtils;

public class Repro {
    public static void main(String[] args) {
        System.out.println("Test for LANG-1824");
        final String searchString = "$$PLACEHOLDER$$";
        final String text = "--BEGIN--\n" + searchString + "\n--END--";
        final String replacement = "a".repeat(Integer.MAX_VALUE / 16 + searchString.length());

        final String expected = text.replace(searchString, replacement);
        final String result   = StringUtils.replace(text, searchString, replacement);

        final boolean lengthMatches = expected.length() == result.length();
        final boolean valueMatches  = expected.equals(result);

        System.out.println("expected.length() = " + expected.length());
        System.out.println("result.length()   = " + result.length());
        System.out.println("Length match: " + lengthMatches);
        System.out.println("Value match:  " + valueMatches);

        if (lengthMatches && valueMatches) {
            System.out.println("PASS");
        } else {
            System.out.println("FAIL");
            System.exit(1);
        }
    }
}
```
**Output:**
<img width="427" height="129" alt="Screenshot 2026-06-19 at 11 17 13 PM" src="https://github.com/user-attachments/assets/f8880da0-f01e-4870-b7f3-ead3b8676429" />

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [x] AI used: Claude (Anthropic, claude-opus-4-7) via the Claude Code CLI. Assisted with Javadoc drafting for the helper. I reviewed every change, validated the arithmetic by hand for each overflow path, and confirmed the existing Strings.replace callers are unaffected. Per ASF guidance: Anthropic's terms place no restrictions inconsistent with the OSD; no third-party material is reproduced in the output.
- [x] Run a successful build using the default [Maven](https://maven.apache.org/).
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.