### PR TITLE
Fix silent int overflow in Fraction.getFraction(double)

### DIFF
--- a/src/main/java/org/apache/commons/lang3/math/Fraction.java
+++ b/src/main/java/org/apache/commons/lang3/math/Fraction.java
@@ -174,7 +174,10 @@ public final class Fraction extends Number implements Comparable<Fraction> {
         if (i == 25) {
             throw new ArithmeticException("Unable to convert double to fraction");
         }
-        return getReducedFraction((numer0 + wholeNumber * denom0) * sign, denom0);
+        // wholeNumber can be up to Integer.MAX_VALUE while denom0 > 1 for any non-integer value,
+        // so the int product overflows for values near the limit; check it instead of wrapping silently.
+        final int numerator = Math.addExact(numer0, mulAndCheck(wholeNumber, denom0));
+        return getReducedFraction(numerator * sign, denom0);
     }
 
     /**

--- a/src/test/java/org/apache/commons/lang3/math/FractionTest.java
+++ b/src/test/java/org/apache/commons/lang3/math/FractionTest.java
@@ -334,6 +334,10 @@ class FractionTest extends AbstractLangTest {
         assertThrows(ArithmeticException.class, () -> Fraction.getFraction(Double.POSITIVE_INFINITY));
         assertThrows(ArithmeticException.class, () -> Fraction.getFraction(Double.NEGATIVE_INFINITY));
         assertThrows(ArithmeticException.class, () -> Fraction.getFraction((double) Integer.MAX_VALUE + 1));
+        // near Integer.MAX_VALUE with a fractional part: numerator overflows an int, so it must throw
+        // rather than silently return a wrong fraction (previously -3/2 and -2147483647/2 respectively)
+        assertThrows(ArithmeticException.class, () -> Fraction.getFraction(2147483646.5d));
+        assertThrows(ArithmeticException.class, () -> Fraction.getFraction(1073741824.5d));
 
         // zero
         Fraction f = Fraction.getFraction(0.0d);


### PR DESCRIPTION
Thanks for your contribution to [Apache Commons](https://commons.apache.org/)! Your help is appreciated!

Before you push a pull request, review this list:

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.

---

Repro: `Fraction.getFraction(2147483646.5)` returns `-3/2` and `getFraction(1073741824.5)` returns `-2147483647/2`.

Cause: the result numerator is rebuilt as `numer0 + wholeNumber * denom0` in `int`. `wholeNumber` can be up to `Integer.MAX_VALUE` and `denom0` is the convergent denominator (`> 1` for any non-integer value), so the product overflows and wraps. The value is not representable as an `int`/`int` `Fraction`, so the documented `ArithmeticException` should be thrown instead of returning a wrong reduced fraction.

Fix: route the numerator reconstruction through the existing `mulAndCheck` and `Math.addExact`, so the overflow is rejected the same way the `value > Integer.MAX_VALUE` guard already rejects out-of-range input. Whole numbers (where `denom0 == 1`) and all in-range values are unaffected.
