### PR TITLE
Keep chop from splitting a trailing surrogate pair

### DIFF
--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -794,6 +794,10 @@ public class StringUtils {
             return EMPTY;
         }
         final int lastIdx = strLen - 1;
+        // keep the cut off the middle of a surrogate pair so the result is never left holding a lone surrogate
+        if (splitsSurrogatePair(str, lastIdx)) {
+            return str.substring(0, lastIdx - 1);
+        }
         final String ret = str.substring(0, lastIdx);
         final char last = str.charAt(lastIdx);
         if (last == CharUtils.LF && ret.charAt(lastIdx - 1) == CharUtils.CR) {

--- a/src/test/java/org/apache/commons/lang3/StringUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringUtilsTest.java
@@ -399,6 +399,10 @@ class StringUtilsTest extends AbstractLangTest {
                 {null, null},
                 {"", ""},
                 {"a", ""},
+                // U+1F600: a trailing supplementary code point must be dropped whole, not split into a lone surrogate
+                {"\uD83D\uDE00", ""},
+                {"x\uD83D\uDE00", "x"},
+                {"\uD83D\uDE00x", "\uD83D\uDE00"},
         };
         for (final String[] chopCase : chopCases) {
             final String original = chopCase[0];


### PR DESCRIPTION
`StringUtils.chop` cuts the last UTF-16 char, so a `String` ending in a supplementary code point is left holding a lone surrogate.

Repro: `chop("x😀")`, a `String` ending in `U+1F600`.
Expected: `"x"`, dropping the whole trailing code point, the same way `chop("a")` returns `""`.
Actual: `"x\uD83D"`, only the low surrogate is removed and a lone high surrogate is left behind (malformed UTF-16).
Cause: the cut is `str.substring(0, length - 1)` with no surrogate check, unlike the sibling `abbreviate`/`truncate` which already guard their cuts with `splitsSurrogatePair`.
Fix: reuse `splitsSurrogatePair(str, length - 1)` to drop both halves when the final char is a low surrogate. The `\r\n` handling and every documented example stay unchanged.

- [x] Read the contribution guidelines for this project.
- [ ] Read the ASF Generative Tooling Guidance if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request.
- [x] Run a successful build using the default Maven goal with `mvn`.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request has a meaningful subject line and body.
