### PR TITLE
Classify supplementary code points in StringUtils is* predicates

### DIFF
--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -3237,10 +3237,12 @@ public class StringUtils {
             return false;
         }
         final int sz = cs.length();
-        for (int i = 0; i < sz; i++) {
-            if (!Character.isLowerCase(cs.charAt(i))) {
+        for (int i = 0; i < sz;) {
+            final int codePoint = Character.codePointAt(cs, i);
+            if (!Character.isLowerCase(codePoint)) {
                 return false;
             }
+            i += Character.charCount(codePoint);
         }
         return true;
     }
@@ -3272,10 +3274,12 @@ public class StringUtils {
             return false;
         }
         final int sz = cs.length();
-        for (int i = 0; i < sz; i++) {
-            if (!Character.isUpperCase(cs.charAt(i))) {
+        for (int i = 0; i < sz;) {
+            final int codePoint = Character.codePointAt(cs, i);
+            if (!Character.isUpperCase(codePoint)) {
                 return false;
             }
+            i += Character.charCount(codePoint);
         }
         return true;
     }
@@ -3306,10 +3310,12 @@ public class StringUtils {
             return false;
         }
         final int sz = cs.length();
-        for (int i = 0; i < sz; i++) {
-            if (!Character.isLetter(cs.charAt(i))) {
+        for (int i = 0; i < sz;) {
+            final int codePoint = Character.codePointAt(cs, i);
+            if (!Character.isLetter(codePoint)) {
                 return false;
             }
+            i += Character.charCount(codePoint);
         }
         return true;
     }
@@ -3341,10 +3347,12 @@ public class StringUtils {
             return false;
         }
         final int sz = cs.length();
-        for (int i = 0; i < sz; i++) {
-            if (!Character.isLetterOrDigit(cs.charAt(i))) {
+        for (int i = 0; i < sz;) {
+            final int codePoint = Character.codePointAt(cs, i);
+            if (!Character.isLetterOrDigit(codePoint)) {
                 return false;
             }
+            i += Character.charCount(codePoint);
         }
         return true;
     }
@@ -3375,11 +3383,12 @@ public class StringUtils {
             return false;
         }
         final int sz = cs.length();
-        for (int i = 0; i < sz; i++) {
-            final char nowChar = cs.charAt(i);
-            if (nowChar != ' ' && !Character.isLetterOrDigit(nowChar)) {
+        for (int i = 0; i < sz;) {
+            final int codePoint = Character.codePointAt(cs, i);
+            if (codePoint != ' ' && !Character.isLetterOrDigit(codePoint)) {
                 return false;
             }
+            i += Character.charCount(codePoint);
         }
         return true;
     }
@@ -3410,11 +3419,12 @@ public class StringUtils {
             return false;
         }
         final int sz = cs.length();
-        for (int i = 0; i < sz; i++) {
-            final char nowChar = cs.charAt(i);
-            if (nowChar != ' ' && !Character.isLetter(nowChar)) {
+        for (int i = 0; i < sz;) {
+            final int codePoint = Character.codePointAt(cs, i);
+            if (codePoint != ' ' && !Character.isLetter(codePoint)) {
                 return false;
             }
+            i += Character.charCount(codePoint);
         }
         return true;
     }
@@ -3608,16 +3618,17 @@ public class StringUtils {
         boolean containsUppercase = false;
         boolean containsLowercase = false;
         final int sz = cs.length();
-        for (int i = 0; i < sz; i++) {
-            final char nowChar = cs.charAt(i);
-            if (Character.isUpperCase(nowChar)) {
+        for (int i = 0; i < sz;) {
+            final int codePoint = Character.codePointAt(cs, i);
+            if (Character.isUpperCase(codePoint)) {
                 containsUppercase = true;
-            } else if (Character.isLowerCase(nowChar)) {
+            } else if (Character.isLowerCase(codePoint)) {
                 containsLowercase = true;
             }
             if (containsUppercase && containsLowercase) {
                 return true;
             }
+            i += Character.charCount(codePoint);
         }
         return false;
     }
@@ -3755,10 +3766,12 @@ public class StringUtils {
             return false;
         }
         final int sz = cs.length();
-        for (int i = 0; i < sz; i++) {
-            if (!Character.isDigit(cs.charAt(i))) {
+        for (int i = 0; i < sz;) {
+            final int codePoint = Character.codePointAt(cs, i);
+            if (!Character.isDigit(codePoint)) {
                 return false;
             }
+            i += Character.charCount(codePoint);
         }
         return true;
     }
@@ -3792,11 +3805,12 @@ public class StringUtils {
             return false;
         }
         final int sz = cs.length();
-        for (int i = 0; i < sz; i++) {
-            final char nowChar = cs.charAt(i);
-            if (nowChar != ' ' && !Character.isDigit(nowChar)) {
+        for (int i = 0; i < sz;) {
+            final int codePoint = Character.codePointAt(cs, i);
+            if (codePoint != ' ' && !Character.isDigit(codePoint)) {
                 return false;
             }
+            i += Character.charCount(codePoint);
         }
         return true;
     }

--- a/src/test/java/org/apache/commons/lang3/StringUtilsIsTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringUtilsIsTest.java
@@ -39,6 +39,9 @@ class StringUtilsIsTest extends AbstractLangTest {
         assertFalse(StringUtils.isAlpha("hkHKHik6iUGHKJgU7tUJgKJGI87GIkug"));
         assertFalse(StringUtils.isAlpha("_"));
         assertFalse(StringUtils.isAlpha("hkHKHik*khbkuh"));
+        // a supplementary letter (U+10400 DESERET CAPITAL LETTER LONG I) is a Unicode letter
+        assertTrue(StringUtils.isAlpha(new String(Character.toChars(0x10400))));
+        assertFalse(StringUtils.isAlpha(new String(Character.toChars(0x1D7CE)))); // supplementary digit
     }
 
     @Test
@@ -54,6 +57,8 @@ class StringUtilsIsTest extends AbstractLangTest {
         assertTrue(StringUtils.isAlphanumeric("hkHKHik6iUGHKJgU7tUJgKJGI87GIkug"));
         assertFalse(StringUtils.isAlphanumeric("_"));
         assertFalse(StringUtils.isAlphanumeric("hkHKHik*khbkuh"));
+        assertTrue(StringUtils.isAlphanumeric(new String(Character.toChars(0x10400)))); // supplementary letter
+        assertTrue(StringUtils.isAlphanumeric(new String(Character.toChars(0x1D7CE)))); // supplementary digit
     }
 
     @Test
@@ -69,6 +74,7 @@ class StringUtilsIsTest extends AbstractLangTest {
         assertTrue(StringUtils.isAlphanumericSpace("hkHKHik6iUGHKJgU7tUJgKJGI87GIkug"));
         assertFalse(StringUtils.isAlphanumericSpace("_"));
         assertFalse(StringUtils.isAlphanumericSpace("hkHKHik*khbkuh"));
+        assertTrue(StringUtils.isAlphanumericSpace(new String(Character.toChars(0x10400)) + " " + new String(Character.toChars(0x1D7CE))));
     }
 
     @Test
@@ -84,6 +90,8 @@ class StringUtilsIsTest extends AbstractLangTest {
         assertFalse(StringUtils.isAlphaSpace("hkHKHik6iUGHKJgU7tUJgKJGI87GIkug"));
         assertFalse(StringUtils.isAlphaSpace("_"));
         assertFalse(StringUtils.isAlphaSpace("hkHKHik*khbkuh"));
+        assertTrue(StringUtils.isAlphaSpace(new String(Character.toChars(0x10400)) + " a")); // supplementary letter
+        assertFalse(StringUtils.isAlphaSpace(new String(Character.toChars(0x1D7CE)))); // supplementary digit
     }
 
     @Test
@@ -132,6 +140,9 @@ class StringUtilsIsTest extends AbstractLangTest {
         assertFalse(StringUtils.isNumeric("hkHKHik*khbkuh"));
         assertFalse(StringUtils.isNumeric("+123"));
         assertFalse(StringUtils.isNumeric("-123"));
+        // a supplementary digit (U+1D7CE MATHEMATICAL BOLD DIGIT ZERO) is a Unicode digit
+        assertTrue(StringUtils.isNumeric(new String(Character.toChars(0x1D7CE))));
+        assertFalse(StringUtils.isNumeric(new String(Character.toChars(0x10400)))); // supplementary letter
     }
 
     @Test
@@ -152,6 +163,8 @@ class StringUtilsIsTest extends AbstractLangTest {
         assertFalse(StringUtils.isNumericSpace("hkHKHik6iUGHKJgU7tUJgKJGI87GIkug"));
         assertFalse(StringUtils.isNumericSpace("_"));
         assertFalse(StringUtils.isNumericSpace("hkHKHik*khbkuh"));
+        assertTrue(StringUtils.isNumericSpace(new String(Character.toChars(0x1D7CE)) + " " + new String(Character.toChars(0x1D7CE))));
+        assertFalse(StringUtils.isNumericSpace(new String(Character.toChars(0x10400)))); // supplementary letter
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/StringUtilsIsTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringUtilsIsTest.java
@@ -39,9 +39,14 @@ class StringUtilsIsTest extends AbstractLangTest {
         assertFalse(StringUtils.isAlpha("hkHKHik6iUGHKJgU7tUJgKJGI87GIkug"));
         assertFalse(StringUtils.isAlpha("_"));
         assertFalse(StringUtils.isAlpha("hkHKHik*khbkuh"));
-        // a supplementary letter (U+10400 DESERET CAPITAL LETTER LONG I) is a Unicode letter
+    }
+
+    @Test
+    void testIsAlphaSupplementary() {
+        // U+10400 DESERET CAPITAL LETTER LONG I is a supplementary Unicode letter
         assertTrue(StringUtils.isAlpha(new String(Character.toChars(0x10400))));
-        assertFalse(StringUtils.isAlpha(new String(Character.toChars(0x1D7CE)))); // supplementary digit
+        // U+1D7CE MATHEMATICAL BOLD DIGIT ZERO is a supplementary digit, not a letter
+        assertFalse(StringUtils.isAlpha(new String(Character.toChars(0x1D7CE))));
     }
 
     @Test
@@ -57,8 +62,13 @@ class StringUtilsIsTest extends AbstractLangTest {
         assertTrue(StringUtils.isAlphanumeric("hkHKHik6iUGHKJgU7tUJgKJGI87GIkug"));
         assertFalse(StringUtils.isAlphanumeric("_"));
         assertFalse(StringUtils.isAlphanumeric("hkHKHik*khbkuh"));
-        assertTrue(StringUtils.isAlphanumeric(new String(Character.toChars(0x10400)))); // supplementary letter
-        assertTrue(StringUtils.isAlphanumeric(new String(Character.toChars(0x1D7CE)))); // supplementary digit
+    }
+
+    @Test
+    void testIsAlphanumericSupplementary() {
+        // both a supplementary letter and a supplementary digit are alphanumeric
+        assertTrue(StringUtils.isAlphanumeric(new String(Character.toChars(0x10400))));
+        assertTrue(StringUtils.isAlphanumeric(new String(Character.toChars(0x1D7CE))));
     }
 
     @Test
@@ -74,6 +84,11 @@ class StringUtilsIsTest extends AbstractLangTest {
         assertTrue(StringUtils.isAlphanumericSpace("hkHKHik6iUGHKJgU7tUJgKJGI87GIkug"));
         assertFalse(StringUtils.isAlphanumericSpace("_"));
         assertFalse(StringUtils.isAlphanumericSpace("hkHKHik*khbkuh"));
+    }
+
+    @Test
+    void testIsAlphanumericSpaceSupplementary() {
+        // a supplementary letter and digit separated by a space
         assertTrue(StringUtils.isAlphanumericSpace(new String(Character.toChars(0x10400)) + " " + new String(Character.toChars(0x1D7CE))));
     }
 
@@ -90,8 +105,14 @@ class StringUtilsIsTest extends AbstractLangTest {
         assertFalse(StringUtils.isAlphaSpace("hkHKHik6iUGHKJgU7tUJgKJGI87GIkug"));
         assertFalse(StringUtils.isAlphaSpace("_"));
         assertFalse(StringUtils.isAlphaSpace("hkHKHik*khbkuh"));
-        assertTrue(StringUtils.isAlphaSpace(new String(Character.toChars(0x10400)) + " a")); // supplementary letter
-        assertFalse(StringUtils.isAlphaSpace(new String(Character.toChars(0x1D7CE)))); // supplementary digit
+    }
+
+    @Test
+    void testIsAlphaSpaceSupplementary() {
+        // a supplementary letter plus a space stays alpha-space
+        assertTrue(StringUtils.isAlphaSpace(new String(Character.toChars(0x10400)) + " a"));
+        // a supplementary digit is not a letter
+        assertFalse(StringUtils.isAlphaSpace(new String(Character.toChars(0x1D7CE))));
     }
 
     @Test
@@ -140,9 +161,14 @@ class StringUtilsIsTest extends AbstractLangTest {
         assertFalse(StringUtils.isNumeric("hkHKHik*khbkuh"));
         assertFalse(StringUtils.isNumeric("+123"));
         assertFalse(StringUtils.isNumeric("-123"));
-        // a supplementary digit (U+1D7CE MATHEMATICAL BOLD DIGIT ZERO) is a Unicode digit
+    }
+
+    @Test
+    void testIsNumericSupplementary() {
+        // U+1D7CE MATHEMATICAL BOLD DIGIT ZERO is a supplementary Unicode digit
         assertTrue(StringUtils.isNumeric(new String(Character.toChars(0x1D7CE))));
-        assertFalse(StringUtils.isNumeric(new String(Character.toChars(0x10400)))); // supplementary letter
+        // U+10400 DESERET CAPITAL LETTER LONG I is a supplementary letter, not a digit
+        assertFalse(StringUtils.isNumeric(new String(Character.toChars(0x10400))));
     }
 
     @Test
@@ -163,8 +189,14 @@ class StringUtilsIsTest extends AbstractLangTest {
         assertFalse(StringUtils.isNumericSpace("hkHKHik6iUGHKJgU7tUJgKJGI87GIkug"));
         assertFalse(StringUtils.isNumericSpace("_"));
         assertFalse(StringUtils.isNumericSpace("hkHKHik*khbkuh"));
+    }
+
+    @Test
+    void testIsNumericSpaceSupplementary() {
+        // two supplementary digits separated by a space
         assertTrue(StringUtils.isNumericSpace(new String(Character.toChars(0x1D7CE)) + " " + new String(Character.toChars(0x1D7CE))));
-        assertFalse(StringUtils.isNumericSpace(new String(Character.toChars(0x10400)))); // supplementary letter
+        // a supplementary letter is not a digit
+        assertFalse(StringUtils.isNumericSpace(new String(Character.toChars(0x10400))));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/StringUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringUtilsTest.java
@@ -946,9 +946,17 @@ class StringUtilsTest extends AbstractLangTest {
         assertFalse(StringUtils.isAllLowerCase("ab c"));
         assertFalse(StringUtils.isAllLowerCase("ab1c"));
         assertFalse(StringUtils.isAllLowerCase("ab/c"));
+    }
+
+    /**
+     * Test for {@link StringUtils#isAllLowerCase(CharSequence)} with supplementary code points.
+     */
+    @Test
+    void testIsAllLowerCaseSupplementary() {
         // U+10428 DESERET SMALL LETTER LONG I is a lowercase supplementary letter
         assertTrue(StringUtils.isAllLowerCase(new String(Character.toChars(0x10428))));
-        assertFalse(StringUtils.isAllLowerCase(new String(Character.toChars(0x10400)))); // uppercase supplementary letter
+        // U+10400 DESERET CAPITAL LETTER LONG I is an uppercase supplementary letter
+        assertFalse(StringUtils.isAllLowerCase(new String(Character.toChars(0x10400))));
     }
 
     /**
@@ -966,9 +974,17 @@ class StringUtilsTest extends AbstractLangTest {
         assertFalse(StringUtils.isAllUpperCase("A C"));
         assertFalse(StringUtils.isAllUpperCase("A1C"));
         assertFalse(StringUtils.isAllUpperCase("A/C"));
+    }
+
+    /**
+     * Test for {@link StringUtils#isAllUpperCase(CharSequence)} with supplementary code points.
+     */
+    @Test
+    void testIsAllUpperCaseSupplementary() {
         // U+10400 DESERET CAPITAL LETTER LONG I is an uppercase supplementary letter
         assertTrue(StringUtils.isAllUpperCase(new String(Character.toChars(0x10400))));
-        assertFalse(StringUtils.isAllUpperCase(new String(Character.toChars(0x10428)))); // lowercase supplementary letter
+        // U+10428 DESERET SMALL LETTER LONG I is a lowercase supplementary letter
+        assertFalse(StringUtils.isAllUpperCase(new String(Character.toChars(0x10428))));
     }
 
     /**
@@ -992,9 +1008,17 @@ class StringUtilsTest extends AbstractLangTest {
         assertTrue(StringUtils.isMixedCase("aBc\n"));
         assertTrue(StringUtils.isMixedCase("A1c"));
         assertTrue(StringUtils.isMixedCase("a/C"));
+    }
+
+    /**
+     * Test for {@link StringUtils#isMixedCase(CharSequence)} with supplementary code points.
+     */
+    @Test
+    void testIsMixedCaseSupplementary() {
         // lowercase 'a' mixed with the uppercase supplementary letter U+10400
         assertTrue(StringUtils.isMixedCase("a" + new String(Character.toChars(0x10400))));
-        assertFalse(StringUtils.isMixedCase(new String(Character.toChars(0x10400)))); // single supplementary letter
+        // a single uppercase supplementary letter is not mixed case
+        assertFalse(StringUtils.isMixedCase(new String(Character.toChars(0x10400))));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/StringUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringUtilsTest.java
@@ -946,6 +946,9 @@ class StringUtilsTest extends AbstractLangTest {
         assertFalse(StringUtils.isAllLowerCase("ab c"));
         assertFalse(StringUtils.isAllLowerCase("ab1c"));
         assertFalse(StringUtils.isAllLowerCase("ab/c"));
+        // U+10428 DESERET SMALL LETTER LONG I is a lowercase supplementary letter
+        assertTrue(StringUtils.isAllLowerCase(new String(Character.toChars(0x10428))));
+        assertFalse(StringUtils.isAllLowerCase(new String(Character.toChars(0x10400)))); // uppercase supplementary letter
     }
 
     /**
@@ -963,6 +966,9 @@ class StringUtilsTest extends AbstractLangTest {
         assertFalse(StringUtils.isAllUpperCase("A C"));
         assertFalse(StringUtils.isAllUpperCase("A1C"));
         assertFalse(StringUtils.isAllUpperCase("A/C"));
+        // U+10400 DESERET CAPITAL LETTER LONG I is an uppercase supplementary letter
+        assertTrue(StringUtils.isAllUpperCase(new String(Character.toChars(0x10400))));
+        assertFalse(StringUtils.isAllUpperCase(new String(Character.toChars(0x10428)))); // lowercase supplementary letter
     }
 
     /**
@@ -986,6 +992,9 @@ class StringUtilsTest extends AbstractLangTest {
         assertTrue(StringUtils.isMixedCase("aBc\n"));
         assertTrue(StringUtils.isMixedCase("A1c"));
         assertTrue(StringUtils.isMixedCase("a/C"));
+        // lowercase 'a' mixed with the uppercase supplementary letter U+10400
+        assertTrue(StringUtils.isMixedCase("a" + new String(Character.toChars(0x10400))));
+        assertFalse(StringUtils.isMixedCase(new String(Character.toChars(0x10400)))); // single supplementary letter
     }
 
     @Test


### PR DESCRIPTION
Repro: `StringUtils.isAlpha(new String(Character.toChars(0x10400)))` (`DESERET CAPITAL LETTER LONG I`, a letter) returns `false`, and `StringUtils.isNumeric(new String(Character.toChars(0x1D7CE)))` (`MATHEMATICAL BOLD DIGIT ZERO`, a digit) returns `false`.

Cause: the `is*` predicates (`isAlpha`, `isAlphaSpace`, `isAlphanumeric`, `isAlphanumericSpace`, `isNumeric`, `isNumericSpace`, `isAllLowerCase`, `isAllUpperCase`, `isMixedCase`) walk the input one `char` at a time and hand each `char` to `Character.isLetter`/`isDigit`/`isLetterOrDigit`/`isUpperCase`/`isLowerCase`. A supplementary code point is two surrogate chars, neither of which is a letter, digit or cased char on its own, so a supplementary letter or digit is rejected even though the Javadoc tests for Unicode letters/digits.

Fix: iterate with `Character.codePointAt` and advance by `Character.charCount`, classifying the whole code point at each site. BMP input keeps the same result (a lone surrogate still classifies as before).