### PR TITLE
Fix NumberUtils min/max varargs dropping the sign of zero

### DIFF
--- a/src/main/java/org/apache/commons/lang3/math/NumberUtils.java
+++ b/src/main/java/org/apache/commons/lang3/math/NumberUtils.java
@@ -761,12 +761,7 @@ public class NumberUtils {
         // Finds and returns max
         double max = array[0];
         for (int j = 1; j < array.length; j++) {
-            if (Double.isNaN(array[j])) {
-                return Double.NaN;
-            }
-            if (array[j] > max) {
-                max = array[j];
-            }
+            max = Math.max(max, array[j]);
         }
         return max;
     }
@@ -804,12 +799,7 @@ public class NumberUtils {
         // Finds and returns max
         float max = array[0];
         for (int j = 1; j < array.length; j++) {
-            if (Float.isNaN(array[j])) {
-                return Float.NaN;
-            }
-            if (array[j] > max) {
-                max = array[j];
-            }
+            max = Math.max(max, array[j]);
         }
         return max;
     }
@@ -1042,12 +1032,7 @@ public class NumberUtils {
         // Finds and returns min
         double min = array[0];
         for (int i = 1; i < array.length; i++) {
-            if (Double.isNaN(array[i])) {
-                return Double.NaN;
-            }
-            if (array[i] < min) {
-                min = array[i];
-            }
+            min = Math.min(min, array[i]);
         }
         return min;
     }
@@ -1085,12 +1070,7 @@ public class NumberUtils {
         // Finds and returns min
         float min = array[0];
         for (int i = 1; i < array.length; i++) {
-            if (Float.isNaN(array[i])) {
-                return Float.NaN;
-            }
-            if (array[i] < min) {
-                min = array[i];
-            }
+            min = Math.min(min, array[i]);
         }
         return min;
     }

--- a/src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java
@@ -1309,6 +1309,24 @@ class NumberUtilsTest extends AbstractLangTest {
     }
 
     @Test
+    void testMinMaxSignedZero() {
+        // The varargs overloads must agree with Math.min/Math.max (and the three-argument
+        // overloads, which delegate to them) on the sign of zero. -0.0 is distinct from 0.0,
+        // e.g. 1 / -0.0 is -Infinity, so the raw bits are asserted here.
+        assertEquals(Double.doubleToRawLongBits(0.0d), Double.doubleToRawLongBits(NumberUtils.max(-0.0d, 0.0d)));
+        assertEquals(Double.doubleToRawLongBits(0.0d), Double.doubleToRawLongBits(NumberUtils.max(0.0d, -0.0d)));
+        assertEquals(Double.doubleToRawLongBits(-0.0d), Double.doubleToRawLongBits(NumberUtils.min(-0.0d, 0.0d)));
+        assertEquals(Double.doubleToRawLongBits(-0.0d), Double.doubleToRawLongBits(NumberUtils.min(0.0d, -0.0d)));
+        assertEquals(Float.floatToRawIntBits(0.0f), Float.floatToRawIntBits(NumberUtils.max(-0.0f, 0.0f)));
+        assertEquals(Float.floatToRawIntBits(0.0f), Float.floatToRawIntBits(NumberUtils.max(0.0f, -0.0f)));
+        assertEquals(Float.floatToRawIntBits(-0.0f), Float.floatToRawIntBits(NumberUtils.min(-0.0f, 0.0f)));
+        assertEquals(Float.floatToRawIntBits(-0.0f), Float.floatToRawIntBits(NumberUtils.min(0.0f, -0.0f)));
+        // the varargs result matches the three-argument overload
+        assertEquals(Double.doubleToRawLongBits(NumberUtils.max(-0.0d, 0.0d, 0.0d)), Double.doubleToRawLongBits(NumberUtils.max(-0.0d, 0.0d)));
+        assertEquals(Double.doubleToRawLongBits(NumberUtils.min(0.0d, -0.0d, 0.0d)), Double.doubleToRawLongBits(NumberUtils.min(0.0d, -0.0d)));
+    }
+
+    @Test
     void testLang747() {
         assertEquals(Integer.valueOf(0x8000), NumberUtils.createNumber("0x8000"));
         assertEquals(Integer.valueOf(0x80000), NumberUtils.createNumber("0x80000"));


### PR DESCRIPTION
`Repro`: `NumberUtils.max(-0.0d, 0.0d)` returns `-0.0` (so `1 / result` is `-Infinity`); `NumberUtils.min(0.0d, -0.0d)` returns `0.0`.

`Cause`: the `double`/`float` varargs overloads pick the extreme with `<`/`>`, which rank `-0.0` and `0.0` as equal, so the sign held in the accumulator survives. `Math.max`/`Math.min`, the three-argument `min`/`max` overloads and `IEEE754rUtils` all return the other sign for these inputs.

`Fix`: run the loop through `Math.max`/`Math.min` in the four `double`/`float` overloads, matching the three-argument versions. Those also propagate `NaN`, so the explicit `isNaN` check is no longer needed and the existing `NaN` results stay the same.