### PR TITLE
Keep StrBuilder.reverse from splitting surrogate pairs

### DIFF
--- a/src/main/java/org/apache/commons/lang3/text/StrBuilder.java
+++ b/src/main/java/org/apache/commons/lang3/text/StrBuilder.java
@@ -2758,10 +2758,25 @@ public class StrBuilder implements CharSequence, Appendable, Serializable, Build
 
         final int half = size / 2;
         final char[] buf = buffer;
+        boolean hasSurrogates = false;
         for (int leftIdx = 0, rightIdx = size - 1; leftIdx < half; leftIdx++, rightIdx--) {
-            final char swap = buf[leftIdx];
-            buf[leftIdx] = buf[rightIdx];
-            buf[rightIdx] = swap;
+            final char left = buf[leftIdx];
+            final char right = buf[rightIdx];
+            buf[leftIdx] = right;
+            buf[rightIdx] = left;
+            hasSurrogates |= Character.isSurrogate(left) || Character.isSurrogate(right);
+        }
+        if (hasSurrogates) {
+            // The plain swap leaves each surrogate pair in low-high order; restore the high-low order so a
+            // reversed supplementary code point stays a valid pair, matching StringBuilder#reverse().
+            for (int i = 0; i < size - 1; i++) {
+                if (Character.isLowSurrogate(buf[i]) && Character.isHighSurrogate(buf[i + 1])) {
+                    final char low = buf[i];
+                    buf[i] = buf[i + 1];
+                    buf[i + 1] = low;
+                    i++;
+                }
+            }
         }
         return this;
     }

--- a/src/test/java/org/apache/commons/lang3/text/StrBuilderTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/StrBuilderTest.java
@@ -1634,6 +1634,21 @@ class StrBuilderTest extends AbstractLangTest {
     }
 
     @Test
+    void testReverseSurrogatePairs() {
+        // U+1F600 GRINNING FACE is a supplementary code point encoded as a surrogate pair; reversing
+        // must keep the pair intact (high before low) like StringBuilder, not split it into garbage.
+        final String emoji = "😀";
+        assertEquals(new StringBuilder("a" + emoji + "b").reverse().toString(), new StrBuilder("a" + emoji + "b").reverse().toString());
+        assertEquals("b" + emoji + "a", new StrBuilder("a" + emoji + "b").reverse().toString());
+
+        final String emoji2 = "😁";
+        assertEquals(emoji2 + emoji, new StrBuilder(emoji + emoji2).reverse().toString());
+
+        // An unpaired high surrogate has no partner and is left where it lands.
+        assertEquals("b\uD800a", new StrBuilder("a\uD800b").reverse().toString());
+    }
+
+    @Test
     void testRightString() {
         final StrBuilder sb = new StrBuilder("left right");
         assertEquals("right", sb.rightString(5));


### PR DESCRIPTION
`Repro:` `new StrBuilder("a" + "😀" + "b").reverse()` returns `b\uDE00\uD83Da` (a low surrogate ahead of its high surrogate), where `new StringBuilder(...).reverse()` returns `b😀a`.
`Cause:` `reverse()` swaps the buffer one `char` at a time, so every surrogate pair is left in low-high order and the supplementary code point becomes malformed UTF-16.
`Fix:` after the char swap, walk the buffer once and swap each adjacent low-high surrogate pair back to high-low, matching `StringBuilder`/`StringBuffer` which this class is documented to mimic. BMP text, lone surrogates and odd-length buffers are untouched.