### PR TITLE
Fix FieldUtils.getField false ambiguity on inherited interface field

### DIFF
--- a/src/main/java/org/apache/commons/lang3/reflect/FieldUtils.java
+++ b/src/main/java/org/apache/commons/lang3/reflect/FieldUtils.java
@@ -217,7 +217,7 @@ public class FieldUtils {
         for (final Class<?> class1 : ClassUtils.getAllInterfaces(cls)) {
             try {
                 final Field test = class1.getField(fieldName);
-                Validate.isTrue(match == null,
+                Validate.isTrue(match == null || match.equals(test),
                         "Reference to field %s is ambiguous relative to %s; a matching field exists on two or more implemented interfaces.", fieldName, cls);
                 match = test;
             } catch (final NoSuchFieldException ignored) {

--- a/src/test/java/org/apache/commons/lang3/reflect/FieldUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/reflect/FieldUtilsTest.java
@@ -73,6 +73,26 @@ class FieldUtilsTest extends AbstractLangTest {
     private PrivatelyShadowedChild privatelyShadowedChild;
     private final Class<? super PublicChild> parentClass = PublicChild.class.getSuperclass();
 
+    interface InterfaceWithConstant {
+        int CONSTANT = 42;
+    }
+
+    interface SubInterfaceA extends InterfaceWithConstant {
+        // inherits CONSTANT
+    }
+
+    interface SubInterfaceB extends InterfaceWithConstant {
+        // inherits CONSTANT
+    }
+
+    static class MultiPathToConstant implements SubInterfaceA, SubInterfaceB {
+        // CONSTANT is reachable through both parents and through the grandparent interface
+    }
+
+    static class SinglePathToConstant implements SubInterfaceA {
+        // CONSTANT is reachable through the sub-interface and its super-interface
+    }
+
     /**
      * Reads the {@code @deprecated} notice on {@link FieldUtils#removeFinalModifier(Field, boolean)}.
      *
@@ -106,6 +126,15 @@ class FieldUtilsTest extends AbstractLangTest {
 
     @Test
     void testAmbig() {
+        assertIllegalArgumentException(() -> FieldUtils.getField(Ambig.class, "VALUE"));
+    }
+
+    @Test
+    void testGetFieldInheritedThroughMultipleInterfacePaths() {
+        // A field reached through more than one interface path resolves to the same Field, so it is not ambiguous.
+        assertEquals(InterfaceWithConstant.class, FieldUtils.getField(SinglePathToConstant.class, "CONSTANT").getDeclaringClass());
+        assertEquals(InterfaceWithConstant.class, FieldUtils.getField(MultiPathToConstant.class, "CONSTANT").getDeclaringClass());
+        // A genuine clash of two different fields on unrelated interfaces is still ambiguous.
         assertIllegalArgumentException(() -> FieldUtils.getField(Ambig.class, "VALUE"));
     }
 


### PR DESCRIPTION
Repro: `FieldUtils.getField(cls, "CONSTANT")` where `cls` implements an interface that extends the interface actually declaring `CONSTANT` (or a diamond where two implemented interfaces share a common super-interface).
Cause: `ClassUtils.getAllInterfaces` also returns the transitively inherited interfaces, so `class1.getField(fieldName)` resolves the same `Field` more than once; the loop rejects on `match == null` alone and raises a false `IllegalArgumentException` about the field being ambiguous across two or more interfaces.
Fix: only reject when the newly found field differs (`match == null || match.equals(test)`). `Field.equals` compares declaring class, name and type, so the identical inherited field dedupes while two different fields on unrelated interfaces still throw.