### PR TITLE
Fix low surrogate false match in containsAny/containsNone/indexOfAny

### DIFF
--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -1091,7 +1091,9 @@ public class StringUtils {
             final char ch = cs.charAt(i);
             for (int j = 0; j < searchLength; j++) {
                 if (searchChars[j] == ch) {
-                    if (!Character.isHighSurrogate(ch) || j == searchLast || i < csLast && searchChars[j + 1] == cs.charAt(i + 1)) {
+                    if (Character.isHighSurrogate(ch)
+                            ? j == searchLast || i < csLast && searchChars[j + 1] == cs.charAt(i + 1)
+                            : j == 0 || !Character.isLowSurrogate(ch) || !Character.isHighSurrogate(searchChars[j - 1]) || i > 0 && searchChars[j - 1] == cs.charAt(i - 1)) {
                         return true;
                     }
                 }
@@ -1261,7 +1263,9 @@ public class StringUtils {
             final char ch = cs.charAt(i);
             for (int j = 0; j < searchLen; j++) {
                 if (searchChars[j] == ch) {
-                    if (!Character.isHighSurrogate(ch) || j == searchLast || i < csLast && searchChars[j + 1] == cs.charAt(i + 1)) {
+                    if (Character.isHighSurrogate(ch)
+                            ? j == searchLast || i < csLast && searchChars[j + 1] == cs.charAt(i + 1)
+                            : j == 0 || !Character.isLowSurrogate(ch) || !Character.isHighSurrogate(searchChars[j - 1]) || i > 0 && searchChars[j - 1] == cs.charAt(i - 1)) {
                         return false;
                     }
                 }
@@ -2835,7 +2839,9 @@ public class StringUtils {
             final char ch = cs.charAt(i);
             for (int j = 0; j < searchLen; j++) {
                 if (searchChars[j] == ch) {
-                    if (!Character.isHighSurrogate(ch) || j == searchLast || i < csLast && searchChars[j + 1] == cs.charAt(i + 1)) {
+                    if (Character.isHighSurrogate(ch)
+                            ? j == searchLast || i < csLast && searchChars[j + 1] == cs.charAt(i + 1)
+                            : j == 0 || !Character.isLowSurrogate(ch) || !Character.isHighSurrogate(searchChars[j - 1]) || i > 0 && searchChars[j - 1] == cs.charAt(i - 1)) {
                         return i;
                     }
                 }

--- a/src/test/java/org/apache/commons/lang3/StringUtilsContainsTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringUtilsContainsTest.java
@@ -18,6 +18,7 @@ package org.apache.commons.lang3;
 
 import static org.apache.commons.lang3.Supplementary.CharU20000;
 import static org.apache.commons.lang3.Supplementary.CharU20001;
+import static org.apache.commons.lang3.Supplementary.CharU24000;
 import static org.apache.commons.lang3.Supplementary.CharUSuppCharHigh;
 import static org.apache.commons.lang3.Supplementary.CharUSuppCharLow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -139,6 +140,23 @@ class StringUtilsContainsTest extends AbstractLangTest {
         // Test:
         assertFalse(StringUtils.containsAny(CharU20000, CharU20001.toCharArray()));
         assertFalse(StringUtils.containsAny(CharU20001, CharU20000.toCharArray()));
+    }
+
+    /**
+     * Two supplementary code points that share their low surrogate but not their high surrogate must not match, otherwise the low half of one pair is treated as
+     * the low half of the other. See https://www.oracle.com/technical-resources/articles/javase/supplementary.html
+     */
+    @Test
+    void testContainsAny_StringCharArrayWithSharedLowSurrogate() {
+        // Sanity check: same low surrogate, different code point.
+        assertEquals(CharU20000.charAt(1), CharU24000.charAt(1));
+        assertEquals(-1, CharU20000.indexOf(CharU24000));
+        // Test:
+        assertFalse(StringUtils.containsAny(CharU20000, CharU24000.toCharArray()));
+        assertFalse(StringUtils.containsAny(CharU24000, CharU20000.toCharArray()));
+        assertFalse(StringUtils.containsAny("abc" + CharU20000 + "xyz", CharU24000.toCharArray()));
+        // A genuine occurrence of the same pair still matches.
+        assertTrue(StringUtils.containsAny("abc" + CharU24000 + "xyz", CharU24000.toCharArray()));
     }
 
     @Test
@@ -342,6 +360,19 @@ class StringUtilsContainsTest extends AbstractLangTest {
         // Test:
         assertTrue(StringUtils.containsNone(CharU20000, CharU20001.toCharArray()));
         assertTrue(StringUtils.containsNone(CharU20001, CharU20000.toCharArray()));
+    }
+
+    /**
+     * Two supplementary code points that share their low surrogate but not their high surrogate must not match. See
+     * https://www.oracle.com/technical-resources/articles/javase/supplementary.html
+     */
+    @Test
+    void testContainsNone_CharArrayWithSharedLowSurrogate() {
+        assertEquals(CharU20000.charAt(1), CharU24000.charAt(1));
+        assertTrue(StringUtils.containsNone(CharU20000, CharU24000.toCharArray()));
+        assertTrue(StringUtils.containsNone(CharU24000, CharU20000.toCharArray()));
+        // A genuine occurrence of the same pair is still found.
+        assertFalse(StringUtils.containsNone("abc" + CharU24000, CharU24000.toCharArray()));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/StringUtilsEqualsIndexOfTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringUtilsEqualsIndexOfTest.java
@@ -18,6 +18,7 @@ package org.apache.commons.lang3;
 
 import static org.apache.commons.lang3.Supplementary.CharU20000;
 import static org.apache.commons.lang3.Supplementary.CharU20001;
+import static org.apache.commons.lang3.Supplementary.CharU24000;
 import static org.apache.commons.lang3.Supplementary.CharUSuppCharHigh;
 import static org.apache.commons.lang3.Supplementary.CharUSuppCharLow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -415,6 +416,19 @@ class StringUtilsEqualsIndexOfTest extends AbstractLangTest {
         assertEquals(-1, StringUtils.indexOfAny(CharUSuppCharHigh, CharU20001.toCharArray()));
         assertFalse(StringUtils.containsAny(CharUSuppCharHigh, CharU20001.toCharArray()));
         assertEquals(-1, StringUtils.indexOfAny("abc" + CharUSuppCharHigh, CharU20000.toCharArray()));
+    }
+
+    /**
+     * A low surrogate that is the low half of a supplementary code point in the search set must not match the low half of a different code point in the input,
+     * otherwise the returned index points inside a surrogate pair. See https://www.oracle.com/technical-resources/articles/javase/supplementary.html
+     */
+    @Test
+    void testIndexOfAny_StringCharArrayWithSharedLowSurrogate() {
+        assertEquals(CharU20000.charAt(1), CharU24000.charAt(1));
+        assertEquals(-1, StringUtils.indexOfAny(CharU20000, CharU24000.toCharArray()));
+        assertEquals(-1, StringUtils.indexOfAny("abc" + CharU20000, CharU24000.toCharArray()));
+        // A genuine occurrence of the same pair is found at the start of the pair.
+        assertEquals(3, StringUtils.indexOfAny("abc" + CharU24000, CharU24000.toCharArray()));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/lang3/Supplementary.java
+++ b/src/test/java/org/apache/commons/lang3/Supplementary.java
@@ -49,6 +49,15 @@ public class Supplementary {
     static final String CharU20001 = "\uD840\uDC01";
 
     /**
+     * Supplementary character U+24000 See https://www.oracle.com/technical-resources/articles/javase/supplementary.html
+     * <p>
+     * Shares its low surrogate (U+DC00) with {@link #CharU20000} but has a different high surrogate, so the two are distinct code points that agree on their
+     * second UTF-16 code unit.
+     * </p>
+     */
+    static final String CharU24000 = "\uD850\uDC00";
+
+    /**
      * Incomplete supplementary character U+20000, <em>high surrogate only</em>.
      * <p>
      * See https://www.oracle.com/technical-resources/articles/javase/supplementary.html


### PR DESCRIPTION
`containsAny`, `containsNone` and `indexOfAny` share one surrogate-aware guard that only special-cases a `high` surrogate.

1. when the matched char is a `low` surrogate the `!isHighSurrogate(ch)` term returns a match without checking the preceding high surrogate, so a low surrogate in the search set matches the low half of a `different` pair in the input.
2. `StringUtils.containsAny("😀", "🨀".toCharArray())` is `true` and `indexOfAny` returns `1` although the inputs are U+1F600 and U+1FA00, distinct code points that only share the low surrogate `\uDE00`; index `1` also lands inside the pair, so slicing there yields malformed UTF-16.

Extended the guard so a low surrogate that is the trailing half of a pair in the search set only matches when the input carries the same high surrogate immediately before. Lone surrogates, BMP chars and matching pairs are unchanged.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
