### PR TITLE
Fix sign extension in BitField.getValue for top-bit fields

### DIFF
--- a/src/main/java/org/apache/commons/lang3/BitField.java
+++ b/src/main/java/org/apache/commons/lang3/BitField.java
@@ -196,7 +196,7 @@ public class BitField {
      * @see #setValue(int,int)
      */
     public int getValue(final int holder) {
-        return getRawValue(holder) >> shiftCount;
+        return getRawValue(holder) >>> shiftCount;
     }
 
     /**
@@ -212,7 +212,7 @@ public class BitField {
      * @since 3.21.0
      */
     public long getValue(final long holder) {
-        return getRawValue(holder) >> shiftCount;
+        return getRawValue(holder) >>> shiftCount;
     }
 
     /**

--- a/src/test/java/org/apache/commons/lang3/BitFieldTest.java
+++ b/src/test/java/org/apache/commons/lang3/BitFieldTest.java
@@ -142,6 +142,26 @@ class BitFieldTest extends AbstractLangTest {
     }
 
     /**
+     * Tests that {@link BitField#getValue(int)} and {@link BitField#getValue(long)} shift the selected bits right without sign extension when the field occupies
+     * the top bit of the holder (bit 31 for int, bit 63 for long).
+     */
+    @Test
+    void testGetValueTopBit() {
+        final BitField bit31 = new BitField(0x80000000);
+        assertEquals(bit31.getValue(-1), 1);
+        assertEquals(bit31.getValue(0), 0);
+        final BitField topByte = new BitField(0xFF000000);
+        assertEquals(topByte.getValue(0xFF000000), 255);
+        // The int and long overloads must agree for the same field and holder.
+        assertEquals(topByte.getValue(0xFF000000L), 255L);
+        final BitField bit63 = new BitField(0x8000000000000000L);
+        assertEquals(bit63.getValue(0x8000000000000000L), 1L);
+        assertEquals(bit63.getValue(0L), 0L);
+        final BitField topNibble = new BitField(0xF000000000000000L);
+        assertEquals(topNibble.getValue(topNibble.setValue(0L, 15L)), 15L);
+    }
+
+    /**
      * Tests that an int mask with the high bit set is treated as 32 unsigned bits on the long methods, instead of being sign-extended into bits 32-63.
      */
     @Test


### PR DESCRIPTION
`BitField.getValue(int)` and `getValue(long)` read the field with `getRawValue` and then shift it down with an arithmetic `>>`. When the field sits on the top bit of the holder (bit 31 for the `int` overload, bit 63 for the `long` overload added in 3.21.0) the masked value is negative, so `>>` sign-extends and the field reads back negative. `new BitField(0x8000000000000000L).getValue(0x8000000000000000L)` gives `-1` for a one-bit field whose value is `1`, and `new BitField(0xFF000000).getValue(0xFF000000)` gives `-1` from the `int` overload while `getValue(long)` returns `255` for the same field.

Use the unsigned `>>>` in both getters so the selected bits come down as magnitude. The value is reconstructed at the shift, so fixing it there also covers `getShortValue`/`getByteValue`, which delegate through `getValue`, and it leaves the mask handling from #1711 untouched. Fields that do not reach the top bit are unchanged because `>>` and `>>>` agree on a non-negative value.
