### PR TITLE
Fix typos and syntax in Javadoc examples and comments

### DIFF
--- a/src/main/java/org/apache/commons/lang3/Range.java
+++ b/src/main/java/org/apache/commons/lang3/Range.java
@@ -44,8 +44,8 @@ public class Range<T> implements Serializable {
         /**
          * Comparable based compare implementation.
          *
-         * @param obj1 left-hand side side of comparison.
-         * @param obj2 right-hand side side of comparison.
+         * @param obj1 left-hand side of comparison.
+         * @param obj2 right-hand side of comparison.
          * @return negative, 0, positive comparison value.
          */
         @Override

--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -447,7 +447,7 @@ public class StringUtils {
      * <pre>
      * StringUtils.appendIfMissing(null, null)      = null
      * StringUtils.appendIfMissing("abc", null)     = "abc"
-     * StringUtils.appendIfMissing("", "xyz"        = "xyz"
+     * StringUtils.appendIfMissing("", "xyz")       = "xyz"
      * StringUtils.appendIfMissing("abc", "xyz")    = "abcxyz"
      * StringUtils.appendIfMissing("abcxyz", "xyz") = "abcxyz"
      * StringUtils.appendIfMissing("abcXYZ", "xyz") = "abcXYZxyz"

--- a/src/main/java/org/apache/commons/lang3/Strings.java
+++ b/src/main/java/org/apache/commons/lang3/Strings.java
@@ -363,7 +363,7 @@ public abstract class Strings {
      * <pre>
      * Strings.CS.appendIfMissing(null, null)      = null
      * Strings.CS.appendIfMissing("abc", null)     = "abc"
-     * Strings.CS.appendIfMissing("", "xyz"        = "xyz"
+     * Strings.CS.appendIfMissing("", "xyz")       = "xyz"
      * Strings.CS.appendIfMissing("abc", "xyz")    = "abcxyz"
      * Strings.CS.appendIfMissing("abcxyz", "xyz") = "abcxyz"
      * Strings.CS.appendIfMissing("abcXYZ", "xyz") = "abcXYZxyz"

--- a/src/main/java/org/apache/commons/lang3/text/StrBuilder.java
+++ b/src/main/java/org/apache/commons/lang3/text/StrBuilder.java
@@ -838,7 +838,7 @@ public class StrBuilder implements CharSequence, Appendable, Serializable, Build
     /**
      * Appends an object to the builder padding on the left to a fixed width.
      * The {@code String.valueOf} of the {@code int} value is used.
-     * If the formatted value is larger than the length, the left-hand side side is lost.
+     * If the formatted value is larger than the length, the left-hand side is lost.
      *
      * @param value  The value to append.
      * @param width  The fixed field width, zero or negative has no effect.
@@ -852,7 +852,7 @@ public class StrBuilder implements CharSequence, Appendable, Serializable, Build
     /**
      * Appends an object to the builder padding on the left to a fixed width.
      * The {@code toString} of the object is used.
-     * If the object is larger than the length, the left-hand side side is lost.
+     * If the object is larger than the length, the left-hand side is lost.
      * If the object is null, the null text value is used.
      *
      * @param obj  The object to append, null uses null text.
@@ -884,7 +884,7 @@ public class StrBuilder implements CharSequence, Appendable, Serializable, Build
     /**
      * Appends an object to the builder padding on the right to a fixed length.
      * The {@code String.valueOf} of the {@code int} value is used.
-     * If the object is larger than the length, the right-hand side side is lost.
+     * If the object is larger than the length, the right-hand side is lost.
      *
      * @param value  The value to append.
      * @param width  The fixed field width, zero or negative has no effect.
@@ -898,7 +898,7 @@ public class StrBuilder implements CharSequence, Appendable, Serializable, Build
     /**
      * Appends an object to the builder padding on the right to a fixed length.
      * The {@code toString} of the object is used.
-     * If the object is larger than the length, the right-hand side side is lost.
+     * If the object is larger than the length, the right-hand side is lost.
      * If the object is null, null text value is used.
      *
      * @param obj  The object to append, null uses null text.

--- a/src/main/java/org/apache/commons/lang3/time/DurationFormatUtils.java
+++ b/src/main/java/org/apache/commons/lang3/time/DurationFormatUtils.java
@@ -349,14 +349,14 @@ public class DurationFormatUtils {
     }
 
     /**
-     * Formats the time gap as a string, using the specified format. Padding the left-hand side side of numbers with zeroes is optional.
+     * Formats the time gap as a string, using the specified format. Padding the left-hand side of numbers with zeroes is optional.
      * <p>
      * This method formats durations using the days and lower fields of the format pattern. Months and larger are not used.
      * </p>
      *
      * @param durationMillis The duration to format.
      * @param format         The way in which to format the duration, not null.
-     * @param padWithZeros   whether to pad the left-hand side side of numbers with 0's.
+     * @param padWithZeros   whether to pad the left-hand side of numbers with 0's.
      * @return The formatted duration, not null.
      * @throws IllegalArgumentException if durationMillis is negative.
      */
@@ -488,7 +488,7 @@ public class DurationFormatUtils {
     }
 
     /**
-     * Formats the time gap as a string, using the specified format. Padding the left-hand side side of numbers with zeroes is optional.
+     * Formats the time gap as a string, using the specified format. Padding the left-hand side of numbers with zeroes is optional.
      *
      * @param startMillis The start of the duration.
      * @param endMillis   The end of the duration.
@@ -502,7 +502,7 @@ public class DurationFormatUtils {
 
     /**
      * <p>
-     * Formats the time gap as a string, using the specified format. Padding the left-hand side side of numbers with zeroes is optional and the time zone may be
+     * Formats the time gap as a string, using the specified format. Padding the left-hand side of numbers with zeroes is optional and the time zone may be
      * specified.
      * <p>
      * When calculating the difference between months/days, it chooses to calculate months first, borrowing the length of the month in which the period starts
@@ -517,7 +517,7 @@ public class DurationFormatUtils {
      * @param startMillis  The start of the duration.
      * @param endMillis    The end of the duration.
      * @param format       The way in which to format the duration, not null.
-     * @param padWithZeros whether to pad the left-hand side side of numbers with 0's.
+     * @param padWithZeros whether to pad the left-hand side of numbers with 0's.
      * @param timezone     The millis are defined in.
      * @return The formatted duration, not null.
      * @throws IllegalArgumentException if startMillis is greater than endMillis.

--- a/src/test/java/org/apache/commons/lang3/builder/EqualsBuilderTest.java
+++ b/src/test/java/org/apache/commons/lang3/builder/EqualsBuilderTest.java
@@ -1262,7 +1262,7 @@ class EqualsBuilderTest extends AbstractBuilderTest {
      *
      * @param to             A TestObject
      * @param toBis          A TestObject, equal to to and toTer
-     * @param toTer          left-hand side side, equal to to and toBis
+     * @param toTer          left-hand side, equal to to and toBis
      * @param to2            A different TestObject
      * @param oToChange      A TestObject that will be changed
      * @param testTransients whether to test transient instance variables


### PR DESCRIPTION
## Summary
This PR fixes syntax errors in Javadoc example snippets and removes duplicated word typos across several classes.

## Details of Changes

1. **Fixed Javadoc code example syntax (missing closing parenthesis `)`):**
   - `StringUtils.appendIfMissing`: Fixed `StringUtils.appendIfMissing("", "xyz" = "xyz"` $\rightarrow$ `StringUtils.appendIfMissing("", "xyz") = "xyz"`
   - `Strings.CS.appendIfMissing`: Fixed `Strings.CS.appendIfMissing("", "xyz" = "xyz"` $\rightarrow$ `Strings.CS.appendIfMissing("", "xyz") = "xyz"`

2. **Fixed duplicated word typos (`side side` $\rightarrow$ `side`):**
   - `DurationFormatUtils`: Fixed repeated `left-hand side side` $\rightarrow$ `left-hand side` across Javadoc tags for `formatDuration` and `formatPeriod`.
   - `Range`: Fixed `left-hand side side` and `right-hand side side` in `ComparableComparator` Javadoc.
   - `StrBuilder`: Fixed `left-hand side side` and `right-hand side side` in `appendFixedWidthPadLeft` and `appendFixedWidthPadRight` Javadocs.
   - `EqualsBuilderTest`: Fixed `left-hand side side` in `testReflectionEqualsEquivalenceRelationship` Javadoc.

## Impact
- Non-functional changes only (documentation and test comments).
- No breaking changes or runtime API modifications.