### PR TITLE
[LANG-1831] Add missing test for ObjectUtils.isEmpty(Object)

### DIFF
--- a/src/test/java/org/apache/commons/lang3/ObjectUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/ObjectUtilsTest.java
@@ -674,6 +674,7 @@ class ObjectUtilsTest extends AbstractLangTest {
         assertFalse(ObjectUtils.isEmpty(NON_EMPTY_MAP));
         assertFalse(ObjectUtils.isEmpty(Optional.of(new Object())));
         assertFalse(ObjectUtils.isEmpty(Optional.ofNullable(new Object())));
+        assertFalse(ObjectUtils.isEmpty(1234));
     }
 
     @Test


### PR DESCRIPTION
Add a missing unit test for ObjectUtils.isEmpty(Object) to verify that
unsupported object types (for example, Integer) are reported as non-empty,
matching the documented behavior.