### PR TITLE
Fix ArrayUtils.reverse range underflow on Integer.MIN_VALUE end

### DIFF
--- a/src/main/java/org/apache/commons/lang3/ArrayUtils.java
+++ b/src/main/java/org/apache/commons/lang3/ArrayUtils.java
@@ -6721,7 +6721,7 @@ public class ArrayUtils {
             return;
         }
         int i = Math.max(startIndexInclusive, 0);
-        int j = Math.min(array.length, endIndexExclusive) - 1;
+        int j = max0(Math.min(array.length, endIndexExclusive)) - 1;
         boolean tmp;
         while (j > i) {
             tmp = array[j];
@@ -6763,7 +6763,7 @@ public class ArrayUtils {
             return;
         }
         int i = Math.max(startIndexInclusive, 0);
-        int j = Math.min(array.length, endIndexExclusive) - 1;
+        int j = max0(Math.min(array.length, endIndexExclusive)) - 1;
         byte tmp;
         while (j > i) {
             tmp = array[j];
@@ -6805,7 +6805,7 @@ public class ArrayUtils {
             return;
         }
         int i = Math.max(startIndexInclusive, 0);
-        int j = Math.min(array.length, endIndexExclusive) - 1;
+        int j = max0(Math.min(array.length, endIndexExclusive)) - 1;
         char tmp;
         while (j > i) {
             tmp = array[j];
@@ -6847,7 +6847,7 @@ public class ArrayUtils {
             return;
         }
         int i = Math.max(startIndexInclusive, 0);
-        int j = Math.min(array.length, endIndexExclusive) - 1;
+        int j = max0(Math.min(array.length, endIndexExclusive)) - 1;
         double tmp;
         while (j > i) {
             tmp = array[j];
@@ -6889,7 +6889,7 @@ public class ArrayUtils {
             return;
         }
         int i = Math.max(startIndexInclusive, 0);
-        int j = Math.min(array.length, endIndexExclusive) - 1;
+        int j = max0(Math.min(array.length, endIndexExclusive)) - 1;
         float tmp;
         while (j > i) {
             tmp = array[j];
@@ -6935,7 +6935,7 @@ public class ArrayUtils {
             return;
         }
         int i = Math.max(startIndexInclusive, 0);
-        int j = Math.min(array.length, endIndexExclusive) - 1;
+        int j = max0(Math.min(array.length, endIndexExclusive)) - 1;
         int tmp;
         while (j > i) {
             tmp = array[j];
@@ -6981,7 +6981,7 @@ public class ArrayUtils {
             return;
         }
         int i = Math.max(startIndexInclusive, 0);
-        int j = Math.min(array.length, endIndexExclusive) - 1;
+        int j = max0(Math.min(array.length, endIndexExclusive)) - 1;
         long tmp;
         while (j > i) {
             tmp = array[j];
@@ -7030,7 +7030,7 @@ public class ArrayUtils {
             return;
         }
         int i = Math.max(startIndexInclusive, 0);
-        int j = Math.min(array.length, endIndexExclusive) - 1;
+        int j = max0(Math.min(array.length, endIndexExclusive)) - 1;
         Object tmp;
         while (j > i) {
             tmp = array[j];
@@ -7076,7 +7076,7 @@ public class ArrayUtils {
             return;
         }
         int i = Math.max(startIndexInclusive, 0);
-        int j = Math.min(array.length, endIndexExclusive) - 1;
+        int j = max0(Math.min(array.length, endIndexExclusive)) - 1;
         short tmp;
         while (j > i) {
             tmp = array[j];

--- a/src/test/java/org/apache/commons/lang3/ArrayUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/ArrayUtilsTest.java
@@ -2855,6 +2855,47 @@ class ArrayUtilsTest extends AbstractLangTest {
     }
 
     @Test
+    void testReverseRangeEndIntMinValue() {
+        // endIndexExclusive == Integer.MIN_VALUE is an undervalue (< start index), documented as no change.
+        // The unclamped `Math.min(length, end) - 1` underflowed to Integer.MAX_VALUE and indexed out of bounds.
+        final boolean[] booleans = {true, false, true};
+        ArrayUtils.reverse(booleans, 0, Integer.MIN_VALUE);
+        assertArrayEquals(new boolean[]{true, false, true}, booleans);
+
+        final byte[] bytes = {1, 2, 3};
+        ArrayUtils.reverse(bytes, 0, Integer.MIN_VALUE);
+        assertArrayEquals(new byte[]{1, 2, 3}, bytes);
+
+        final char[] chars = {'a', 'b', 'c'};
+        ArrayUtils.reverse(chars, 0, Integer.MIN_VALUE);
+        assertArrayEquals(new char[]{'a', 'b', 'c'}, chars);
+
+        final double[] doubles = {1, 2, 3};
+        ArrayUtils.reverse(doubles, 0, Integer.MIN_VALUE);
+        assertArrayEquals(new double[]{1, 2, 3}, doubles);
+
+        final float[] floats = {1, 2, 3};
+        ArrayUtils.reverse(floats, 0, Integer.MIN_VALUE);
+        assertArrayEquals(new float[]{1, 2, 3}, floats);
+
+        final int[] ints = {1, 2, 3};
+        ArrayUtils.reverse(ints, 0, Integer.MIN_VALUE);
+        assertArrayEquals(new int[]{1, 2, 3}, ints);
+
+        final long[] longs = {1, 2, 3};
+        ArrayUtils.reverse(longs, 0, Integer.MIN_VALUE);
+        assertArrayEquals(new long[]{1, 2, 3}, longs);
+
+        final Object[] objects = {"a", "b", "c"};
+        ArrayUtils.reverse(objects, 0, Integer.MIN_VALUE);
+        assertArrayEquals(new Object[]{"a", "b", "c"}, objects);
+
+        final short[] shorts = {1, 2, 3};
+        ArrayUtils.reverse(shorts, 0, Integer.MIN_VALUE);
+        assertArrayEquals(new short[]{1, 2, 3}, shorts);
+    }
+
+    @Test
     void testSameLength() {
         final Object[] nullArray = null;
         final Object[] emptyArray = {};


### PR DESCRIPTION
Repro: `ArrayUtils.reverse(new int[]{1, 2, 3}, 0, Integer.MIN_VALUE)`.
Expected: no change, since the `endIndexExclusive` Javadoc documents an undervalue `< start index` as no change.
Actual: `ArrayIndexOutOfBoundsException: Index 2147483647 out of bounds for length 3`.
Cause: `Math.min(array.length, endIndexExclusive) - 1` keeps `Integer.MIN_VALUE` and the `- 1` underflows to `Integer.MAX_VALUE`, so the `while (j > i)` loop indexes past the array. All nine primitive and `Object` range overloads share the line.
Fix: clamp the end to zero before the decrement with the existing `max0` helper, as the sibling `subarray` and `shift` methods already do. Every other negative end was already a no-op, so valid ranges are unchanged.