### PR TITLE
Fix Strings.CI.indexOf() returning out-of-range index for empty search

### DIFF
--- a/src/main/java/org/apache/commons/lang3/Strings.java
+++ b/src/main/java/org/apache/commons/lang3/Strings.java
@@ -152,7 +152,7 @@ public abstract class Strings {
                 startPos = 0;
             }
             final int endLimit = str.length() - searchStr.length() + 1;
-            if (startPos > endLimit) {
+            if (startPos >= endLimit) {
                 return INDEX_NOT_FOUND;
             }
             if (searchStr.length() == 0) {

--- a/src/test/java/org/apache/commons/lang3/StringsTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringsTest.java
@@ -67,13 +67,16 @@ class StringsTest extends AbstractLangTest {
     @Test
     void testCaseInsensitiveIndexOfEmptyOutOfRange() {
         // repro: returned 4 (past the end of a length-3 string) before the fix
-        assertEquals(-1, Strings.CI.indexOf("abc", "", 4));
+        final String emptySearch = StringUtils.EMPTY;
+        assertEquals(-1, Strings.CI.indexOf("abc", emptySearch, 4));
         // documented out-of-range example, also -1
-        assertEquals(-1, Strings.CI.indexOf("abc", "", 9));
+        assertEquals(-1, Strings.CI.indexOf("abc", emptySearch, 9));
         // the end position is still a valid empty match
-        assertEquals(3, Strings.CI.indexOf("abc", "", 3));
-        assertEquals(2, Strings.CI.indexOf("aabaabaa", "", 2));
-        assertEquals(0, Strings.CI.indexOf("", "", 0));
+        assertEquals(3, Strings.CI.indexOf("abc", emptySearch, 3));
+        assertEquals(2, Strings.CI.indexOf("aabaabaa", emptySearch, 2));
+        assertEquals(0, Strings.CI.indexOf(emptySearch, emptySearch, 0));
+        assertEquals(0, Strings.CI.indexOf(emptySearch, emptySearch, -1));
+        assertEquals(0, Strings.CI.indexOf("a", emptySearch, -1));
     }
 
     /**

--- a/src/test/java/org/apache/commons/lang3/StringsTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringsTest.java
@@ -60,6 +60,23 @@ class StringsTest extends AbstractLangTest {
     }
 
     /**
+     * For an empty search the case-insensitive {@code indexOf} returned {@code startPos} unchanged once it reached
+     * {@code str.length() + 1}, so a start position one past the end yielded an index beyond the string instead of
+     * {@code -1}.
+     */
+    @Test
+    void testCaseInsensitiveIndexOfEmptyOutOfRange() {
+        // repro: returned 4 (past the end of a length-3 string) before the fix
+        assertEquals(-1, Strings.CI.indexOf("abc", "", 4));
+        // documented out-of-range example, also -1
+        assertEquals(-1, Strings.CI.indexOf("abc", "", 9));
+        // the end position is still a valid empty match
+        assertEquals(3, Strings.CI.indexOf("abc", "", 3));
+        assertEquals(2, Strings.CI.indexOf("aabaabaa", "", 2));
+        assertEquals(0, Strings.CI.indexOf("", "", 0));
+    }
+
+    /**
      * {@code U+0130} lower-cases to the two-char sequence {@code "i̇"} outside Turkish locales, so pre-lower-casing the
      * search argument made the case-insensitive replace look for a two-char needle that no longer matches the single source
      * character.


### PR DESCRIPTION
1. `CiStrings.indexOf` (the case-insensitive `Strings.CI.indexOf`) bails out only when `startPos > endLimit`, where `endLimit = str.length() - searchStr.length() + 1`.
2. For an empty search `endLimit` is `str.length() + 1`, so a `startPos` of exactly `str.length() + 1` slips past the guard and the empty-search branch returns `startPos` unchanged.

Repro: `Strings.CI.indexOf("abc", "", 4)`
Expected: `-1` (the class Javadoc documents out-of-range start positions as `-1`, e.g. `Strings.CI.indexOf("abc", "", 9) = -1`)
Actual: `4`, an index one past the end of a length-`3` string

The case-sensitive `CS.indexOf` delegates to `String.indexOf` and clamps, so only the hand-rolled `CI` implementation is affected. Changed the guard to `startPos >= endLimit`; `-1` is returned once `startPos` passes the last valid empty-match position (`str.length()`), and every documented example is unchanged.

---

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
