### PR TITLE
Fix StrBuilder.lastIndexOf(String) start index for an empty search

### DIFF
--- a/src/main/java/org/apache/commons/lang3/text/StrBuilder.java
+++ b/src/main/java/org/apache/commons/lang3/text/StrBuilder.java
@@ -2362,7 +2362,7 @@ public class StrBuilder implements CharSequence, Appendable, Serializable, Build
      * @return The last index of the string, or -1 if not found.
      */
     public int lastIndexOf(final String str) {
-        return lastIndexOf(str, size - 1);
+        return lastIndexOf(str, size);
     }
 
     /**

--- a/src/test/java/org/apache/commons/lang3/text/StrBuilderTest.java
+++ b/src/test/java/org/apache/commons/lang3/text/StrBuilderTest.java
@@ -1059,6 +1059,11 @@ class StrBuilderTest extends AbstractLangTest {
         assertEquals(1, sb.lastIndexOf("ba"));
         assertEquals("abab".lastIndexOf("ba"), sb.lastIndexOf("ba"));
 
+        assertEquals(4, sb.lastIndexOf(""));
+        //should work like String#lastIndexOf
+        assertEquals("abab".lastIndexOf(""), sb.lastIndexOf(""));
+        assertEquals("".lastIndexOf(""), new StrBuilder().lastIndexOf(""));
+
         assertEquals(-1, sb.lastIndexOf("z"));
 
         assertEquals(-1, sb.lastIndexOf((String) null));


### PR DESCRIPTION
1. Cause: `lastIndexOf(String)` delegates to `lastIndexOf(String, int)` with `size - 1`, but the last valid start position for an empty search string is `size`.
2. Change: pass `size`. Non-empty searches are unaffected, because their last possible match start is `size - str.length()`, which is at most `size - 1`.

Repro:

```java
new StrBuilder("abc").lastIndexOf("")     // expected 3, actual 2
new StrBuilder("").lastIndexOf("")        // expected 0, actual -1
new StrBuilder("abc").lastIndexOf("", 3)  // 3, the two-arg overload is already correct
new StrBuilder("abc").indexOf("")         // 0
new StrBuilder("abc").contains("")        // true
```

`String.lastIndexOf`, `StringBuilder.lastIndexOf` and `StringUtils.lastIndexOf` all return the length for an empty search, so `StrBuilder` disagreed with both the JDK and the rest of Lang, and with its own `indexOf` and `contains`. Found by differential fuzzing of `StrBuilder` against `StringBuilder`; over 400k random cases this was the only method that diverged. The new assertions in `StrBuilderTest.testLastIndexOf_String` fail without the runtime change (`expected: <4> but was: <3>`).

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.

`TextStringBuilder` in Commons Text (checked against `master`) has the same `size - 1` in `lastIndexOf(String)`, and its hand-rolled two-arg overload clamps `startIndex` to `size - 1` before the empty-search early return, so both overloads diverge there. Glad to raise a matching PR if that is useful.
