### PR TITLE
Keep DurationFormatUtils.lexx() from merging repeated fields split by a literal

### DIFF
--- a/src/main/java/org/apache/commons/lang3/time/DurationFormatUtils.java
+++ b/src/main/java/org/apache/commons/lang3/time/DurationFormatUtils.java
@@ -676,12 +676,14 @@ public class DurationFormatUtils {
                 }
                 optionalIndex++;
                 inOptional = true;
+                previous = null;
                 break;
             case ']':
                 if (!inOptional) {
                     throw new IllegalArgumentException("Attempting to close unopened optional block at index: " + i);
                 }
                 inOptional = false;
+                previous = null;
                 break;
             case '\'':
                 if (inLiteral) {
@@ -707,6 +709,7 @@ public class DurationFormatUtils {
                         inLiteral = true;
                     }
                 }
+                previous = null;
                 break;
             case 'y':
                 value = y;
@@ -735,6 +738,7 @@ public class DurationFormatUtils {
                     list.add(new Token(buffer, inOptional, optionalIndex));
                 }
                 buffer.append(ch);
+                previous = null;
             }
             if (value != null) {
                 if (previous != null && previous.getValue().equals(value)) {

--- a/src/test/java/org/apache/commons/lang3/time/DurationFormatUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/DurationFormatUtilsTest.java
@@ -123,6 +123,21 @@ class DurationFormatUtilsTest extends AbstractLangTest {
                 DurationFormatUtils.formatDuration(Duration.ofDays(1).plusHours(1).plusMinutes(1).plusSeconds(1).plusMillis(1).toMillis(), format));
     }
 
+    @Test
+    void testRepeatedTokenSeparatedByLiteral() {
+        final long fiveHours = Duration.ofHours(5).toMillis();
+        // the same field letter on either side of a literal are two separate fields, not one padded field
+        assertEquals("5x5", DurationFormatUtils.formatDuration(fiveHours, "HxH", false));
+        assertEquals("5x5", DurationFormatUtils.formatDuration(fiveHours, "H'x'H", false));
+        // each H is a single-width field, so padding does not turn either into "05"
+        assertEquals("5x5", DurationFormatUtils.formatDuration(fiveHours, "HxH", true));
+        // separated by an optional block
+        assertEquals("5x5", DurationFormatUtils.formatDuration(fiveHours, "H[x]H", false));
+        assertEquals("2-2", DurationFormatUtils.formatDuration(Duration.ofDays(2).toMillis(), "d-d", false));
+        // adjacent repeats still collapse into a single padded field
+        assertEquals("05", DurationFormatUtils.formatDuration(fiveHours, "HH", true));
+    }
+
     /** See https://issues.apache.org/bugzilla/show_bug.cgi?id=38401 */
     @Test
     void testBugzilla38401() {


### PR DESCRIPTION
`Repro:` `formatDuration(Duration.ofHours(5).toMillis(), "HxH", false)` returns `5x`, and `formatDuration(Duration.ofDays(2).toMillis(), "d-d", false)` returns `2-`.
`Expected:` `5x5` and `2-2` — the field letter on each side of the literal is a separate field.
`Actual:` the trailing field is dropped and folded into the first token, whose pad width silently grows.
`Cause:` `lexx` keeps a `previous` pointer so adjacent identical field letters (`HH`) collapse into one padded token, but it never clears that pointer when a non-field character is seen. The run therefore leaks across a plain literal, a quoted literal, and `[`/`]` blocks, so `HxH` merges the two `H`s while `HmH` (separated by another field) does not.
`Fix:` reset `previous` in the `[`, `]`, quote and default branches so a run only collapses when the letters are truly adjacent. `HH` still collapses; `H'x'H`, `H[x]H` and `d-d` no longer do.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
