### PR TITLE
Keep WordUtils.wrap from splitting a surrogate pair

### DIFF
--- a/src/main/java/org/apache/commons/lang3/text/WordUtils.java
+++ b/src/main/java/org/apache/commons/lang3/text/WordUtils.java
@@ -679,10 +679,14 @@ public class WordUtils {
                 offset = endOfWrapAt;
             } else // really long word or URL
             if (wrapLongWords) {
-                // wrap really long word one line at a time
-                wrappedLine.append(str, offset, wrapLength + offset);
+                // wrap really long word one line at a time, but keep a surrogate pair whole
+                int wrapAt = wrapLength + offset;
+                if (Character.isHighSurrogate(str.charAt(wrapAt - 1)) && Character.isLowSurrogate(str.charAt(wrapAt))) {
+                    wrapAt++;
+                }
+                wrappedLine.append(str, offset, wrapAt);
                 wrappedLine.append(newLineStr);
-                offset += wrapLength;
+                offset = wrapAt;
             } else {
                 // do not wrap really long word, just extend beyond limit
                 matcher = patternToWrapOn.matcher(str.substring(offset + wrapLength));

--- a/src/test/java/org/apache/commons/lang3/text/WordUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/WordUtilsTest.java
@@ -452,6 +452,14 @@ class WordUtilsTest extends AbstractLangTest {
         assertEquals(expected, WordUtils.wrap(input, 20, "\n", false));
         expected = "Click here,\nhttps://commons.apac\nhe.org, to jump to\nthe commons website";
         assertEquals(expected, WordUtils.wrap(input, 20, "\n", true));
+
+        // a hard break for a long word must not split a surrogate pair across the new line
+        input = "a\uD83D\uDE00\uD83D\uDE00\uD83D\uDE00\uD83D\uDE00";
+        expected = "a\uD83D\uDE00\uD83D\uDE00\n\uD83D\uDE00\uD83D\uDE00";
+        assertEquals(expected, WordUtils.wrap(input, 4, "\n", true));
+        input = "\uD83D\uDE00\uD83D\uDE00\uD83D\uDE00";
+        expected = "\uD83D\uDE00\uD83D\uDE00\n\uD83D\uDE00";
+        assertEquals(expected, WordUtils.wrap(input, 3, "\n", true));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Repro: `WordUtils.wrap("a😀😀😀😀", 4, "\n", true)`, four `U+1F600` after a leading `a`.
Cause: with `wrapLongWords` set, a word longer than the column is hard-broken at the fixed char offset `wrapLength + offset` and the new-line is inserted there. When that offset lands between the high and low surrogate of a supplementary code point the pair is split, so a lossless wrap emits a lone high surrogate at the end of one line and a lone low surrogate at the start of the next.
Fix: nudge the break one char forward when it would land inside a pair, keeping the whole code point on the current line. BMP input and the delimiter-based wrap paths are unaffected.