### PR TITLE
Fix negative week year formatting in FastDatePrinter

### DIFF
--- a/src/main/java/org/apache/commons/lang3/time/FastDatePrinter.java
+++ b/src/main/java/org/apache/commons/lang3/time/FastDatePrinter.java
@@ -864,11 +864,16 @@ public class FastDatePrinter implements DatePrinter, Serializable {
         public void appendTo(final Appendable buffer, final Calendar calendar) throws IOException {
             // Some Calendar implementations (JapaneseImperialCalendar) do not support week-dates.
             // Fall back to Calendar.YEAR in that case.
-            rule.appendTo(buffer, calendar.isWeekDateSupported() ? calendar.getWeekYear() : calendar.get(Calendar.YEAR));
+            appendTo(buffer, calendar.isWeekDateSupported() ? calendar.getWeekYear() : calendar.get(Calendar.YEAR));
         }
 
         @Override
-        public void appendTo(final Appendable buffer, final int value) throws IOException {
+        public void appendTo(final Appendable buffer, int value) throws IOException {
+            // A week year is proleptic, so a BC date gives a negative value the digit rules cannot render.
+            if (value < 0) {
+                buffer.append('-');
+                value = -value;
+            }
             rule.appendTo(buffer, value);
         }
 

--- a/src/test/java/org/apache/commons/lang3/time/FastDatePrinterTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/FastDatePrinterTest.java
@@ -446,4 +446,26 @@ class FastDatePrinterTest extends AbstractLangTest {
         assertEquals("2021", printer4DigitAnotherFallback.format(cal));
         assertEquals("21", printer2Digits.format(cal));
     }
+
+    @DefaultLocale(language = "en", country = "US")
+    @DefaultTimeZone("America/New_York")
+    @Test
+    void testWeekYearBc() {
+        final GregorianCalendar cal = new GregorianCalendar(42, Calendar.JULY, 15);
+        cal.set(Calendar.ERA, GregorianCalendar.BC);
+        assertEquals(-41, cal.getWeekYear());
+        assertEquals(new SimpleDateFormat("YYYY").format(cal.getTime()), getInstance("YYYY").format(cal));
+        assertEquals(new SimpleDateFormat("YYYYY").format(cal.getTime()), getInstance("YYYYY").format(cal));
+        assertEquals(new SimpleDateFormat("YY").format(cal.getTime()), getInstance("YY").format(cal));
+        assertEquals("-0041", getInstance("YYYY").format(cal));
+        assertEquals("-00041", getInstance("YYYYY").format(cal));
+        assertEquals("-41", getInstance("YY").format(cal));
+        // Padded to four digits like the AD case, see testWeekYear.
+        assertEquals("-0041", getInstance("YYY").format(cal));
+        assertEquals("-0041", getInstance("Y").format(cal));
+        // The week year of 1 BC is 0, which the digit rules already render.
+        final GregorianCalendar oneBc = new GregorianCalendar(1, Calendar.JULY, 15);
+        oneBc.set(Calendar.ERA, GregorianCalendar.BC);
+        assertEquals("0000", getInstance("YYYY").format(oneBc));
+    }
 }


### PR DESCRIPTION
- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.

`Repro`: `FastDateFormat.getInstance("YYYY").format(cal)` where `cal` is 15 July 42 BC, that is a `GregorianCalendar` with `ERA` set to `GregorianCalendar.BC`.
`Expected`: `-0041`, what `SimpleDateFormat` prints for the same date and pattern.
`Actual`: `000` followed by `U+0007`. `YY` gives `,/` against `SimpleDateFormat`'s `-41`.

1. `GregorianCalendar.getWeekYear()` is proleptic, so a BC date gives a negative week year (`-41` here) and `WeekYear` hands it to the wrapped `NumberRule` unchanged.
2. The digit rules build each character arithmetically (`(char) (value + '0')`, `value / 10 + '0'`), so a negative value walks below `'0'` and lands on control characters or unrelated code points rather than digits.

`Fix`: emit the sign in `WeekYear` and pass the magnitude down, the same handling `TimeZoneNumberRule` and `Iso8601_Rule` already apply to negative UTC offsets. Every other rule takes its value from `Calendar.get`, which never returns a negative, so `getWeekYear` is the only source of one; `YYY` and `Y` keep the four-digit padding the class Javadoc describes.

Checked `YYYY` against `SimpleDateFormat` over 46,667 dates spanning 249 BC to 4188 AD: 2,611 mismatches before this change, 337 of them carrying a control character, and 0 after.
