### PR TITLE
[LANG-1833] Handle ParsePosition index beyond source string length cleanly

### DIFF
--- a/src/main/java/org/apache/commons/lang3/time/FastDateParser.java
+++ b/src/main/java/org/apache/commons/lang3/time/FastDateParser.java
@@ -1043,6 +1043,11 @@ public class FastDateParser implements DateParser, Serializable {
      */
     @Override
     public Date parse(final String source, final ParsePosition pos) {
+        final int startIndex = pos.getIndex();
+        if (startIndex > source.length()) {
+            pos.setErrorIndex(startIndex);
+            return null;
+        }
         // timing tests indicate getting new instance is 19% faster than cloning
         final Calendar cal = Calendar.getInstance(timeZone, locale);
         cal.clear();
@@ -1062,6 +1067,11 @@ public class FastDateParser implements DateParser, Serializable {
      */
     @Override
     public boolean parse(final String source, final ParsePosition pos, final Calendar calendar) {
+        final int startIndex = pos.getIndex();
+        if (startIndex > source.length()) {
+            pos.setErrorIndex(startIndex);
+            return false;
+        }
         final ListIterator<StrategyAndWidth> lt = patterns.listIterator();
         while (lt.hasNext()) {
             final StrategyAndWidth strategyAndWidth = lt.next();

--- a/src/test/java/org/apache/commons/lang3/time/FastDateParserTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/FastDateParserTest.java
@@ -564,6 +564,27 @@ class FastDateParserTest extends AbstractLangTest {
     }
 
     @Test
+    public void testParsePositionBeyondInputLength() {
+        final String source = "Jan";
+        final int startingIndex = 10;
+        final String[] patterns = new String[] {"yyyy", "MM", "dd", "HH", "'x'", "-", "/", ":", " 'at' ", "MMM", "EEEE", "a", "z"};
+        for (final String pattern : patterns) {
+            final DateParser parser = getInstance(pattern);
+            final ParsePosition pos1 = new ParsePosition(startingIndex);
+            final Date date = parser.parse(source, pos1);
+            assertNull(date);
+            assertEquals(startingIndex, pos1.getIndex());
+            assertEquals(startingIndex, pos1.getErrorIndex());
+            final ParsePosition pos2 = new ParsePosition(startingIndex);
+            final Calendar cal = Calendar.getInstance();
+            final boolean success = parser.parse(source, pos2, cal);
+            assertFalse(success);
+            assertEquals(startingIndex, pos2.getIndex());
+            assertEquals(startingIndex, pos2.getErrorIndex());
+        }
+    }
+
+    @Test
     void testParseOffset() {
         final DateParser parser = getInstance(YMD_SLASH);
         final Date date = parser.parse("Today is 2015/07/04", new ParsePosition(9));


### PR DESCRIPTION
Regression test approved that this was a bug:

```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.commons.lang3.time.FastDateParserTest
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.182 s <<< FAILURE! -- in org.apache.commons.lang3.time.FastDateParserTest
[ERROR] org.apache.commons.lang3.time.FastDateParserTest.testParsePositionBeyondInputLength -- Time elapsed: 0.100 s <<< ERROR!
java.lang.StringIndexOutOfBoundsException: Range [10, 3) out of bounds for length 3
        at java.base/jdk.internal.util.Preconditions$1.apply(Preconditions.java:55)
        at java.base/jdk.internal.util.Preconditions$1.apply(Preconditions.java:52)
        at java.base/jdk.internal.util.Preconditions$4.apply(Preconditions.java:213)
        at java.base/jdk.internal.util.Preconditions$4.apply(Preconditions.java:210)
        at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:98)
        at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckFromToIndex(Preconditions.java:112)
        at java.base/jdk.internal.util.Preconditions.checkFromToIndex(Preconditions.java:349)
        at java.base/java.lang.String.checkBoundsBeginEnd(String.java:4937)
        at java.base/java.lang.String.substring(String.java:2899)
        at java.base/java.lang.String.substring(String.java:2872)
        at org.apache.commons.lang3.time.FastDateParser$PatternStrategy.parse(FastDateParser.java:356)
        at org.apache.commons.lang3.time.FastDateParser.parse(FastDateParser.java:1069)
        at org.apache.commons.lang3.time.FastDateParser.parse(FastDateParser.java:1049)
        at org.apache.commons.lang3.time.FastDateParserTest.testParsePositionBeyondInputLength(FastDateParserTest.java:574)
        at java.base/java.lang.reflect.Method.invoke(Method.java:565)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1604)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1604)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Errors: 
[ERROR]   FastDateParserTest.testParsePositionBeyondInputLength:574 » StringIndexOutOfBounds Range [10, 3) out of bounds for length 3
[INFO] 
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  21.275 s
[INFO] Finished at: 2026-07-27T21:14:27+02:00
[INFO] ------------------------------------------------------------------------
```

Related: LANG-1833