### PR TITLE
Fix int overflow in FluentBitSet.setInclusive at Integer.MAX_VALUE

### DIFF
--- a/src/main/java/org/apache/commons/lang3/util/FluentBitSet.java
+++ b/src/main/java/org/apache/commons/lang3/util/FluentBitSet.java
@@ -517,7 +517,13 @@ public final class FluentBitSet implements Cloneable, Serializable {
      * @return {@code this} instance.
      */
     public FluentBitSet setInclusive(final int fromIndex, final int toIndex) {
-        bitSet.set(fromIndex, toIndex + 1);
+        if (toIndex == Integer.MAX_VALUE) {
+            // toIndex + 1 would overflow to Integer.MIN_VALUE.
+            bitSet.set(fromIndex, toIndex);
+            bitSet.set(toIndex);
+        } else {
+            bitSet.set(fromIndex, toIndex + 1);
+        }
         return this;
     }
 

--- a/src/test/java/org/apache/commons/lang3/util/FluentBitSetTest.java
+++ b/src/test/java/org/apache/commons/lang3/util/FluentBitSetTest.java
@@ -32,6 +32,7 @@ import org.apache.commons.lang3.AbstractLangTest;
 import org.apache.commons.lang3.ArrayUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 /**
  * Tests {@link FluentBitSet}.
@@ -1605,6 +1606,22 @@ class FluentBitSetTest extends AbstractLangTest {
         } catch (final IndexOutOfBoundsException e) {
             // Correct behavior
         }
+    }
+
+    /**
+     * Tests {@link FluentBitSet#setInclusive(int, int)} at the {@link Integer#MAX_VALUE} boundary.
+     * <p>
+     * Needs a large heap because bit {@link Integer#MAX_VALUE} forces the backing array to full size.
+     * </p>
+     */
+    @Test
+    @EnabledIfSystemProperty(named = "test.large.heap", matches = "true")
+    void test_setInclusive_maxValue() {
+        final FluentBitSet bs = newInstance();
+        // toIndex == Integer.MAX_VALUE is a legal inclusive bound, not a documented throw case.
+        bs.setInclusive(Integer.MAX_VALUE, Integer.MAX_VALUE);
+        assertTrue(bs.get(Integer.MAX_VALUE), "bit Integer.MAX_VALUE should be set");
+        assertEquals(1, bs.cardinality());
     }
 
     /**


### PR DESCRIPTION
`Repro:` `new FluentBitSet().setInclusive(0, Integer.MAX_VALUE)` throws `IndexOutOfBoundsException: toIndex < 0: -2147483648`, and so does `setInclusive(Integer.MAX_VALUE, Integer.MAX_VALUE)`.

`Cause:` `setInclusive` converts the inclusive `toIndex` into `BitSet.set`'s exclusive upper bound with `toIndex + 1`, which overflows to `Integer.MIN_VALUE` when `toIndex` is `Integer.MAX_VALUE`. The Javadoc only documents a throw when an index is negative or `fromIndex` is larger than `toIndex`, so a legal top-of-range call throws instead of setting the bits.

`Fix:` special-case `toIndex == Integer.MAX_VALUE` so the range and the top bit are set without the overflowing increment; every other input keeps the existing single `set` call. The regression test is guarded by `@EnabledIfSystemProperty(named = "test.large.heap", matches = "true")` like the existing large-heap test, since bit `Integer.MAX_VALUE` needs the full backing array; it fails on the current code and passes with the fix.