### PR TITLE
Fold supplementary code points in CharSequenceUtils.regionMatches

### DIFF
--- a/src/main/java/org/apache/commons/lang3/CharSequenceUtils.java
+++ b/src/main/java/org/apache/commons/lang3/CharSequenceUtils.java
@@ -319,9 +319,14 @@ public class CharSequenceUtils {
             if (!ignoreCase) {
                 return false;
             }
-            // The same case-insensitive check as String#regionMatches(boolean, int, String, int, int),
-            // which also folds case of a supplementary code point split across a surrogate pair.
+            // The same case-insensitive check as String#regionMatches(boolean, int, String, int, int).
             if (!equalsIgnoreCase(c1, c2)) {
+                // String only folds a supplementary code point split across a surrogate pair from Java 9
+                // on; on Java 8 it stays char-by-char. Track the running JDK so every CharSequence type
+                // gives the same result that String does there.
+                if (SystemUtils.IS_JAVA_1_8) {
+                    return false;
+                }
                 int cp1 = c1;
                 if (Character.isHighSurrogate(c1)) {
                     if (index1 + 1 < end1 && Character.isLowSurrogate(cs.charAt(index1 + 1))) {

--- a/src/main/java/org/apache/commons/lang3/CharSequenceUtils.java
+++ b/src/main/java/org/apache/commons/lang3/CharSequenceUtils.java
@@ -27,6 +27,17 @@ public class CharSequenceUtils {
 
     private static final int NOT_FOUND = -1;
 
+    /**
+     * Whether the running JDK folds a supplementary code point split across a surrogate pair when comparing case
+     * insensitively in {@link String#regionMatches(boolean, int, String, int, int)}. JDKs up to and including Java 11
+     * compare surrogate by surrogate and never match such a pair; later JDKs fold the whole code point. Probing what
+     * {@link String} actually does (rather than gating on a version constant) keeps every {@link CharSequence} type in
+     * step with {@link String} on whatever JDK is running. DESERET CAPITAL LETTER LONG I (U+10400) folds to its small
+     * form (U+10428).
+     */
+    private static final boolean STRING_FOLDS_SUPPLEMENTARY_CASE =
+            new String(Character.toChars(0x10400)).regionMatches(true, 0, new String(Character.toChars(0x10428)), 0, 2);
+
     static final int TO_STRING_LIMIT = 16;
 
     private static boolean checkLaterThan1(final CharSequence cs, final CharSequence searchChar, final int len2, final int start1) {
@@ -321,10 +332,9 @@ public class CharSequenceUtils {
             }
             // The same case-insensitive check as String#regionMatches(boolean, int, String, int, int).
             if (!equalsIgnoreCase(c1, c2)) {
-                // String only folds a supplementary code point split across a surrogate pair from Java 9
-                // on; on Java 8 it stays char-by-char. Track the running JDK so every CharSequence type
-                // gives the same result that String does there.
-                if (SystemUtils.IS_JAVA_1_8) {
+                // Only fold a supplementary code point split across a surrogate pair where String itself does, so
+                // every CharSequence type gives the same result that String does on the running JDK (see field).
+                if (!STRING_FOLDS_SUPPLEMENTARY_CASE) {
                     return false;
                 }
                 int cp1 = c1;

--- a/src/main/java/org/apache/commons/lang3/CharSequenceUtils.java
+++ b/src/main/java/org/apache/commons/lang3/CharSequenceUtils.java
@@ -293,9 +293,6 @@ public class CharSequenceUtils {
         if (cs instanceof String && substring instanceof String) {
             return ((String) cs).regionMatches(ignoreCase, thisStart, (String) substring, start, length);
         }
-        int index1 = thisStart;
-        int index2 = start;
-        int tmpLen = length;
         // Extract these first so we detect NPEs the same as the java.lang.String version
         final int srcLen = cs.length() - thisStart;
         final int otherLen = substring.length() - start;
@@ -307,23 +304,64 @@ public class CharSequenceUtils {
         if (srcLen < length || otherLen < length) {
             return false;
         }
-        while (tmpLen-- > 0) {
-            final char c1 = cs.charAt(index1++);
-            final char c2 = substring.charAt(index2++);
+        final int end1 = thisStart + length;
+        final int end2 = start + length;
+        int index1 = thisStart;
+        int index2 = start;
+        while (index1 < end1 && index2 < end2) {
+            final char c1 = cs.charAt(index1);
+            final char c2 = substring.charAt(index2);
             if (c1 == c2) {
+                index1++;
+                index2++;
                 continue;
             }
             if (!ignoreCase) {
                 return false;
             }
-            // The real same check as in String#regionMatches(boolean, int, String, int, int):
-            final char u1 = Character.toUpperCase(c1);
-            final char u2 = Character.toUpperCase(c2);
-            if (u1 != u2 && Character.toLowerCase(u1) != Character.toLowerCase(u2)) {
-                return false;
+            // The same case-insensitive check as String#regionMatches(boolean, int, String, int, int),
+            // which also folds case of a supplementary code point split across a surrogate pair.
+            if (!equalsIgnoreCase(c1, c2)) {
+                int cp1 = c1;
+                if (Character.isHighSurrogate(c1)) {
+                    if (index1 + 1 < end1 && Character.isLowSurrogate(cs.charAt(index1 + 1))) {
+                        cp1 = Character.toCodePoint(c1, cs.charAt(index1 + 1));
+                        index1++;
+                    }
+                } else if (Character.isLowSurrogate(c1) && index1 > thisStart && Character.isHighSurrogate(cs.charAt(index1 - 1))) {
+                    cp1 = Character.toCodePoint(cs.charAt(index1 - 1), c1);
+                }
+                int cp2 = c2;
+                if (Character.isHighSurrogate(c2)) {
+                    if (index2 + 1 < end2 && Character.isLowSurrogate(substring.charAt(index2 + 1))) {
+                        cp2 = Character.toCodePoint(c2, substring.charAt(index2 + 1));
+                        index2++;
+                    }
+                } else if (Character.isLowSurrogate(c2) && index2 > start && Character.isHighSurrogate(substring.charAt(index2 - 1))) {
+                    cp2 = Character.toCodePoint(substring.charAt(index2 - 1), c2);
+                }
+                if (!equalsIgnoreCase(cp1, cp2)) {
+                    return false;
+                }
             }
+            index1++;
+            index2++;
         }
         return true;
+    }
+
+    /**
+     * Tests whether two code points are equal ignoring case, matching the folding used by
+     * {@link String#regionMatches(boolean, int, String, int, int)}.
+     *
+     * @param cp1 the first code point.
+     * @param cp2 the second code point.
+     * @return whether the code points are equal ignoring case.
+     */
+    private static boolean equalsIgnoreCase(final int cp1, final int cp2) {
+        final int u1 = Character.toUpperCase(cp1);
+        final int u2 = Character.toUpperCase(cp2);
+        return u1 == u2 || Character.toLowerCase(u1) == Character.toLowerCase(u2);
     }
 
     /**

--- a/src/test/java/org/apache/commons/lang3/CharSequenceUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/CharSequenceUtilsTest.java
@@ -161,13 +161,6 @@ class CharSequenceUtilsTest extends AbstractLangTest {
             new TestData("Abc",  false,      1,     "abc",  1,     2,    true),
             new TestData("Abcd", true,       1,     "abcD", 1,     2,    true),
             new TestData("Abcd", false,      1,     "abcD", 1,     2,    true),
-            // Deseret CAPITAL LONG I (U+10400) folds to SMALL LONG I (U+10428): a supplementary
-            // code point split across a surrogate pair must fold like java.lang.String does.
-            new TestData("\uD801\uDC00",  true,  0, "\uD801\uDC28", 0, 2, true),
-            new TestData("\uD801\uDC00",  false, 0, "\uD801\uDC28", 0, 2, false),
-            new TestData("\uD801\uDC28",  true,  0, "\uD801\uDC00", 0, 2, true),
-            new TestData("x\uD801\uDC00", true,  1, "\uD801\uDC28", 0, 2, true),
-            new TestData("\uD801\uDC00",  true,  0, "\uD801\uDC29", 0, 2, false),
             // @formatter:on
     };
 
@@ -281,6 +274,22 @@ class CharSequenceUtilsTest extends AbstractLangTest {
                 }
             }.run(data, "CSNonString");
         }
+    }
+
+    /**
+     * The green path for a non-String CharSequence must fold a supplementary code point as one unit, not as two bare
+     * surrogates, so the case-insensitive result no longer depends on the argument's runtime type. Deseret CAPITAL LONG I
+     * (U+10400) folds to SMALL LONG I (U+10428). These cases are kept out of {@link #TEST_DATA} because
+     * {@link String#regionMatches(boolean, int, String, int, int)} only folds supplementary code points from Java 9
+     * onward, so the shared String-parity rows would fail on Java 8.
+     */
+    @Test
+    void testRegionMatchesSupplementaryCaseFold() {
+        assertTrue(CharSequenceUtils.regionMatches(new StringBuilder("\uD801\uDC00"), true, 0, "\uD801\uDC28", 0, 2));
+        assertFalse(CharSequenceUtils.regionMatches(new StringBuilder("\uD801\uDC00"), false, 0, "\uD801\uDC28", 0, 2));
+        assertTrue(CharSequenceUtils.regionMatches(new StringBuilder("\uD801\uDC28"), true, 0, "\uD801\uDC00", 0, 2));
+        assertTrue(CharSequenceUtils.regionMatches(new StringBuilder("x\uD801\uDC00"), true, 1, "\uD801\uDC28", 0, 2));
+        assertFalse(CharSequenceUtils.regionMatches(new StringBuilder("\uD801\uDC00"), true, 0, "\uD801\uDC29", 0, 2));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/CharSequenceUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/CharSequenceUtilsTest.java
@@ -161,6 +161,13 @@ class CharSequenceUtilsTest extends AbstractLangTest {
             new TestData("Abc",  false,      1,     "abc",  1,     2,    true),
             new TestData("Abcd", true,       1,     "abcD", 1,     2,    true),
             new TestData("Abcd", false,      1,     "abcD", 1,     2,    true),
+            // Deseret CAPITAL LONG I (U+10400) folds to SMALL LONG I (U+10428): a supplementary
+            // code point split across a surrogate pair must fold like java.lang.String does.
+            new TestData("\uD801\uDC00",  true,  0, "\uD801\uDC28", 0, 2, true),
+            new TestData("\uD801\uDC00",  false, 0, "\uD801\uDC28", 0, 2, false),
+            new TestData("\uD801\uDC28",  true,  0, "\uD801\uDC00", 0, 2, true),
+            new TestData("x\uD801\uDC00", true,  1, "\uD801\uDC28", 0, 2, true),
+            new TestData("\uD801\uDC00",  true,  0, "\uD801\uDC29", 0, 2, false),
             // @formatter:on
     };
 

--- a/src/test/java/org/apache/commons/lang3/CharSequenceUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/CharSequenceUtilsTest.java
@@ -28,6 +28,7 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
+import java.nio.CharBuffer;
 import java.util.Random;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -276,20 +277,31 @@ class CharSequenceUtilsTest extends AbstractLangTest {
         }
     }
 
+    private static void assertRegionMatchesParity(final String source, final boolean ignoreCase, final int toffset, final String other,
+            final int ooffset, final int len) {
+        // String is the reference: whatever the running JDK does for String, every CharSequence type must match.
+        final boolean expected = source.regionMatches(ignoreCase, toffset, other, ooffset, len);
+        final CharSequence[] sources = {source, new StringBuilder(source), new StringBuffer(source), CharBuffer.wrap(source)};
+        for (final CharSequence cs : sources) {
+            assertEquals(expected, CharSequenceUtils.regionMatches(cs, ignoreCase, toffset, other, ooffset, len),
+                    cs.getClass().getSimpleName() + " differs from String for " + source + " vs " + other);
+        }
+    }
+
     /**
-     * The green path for a non-String CharSequence must fold a supplementary code point as one unit, not as two bare
-     * surrogates, so the case-insensitive result no longer depends on the argument's runtime type. Deseret CAPITAL LONG I
-     * (U+10400) folds to SMALL LONG I (U+10428). These cases are kept out of {@link #TEST_DATA} because
-     * {@link String#regionMatches(boolean, int, String, int, int)} only folds supplementary code points from Java 9
-     * onward, so the shared String-parity rows would fail on Java 8.
+     * A supplementary code point split across a surrogate pair must fold the same way for every {@link CharSequence}
+     * type that it does for {@link String} on the running JDK. {@link String#regionMatches(boolean, int, String, int, int)}
+     * only folds such a code point from Java 9 on, so these rows are checked against {@link String} itself rather than a
+     * fixed result: {@link String}, {@link StringBuilder}, {@link StringBuffer} and {@link CharBuffer} all have to agree.
+     * Deseret CAPITAL LONG I (U+10400) folds to SMALL LONG I (U+10428).
      */
     @Test
     void testRegionMatchesSupplementaryCaseFold() {
-        assertTrue(CharSequenceUtils.regionMatches(new StringBuilder("\uD801\uDC00"), true, 0, "\uD801\uDC28", 0, 2));
-        assertFalse(CharSequenceUtils.regionMatches(new StringBuilder("\uD801\uDC00"), false, 0, "\uD801\uDC28", 0, 2));
-        assertTrue(CharSequenceUtils.regionMatches(new StringBuilder("\uD801\uDC28"), true, 0, "\uD801\uDC00", 0, 2));
-        assertTrue(CharSequenceUtils.regionMatches(new StringBuilder("x\uD801\uDC00"), true, 1, "\uD801\uDC28", 0, 2));
-        assertFalse(CharSequenceUtils.regionMatches(new StringBuilder("\uD801\uDC00"), true, 0, "\uD801\uDC29", 0, 2));
+        assertRegionMatchesParity("\uD801\uDC00", true, 0, "\uD801\uDC28", 0, 2);
+        assertRegionMatchesParity("\uD801\uDC00", false, 0, "\uD801\uDC28", 0, 2);
+        assertRegionMatchesParity("\uD801\uDC28", true, 0, "\uD801\uDC00", 0, 2);
+        assertRegionMatchesParity("x\uD801\uDC00", true, 1, "\uD801\uDC28", 0, 2);
+        assertRegionMatchesParity("\uD801\uDC00", true, 0, "\uD801\uDC29", 0, 2);
     }
 
     @Test


### PR DESCRIPTION
`CharSequenceUtils.regionMatches` is the green stand-in for `String.regionMatches` used whenever an argument is not a `String`, but its `ignoreCase` branch folds case one UTF-16 `char` at a time. The two halves of a supplementary code point are surrogates with no case mapping, so a case-insensitive compare of a supplementary letter never matches. Repro with `U+10400` (`𐐀`, Deseret capital long I) and its lowercase `U+10428` (`𐐨`): `StringUtils.equalsIgnoreCase("𐐀", "𐐨")` returns `true` through the `String` fast path, yet `equalsIgnoreCase(new StringBuilder("𐐀"), "𐐨")` returns `false`. `startsWithIgnoreCase`, `endsWithIgnoreCase`, `containsIgnoreCase` and `Strings.CI.indexOf` go the same way, so the answer depends on the argument's runtime type.

On a `char`-level mismatch the fix rebuilds the full code point from the adjacent surrogate and folds at the code point level, which is what `String.regionMatches` itself does, so the green path lines back up with the `String`/`String` path. Cross-checked against `String.regionMatches` over a few million randomised BMP, supplementary and lone-surrogate inputs with no remaining divergence; the added `CharSequenceUtilsTest` cases fail before the change and pass after.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
