### PR TITLE
Fix CsvUnescaper bounds error on a single quote field

### DIFF
--- a/src/main/java/org/apache/commons/lang3/StringEscapeUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringEscapeUtils.java
@@ -81,7 +81,7 @@ public class StringEscapeUtils {
             if (index != 0) {
                 throw new IllegalStateException("CsvUnescaper should never reach the [1] index");
             }
-            if (input.charAt(0) != CSV_QUOTE || input.charAt(input.length() - 1) != CSV_QUOTE) {
+            if (input.length() < 2 || input.charAt(0) != CSV_QUOTE || input.charAt(input.length() - 1) != CSV_QUOTE) {
                 out.write(input.toString());
                 return Character.codePointCount(input, 0, input.length());
             }

--- a/src/test/java/org/apache/commons/lang3/StringEscapeUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringEscapeUtilsTest.java
@@ -430,6 +430,9 @@ class StringEscapeUtilsTest extends AbstractLangTest {
         assertNull(StringEscapeUtils.unescapeCsv(null));
 
         assertEquals("\"foo.bar\"", StringEscapeUtils.unescapeCsv("\"foo.bar\""));
+
+        // a single quote is not an enclosing pair, so it passes through unchanged
+        assertEquals("\"", StringEscapeUtils.unescapeCsv("\""));
     }
 
     @Test


### PR DESCRIPTION
`Repro:` `StringEscapeUtils.unescapeCsv("\"")` (a field that is a single `"`) throws `StringIndexOutOfBoundsException: begin 1, end 0, length 1`.
`Cause:` `CsvUnescaper` decides a field is quoted when its first and last char are both `"`. For a one-char input the one quote is both ends, so the strip path runs `subSequence(1, length - 1)` = `subSequence(1, 0)`, an inverted range.
`Fix:` require at least two chars before treating the field as quoted, so a lone `"` falls through unchanged like any other non-quoted field.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
