### PR TITLE
Fix CharRange.contains(CharRange) for negated argument ranges

### DIFF
--- a/src/main/java/org/apache/commons/lang3/CharRange.java
+++ b/src/main/java/org/apache/commons/lang3/CharRange.java
@@ -269,6 +269,18 @@ final class CharRange implements Iterable<Character>, Serializable {
             return range.end < start || range.start > end;
         }
         if (range.negated) {
+            // range denotes [0, range.start - 1] union [range.end + 1, Character.MAX_VALUE]
+            final boolean lowEmpty = range.start == 0;
+            final boolean highEmpty = range.end == Character.MAX_VALUE;
+            if (lowEmpty && highEmpty) {
+                return true; // range denotes the empty set
+            }
+            if (lowEmpty) {
+                return end == Character.MAX_VALUE && start <= range.end + 1;
+            }
+            if (highEmpty) {
+                return start == 0 && end + 1 >= range.start;
+            }
             return start == 0 && end == Character.MAX_VALUE;
         }
         return start <= range.start && end >= range.end;

--- a/src/test/java/org/apache/commons/lang3/CharRangeTest.java
+++ b/src/test/java/org/apache/commons/lang3/CharRangeTest.java
@@ -261,6 +261,33 @@ class CharRangeTest extends AbstractLangTest {
     }
 
     @Test
+    void testContains_Charrange_negatedArgumentTouchingBounds() {
+        // A negated argument denotes [0, start - 1] union [end + 1, MAX_VALUE]. When its excluded range touches 0 or
+        // MAX_VALUE that set collapses to the empty set or a single contiguous interval, so a non-full range can contain it.
+        final CharRange emptySet = CharRange.isNotIn((char) 0, Character.MAX_VALUE);
+        assertTrue(CharRange.is('x').contains(emptySet));
+        assertTrue(CharRange.isIn((char) 0, Character.MAX_VALUE).contains(emptySet));
+
+        // isNotIn(0, 'a' - 1) denotes ['a', MAX_VALUE]
+        final CharRange fromA = CharRange.isNotIn((char) 0, (char) ('a' - 1));
+        assertTrue(CharRange.isIn('a', Character.MAX_VALUE).contains(fromA));
+        assertTrue(CharRange.isIn('Z', Character.MAX_VALUE).contains(fromA));
+        assertFalse(CharRange.isIn('b', Character.MAX_VALUE).contains(fromA));
+        assertFalse(CharRange.isIn('a', 'z').contains(fromA));
+
+        // isNotIn('b', MAX_VALUE) denotes [0, 'a']
+        final CharRange upToA = CharRange.isNotIn('b', Character.MAX_VALUE);
+        assertTrue(CharRange.isIn((char) 0, 'a').contains(upToA));
+        assertTrue(CharRange.isIn((char) 0, 'b').contains(upToA));
+        assertFalse(CharRange.isIn((char) 1, 'a').contains(upToA));
+        assertFalse(CharRange.isIn((char) 0, 'Z').contains(upToA));
+
+        // A fully interior excluded range is still only contained by the full range.
+        assertFalse(CharRange.is('c').contains(CharRange.isNot('c')));
+        assertTrue(CharRange.isIn((char) 0, Character.MAX_VALUE).contains(CharRange.isNot('c')));
+    }
+
+    @Test
     void testContainsNullArg() {
         final CharRange range = CharRange.is('a');
         final NullPointerException e = assertNullPointerException(() -> range.contains(null));


### PR DESCRIPTION
Repro: `CharRange.isIn('a', Character.MAX_VALUE).contains(CharRange.isNotIn((char) 0, (char) ('a' - 1)))` returns `false`, but the argument denotes `['a', MAX_VALUE]`, the same set as the receiver, so it should be `true`. `CharRange.is('x').contains(CharRange.isNotIn((char) 0, Character.MAX_VALUE))` also returns `false` although the argument is the empty set.
Cause: in the non-negated-receiver / negated-argument branch, `contains(CharRange)` only accepts a negated argument when the receiver is the full `[0, MAX_VALUE]` range. A negated range denotes `[0, start - 1]` union `[end + 1, MAX_VALUE]`, which is empty when it spans the whole domain and a single contiguous interval when its excluded range touches `0` or `MAX_VALUE`; a smaller receiver can hold those.
Fix: handle the empty-set and single-interval cases in that branch, keeping the full-range requirement only when the excluded range is strictly interior. The other three negation combinations are left as they were.

Checked against the per-character oracle `contains(char)` over a boundary sweep: 422 mismatches before, 0 after. Regression assertions added in `CharRangeTest`.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
