### PR TITLE
[LANG-1832] Improve test coverage for ObjectUtils.wait(Duration)

### DIFF
--- a/src/test/java/org/apache/commons/lang3/ObjectUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/ObjectUtilsTest.java
@@ -889,13 +889,13 @@ class ObjectUtilsTest extends AbstractLangTest {
 
     @Test
     void testWaitDuration() throws InterruptedException {
-        Object lock = new Object();
+        final Object lock = new Object();
 
-        long start = System.nanoTime();
+        final long start = System.nanoTime();
         synchronized (lock) {
             ObjectUtils.wait(lock, Duration.ofMillis(100));
         }
-        long elapsed = System.nanoTime() - start;
+        final long elapsed = System.nanoTime() - start;
 
         assertTrue(elapsed >= Duration.ofMillis(100).toNanos());
 

--- a/src/test/java/org/apache/commons/lang3/ObjectUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/ObjectUtilsTest.java
@@ -890,15 +890,12 @@ class ObjectUtilsTest extends AbstractLangTest {
     @Test
     void testWaitDuration() throws InterruptedException {
         final Object lock = new Object();
-
         final long start = System.nanoTime();
         synchronized (lock) {
             ObjectUtils.wait(lock, Duration.ofMillis(100));
         }
         final long elapsed = System.nanoTime() - start;
-
         assertTrue(elapsed >= Duration.ofMillis(100).toNanos());
-
         assertThrows(IllegalArgumentException.class, () -> ObjectUtils.wait(new Object(), Duration.ofSeconds(-10)));
         assertThrows(IllegalMonitorStateException.class, () -> ObjectUtils.wait(new Object(), Duration.ZERO));
     }

--- a/src/test/java/org/apache/commons/lang3/ObjectUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/ObjectUtilsTest.java
@@ -888,7 +888,18 @@ class ObjectUtilsTest extends AbstractLangTest {
     }
 
     @Test
-    void testWaitDuration() {
+    void testWaitDuration() throws InterruptedException {
+        Object lock = new Object();
+
+        long start = System.nanoTime();
+        synchronized (lock) {
+            ObjectUtils.wait(lock, Duration.ofMillis(100));
+        }
+        long elapsed = System.nanoTime() - start;
+
+        assertTrue(elapsed >= Duration.ofMillis(100).toNanos());
+
+        assertThrows(IllegalArgumentException.class, () -> ObjectUtils.wait(new Object(), Duration.ofSeconds(-10)));
         assertThrows(IllegalMonitorStateException.class, () -> ObjectUtils.wait(new Object(), Duration.ZERO));
     }
 


### PR DESCRIPTION
Add unit tests for ObjectUtils.wait(Duration) covering successful waiting
with a positive duration and IllegalArgumentException for negative durations.
These tests improve coverage without changing production behavior.