### PR TITLE
Fix WordUtils.containsAllWords missing words across line breaks

### DIFF
--- a/src/main/java/org/apache/commons/lang3/text/WordUtils.java
+++ b/src/main/java/org/apache/commons/lang3/text/WordUtils.java
@@ -198,7 +198,7 @@ public class WordUtils {
             if (StringUtils.isBlank(w)) {
                 return false;
             }
-            final Pattern p = Pattern.compile(".*\\b" + Pattern.quote(w.toString()) + "\\b.*");
+            final Pattern p = Pattern.compile(".*\\b" + Pattern.quote(w.toString()) + "\\b.*", Pattern.DOTALL);
             if (!p.matcher(word).matches()) {
                 return false;
             }

--- a/src/test/java/org/apache/commons/lang3/text/WordUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/WordUtilsTest.java
@@ -171,6 +171,14 @@ class WordUtilsTest extends AbstractLangTest {
     }
 
     @Test
+    void testContainsAllWordsWithNewline() {
+        assertTrue(WordUtils.containsAllWords("foo\nbar", "bar"));
+        assertTrue(WordUtils.containsAllWords("foo\nbar", "foo"));
+        assertTrue(WordUtils.containsAllWords("lorem ipsum\ndolor sit\namet", "ipsum", "amet", "lorem"));
+        assertFalse(WordUtils.containsAllWords("foo\nbar", "baz"));
+    }
+
+    @Test
     void testInitials_String() {
         assertNull(WordUtils.initials(null));
         assertEquals("", WordUtils.initials(""));


### PR DESCRIPTION
1. `containsAllWords` builds the per-word regex `.*\b<word>\b.*` and runs it with `matches()`, but compiles it without `Pattern.DOTALL`, so `.` never matches a line terminator.
2. `matches()` has to consume the whole input, so a word sitting on a different line than the surrounding `.*` can reach is never found.

Repro: `WordUtils.containsAllWords("foo\nbar", "bar")`
Expected: `true` (`bar` is present as a whole word)
Actual: `false`
Fix: compile the pattern with `Pattern.DOTALL` so the leading and trailing `.*` span line breaks. The `\b` anchors are unchanged, so single-line results and the documented examples behave the same and no false positive is introduced.

The same regex is in `commons-text` `WordUtils.containsAllWords`.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
