### PR TITLE
Fix MethodUtils.getMatchingMethod false ambiguity on boxed arguments

### DIFF
--- a/src/main/java/org/apache/commons/lang3/reflect/MethodUtils.java
+++ b/src/main/java/org/apache/commons/lang3/reflect/MethodUtils.java
@@ -90,7 +90,12 @@ public class MethodUtils {
                 continue;
             }
             if (ClassUtils.isAssignable(aClass, toClass, true) && !ClassUtils.isAssignable(aClass, toClass, false)) {
+                // Autoboxing/unboxing conversion. When a primitive is boxed, rank the exact
+                // wrapper ahead of any of its supertypes so the most specific overload wins.
                 answer++;
+                if (aClass.isPrimitive() && !ClassUtils.primitiveToWrapper(aClass).equals(toClass)) {
+                    answer += 2;
+                }
             } else {
                 answer += 2;
             }

--- a/src/test/java/org/apache/commons/lang3/reflect/MethodUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/reflect/MethodUtilsTest.java
@@ -118,6 +118,12 @@ class MethodUtilsTest extends AbstractLangTest {
 
         public void testMethod4(final Long aLong, final Long anotherLong) {
         }
+
+        public void testMethod5(final Integer anInteger) {
+        }
+
+        public void testMethod5(final Number aNumber) {
+        }
     }
 
     private static final class GetMatchingMethodImpl extends AbstractGetMatchingMethod {
@@ -813,6 +819,11 @@ class MethodUtilsTest extends AbstractLangTest {
         assertEquals(MethodUtils.getMatchingMethod(GetMatchingMethodClass.class, "testMethod3", Long.TYPE, null),
                 GetMatchingMethodClass.class.getMethod("testMethod3", Long.TYPE, Long.class));
         assertThrows(IllegalStateException.class, () -> MethodUtils.getMatchingMethod(GetMatchingMethodClass.class, "testMethod4", null, null));
+        // A primitive argument boxes to the exact wrapper overload, not to one of its supertypes.
+        assertEquals(MethodUtils.getMatchingMethod(GetMatchingMethodClass.class, "testMethod5", Integer.TYPE),
+                GetMatchingMethodClass.class.getMethod("testMethod5", Integer.class));
+        assertEquals(MethodUtils.getMatchingMethod(GetMatchingMethodClass.class, "testMethod5", Integer.class),
+                GetMatchingMethodClass.class.getMethod("testMethod5", Integer.class));
         assertEquals(MethodUtils.getMatchingMethod(GetMatchingMethodImpl.class, "testMethod5", RuntimeException.class),
                 GetMatchingMethodImpl.class.getMethod("testMethod5", Exception.class));
         assertEquals(GetMatchingMethodImpl.class.getMethod("testMethod6"), MethodUtils.getMatchingMethod(GetMatchingMethodImpl.class, "testMethod6"));


### PR DESCRIPTION
`MethodUtils.getMatchingMethod` ranks overloads with the private `distance` helper, which charges a flat `+1` for any autoboxing conversion. For a primitive argument that makes `int` to `Integer` and `int` to `Number` both score `1`, so when a class declares both `f(Integer)` and `f(Number)` the call `getMatchingMethod(cls, "f", int.class)` puts two candidates in the same distance bucket and throws `IllegalStateException: Found multiple candidates`, even though `javac` resolves `f(someInt)` unambiguously to `f(Integer)`.

The fix keeps the flat penalty when a primitive boxes to its exact wrapper but adds the supertype cost when it boxes to a supertype, so `int` to `Integer` ranks strictly below `int` to `Number`. `distance` is private to `getMatchingMethod`, so the change stays inside that resolver; the auto-unboxing direction and every existing resolution are unaffected.