### PR TITLE
Keep abbreviateMiddle off surrogate pair boundaries

### DIFF
--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -429,8 +429,15 @@ public class StringUtils {
             return str;
         }
         final int targetString = length - middle.length();
-        final int startOffset = targetString / 2 + targetString % 2;
-        final int endOffset = str.length() - targetString / 2;
+        int startOffset = targetString / 2 + targetString % 2;
+        int endOffset = str.length() - targetString / 2;
+        // keep both cuts off the middle of a surrogate pair so the result is never left holding a lone surrogate
+        if (splitsSurrogatePair(str, startOffset)) {
+            startOffset--;
+        }
+        if (splitsSurrogatePair(str, endOffset)) {
+            endOffset++;
+        }
         return str.substring(0, startOffset) + middle + str.substring(endOffset);
     }
 

--- a/src/test/java/org/apache/commons/lang3/StringUtilsAbbreviateTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringUtilsAbbreviateTest.java
@@ -208,6 +208,34 @@ class StringUtilsAbbreviateTest extends AbstractLangTest {
     }
 
     @Test
+    void testAbbreviateMiddleSurrogatePair() {
+        // U+1F600 GRINNING FACE is a single supplementary code point stored as a surrogate pair
+        final String grin = "😀";
+        // the head cut backs off the pair so the middle is never preceded by a lone high surrogate
+        assertEquals("a." + "b", StringUtils.abbreviateMiddle("a" + grin + grin + "b", ".", 4));
+        // the tail cut skips the orphaned low surrogate so the middle is never followed by one
+        assertEquals(grin + "..", StringUtils.abbreviateMiddle(grin + "abc" + grin, "..", 5));
+        // a cut that lands between two whole code points is unchanged
+        assertEquals("ab.d", StringUtils.abbreviateMiddle("ab" + grin + "cd", ".", 4));
+        assertEquals("ab.f", StringUtils.abbreviateMiddle("abcdef", ".", 4));
+        // results stay within length and never contain an unpaired surrogate
+        final String source = "a" + grin + "b" + grin + "cd" + grin + "ef";
+        for (int len = 3; len < source.length(); len++) {
+            final String result = StringUtils.abbreviateMiddle(source, ".", len);
+            assertTrue(result.length() <= len, () -> "result longer than length: " + result);
+            for (int i = 0; i < result.length(); i++) {
+                final char ch = result.charAt(i);
+                if (Character.isHighSurrogate(ch)) {
+                    assertTrue(i + 1 < result.length() && Character.isLowSurrogate(result.charAt(i + 1)), "lone high surrogate in: " + result);
+                    i++; // skip the paired low surrogate
+                } else {
+                    assertFalse(Character.isLowSurrogate(ch), "lone low surrogate in: " + result);
+                }
+            }
+        }
+    }
+
+    @Test
     void testAbbreviateSurrogatePair() {
         // U+1F600 GRINNING FACE is a single supplementary code point stored as a surrogate pair
         final String grin = "😀";


### PR DESCRIPTION
Repro: with U+1F600 GRINNING FACE (a surrogate pair) as `EMOJI`, `StringUtils.abbreviateMiddle("a" + EMOJI + EMOJI + "b", ".", 4)` returns `a` plus a lone high surrogate before the middle, and `StringUtils.abbreviateMiddle(EMOJI + "abc" + EMOJI, "..", 5)` returns a lone low surrogate after the middle.
Cause: the head and tail cut offsets are computed in `char` units and sliced with `String.substring`, so a cut that lands between the two halves of a surrogate pair leaves an unpaired surrogate in the result. #1719 fixed the same defect in `abbreviate` and `truncate`, but the sibling `abbreviateMiddle` was left out.
Fix: reuse the `splitsSurrogatePair` helper introduced by #1719 to nudge each cut to the nearest code-point edge before slicing, so a pair is never split. The result still never exceeds `length`, and cuts that already sit between whole code points are unchanged. The new test fails on the current code and passes with the fix.
