### PR TITLE
Fix int overflow in DurationFormatUtils.formatPeriod

### DIFF
--- a/src/main/java/org/apache/commons/lang3/time/DurationFormatUtils.java
+++ b/src/main/java/org/apache/commons/lang3/time/DurationFormatUtils.java
@@ -540,12 +540,12 @@ public class DurationFormatUtils {
         end.setTime(new Date(endMillis));
         // initial estimates
         long milliseconds = end.get(Calendar.MILLISECOND) - start.get(Calendar.MILLISECOND);
-        int seconds = end.get(Calendar.SECOND) - start.get(Calendar.SECOND);
-        int minutes = end.get(Calendar.MINUTE) - start.get(Calendar.MINUTE);
-        int hours = end.get(Calendar.HOUR_OF_DAY) - start.get(Calendar.HOUR_OF_DAY);
-        int days = end.get(Calendar.DAY_OF_MONTH) - start.get(Calendar.DAY_OF_MONTH);
-        int months = end.get(Calendar.MONTH) - start.get(Calendar.MONTH);
-        int years = end.get(Calendar.YEAR) - start.get(Calendar.YEAR);
+        long seconds = end.get(Calendar.SECOND) - start.get(Calendar.SECOND);
+        long minutes = end.get(Calendar.MINUTE) - start.get(Calendar.MINUTE);
+        long hours = end.get(Calendar.HOUR_OF_DAY) - start.get(Calendar.HOUR_OF_DAY);
+        long days = end.get(Calendar.DAY_OF_MONTH) - start.get(Calendar.DAY_OF_MONTH);
+        long months = end.get(Calendar.MONTH) - start.get(Calendar.MONTH);
+        long years = end.get(Calendar.YEAR) - start.get(Calendar.YEAR);
         // each initial estimate is adjusted in case it is under 0
         while (milliseconds < 0) {
             milliseconds += DateUtils.MILLIS_PER_SECOND;

--- a/src/test/java/org/apache/commons/lang3/time/DurationFormatUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/DurationFormatUtilsTest.java
@@ -478,6 +478,19 @@ class DurationFormatUtilsTest extends AbstractLangTest {
         assertIllegalArgumentException(() -> DurationFormatUtils.formatPeriod(5000, 2500, "yy/MM"));
     }
 
+    @Test
+    void testFormatPeriodLargeFunnelledValue() {
+        final TimeZone gmt = TimeZones.getTimeZone("GMT");
+        // ~69 years, chosen so the seconds count exceeds Integer.MAX_VALUE once days/hours/minutes are
+        // funnelled into the single requested field.
+        final long endMillis = 2_175_984_000_000L;
+        assertEquals("2175984000", DurationFormatUtils.formatPeriod(0, endMillis, "s", true, gmt));
+        assertEquals("2175984000000", DurationFormatUtils.formatPeriod(0, endMillis, "S", true, gmt));
+        // formatPeriod must agree with formatDuration, which reduces the same span in long arithmetic.
+        assertEquals(DurationFormatUtils.formatDuration(endMillis, "s"),
+                DurationFormatUtils.formatPeriod(0, endMillis, "s", true, gmt));
+    }
+
     @SuppressWarnings("deprecation")
     @Test
     void testFormatPeriodISO() {

--- a/src/test/java/org/apache/commons/lang3/time/DurationFormatUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/DurationFormatUtilsTest.java
@@ -491,6 +491,25 @@ class DurationFormatUtilsTest extends AbstractLangTest {
                 DurationFormatUtils.formatPeriod(0, endMillis, "s", true, gmt));
     }
 
+    @Test
+    void testFormatPeriodLongRangeBounds() {
+        // A one-millisecond span sitting at the extremes of the long input range must still reduce
+        // correctly, confirming formatPeriod handles the whole range of millisecond inputs.
+        assertFormatPeriodOneMilli(Long.MAX_VALUE - 1, Long.MAX_VALUE);
+        assertFormatPeriodOneMilli(Long.MIN_VALUE, Long.MIN_VALUE + 1);
+        assertFormatPeriodOneMilli((long) Integer.MIN_VALUE - 1, Integer.MIN_VALUE);
+    }
+
+    private void assertFormatPeriodOneMilli(final long startMillis, final long endMillis) {
+        final TimeZone gmt = TimeZones.getTimeZone("GMT");
+        assertEquals("1", DurationFormatUtils.formatPeriod(startMillis, endMillis, "S", true, gmt));
+        assertEquals("0/0/0/0/0/0.001",
+                DurationFormatUtils.formatPeriod(startMillis, endMillis, "y/M/d/H/m/s.S", true, gmt));
+        // formatPeriod must agree with formatDuration over the full range, not just spans near the epoch.
+        assertEquals(DurationFormatUtils.formatDuration(endMillis - startMillis, "S"),
+                DurationFormatUtils.formatPeriod(startMillis, endMillis, "S", true, gmt));
+    }
+
     @SuppressWarnings("deprecation")
     @Test
     void testFormatPeriodISO() {


### PR DESCRIPTION
Thanks for your contribution to [Apache Commons](https://commons.apache.org/)! Your help is appreciated!

Before you push a pull request, review this list:

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.

---

Repro: `DurationFormatUtils.formatPeriod(0, 2175984000000L, "s", true, gmt)` for a ~69 year span (`gmt` is `TimeZone.getTimeZone("GMT")`).
Expected: `2175984000`, the value the sibling `formatDuration(2175984000000L, "s")` returns for the same span.
Actual: `-2118983296`.

Cause: `formatPeriod` keeps its day/hour/minute/second estimates in `int`. When the format omits a higher field, that field is funnelled into the next lower one (`hours += 24 * days`, `minutes += 60 * hours`, `seconds += 60 * minutes`) in `int` arithmetic before the values widen to the `long` parameters of `format`. Past a few decades the second (or millisecond) count exceeds `Integer.MAX_VALUE` and the multiply wraps negative.

Fix: declare the six estimate locals as `long` so the reduction runs in `long`, the same way `formatDuration` already reduces the span. `milliseconds` was already `long`; normal-size durations produce identical output.
