### PR TITLE
Reject sign characters in UnicodeUnescaper hex values

### DIFF
--- a/src/main/java/org/apache/commons/lang3/text/translate/UnicodeUnescaper.java
+++ b/src/main/java/org/apache/commons/lang3/text/translate/UnicodeUnescaper.java
@@ -59,6 +59,11 @@ public class UnicodeUnescaper extends CharSequenceTranslator {
                 // Get 4 hex digits
                 final CharSequence unicode = input.subSequence(index + i, index + i + 4);
 
+                final char firstChar = unicode.charAt(0);
+                if (firstChar == '+' || firstChar == '-') {
+                    // Integer.parseInt accepts a leading sign, but a Unicode value is unsigned hex.
+                    throw new IllegalArgumentException("Sign character in unicode value: '" + unicode + "'");
+                }
                 try {
                     final int value = Integer.parseInt(unicode.toString(), 16);
                     out.write((char) value);

--- a/src/test/java/org/apache/commons/lang3/text/translate/UnicodeUnescaperTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/translate/UnicodeUnescaperTest.java
@@ -40,6 +40,23 @@ class UnicodeUnescaperTest extends AbstractLangTest {
                 "A lack of digits in a Unicode escape sequence failed to throw an exception");
     }
 
+    @Test
+    void testSignedValue() {
+        final UnicodeUnescaper uu = new UnicodeUnescaper();
+
+        // Integer.parseInt accepts a leading sign, so these used to decode to a bogus char instead of throwing.
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> uu.translate("\\u-047"),
+                "A signed Unicode escape sequence failed to throw an exception");
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> uu.translate("\\u++0047"),
+                "A signed Unicode escape sequence failed to throw an exception");
+        // The documented u+ notation is still accepted.
+        assertEquals("G", uu.translate("\\u+0047"), "Failed to unescape Unicode characters with 'u+' notation");
+    }
+
     // Requested in LANG-507
     @Test
     void testUPlus() {


### PR DESCRIPTION
`UnicodeUnescaper.translate` reads the four-character value of a `\uXXXX` escape with `Integer.parseInt(value, 16)`, which tolerates a leading sign.

1. `\u-047` decodes to `U+FFB9` rather than being rejected, because `parseInt("-047", 16)` returns `-71`.
2. an embedded sign such as `\u02-3` already throws `IllegalArgumentException`, so accepting a leading sign is inconsistent.

Reject a leading `+`/`-` in the value field before parsing. The documented `u+` notation (`\u+0047`) is unaffected.

Repro: `new UnicodeUnescaper().translate("\\u-047")`
Expected: `IllegalArgumentException`
Actual: returns the string `\uFFB9`