### PR TITLE
Keep StringUtils stripStart and stripEnd off surrogate pair boundaries

### DIFF
--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -8091,8 +8091,12 @@ public class StringUtils {
         } else if (stripChars.isEmpty()) {
             return str;
         } else {
-            while (end != 0 && stripChars.indexOf(str.charAt(end - 1)) != INDEX_NOT_FOUND) {
-                end--;
+            while (end != 0) {
+                final int codePoint = str.codePointBefore(end);
+                if (stripChars.indexOf(codePoint) == INDEX_NOT_FOUND) {
+                    break;
+                }
+                end -= Character.charCount(codePoint);
             }
         }
         return str.substring(0, end);
@@ -8137,8 +8141,12 @@ public class StringUtils {
         } else if (stripChars.isEmpty()) {
             return str;
         } else {
-            while (start != strLen && stripChars.indexOf(str.charAt(start)) != INDEX_NOT_FOUND) {
-                start++;
+            while (start != strLen) {
+                final int codePoint = str.codePointAt(start);
+                if (stripChars.indexOf(codePoint) == INDEX_NOT_FOUND) {
+                    break;
+                }
+                start += Character.charCount(codePoint);
             }
         }
         return str.substring(start);

--- a/src/test/java/org/apache/commons/lang3/StringUtilsStripTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringUtilsStripTest.java
@@ -242,6 +242,24 @@ class StringUtilsStripTest extends AbstractLangTest {
     }
 
     @Test
+    void testStripSupplementaryCodePoints() {
+        // U+1D51E and U+1D51F share the high surrogate \uD835; U+1D11E shares the low surrogate \uDD1E with U+1D51E.
+        final String mathA = "\uD835\uDD1E"; // U+1D51E
+        final String mathB = "\uD835\uDD1F"; // U+1D51F
+        final String clef = "\uD834\uDD1E";  // U+1D11E
+
+        // A supplementary strip character must not match a code point that only shares one surrogate half.
+        assertEquals(mathA + "abc", StringUtils.stripStart(mathA + "abc", mathB));
+        assertEquals("abc" + clef, StringUtils.stripEnd("abc" + clef, mathA));
+        assertEquals(mathA + "abc" + mathA, StringUtils.strip(mathA + "abc" + mathA, mathB));
+
+        // Genuine membership still strips the whole supplementary code point.
+        assertEquals("abc", StringUtils.stripStart(mathA + mathA + "abc", mathA));
+        assertEquals("abc", StringUtils.stripEnd("abc" + mathA + mathA, mathA));
+        assertEquals("abc", StringUtils.strip(mathA + "abc" + mathA, mathA));
+    }
+
+    @Test
     void testStripToEmptyString() {
         assertEquals("", StringUtils.stripToEmpty(null));
         assertEquals("", StringUtils.stripToEmpty(""));


### PR DESCRIPTION
Repro: `StringUtils.stripStart("𝔞abc", "𝔟")` — input starts with U+1D51E, the strip set holds only U+1D51F, and the two share the high surrogate `\uD835`.
Expected: `"𝔞abc"` unchanged, since U+1D51E is not in `{U+1D51F}`.
Actual: `"\uDD1Eabc"` — only the high surrogate is removed, so a well-formed input becomes ill-formed UTF-16. `stripEnd`/`strip`/`stripAll` corrupt the same way against a supplementary strip character that shares either surrogate half (for example `stripEnd("abc𝄞", "𝔞")` returns `"abc\uD834"`).
Cause: both membership loops test one `char` at a time with `stripChars.indexOf(str.charAt(...))`, and `String.indexOf(char)` matches a single surrogate half of a supplementary set character.
Fix: walk the strip membership by code point (`codePointAt`/`codePointBefore` + `Character.charCount`) so a supplementary strip character only matches a whole code point and the cut can never land inside a pair. The already surrogate-aware `containsAny`/`containsNone`/`indexOfAny`/`indexOfAnyBut` agree the character is not a member on these inputs. BMP input and the `null` (whitespace) path are unchanged.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
