### PR TITLE
Stop ExtendedMessageFormat seekNonWs reading past the pattern end

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -46,6 +46,7 @@ The <action> type attribute can be add,update,fix,remove.
   <body>
   <release version="3.21.0" date="YYY-MM-DD" description="This is a feature and maintenance release. Java 8 or later is required.">
     <!-- FIX -->
+    <action                   type="fix" dev="ggregory" due-to="Javid Khan, Gary Gregory">Stop ExtendedMessageFormat seekNonWs reading past the pattern end.</action>
     <action                   type="fix" dev="ggregory" due-to="ThrawnCA">Fix spelling and grammar in StringUtils #1486.</action>
     <action                   type="fix" dev="ggregory" due-to="Michael Hausegger, Gary Gregory">Add ConversionTest assertions to increase coverage #1489.</action>
     <action                   type="fix" dev="ggregory" due-to="Boda65665, Gary Gregory">Use Class&lt;?&gt; instead of Class&lt;? extends Object&gt; in MethodUtils #1491.</action>

--- a/src/main/java/org/apache/commons/lang3/text/ExtendedMessageFormat.java
+++ b/src/main/java/org/apache/commons/lang3/text/ExtendedMessageFormat.java
@@ -453,12 +453,14 @@ public class ExtendedMessageFormat extends MessageFormat {
      * @param pos current position
      */
     private void seekNonWs(final String pattern, final ParsePosition pos) {
-        int len;
         final char[] buffer = pattern.toCharArray();
-        do {
-            len = StrMatcher.splitMatcher().isMatch(buffer, pos.getIndex());
+        while (pos.getIndex() < buffer.length) {
+            final int len = StrMatcher.splitMatcher().isMatch(buffer, pos.getIndex());
+            if (len == 0) {
+                break;
+            }
             pos.setIndex(pos.getIndex() + len);
-        } while (len > 0 && pos.getIndex() < pattern.length());
+        }
     }
 
     /**

--- a/src/test/java/org/apache/commons/lang3/text/ExtendedMessageFormatTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/ExtendedMessageFormatTest.java
@@ -294,6 +294,21 @@ class ExtendedMessageFormatTest extends AbstractLangTest {
         assertThrowsExactly(IllegalArgumentException.class, () -> new ExtendedMessageFormat("{0 ", new HashMap<>()));
     }
 
+    @Test
+    void testTruncatedFormatElementWithRegistry() {
+        // Sanity check to match JRE
+        assertThrowsExactly(IllegalArgumentException.class, () -> new MessageFormat("{"));
+        assertThrowsExactly(IllegalArgumentException.class, () -> new MessageFormat("{0,"));
+        assertThrowsExactly(IllegalArgumentException.class, () -> new MessageFormat("{0}extra{"));
+        // A format element left unterminated at the end of the pattern used to make the
+        // registry-based constructor seek one past the buffer and throw
+        // ArrayIndexOutOfBoundsException; it should report the documented
+        // IllegalArgumentException, as the plain constructor already does.
+        assertThrowsExactly(IllegalArgumentException.class, () -> new ExtendedMessageFormat("{", new HashMap<>()));
+        assertThrowsExactly(IllegalArgumentException.class, () -> new ExtendedMessageFormat("{0,", new HashMap<>()));
+        assertThrowsExactly(IllegalArgumentException.class, () -> new ExtendedMessageFormat("{0}extra{", new HashMap<>()));
+    }
+
     /**
      * Test the built-in choice format.
      */


### PR DESCRIPTION
Port of apache/commons-text#759 to the equivalent org.apache.commons.lang3.text.ExtendedMessageFormat.

The registry-based ExtendedMessageFormat constructor parses its pattern with seekNonWs, which asks the split matcher about the character at the current parse index without first checking it is still inside the buffer. A truncated format element such as {, {0, or trailing text like {0}extra{ leaves the parse position at the end of the pattern, so the matcher reads one past the char array and the constructor throws ArrayIndexOutOfBoundsException rather than the documented IllegalArgumentException that the plain constructor already gives for the same input.

This bounds the seek to the pattern length so those patterns report the usual unterminated-format-element error. A regression test covers the three shapes above, alongside the JRE sanity checks you added post-merge on the commons-text side.