### PR TITLE
Skip Chuvash locale parser tests on Java 27

### DIFF
--- a/src/test/java/org/apache/commons/lang3/LocaleProblems.java
+++ b/src/test/java/org/apache/commons/lang3/LocaleProblems.java
@@ -38,6 +38,7 @@ public class LocaleProblems {
         // "cv_RU" is a problem on Java version: 26-beta, vendor: Eclipse Adoptium, runtime: /opt/hostedtoolcache/Java_Temurin-Hotspot_jdk/26.0.0-ea.27.0.ea/x64
         // Same for "cv"
         UNSUPPORTED_CAT_A.put(JavaVersion.JAVA_26, Arrays.asList("cv", "cv_RU"));
+        UNSUPPORTED_CAT_A.put(JavaVersion.JAVA_27, Arrays.asList("cv", "cv_RU"));
     }
 
     // needs a better name.
@@ -46,6 +47,7 @@ public class LocaleProblems {
         UNSUPPORTED_CAT_B = new HashMap<>();
         // "cv_RU_#Cyrl" is a problem on Java version: 26-beta, vendor: Eclipse Adoptium, runtime: /opt/hostedtoolcache/Java_Temurin-Hotspot_jdk/26.0.0-ea.27.0.ea/x64
         UNSUPPORTED_CAT_B.put(JavaVersion.JAVA_26, Arrays.asList("cv", "cv_RU", "cv_RU_#Cyrl"));
+        UNSUPPORTED_CAT_B.put(JavaVersion.JAVA_27, Arrays.asList("cv", "cv_RU", "cv_RU_#Cyrl"));
     }
 
     private static void assumeLocaleSupported(final Locale locale, final Map<JavaVersion, List<String>> unsupportedCatA, final ParseException e) {


### PR DESCRIPTION
FastDateParser locale round-trip tests fail for Chuvash locales (`cv`, `cv_RU`, and `cv_RU_#Cyrl`) on the Java 27-ea CI job.
These locales are already excluded on Java 26 through LocaleProblems because of JDK locale parsing differences. Java 27-ea shows the same failures, so this PR extends the same test assumptions to Java 27.
This is a test-only change and does not change FastDateParser runtime behavior.
Tested locally with Java 26:
mvn test -Dtest=FastDateParserJava15BugTest,FastDateParserTest

- [x] Read the contribution guidelines for this project.
- [x] Read the ASF Generative Tooling Guidance.
- [ ] Ran a successful build using the default Maven goal with `mvn`.
- [x] Updated test assumptions for the Java 27 CI failure.
- [x] Wrote a pull request description explaining what changed and why.
- [x] Commit has a meaningful subject line and body.