### PR TITLE
Reject hex letters in NumericEntityUnescaper decimal scan

### DIFF
--- a/src/main/java/org/apache/commons/lang3/text/translate/NumericEntityUnescaper.java
+++ b/src/main/java/org/apache/commons/lang3/text/translate/NumericEntityUnescaper.java
@@ -120,8 +120,10 @@ public class NumericEntityUnescaper extends CharSequenceTranslator {
                 }
             }
             int end = start;
-            // Note that this supports character codes without a ; on the end
-            while (end < seqEnd && CharUtils.isHex(input.charAt(end))) {
+            // Note that this supports character codes without a ; on the end.
+            // A decimal entity (&#...) only holds decimal digits; a-f are hex digits and must
+            // not be consumed here, otherwise the following text is swallowed into a failed parse.
+            while (end < seqEnd && (isHex ? CharUtils.isHex(input.charAt(end)) : CharUtils.isAsciiNumeric(input.charAt(end)))) {
                 end++;
             }
             final boolean semiNext = end != seqEnd && input.charAt(end) == ';';

--- a/src/test/java/org/apache/commons/lang3/text/translate/NumericEntityUnescaperTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/translate/NumericEntityUnescaperTest.java
@@ -56,6 +56,15 @@ class NumericEntityUnescaperTest extends AbstractLangTest {
     }
 
     @Test
+    void testDecimalEntityFollowedByHexLetter() {
+        // A decimal entity ends at the first non-decimal character, so a following a-f letter is text, not part of the number.
+        final NumericEntityUnescaper neu = new NumericEntityUnescaper(NumericEntityUnescaper.OPTION.semiColonOptional);
+        assertEquals("0abc", neu.translate("&#48abc"), "Failed to stop a decimal entity at a trailing hex letter");
+        assertEquals("Test 0 not test", neu.translate("Test &#48 not test"), "Failed on a decimal entity terminated by a space");
+        assertEquals("0xyz", neu.translate("&#48xyz"), "Failed on a decimal entity terminated by a non-hex letter");
+    }
+
+    @Test
     void testUnfinishedEntity() {
         // parse it
         NumericEntityUnescaper neu = new NumericEntityUnescaper(NumericEntityUnescaper.OPTION.semiColonOptional);


### PR DESCRIPTION
`Repro`: with `OPTION.semiColonOptional`, `translate("&#48abc")` returns `&#48abc`, yet `translate("&#48xyz")` returns `0xyz` and `translate("&#48 not test")` returns `0 not test`.
`Cause`: the digit scan in `translate` uses `CharUtils.isHex` for both the `&#x` and the `&#` forms, so a decimal entity pulls a trailing `a`-`f` into the number and the base-10 `Integer.parseInt` then throws, leaving the entity unescaped. The class only documents the decimal form as `\d+`.
`Fix`: scan decimal digits with `CharUtils.isAsciiNumeric` in the decimal branch, keeping `CharUtils.isHex` for `&#x`. The documented `\d+` form and the default `semiColonRequired` behaviour are unchanged.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
