### PR TITLE
Fix StringUtils.getDigits dropping supplementary digits

### DIFF
--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -2076,11 +2076,12 @@ public class StringUtils {
         final char[] buffer = new char[len];
         int count = 0;
 
-        for (int i = 0; i < len; i++) {
-            final char tempChar = str.charAt(i);
-            if (Character.isDigit(tempChar)) {
-                buffer[count++] = tempChar;
+        for (int i = 0; i < len;) {
+            final int codePoint = str.codePointAt(i);
+            if (Character.isDigit(codePoint)) {
+                count += Character.toChars(codePoint, buffer, count);
             }
+            i += Character.charCount(codePoint);
         }
         return new String(buffer, 0, count);
     }

--- a/src/test/java/org/apache/commons/lang3/StringUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringUtilsTest.java
@@ -719,6 +719,14 @@ class StringUtilsTest extends AbstractLangTest {
     }
 
     @Test
+    void testGetDigitsSupplementary() {
+        // U+1D7CF MATHEMATICAL BOLD DIGIT ONE: Character.isDigit is true but it is a surrogate pair
+        final String mathOne = new String(Character.toChars(0x1D7CF));
+        assertEquals(mathOne, StringUtils.getDigits(mathOne));
+        assertEquals(mathOne + "9", StringUtils.getDigits("a" + mathOne + "9"));
+    }
+
+    @Test
     void testGetFuzzyDistance() {
         assertEquals(0, StringUtils.getFuzzyDistance("", "", Locale.ENGLISH));
         assertEquals(0, StringUtils.getFuzzyDistance("Workshop", "b", Locale.ENGLISH));


### PR DESCRIPTION
1. `getDigits` scans the input one `char` at a time and calls `Character.isDigit(char)`, so a supplementary digit such as `U+1D7CF` (MATHEMATICAL BOLD DIGIT ONE) is dropped: neither surrogate half is itself a digit, even though `Character.isDigit` reports the code point as a digit.
2. Switched the scan to code points (`codePointAt`/`charCount`) and write the matched code point back with `Character.toChars`.

Repro `getDigits("a" + new String(Character.toChars(0x1D7CF)) + "9")`: expected the supplementary digit then `9`, actual `9`. BMP input (including the existing Devanagari case) is unchanged.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
