### PR TITLE
Emit surrogate pair for supplementary code points in UnicodeEscaper

### DIFF
--- a/src/main/java/org/apache/commons/lang3/text/translate/UnicodeEscaper.java
+++ b/src/main/java/org/apache/commons/lang3/text/translate/UnicodeEscaper.java
@@ -102,7 +102,8 @@ public class UnicodeEscaper extends CodePointTranslator {
     }
 
     /**
-     * Converts the given code point to a hexadecimal string of the form {@code "\\uXXXX"}
+     * Converts the given code point to a hexadecimal string of the form {@code "\\uXXXX"}, or the
+     * surrogate pair form {@code "\\uXXXX\\uXXXX"} for a supplementary code point.
      *
      * @param codePoint
      *            a Unicode code point.
@@ -110,7 +111,11 @@ public class UnicodeEscaper extends CodePointTranslator {
      * @since 3.2
      */
     protected String toUtf16Escape(final int codePoint) {
-        return "\\u" + hex(codePoint);
+        if (Character.isBmpCodePoint(codePoint)) {
+            return "\\u" + hex(codePoint);
+        }
+        final char[] surrogatePair = Character.toChars(codePoint);
+        return "\\u" + hex(surrogatePair[0]) + "\\u" + hex(surrogatePair[1]);
     }
 
     /**

--- a/src/test/java/org/apache/commons/lang3/text/translate/UnicodeEscaperTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/translate/UnicodeEscaperTest.java
@@ -51,4 +51,14 @@ class UnicodeEscaperTest extends AbstractLangTest {
         final String result = ue.translate(input);
         assertEquals("AD\\u0046\\u0047Z", result, "Failed to escape Unicode characters via the between method");
     }
+
+    @Test
+    void testSupplementary() {
+        final UnicodeEscaper ue = UnicodeEscaper.above(0x7f);
+        // U+10437 (DESERET SMALL LETTER YEE) encodes to surrogate pair U+D801 U+DC37.
+        final String input = new String(Character.toChars(0x10437));
+        final String result = ue.translate(input);
+        assertEquals("\\uD801\\uDC37", result, "Supplementary code point must escape to a surrogate pair");
+        assertEquals(input, new UnicodeUnescaper().translate(result), "Escaped supplementary code point must round-trip");
+    }
 }


### PR DESCRIPTION
Repro: escape any supplementary code point with the base `UnicodeEscaper`, e.g. `UnicodeEscaper.above(0x7f).translate(new String(Character.toChars(0x10437)))`.
Expected: `\uD801\uDC37`.
Actual: `\u10437`, a single `\u` carrying five hex digits, which no `\u` reader decodes back to U+10437 (`UnicodeUnescaper` reads `\u1043` then a literal `7`).
Cause: `toUtf16Escape` returns `"\\u" + hex(codePoint)`, but a code point above `0xffff` does not fit the four hex digits a `\u` escape holds, so the surrogate split is never applied.
Fix: emit the surrogate-pair form `\uXXXX\uXXXX` for supplementary code points, matching the method name and the behaviour `JavaUnicodeEscaper` already has. BMP code points are untouched.
