### PR TITLE
Keep HashCodeBuilder.append(Object) from poisoning reflection hashCode

### DIFF
--- a/src/main/java/org/apache/commons/lang3/builder/HashCodeBuilder.java
+++ b/src/main/java/org/apache/commons/lang3/builder/HashCodeBuilder.java
@@ -170,6 +170,13 @@ public class HashCodeBuilder extends AbstractReflection implements Builder<Integ
     private static final ThreadLocal<Set<IDKey>> REGISTRY = ThreadLocal.withInitial(HashSet::new);
 
     /**
+     * A registry of objects being appended by {@link #append(Object)}, kept separate from {@link #REGISTRY} so that
+     * guarding {@code append} against its own re-entrant cycles does not trip the reflection cycle guard checked by
+     * {@link #reflectionAppend(Object, Class, HashCodeBuilder, boolean, String[], boolean)}.
+     */
+    private static final ThreadLocal<Set<IDKey>> APPEND_REGISTRY = ThreadLocal.withInitial(HashSet::new);
+
+    /**
      * Constructs a new Builder.
      *
      * @return A new Builder.
@@ -542,6 +549,38 @@ public class HashCodeBuilder extends AbstractReflection implements Builder<Integ
     }
 
     /**
+     * Tests whether the append registry contains the given object. Used by {@link #append(Object)} to break its own re-entrant cycles.
+     *
+     * @param value The object to look up in the append registry.
+     * @return {@code true} if the append registry contains the given object.
+     */
+    private static boolean isAppendRegistered(final Object value) {
+        return APPEND_REGISTRY.get().contains(new IDKey(value));
+    }
+
+    /**
+     * Registers the given object in the append registry.
+     *
+     * @param value The object to register.
+     */
+    private static void appendRegister(final Object value) {
+        APPEND_REGISTRY.get().add(new IDKey(value));
+    }
+
+    /**
+     * Unregisters the given object from the append registry.
+     *
+     * @param value The object to unregister.
+     */
+    private static void appendUnregister(final Object value) {
+        final Set<IDKey> registry = APPEND_REGISTRY.get();
+        registry.remove(new IDKey(value));
+        if (registry.isEmpty()) {
+            APPEND_REGISTRY.remove();
+        }
+    }
+
+    /**
      * Constant to use in building the hashCode.
      */
     private final int constant;
@@ -820,22 +859,22 @@ public class HashCodeBuilder extends AbstractReflection implements Builder<Integ
     public HashCodeBuilder append(final Object object) {
         if (object == null) {
             total = total * constant;
-        } else if (isRegistered(object)) {
+        } else if (isRegistered(object) || isAppendRegistered(object)) {
             // Cycle detected: skip to avoid infinite recursion (mirrors reflectionAppend).
             total = total * constant;
         } else if (ObjectUtils.isArray(object)) {
             try {
-                register(object);
+                appendRegister(object);
                 appendArray(object);
             } finally {
-                unregister(object);
+                appendUnregister(object);
             }
         } else {
             try {
-                register(object);
+                appendRegister(object);
                 total = total * constant + object.hashCode();
             } finally {
-                unregister(object);
+                appendUnregister(object);
             }
         }
         return this;

--- a/src/test/java/org/apache/commons/lang3/builder/HashCodeBuilderTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/HashCodeBuilderTest.java
@@ -66,6 +66,48 @@ class HashCodeBuilderTest extends AbstractLangTest {
         }
     }
 
+    /**
+     * A reflection test fixture whose {@code hashCode()} is reflection based.
+     */
+    static final class ReflectionHashCodeMember {
+        final int value;
+
+        ReflectionHashCodeMember(final int value) {
+            this.value = value;
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            return EqualsBuilder.reflectionEquals(this, o);
+        }
+
+        @Override
+        public int hashCode() {
+            return HashCodeBuilder.reflectionHashCode(this);
+        }
+    }
+
+    /**
+     * Holds a {@link ReflectionHashCodeMember} and is itself reflection hashed.
+     */
+    static final class ReflectionHashCodeHolder {
+        final ReflectionHashCodeMember member;
+
+        ReflectionHashCodeHolder(final ReflectionHashCodeMember member) {
+            this.member = member;
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            return EqualsBuilder.reflectionEquals(this, o);
+        }
+
+        @Override
+        public int hashCode() {
+            return HashCodeBuilder.reflectionHashCode(this);
+        }
+    }
+
     static class TestObject {
         private int a;
 
@@ -634,6 +676,25 @@ class HashCodeBuilderTest extends AbstractLangTest {
         final TestObjectHashCodeExclude2 two = new TestObjectHashCodeExclude2(1, 2);
         assertEquals(INITIAL * CONSTANT + 2, HashCodeBuilder.reflectionHashCode(one));
         assertEquals(INITIAL, HashCodeBuilder.reflectionHashCode(two));
+    }
+
+    /**
+     * {@code append(Object)} must not collapse an object whose own {@code hashCode()} is reflection based to the bare
+     * initial value. Regression for the cycle guard leaking into the reflection registry.
+     */
+    @Test
+    void testAppendObjectReflectionHashCodeNotPoisoned() {
+        final ReflectionHashCodeMember member = new ReflectionHashCodeMember(42);
+        assertEquals(INITIAL * CONSTANT + member.hashCode(),
+            new HashCodeBuilder(INITIAL, CONSTANT).append((Object) member).toHashCode());
+
+        // The same defect reached through a normal, acyclic graph: a nested object's content must still influence
+        // the enclosing reflection hash.
+        final int h1 = new ReflectionHashCodeHolder(new ReflectionHashCodeMember(1)).hashCode();
+        final int h2 = new ReflectionHashCodeHolder(new ReflectionHashCodeMember(2)).hashCode();
+        assertNotEquals(h1, h2);
+
+        assertTrue(HashCodeBuilder.getRegistry().isEmpty());
     }
 
 }


### PR DESCRIPTION
Repro: `new HashCodeBuilder(17, 37).append((Object) x).toHashCode()` where `x.hashCode()` is `HashCodeBuilder.reflectionHashCode(x)` returns `17 * 37 + 17` instead of `17 * 37 + x.hashCode()`. The same collapse hits an ordinary acyclic graph: `reflectionHashCode(holder)` drops the content of any field whose own `hashCode()` is reflection based, so two holders differing only in such a field share a hash while `reflectionEquals` reports them unequal.
Cause: the cycle guard added in #1650 has `append(Object)` call `register(object)` on the same `REGISTRY` that `reflectionAppend` consults, so `x`'s reflective `hashCode()` finds `x` already registered, mistakes it for a cycle and returns the bare initial value.
Fix: `append(Object)` keeps a separate append registry for its re-entrancy guard and still checks `REGISTRY`, so reflection cycles (including the mutually referential `testReflectionObjectCycle`) behave exactly as before.

Added `testAppendObjectReflectionHashCodeNotPoisoned`; it fails before (expected `1300`, was `646`) and passes after.