### PR TITLE
Match String case folding in StrBuilder.equalsIgnoreCase

### DIFF
--- a/src/main/java/org/apache/commons/lang3/text/StrBuilder.java
+++ b/src/main/java/org/apache/commons/lang3/text/StrBuilder.java
@@ -1912,8 +1912,12 @@ public class StrBuilder implements CharSequence, Appendable, Serializable, Build
         for (int i = size - 1; i >= 0; i--) {
             final char c1 = thisBuf[i];
             final char c2 = otherBuf[i];
-            if (c1 != c2 && Character.toUpperCase(c1) != Character.toUpperCase(c2)) {
-                return false;
+            if (c1 != c2) {
+                final char u1 = Character.toUpperCase(c1);
+                final char u2 = Character.toUpperCase(c2);
+                if (u1 != u2 && Character.toLowerCase(u1) != Character.toLowerCase(u2)) {
+                    return false;
+                }
             }
         }
         return true;

--- a/src/test/java/org/apache/commons/lang3/text/StrBuilderTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/StrBuilderTest.java
@@ -698,6 +698,16 @@ class StrBuilderTest extends AbstractLangTest {
 
         sb2.clear().append("aBc");
         assertTrue(sb1.equalsIgnoreCase(sb2));
+
+        // characters that only fold together via toLowerCase, matching String.equalsIgnoreCase
+        sb1.clear().append("\u004B"); // LATIN CAPITAL LETTER K
+        sb2.clear().append("\u212A"); // KELVIN SIGN, lower-cases to 'k'
+        assertTrue(sb1.equalsIgnoreCase(sb2));
+        assertTrue(sb2.equalsIgnoreCase(sb1));
+
+        sb1.clear().append("\u00E5"); // LATIN SMALL LETTER A WITH RING ABOVE
+        sb2.clear().append("\u212B"); // ANGSTROM SIGN, lower-cases to the same
+        assertTrue(sb1.equalsIgnoreCase(sb2));
     }
 
     @Test


### PR DESCRIPTION
`Repro`: `new StrBuilder("K").equalsIgnoreCase(new StrBuilder("K"))` (KELVIN SIGN vs `K`) returns `false`, and so does the å/ANGSTROM pair `new StrBuilder("å").equalsIgnoreCase(new StrBuilder("Å"))`. `String.equalsIgnoreCase` returns `true` for both.

`Cause`: the per-character loop only rules a differing pair equal when `Character.toUpperCase(c1) == Character.toUpperCase(c2)`. Characters that fold together only through their lower-case mapping (`U+212A` → `k`, `U+212B` → `å`) fail that test, so the whole compare reports not-equal.

`Fix`: also accept the pair when `Character.toLowerCase` of the upper-cased chars agrees, the same fold `String#regionMatches` and this library's own `CharSequenceUtils.equalsIgnoreCase` already use. The case-sensitive `equals` sibling is untouched.