### PR TITLE
Keep initials from splitting a supplementary code point

### DIFF
--- a/src/main/java/org/apache/commons/lang3/text/WordUtils.java
+++ b/src/main/java/org/apache/commons/lang3/text/WordUtils.java
@@ -265,7 +265,7 @@ public class WordUtils {
             return StringUtils.EMPTY;
         }
         final int strLen = str.length();
-        final char[] buf = new char[strLen / 2 + 1];
+        final char[] buf = new char[strLen];
         int count = 0;
         boolean lastWasGap = true;
         for (int i = 0; i < strLen; i++) {
@@ -276,6 +276,10 @@ public class WordUtils {
             }
             if (lastWasGap) {
                 buf[count++] = ch;
+                // keep a supplementary code point's low surrogate with its high half
+                if (Character.isHighSurrogate(ch) && i + 1 < strLen && Character.isLowSurrogate(str.charAt(i + 1))) {
+                    buf[count++] = str.charAt(++i);
+                }
                 lastWasGap = false;
             }
         }

--- a/src/test/java/org/apache/commons/lang3/text/WordUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/WordUtilsTest.java
@@ -186,6 +186,14 @@ class WordUtilsTest extends AbstractLangTest {
     }
 
     @Test
+    void testInitials_SupplementaryCodePoint() {
+        final String emoji = new String(Character.toChars(0x1F600));
+        assertEquals("B" + emoji + "L", WordUtils.initials("Ben " + emoji + "mile Lee"));
+        assertEquals(emoji, WordUtils.initials(emoji + "abc"));
+        assertEquals("B" + emoji + "L", WordUtils.initials("Ben." + emoji + "mile.Lee", '.'));
+    }
+
+    @Test
     void testInitials_String_charArray() {
         char[] array = null;
         assertNull(WordUtils.initials(null, array));


### PR DESCRIPTION
Repro: `WordUtils.initials("Ben 😀mile Lee")` where the second word begins with U+1F600.
Cause: the loop copies the first `char` after a delimiter and skips the rest of the word, so a word that starts with a supplementary code point keeps only the high surrogate and the low half is dropped, leaving a lone surrogate in the result (`B` + U+D83D + `L`).
Fix: copy the trailing low surrogate together with its high half, and size the buffer to the input length so a two-`char` initial cannot run past it. BMP input is unchanged.