### PR TITLE
Keep FastDateParser numeric parse from throwing on int overflow

### DIFF
--- a/src/main/java/org/apache/commons/lang3/time/FastDateParser.java
+++ b/src/main/java/org/apache/commons/lang3/time/FastDateParser.java
@@ -305,7 +305,15 @@ public class FastDateParser implements DateParser, Serializable {
                 pos.setErrorIndex(idx);
                 return false;
             }
-            final int value = Integer.parseInt(source.substring(pos.getIndex(), idx));
+            final int value;
+            try {
+                value = Integer.parseInt(source.substring(pos.getIndex(), idx));
+            } catch (final NumberFormatException nfe) {
+                // A run of digits that overflows int cannot be represented by this field; signal a parse failure
+                // rather than letting NumberFormatException escape the ParsePosition-based parse methods.
+                pos.setErrorIndex(pos.getIndex());
+                return false;
+            }
             pos.setIndex(idx);
             calendar.set(field, modify(parser, value));
             return true;

--- a/src/test/java/org/apache/commons/lang3/time/FastDateParserTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/FastDateParserTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -409,6 +410,20 @@ class FastDateParserTest extends AbstractLangTest {
         // Thu Mar 16 00:00:00 KST 81724
         actual = fdp.parse("20150429113100");
         assertEquals(expected, actual);
+    }
+
+    @ParameterizedTest
+    @MethodSource(DATE_PARSER_PARAMETERS)
+    void testLang1359(final TriFunction<String, TimeZone, Locale, DateParser> dpProvider) {
+        // A trailing numeric field is unbounded, so a digit run that overflows int must fail the parse
+        // through the ParsePosition/ParseException contract, not escape as a NumberFormatException.
+        final DateParser fdp = getInstance(dpProvider, "yyyy", TimeZones.GMT, Locale.US);
+        final String overflow = "99999999999";
+        assertThrows(ParseException.class, () -> fdp.parse(overflow));
+        final ParsePosition pos = new ParsePosition(0);
+        assertNull(fdp.parseObject(overflow, pos));
+        assertTrue(pos.getErrorIndex() >= 0);
+        assertEquals(0, pos.getIndex());
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Repro: parse an untrusted date whose numeric field is a digit run that overflows `int`, e.g. `FastDateFormat.getInstance("yyyy").parse("99999999999")`, or `getInstance("yyyy").parseObject("99999999999", new ParsePosition(0))`.
Cause: `NumberStrategy.parse` scans an unbounded run of digits for a trailing or standalone numeric field (its `maxWidth` is `0`) and passes the whole run to `Integer.parseInt`. A run that overflows `int` makes `parseInt` throw `NumberFormatException`, which escapes uncaught, so `parse(String)` throws `NumberFormatException` rather than the declared `ParseException`, and the `ParsePosition` overloads (`parse`, `parseObject`) throw instead of returning `null` with an error index as the `java.text.Format` contract requires.
Fix: catch the overflow inside `NumberStrategy.parse` and signal a parse failure the same way the existing empty-digit branch already does (`setErrorIndex` then return `false`), so the field is simply unparseable instead of crashing the parser. Valid inputs are unchanged and it is the only `Integer.parseInt` in the class.