### PR TITLE
[LANG-1828] Fix OOM in StringUtils.leftPad/rightPad when size is Integer.MIN_VALUE

### DIFF
--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -5197,6 +5197,9 @@ public class StringUtils {
         if (str == null) {
             return null;
         }
+        if (size <= str.length()) {
+            return str;
+        }
         final int pads = size - str.length();
         if (pads <= 0) {
             return str; // returns original String when possible
@@ -5234,6 +5237,9 @@ public class StringUtils {
     public static String leftPad(final String str, final int size, String padStr) {
         if (str == null) {
             return null;
+        }
+        if (size <= str.length()) {
+            return str;
         }
         if (isEmpty(padStr)) {
             padStr = SPACE;
@@ -6991,6 +6997,9 @@ public class StringUtils {
         if (str == null) {
             return null;
         }
+        if (size <= str.length()) {
+            return str;
+        }
         final int pads = size - str.length();
         if (pads <= 0) {
             return str; // returns original String when possible
@@ -7028,6 +7037,9 @@ public class StringUtils {
     public static String rightPad(final String str, final int size, String padStr) {
         if (str == null) {
             return null;
+        }
+        if (size <= str.length()) {
+            return str;
         }
         if (isEmpty(padStr)) {
             padStr = SPACE;

--- a/src/test/java/org/apache/commons/lang3/StringUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringUtilsTest.java
@@ -1323,6 +1323,7 @@ class StringUtilsTest extends AbstractLangTest {
         assertEquals("     ", StringUtils.leftPad("", 5));
         assertEquals("  abc", StringUtils.leftPad("abc", 5));
         assertEquals("abc", StringUtils.leftPad("abc", 2));
+        assertEquals("abc", StringUtils.leftPad("abc", Integer.MIN_VALUE));
     }
 
     @Test
@@ -1333,6 +1334,7 @@ class StringUtilsTest extends AbstractLangTest {
         assertEquals("xxabc", StringUtils.leftPad("abc", 5, 'x'));
         assertEquals("\uffff\uffffabc", StringUtils.leftPad("abc", 5, '\uffff'));
         assertEquals("abc", StringUtils.leftPad("abc", 2, ' '));
+        assertEquals("abc", StringUtils.leftPad("abc", Integer.MIN_VALUE, ' '));
         final String str = StringUtils.leftPad("aaa", 10000, 'a');  // bigger than pad length
         assertEquals(10000, str.length());
         assertTrue(StringUtils.containsOnly(str, 'a'));
@@ -1350,6 +1352,7 @@ class StringUtilsTest extends AbstractLangTest {
         assertEquals("abc", StringUtils.leftPad("abc", -1, " "));
         assertEquals("  abc", StringUtils.leftPad("abc", 5, null));
         assertEquals("  abc", StringUtils.leftPad("abc", 5, ""));
+        assertEquals("abc", StringUtils.leftPad("abc", Integer.MIN_VALUE, " "));
     }
 
     @Test
@@ -2202,6 +2205,7 @@ class StringUtilsTest extends AbstractLangTest {
         assertEquals("abc  ", StringUtils.rightPad("abc", 5));
         assertEquals("abc", StringUtils.rightPad("abc", 2));
         assertEquals("abc", StringUtils.rightPad("abc", -1));
+        assertEquals("abc", StringUtils.rightPad("abc", Integer.MIN_VALUE));
     }
 
     @Test
@@ -2212,6 +2216,7 @@ class StringUtilsTest extends AbstractLangTest {
         assertEquals("abc", StringUtils.rightPad("abc", 2, ' '));
         assertEquals("abc", StringUtils.rightPad("abc", -1, ' '));
         assertEquals("abcxx", StringUtils.rightPad("abc", 5, 'x'));
+        assertEquals("abc", StringUtils.rightPad("abc", Integer.MIN_VALUE, ' '));
         final String str = StringUtils.rightPad("aaa", 10000, 'a');  // bigger than pad length
         assertEquals(10000, str.length());
         assertTrue(StringUtils.containsOnly(str, 'a'));
@@ -2229,6 +2234,7 @@ class StringUtilsTest extends AbstractLangTest {
         assertEquals("abc", StringUtils.rightPad("abc", -1, " "));
         assertEquals("abc  ", StringUtils.rightPad("abc", 5, null));
         assertEquals("abc  ", StringUtils.rightPad("abc", 5, ""));
+        assertEquals("abc", StringUtils.rightPad("abc", Integer.MIN_VALUE, " "));
     }
 
     @Test


### PR DESCRIPTION
This issue is tracked as [LANG-1828](https://issues.apache.org/jira/browse/LANG-1828).

**Repro:**
`size - str.length()` underflows when `size = Integer.MIN_VALUE`, bypassing the `pads <= 0` early return and causing an OOM allocation. 

**Fix:** Short-circuiting on `size <= str.length()` before the subtraction — no behavior change for any valid input.

**Methods affected:**
- leftPad(String, int, char)
- leftPad(String, int, String)
- rightPad(String, int, char)
- rightPad(String, int, String)

<details>
<summary><b>Compatibility report</b> (<code>mvn package japicmp:cmp</code> against 3.20.0)</summary>

### `org.apache.commons.lang3.StringUtils`

- [X] Binary-compatible
- [X] Source-compatible
- [X] Serialization-compatible

| Status   | Modifiers | Type  | Name          | Extends    | JDK   | Serialization       | Compatibility Changes |
|----------|-----------|-------|---------------|------------|-------|---------------------|-----------------------|
| Modified | `public`  | Class | `StringUtils` | [`Object`] | JDK 8 | ![Not serializable] | ![No changes]         |
</details>

Before you push a pull request, review this list:

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [x] AI used: Claude (Anthropic, claude-opus-4-7) via the Claude Code CLI, to draft this PR description. Per ASF guidance: Anthropic's terms place no restrictions inconsistent with the OSD; no third-party material is reproduced in the output.
- [x] Run a successful build using the default [Maven](https://maven.apache.org/).
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
