### PR TITLE
Keep FastDateParser.parse error message intact for Japanese imperial locale

### DIFF
--- a/src/main/java/org/apache/commons/lang3/time/FastDateParser.java
+++ b/src/main/java/org/apache/commons/lang3/time/FastDateParser.java
@@ -1028,7 +1028,7 @@ public class FastDateParser implements DateParser, Serializable {
             final int errorIndex = pp.getErrorIndex();
             final String msg = String.format("Unparseable date: '%s', parse position = %s", source, pp);
             if (locale.equals(JAPANESE_IMPERIAL)) {
-                throw new ParseException(String.format("; the %s locale does not support dates before 1868-01-01.", locale, msg), errorIndex);
+                throw new ParseException(String.format("%s; the %s locale does not support dates before 1868-01-01.", msg, locale), errorIndex);
             }
             throw new ParseException(msg, errorIndex);
         }

--- a/src/test/java/org/apache/commons/lang3/time/FastDateParserTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/FastDateParserTest.java
@@ -428,6 +428,19 @@ class FastDateParserTest extends AbstractLangTest {
 
     @ParameterizedTest
     @MethodSource(DATE_PARSER_PARAMETERS)
+    void testParseErrorMessageJapaneseImperial(final TriFunction<String, TimeZone, Locale, DateParser> dpProvider) {
+        // The Japanese imperial branch of parse(String) must keep the "Unparseable date" diagnostic
+        // (source text and parse position), not drop it and emit a message starting with a stray ';'.
+        final DateParser fdp = getInstance(dpProvider, "yyyy", TimeZones.GMT, FastDateParser.JAPANESE_IMPERIAL);
+        final String source = "not-a-date";
+        final ParseException e = assertThrows(ParseException.class, () -> fdp.parse(source));
+        final String message = e.getMessage();
+        assertTrue(message.startsWith("Unparseable date: '" + source + "'"), message);
+        assertTrue(message.contains("does not support dates before 1868-01-01."), message);
+    }
+
+    @ParameterizedTest
+    @MethodSource(DATE_PARSER_PARAMETERS)
     void testLang1380(final TriFunction<String, TimeZone, Locale, DateParser> dpProvider) throws ParseException {
         final Calendar expected = Calendar.getInstance(TimeZones.GMT, Locale.FRANCE);
         expected.clear();


### PR DESCRIPTION
Repro: parse an unparseable date under the `JAPANESE_IMPERIAL` locale (`ja_JP_JP`), e.g. `FastDateFormat.getInstance("yyyy", TimeZones.GMT, new Locale("ja", "JP", "JP")).parse("not-a-date")`.
Cause: `parse(String)` builds `msg` = `Unparseable date: '<source>', parse position = <pp>`, then for the imperial locale throws `String.format("; the %s locale does not support dates before 1868-01-01.", locale, msg)`. The template holds a single `%s`, bound to `locale`, so the second argument `msg` is silently ignored: the whole `Unparseable date` diagnostic (source text and parse position) is dropped and the message begins with a stray `; `, unlike the non-imperial branch which throws `msg`.
Fix: give the template a leading `%s` for `msg` so the diagnostic survives, matching the non-imperial branch.