### PR TITLE
Reject non-ASCII hex characters in Conversion.hexDigitToInt

### DIFF
--- a/src/main/java/org/apache/commons/lang3/Conversion.java
+++ b/src/main/java/org/apache/commons/lang3/Conversion.java
@@ -727,11 +727,10 @@ public class Conversion {
      * @throws IllegalArgumentException if {@code hexDigit} is not a hexadecimal digit.
      */
     public static int hexDigitToInt(final char hexChar) {
-        final int digit = Character.digit(hexChar, 16);
-        if (digit < 0) {
+        if (!CharUtils.isHex(hexChar)) {
             throw new IllegalArgumentException("Cannot convert '" + hexChar + "' to a hexadecimal digit");
         }
-        return digit;
+        return Character.digit(hexChar, 16);
     }
 
     /**

--- a/src/test/java/org/apache/commons/lang3/ConversionTest.java
+++ b/src/test/java/org/apache/commons/lang3/ConversionTest.java
@@ -688,6 +688,11 @@ class ConversionTest extends AbstractLangTest {
         assertEquals(15, Conversion.hexDigitToInt('F'));
         assertEquals(15, Conversion.hexDigitToInt('f'));
         assertIllegalArgumentException(() -> Conversion.hexDigitToInt('G'));
+        assertIllegalArgumentException(() -> Conversion.hexDigitToInt('\uFF41')); // FULLWIDTH LATIN SMALL LETTER A
+        assertIllegalArgumentException(() -> Conversion.hexDigitToInt('\uFF26')); // FULLWIDTH LATIN CAPITAL LETTER F
+        assertIllegalArgumentException(() -> Conversion.hexDigitToInt('\uFF19')); // FULLWIDTH DIGIT NINE
+        assertIllegalArgumentException(() -> Conversion.hexDigitToInt('\u0669')); // ARABIC-INDIC DIGIT NINE
+        assertIllegalArgumentException(() -> Conversion.hexDigitToInt('\u096B')); // DEVANAGARI DIGIT FIVE
     }
 
     /**
@@ -723,6 +728,7 @@ class ConversionTest extends AbstractLangTest {
         assertThrows(StringIndexOutOfBoundsException.class, () -> Conversion.hexToInt(src, Integer.MIN_VALUE, 0, 0, 1));
         assertThrows(StringIndexOutOfBoundsException.class, () -> Conversion.hexToInt(src, Integer.MAX_VALUE, 0, 0, 1));
         assertIllegalArgumentException(() -> Conversion.hexToInt(src, Integer.MAX_VALUE, 0, 0, Integer.SIZE));
+        assertIllegalArgumentException(() -> Conversion.hexToInt("\uFF41\uFF41", 0, 0, 0, 2));
     }
 
     /**


### PR DESCRIPTION
`Repro`: `Conversion.hexToInt("ａａ", 0, 0, 0, 2)` (two U+FF41 FULLWIDTH LATIN SMALL LETTER A) returns `170`, the same value as the ASCII `"aa"`, and `Conversion.hexDigitToInt('٩')` (U+0669 ARABIC-INDIC DIGIT NINE) returns `9`. Both should throw.
`Cause`: `hexDigitToInt` reads the digit with `Character.digit(hexChar, 16)`, which by its own specification recognises every Unicode decimal digit and the fullwidth Latin letters U+FF21-U+FF3A / U+FF41-U+FF5A, not only `0-9a-fA-F`. The sibling converters `hexDigitMsb0ToInt`, `hexDigitToBinary` and `hexDigitMsb0ToBinary` switch over ASCII and do throw on the same chars, and `CharUtils.isHex` agrees with them. Since `hexDigitToInt` is the digit decoder behind `hexToByte`, `hexToShort`, `hexToInt` and `hexToLong`, the whole hex-string surface accepts homoglyphs, and strings that differ collapse onto one value.
`Fix`: screen the char with `CharUtils.isHex` before converting, reusing the message the siblings already use. `Character.digit` occurs once in the library, so this is the only site; ASCII input is unchanged.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
