### PR TITLE
Fix spurious overflow in Fraction.multiplyBy for unreduced operands

### DIFF
--- a/src/main/java/org/apache/commons/lang3/math/Fraction.java
+++ b/src/main/java/org/apache/commons/lang3/math/Fraction.java
@@ -766,9 +766,14 @@ public final class Fraction extends Number implements Comparable<Fraction> {
         }
         // knuth 4.5.1
         // make sure we don't overflow unless the result *must* overflow.
-        final int d1 = greatestCommonDivisor(numerator, fraction.denominator);
-        final int d2 = greatestCommonDivisor(fraction.numerator, denominator);
-        return getReducedFraction(mulAndCheck(numerator / d1, fraction.numerator / d2), mulPosAndCheck(denominator / d2, fraction.denominator / d1));
+        // Reduce both operands first: the cross-gcd below cancels the cross terms only, so a
+        // factor shared inside an unreduced operand survives into the product and can overflow
+        // an int even when the reduced result fits.
+        final Fraction a = reduce();
+        final Fraction b = fraction.reduce();
+        final int d1 = greatestCommonDivisor(a.numerator, b.denominator);
+        final int d2 = greatestCommonDivisor(b.numerator, a.denominator);
+        return getReducedFraction(mulAndCheck(a.numerator / d1, b.numerator / d2), mulPosAndCheck(a.denominator / d2, b.denominator / d1));
     }
 
     /**

--- a/src/main/java/org/apache/commons/lang3/math/Fraction.java
+++ b/src/main/java/org/apache/commons/lang3/math/Fraction.java
@@ -769,11 +769,15 @@ public final class Fraction extends Number implements Comparable<Fraction> {
         // Reduce both operands first: the cross-gcd below cancels the cross terms only, so a
         // factor shared inside an unreduced operand survives into the product and can overflow
         // an int even when the reduced result fits.
-        final Fraction a = reduce();
-        final Fraction b = fraction.reduce();
-        final int d1 = greatestCommonDivisor(a.numerator, b.denominator);
-        final int d2 = greatestCommonDivisor(b.numerator, a.denominator);
-        return getReducedFraction(mulAndCheck(a.numerator / d1, b.numerator / d2), mulPosAndCheck(a.denominator / d2, b.denominator / d1));
+        final int thisGcd = greatestCommonDivisor(numerator, denominator);
+        final int thatGcd = greatestCommonDivisor(fraction.numerator, fraction.denominator);
+        final int thisNumerator = numerator / thisGcd;
+        final int thisDenominator = denominator / thisGcd;
+        final int thatNumerator = fraction.numerator / thatGcd;
+        final int thatDenominator = fraction.denominator / thatGcd;
+        final int d1 = greatestCommonDivisor(thisNumerator, thatDenominator);
+        final int d2 = greatestCommonDivisor(thatNumerator, thisDenominator);
+        return getReducedFraction(mulAndCheck(thisNumerator / d1, thatNumerator / d2), mulPosAndCheck(thisDenominator / d2, thatDenominator / d1));
     }
 
     /**

--- a/src/test/java/org/apache/commons/lang3/math/FractionTest.java
+++ b/src/test/java/org/apache/commons/lang3/math/FractionTest.java
@@ -303,6 +303,11 @@ class FractionTest extends AbstractLangTest {
 
         final Fraction negative = Fraction.getFraction(1, -Integer.MAX_VALUE);
         assertThrows(ArithmeticException.class, () -> negative.divideBy(negative.invert())); // Should overflow
+
+        // An unreduced divisor must not trigger a spurious overflow when the reduced quotient fits an int.
+        f = Fraction.getFraction(-1, 46341).divideBy(Fraction.getFraction(1000000, 100));
+        assertEquals(-1, f.getNumerator());
+        assertEquals(463410000, f.getDenominator());
     }
 
     @Test
@@ -747,6 +752,15 @@ class FractionTest extends AbstractLangTest {
 
         final Fraction fr2 = Fraction.getFraction(1, -Integer.MAX_VALUE);
         assertThrows(ArithmeticException.class, () -> fr2.multiplyBy(fr2));
+
+        // An unreduced operand must not trigger a spurious overflow when the reduced product fits an int.
+        f = Fraction.getFraction(-1, 46341).multiplyBy(Fraction.getFraction(100, 1000000));
+        assertEquals(-1, f.getNumerator());
+        assertEquals(463410000, f.getDenominator());
+
+        f = Fraction.getFraction(1, 10000).multiplyBy(Fraction.getFraction(100, 1000000));
+        assertEquals(1, f.getNumerator());
+        assertEquals(100000000, f.getDenominator());
     }
 
     @Test


### PR DESCRIPTION
`Repro`: `Fraction.getFraction(-1, 46341).multiplyBy(Fraction.getFraction(100, 1000000))` throws `ArithmeticException: overflow: mulPos`, yet the same value with a reduced operand, `Fraction.getFraction(-1, 46341).multiplyBy(Fraction.getFraction(1, 10000))`, returns `-1/463410000`. `divideBy` and `pow` route through `multiplyBy` and behave the same way.
`Cause`: the Knuth 4.5.1 cross-gcd (`d1 = gcd(numerator, fraction.denominator)`, `d2 = gcd(fraction.numerator, denominator)`) cancels the cross terms only and assumes both operands are already in lowest terms. A `Fraction` from `getFraction` is not reduced, so a factor shared inside an operand survives into the `mulAndCheck`/`mulPosAndCheck` product and overflows an `int` before `getReducedFraction` can cancel it, although the resulting numerator (`-1`) and denominator (`463410000`) both fit. The Javadoc only permits a throw when the resulting numerator or denominator exceeds `Integer.MAX_VALUE`.
`Fix`: reduce both operands before the cross-gcd multiply. The product still passes through `getReducedFraction`, so the value is unchanged and the operation now overflows only when the reduced result genuinely exceeds `int`. `add`/`subtract` are untouched; they return unreduced results by design.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
