### PR TITLE
Keep ExtendedMessageFormat from rejecting a quoted format style

### DIFF
--- a/src/main/java/org/apache/commons/lang3/text/ExtendedMessageFormat.java
+++ b/src/main/java/org/apache/commons/lang3/text/ExtendedMessageFormat.java
@@ -382,21 +382,24 @@ public class ExtendedMessageFormat extends MessageFormat {
         seekNonWs(pattern, pos);
         final int text = pos.getIndex();
         int depth = 1;
-        for (; pos.getIndex() < pattern.length(); next(pos)) {
+        while (pos.getIndex() < pattern.length()) {
             switch (pattern.charAt(pos.getIndex())) {
             case START_FE:
                 depth++;
+                next(pos);
                 break;
             case END_FE:
                 depth--;
                 if (depth == 0) {
                     return pattern.substring(text, pos.getIndex());
                 }
+                next(pos);
                 break;
             case QUOTE:
                 getQuotedString(pattern, pos);
                 break;
             default:
+                next(pos);
                 break;
             }
         }

--- a/src/test/java/org/apache/commons/lang3/text/ExtendedMessageFormatTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/ExtendedMessageFormatTest.java
@@ -345,6 +345,19 @@ class ExtendedMessageFormatTest extends AbstractLangTest {
     }
 
     /**
+     * A format element whose format style ends with a quoted literal immediately before the closing brace is a valid
+     * pattern (accepted by {@link MessageFormat} and by this class when no registry is supplied), but the registry
+     * parsing path rejected it with "Unterminated format element".
+     */
+    @Test
+    void testQuotedLiteralAtEndOfFormatElement() {
+        assertEquals("ABC", new ExtendedMessageFormat("{0,upper,'x'}", registry).format(new Object[] {"abc"}));
+        assertEquals("ABC", new ExtendedMessageFormat("{0,upper,'}'}", registry).format(new Object[] {"abc"}));
+        // a built-in format style ending in a quote only reaches the registry parser because the registry is non-null
+        assertEquals("5%", new ExtendedMessageFormat("{0,number,0'%'}", registry).format(new Object[] {Integer.valueOf(5)}));
+    }
+
+    /**
      * Test equals() and hashCode().
      */
     @Test


### PR DESCRIPTION
`ExtendedMessageFormat.parseFormatDescription` walks a format element's style with a `for` loop whose update clause always calls `next(pos)`, but the `QUOTE` branch hands off to `getQuotedString`, which already leaves `pos` one past the closing quote. The loop then advances a second time and skips the character right after that quote, so when a style ends with a quoted literal the terminating `}` is never seen: `depth` never returns to `0`, the loop runs off the end, and the constructor throws `IllegalArgumentException: Unterminated format element`. This only happens on the registry path, so `new ExtendedMessageFormat("{0,number,0'%'}", registry)` throws even though `java.text.MessageFormat` and `ExtendedMessageFormat` without a registry both parse that pattern to `5%`.

The fix switches the loop to the `while` form the two sibling parsers in this class already use (`applyPattern`, `insertFormats`): advance one position per non-quote branch and let the `QUOTE` branch's `getQuotedString` do its own advance. Leaving the position arithmetic to the single loop that consumes the quoted run is what stops the double count. The added test fails before the change with the `Unterminated format element` exception and passes after.