### PR TITLE
Find NaN in ArrayUtils.lastIndexOf for double and float arrays

### DIFF
--- a/src/main/java/org/apache/commons/lang3/ArrayUtils.java
+++ b/src/main/java/org/apache/commons/lang3/ArrayUtils.java
@@ -4265,6 +4265,9 @@ public class ArrayUtils {
      * @return the last index of the value within the array, {@link #INDEX_NOT_FOUND} ({@code -1}) if not found or {@code null} array input.
      */
     public static int lastIndexOf(final double[] array, final double valueToFind, int startIndex) {
+        if (Double.isNaN(valueToFind)) {
+            return lastIndexOfNaN(array, startIndex);
+        }
         if (isEmpty(array) || startIndex < 0) {
             return INDEX_NOT_FOUND;
         }
@@ -4296,6 +4299,9 @@ public class ArrayUtils {
      * @return the last index of the value within the array, {@link #INDEX_NOT_FOUND} ({@code -1}) if not found or {@code null} array input.
      */
     public static int lastIndexOf(final double[] array, final double valueToFind, int startIndex, final double tolerance) {
+        if (Double.isNaN(valueToFind)) {
+            return lastIndexOfNaN(array, startIndex);
+        }
         if (isEmpty(array) || startIndex < 0) {
             return INDEX_NOT_FOUND;
         }
@@ -4347,8 +4353,10 @@ public class ArrayUtils {
         if (startIndex >= array.length) {
             startIndex = array.length - 1;
         }
+        final boolean searchNaN = Float.isNaN(valueToFind);
         for (int i = startIndex; i >= 0; i--) {
-            if (valueToFind == array[i]) {
+            final float element = array[i];
+            if (valueToFind == element || searchNaN && Float.isNaN(element)) {
                 return i;
             }
         }
@@ -4529,6 +4537,24 @@ public class ArrayUtils {
         }
         for (int i = startIndex; i >= 0; i--) {
             if (valueToFind == array[i]) {
+                return i;
+            }
+        }
+        return INDEX_NOT_FOUND;
+    }
+
+    /**
+     * Finds the last index of the NaN value in a double array.
+     * @param array the array to traverse backwards for NaN, may be {@code null}.
+     * @param startIndex the start index to traverse backwards from.
+     * @return the last index of the NaN value within the array, {@link #INDEX_NOT_FOUND} ({@code -1}) if not found or {@code null} array input.
+     */
+    private static int lastIndexOfNaN(final double[] array, final int startIndex) {
+        if (isEmpty(array) || startIndex < 0) {
+            return INDEX_NOT_FOUND;
+        }
+        for (int i = Math.min(startIndex, array.length - 1); i >= 0; i--) {
+            if (Double.isNaN(array[i])) {
                 return i;
             }
         }

--- a/src/test/java/org/apache/commons/lang3/ArrayUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/ArrayUtilsTest.java
@@ -1825,6 +1825,16 @@ class ArrayUtilsTest extends AbstractLangTest {
     }
 
     @Test
+    void testLastIndexOfDoubleNaN() {
+        final double[] array = { Double.NaN, Double.NEGATIVE_INFINITY, Double.NaN, Double.POSITIVE_INFINITY };
+        assertEquals(2, ArrayUtils.lastIndexOf(array, Double.NaN));
+        assertEquals(2, ArrayUtils.lastIndexOf(array, Double.NaN, (double) 0));
+        assertEquals(0, ArrayUtils.lastIndexOf(array, Double.NaN, 1));
+        assertEquals(0, ArrayUtils.lastIndexOf(array, Double.NaN, 1, (double) 0));
+        assertEquals(-1, ArrayUtils.lastIndexOf(array, Double.NaN, -1));
+    }
+
+    @Test
     void testLastIndexOfDoubleTolerance() {
         double[] array = null;
         assertEquals(-1, ArrayUtils.lastIndexOf(array, (double) 0, (double) 0));
@@ -1882,6 +1892,14 @@ class ArrayUtilsTest extends AbstractLangTest {
         assertEquals(2, ArrayUtils.lastIndexOf(array, 2));
         assertEquals(3, ArrayUtils.lastIndexOf(array, 3));
         assertEquals(-1, ArrayUtils.lastIndexOf(array, 99));
+    }
+
+    @Test
+    void testLastIndexOfFloatNaN() {
+        final float[] array = { Float.NaN, Float.NEGATIVE_INFINITY, Float.NaN, Float.POSITIVE_INFINITY };
+        assertEquals(2, ArrayUtils.lastIndexOf(array, Float.NaN));
+        assertEquals(0, ArrayUtils.lastIndexOf(array, Float.NaN, 1));
+        assertEquals(-1, ArrayUtils.lastIndexOf(array, Float.NaN, -1));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/ArrayUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/ArrayUtilsTest.java
@@ -1835,6 +1835,17 @@ class ArrayUtilsTest extends AbstractLangTest {
     }
 
     @Test
+    void testLastIndexOfDoubleInfinity() {
+        final double[] array = { Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY };
+        assertEquals(2, ArrayUtils.lastIndexOf(array, Double.POSITIVE_INFINITY));
+        assertEquals(3, ArrayUtils.lastIndexOf(array, Double.NEGATIVE_INFINITY));
+        assertEquals(0, ArrayUtils.lastIndexOf(array, Double.POSITIVE_INFINITY, 1));
+        assertEquals(1, ArrayUtils.lastIndexOf(array, Double.NEGATIVE_INFINITY, 2));
+        assertEquals(2, ArrayUtils.lastIndexOf(array, Double.POSITIVE_INFINITY, array.length, (double) 0));
+        assertEquals(1, ArrayUtils.lastIndexOf(array, Double.NEGATIVE_INFINITY, 2, (double) 0));
+    }
+
+    @Test
     void testLastIndexOfDoubleTolerance() {
         double[] array = null;
         assertEquals(-1, ArrayUtils.lastIndexOf(array, (double) 0, (double) 0));
@@ -1900,6 +1911,15 @@ class ArrayUtilsTest extends AbstractLangTest {
         assertEquals(2, ArrayUtils.lastIndexOf(array, Float.NaN));
         assertEquals(0, ArrayUtils.lastIndexOf(array, Float.NaN, 1));
         assertEquals(-1, ArrayUtils.lastIndexOf(array, Float.NaN, -1));
+    }
+
+    @Test
+    void testLastIndexOfFloatInfinity() {
+        final float[] array = { Float.POSITIVE_INFINITY, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY, Float.NEGATIVE_INFINITY };
+        assertEquals(2, ArrayUtils.lastIndexOf(array, Float.POSITIVE_INFINITY));
+        assertEquals(3, ArrayUtils.lastIndexOf(array, Float.NEGATIVE_INFINITY));
+        assertEquals(0, ArrayUtils.lastIndexOf(array, Float.POSITIVE_INFINITY, 1));
+        assertEquals(1, ArrayUtils.lastIndexOf(array, Float.NEGATIVE_INFINITY, 2));
     }
 
     @Test


### PR DESCRIPTION
Repro: `ArrayUtils.lastIndexOf(new double[]{Double.NaN}, Double.NaN)` returns `-1`, while `ArrayUtils.indexOf` on the same array returns `0` (and `contains` returns `true`).
Cause: `indexOf(double[])`/`indexOf(float[])` were given explicit `NaN` matching (the `indexOfNaN` helper for `double`, a `searchNaN` flag for `float`), but the `lastIndexOf` overloads still only compare with `valueToFind == array[i]`, which is never `true` for `NaN`.
Fix: route the two `double` `lastIndexOf` overloads (with `startIndex`, and with `startIndex`+`tolerance`) through a new private `lastIndexOfNaN` helper that mirrors `indexOfNaN`, and add the same `searchNaN` check to `lastIndexOf(float[], float, int)`, so `lastIndexOf` agrees with `indexOf` on `NaN`.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
