### PR TITLE
Handle supplementary code points in WordUtils case methods

### DIFF
--- a/src/main/java/org/apache/commons/lang3/text/WordUtils.java
+++ b/src/main/java/org/apache/commons/lang3/text/WordUtils.java
@@ -301,8 +301,11 @@ public class WordUtils {
     /**
      * Tests if the code point is a delimiter.
      *
+     * <p>A {@code null} {@code delimiters} array treats any whitespace code point, as defined by
+     * {@link Character#isWhitespace(int)}, as a delimiter.</p>
+     *
      * @param codePoint  the code point to check.
-     * @param delimiters  the delimiters.
+     * @param delimiters  the delimiters, {@code null} matches whitespace.
      * @return true if it is a delimiter.
      */
     private static boolean isDelimiter(final int codePoint, final char[] delimiters) {

--- a/src/main/java/org/apache/commons/lang3/text/WordUtils.java
+++ b/src/main/java/org/apache/commons/lang3/text/WordUtils.java
@@ -99,14 +99,15 @@ public class WordUtils {
         }
         final char[] buffer = str.toCharArray();
         boolean capitalizeNext = true;
-        for (int i = 0; i < buffer.length; i++) {
-            final char ch = buffer[i];
-            if (isDelimiter(ch, delimiters)) {
+        for (int i = 0; i < buffer.length;) {
+            final int codePoint = Character.codePointAt(buffer, i);
+            if (isDelimiter(codePoint, delimiters)) {
                 capitalizeNext = true;
             } else if (capitalizeNext) {
-                buffer[i] = Character.toTitleCase(ch);
+                Character.toChars(Character.toTitleCase(codePoint), buffer, i);
                 capitalizeNext = false;
             }
+            i += Character.charCount(codePoint);
         }
         return new String(buffer);
     }
@@ -298,6 +299,25 @@ public class WordUtils {
     }
 
     /**
+     * Tests if the code point is a delimiter.
+     *
+     * @param codePoint  the code point to check.
+     * @param delimiters  the delimiters.
+     * @return true if it is a delimiter.
+     */
+    private static boolean isDelimiter(final int codePoint, final char[] delimiters) {
+        if (delimiters == null) {
+            return Character.isWhitespace(codePoint);
+        }
+        for (final char delimiter : delimiters) {
+            if (codePoint == delimiter) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * Swaps the case of a String using a word based algorithm.
      *
      * <ul>
@@ -327,21 +347,22 @@ public class WordUtils {
 
         boolean whitespace = true;
 
-        for (int i = 0; i < buffer.length; i++) {
-            final char ch = buffer[i];
-            if (Character.isUpperCase(ch) || Character.isTitleCase(ch)) {
-                buffer[i] = Character.toLowerCase(ch);
+        for (int i = 0; i < buffer.length;) {
+            final int codePoint = Character.codePointAt(buffer, i);
+            if (Character.isUpperCase(codePoint) || Character.isTitleCase(codePoint)) {
+                Character.toChars(Character.toLowerCase(codePoint), buffer, i);
                 whitespace = false;
-            } else if (Character.isLowerCase(ch)) {
+            } else if (Character.isLowerCase(codePoint)) {
                 if (whitespace) {
-                    buffer[i] = Character.toTitleCase(ch);
+                    Character.toChars(Character.toTitleCase(codePoint), buffer, i);
                     whitespace = false;
                 } else {
-                    buffer[i] = Character.toUpperCase(ch);
+                    Character.toChars(Character.toUpperCase(codePoint), buffer, i);
                 }
             } else {
-                whitespace = Character.isWhitespace(ch);
+                whitespace = Character.isWhitespace(codePoint);
             }
+            i += Character.charCount(codePoint);
         }
         return new String(buffer);
     }
@@ -399,14 +420,15 @@ public class WordUtils {
         }
         final char[] buffer = str.toCharArray();
         boolean uncapitalizeNext = true;
-        for (int i = 0; i < buffer.length; i++) {
-            final char ch = buffer[i];
-            if (isDelimiter(ch, delimiters)) {
+        for (int i = 0; i < buffer.length;) {
+            final int codePoint = Character.codePointAt(buffer, i);
+            if (isDelimiter(codePoint, delimiters)) {
                 uncapitalizeNext = true;
             } else if (uncapitalizeNext) {
-                buffer[i] = Character.toLowerCase(ch);
+                Character.toChars(Character.toLowerCase(codePoint), buffer, i);
                 uncapitalizeNext = false;
             }
+            i += Character.charCount(codePoint);
         }
         return new String(buffer);
     }

--- a/src/test/java/org/apache/commons/lang3/text/WordUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/WordUtilsTest.java
@@ -278,6 +278,25 @@ class WordUtilsTest extends AbstractLangTest {
     }
 
     @Test
+    void testCase_SupplementaryCodePoint() {
+        // Deseret long-i: capital U+10400, small U+10428 (each a surrogate pair)
+        final String cap = new String(Character.toChars(0x10400));
+        final String small = new String(Character.toChars(0x10428));
+
+        assertEquals(cap + "bc", WordUtils.capitalize(small + "bc"));
+        assertEquals("Ben " + cap + "ee", WordUtils.capitalize("ben " + small + "ee"));
+        assertEquals("Ben." + cap + "ee", WordUtils.capitalize("ben." + small + "ee", '.'));
+        assertEquals(cap + "bc", WordUtils.capitalizeFully(cap + "BC"));
+
+        assertEquals(small + "BC", WordUtils.uncapitalize(cap + "BC"));
+        assertEquals("a." + small + "BC", WordUtils.uncapitalize("a." + cap + "BC", '.'));
+
+        assertEquals(small, WordUtils.swapCase(cap));
+        assertEquals(cap, WordUtils.swapCase(small));
+        assertEquals("A" + small, WordUtils.swapCase("a" + cap));
+    }
+
+    @Test
     void testLANG1292() {
         // Prior to fix, this was throwing StringIndexOutOfBoundsException
         WordUtils.wrap("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa "


### PR DESCRIPTION
Repro: capitalise any word that begins with a supplementary cased letter, e.g. `WordUtils.capitalize("𐐨bc")` where `𐐨` is Deseret small long-i `U+10428`.
Cause: `capitalize`, `capitalizeFully`, `uncapitalize` and `swapCase` iterate one `char` at a time and call `Character.toTitleCase`/`toUpperCase`/`toLowerCase` on each unit. The two surrogate halves of a supplementary code point carry no case mapping, so the letter is left as-is and the result diverges from `StringUtils.capitalize`/`swapCase`, which already work on code points (`capitalize` yields `U+10428` instead of `U+10400`, `swapCase` leaves `U+10400` unchanged).
Fix: iterate with `Character.codePointAt` and write the mapped code point back with `Character.toChars`. A case mapping never changes the UTF-16 length, so the existing buffer is reused; BMP input and lone surrogates are untouched.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
