### PR TITLE
Fix the overflow bound direction in Instants.toMillisSince(Instant)

### DIFF
--- a/src/main/java/org/apache/commons/lang3/time/Instants.java
+++ b/src/main/java/org/apache/commons/lang3/time/Instants.java
@@ -17,6 +17,7 @@
 
 package org.apache.commons.lang3.time;
 
+import java.time.Duration;
 import java.time.Instant;
 
 /**
@@ -86,11 +87,13 @@ public class Instants {
      * @return long The duration in milliseconds since the given Instant.
      */
     public static long toMillisSince(final Instant instant) {
-        final Instant instant2 = toInstant(instant);
+        // The sign of the duration is the opposite of the sign of the instant's epoch second: an instant far in the past
+        // yields a large positive duration, an instant far in the future a large negative one. Bind on the duration.
+        final Duration duration = DurationUtils.since(toInstant(instant));
         try {
-            return DurationUtils.since(instant2).toMillis();
+            return duration.toMillis();
         } catch (final ArithmeticException e) {
-            return toBound(instant2, Long.MIN_VALUE, Long.MAX_VALUE);
+            return duration.isNegative() ? Long.MIN_VALUE : Long.MAX_VALUE;
         }
     }
 

--- a/src/test/java/org/apache/commons/lang3/time/InstantsTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/InstantsTest.java
@@ -179,23 +179,21 @@ class InstantsTest extends AbstractLangTest {
     }
 
     /**
-     * {@link Instant#MAX} (positive epoch second): the huge negative duration from Instant.MAX to now
-     * overflows {@code long} millis; the bound is {@link Long#MAX_VALUE} because the instant's epoch
-     * second is positive.
+     * {@link Instant#MAX} is in the future, so the duration from it to now is negative and underflows {@code long}
+     * millis; the bound is {@link Long#MIN_VALUE}.
      */
     @Test
-    void testToMillisSinceInstantMaxOverflowReturnsMaxValue() {
-        assertEquals(Long.MAX_VALUE, Instants.toMillisSince(Instant.MAX));
+    void testToMillisSinceInstantMaxUnderflowReturnsMinValue() {
+        assertEquals(Long.MIN_VALUE, Instants.toMillisSince(Instant.MAX));
     }
 
     /**
-     * {@link Instant#MIN} (negative epoch second): the huge positive duration from Instant.MIN to now
-     * overflows {@code long} millis; the bound is {@link Long#MIN_VALUE} because the instant's epoch
-     * second is negative.
+     * {@link Instant#MIN} is in the past, so the duration from it to now is positive and overflows {@code long}
+     * millis; the bound is {@link Long#MAX_VALUE}.
      */
     @Test
-    void testToMillisSinceInstantMinOverflowReturnsMinValue() {
-        assertEquals(Long.MIN_VALUE, Instants.toMillisSince(Instant.MIN));
+    void testToMillisSinceInstantMinOverflowReturnsMaxValue() {
+        assertEquals(Long.MAX_VALUE, Instants.toMillisSince(Instant.MIN));
     }
 
     /**


### PR DESCRIPTION
`Instants.toMillisSince(Instant)` documents two bounds:

> - If the duration milliseconds are greater than `Long.MAX_VALUE`, then return `Long.MAX_VALUE`.
> - If the duration milliseconds are lesser than `Long.MIN_VALUE`, then return `Long.MIN_VALUE`.

It selects the bound with `toBound(instant2, Long.MIN_VALUE, Long.MAX_VALUE)`, which tests the sign of the *instant's* epoch second. The value being bound is `DurationUtils.since(instant)`, the duration from that instant to now, and its sign is the opposite one: a past instant yields a positive duration, a future instant a negative one. The suite already pins that convention in `testToMillisSincePastInstantIsPositive` and `testToMillisSinceFutureInstantIsNegative`.

`Duration.toMillis()` only overflows past roughly ±292 million years, so an instant is either far enough in the past that both the duration and the epoch second are extreme, or far enough in the future that they are, and the two always disagree in sign. Every reachable overflow is therefore bound to the wrong end. Against master (8f8f3b2):

```
Duration.between(Instant.MIN, now).isNegative() = false   (seconds=31557015952864320)
  Javadoc says: millis > Long.MAX_VALUE  ->  9223372036854775807
  actual                                ->  -9223372036854775808

Duration.between(Instant.MAX, now).isNegative() = true    (seconds=-31556888078758080)
  Javadoc says: millis < Long.MIN_VALUE  ->  -9223372036854775808
  actual                                ->   9223372036854775807
```

`toEpochMillis` is unaffected: there the quantity being bound *is* the instant, so the epoch-second test in `toBound` is the right discriminator. Only `toMillisSince` reuses it against a quantity of the opposite sign.

The fix keeps the `Duration` and binds on `duration.isNegative()`, which is the quantity the Javadoc describes. Results that do not overflow are unchanged.

The two existing overflow tests asserted the old behavior, and their Javadoc says so explicitly ("the bound is `Long.MAX_VALUE` because the instant's epoch second is positive"), so they are inverted and renamed for the direction they now cover. Both fail without this change. `Instants` is new in 3.21.0 and not yet released, so no released behavior changes.

Verified locally on JDK 21 with the default goal (`mvn`): 89186 tests, 0 failures, 0 errors, and rat, checkstyle, japicmp, spotbugs, pmd and javadoc all clean.


### CI note

`build (28-ea, true, ubuntu-latest)` is red on this pull request and it is red on master for the same
reason: `FastDateParserTest` and `FastDateParserJava15BugTest` fail on JDK 28-ea over BC-era and
locale date parsing, which this change does not touch. The same job fails on the master runs
[30764624191](https://github.com/apache/commons-lang/actions/runs/30764624191) (7d15536, after this
pull request was opened) and [30568119944](https://github.com/apache/commons-lang/actions/runs/30568119944)
(8f8f3b2, the commit this branch is based on). The other matrix jobs pass, 27-ea included.

### AI tool disclosure

Answering the checklist item, and following the
[ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html):

I used an AI coding tool, Claude Code (Anthropic Claude), to write this pull request. It produced the
analysis of the sign mismatch between `toBound`'s epoch-second discriminator and the duration being
bound, the change in `Instants.toMillisSince`, and the two inverted and renamed overflow tests. The
overflow values quoted above were reproduced against master and the full default `mvn` goal was run
locally before submitting, and I can answer questions about any part of the diff.
