### PR TITLE
Keep StringUtils left, right, mid, and overlay off surrogate pair boundaries

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -248,6 +248,7 @@ java.lang.NullPointerException: Cannot invoke
     <action                   type="fix" dev="ggregory" due-to="alhuda, Gary Gregory">Fix CharRange.contains(CharRange) for negated argument ranges (#1775).</action>
     <action                   type="fix" dev="ggregory" due-to="Gary Gregory">Fix SpotBugs USO_UNSAFE_METHOD_SYNCHRONIZATION in CharSet.</action>
     <action                   type="fix" dev="ggregory" due-to="alhuda, Gary Gregory">Keep StopWatch.formatSplitTime from clamping splits to int millis (#1777).</action>
+    <action                   type="fix" dev="ggregory" due-to="gaurav kumar pandey, Gary Gregory">Keep StringUtils left, right, mid, and overlay off surrogate pair boundaries (#1776).</action>
     <!-- ADD -->
     <action                   type="add" dev="ggregory" due-to="Gary Gregory">Add JavaVersion.JAVA_27.</action>
     <action                   type="add" dev="ggregory" due-to="Gary Gregory">Add SystemUtils.IS_JAVA_27.</action>

--- a/src/main/java/org/apache/commons/lang3/StringUtils.java
+++ b/src/main/java/org/apache/commons/lang3/StringUtils.java
@@ -5161,7 +5161,12 @@ public class StringUtils {
         if (str.length() <= len) {
             return str;
         }
-        return str.substring(0, len);
+        int cut = len;
+        // keep the cut off the middle of a surrogate pair so the result is never left holding a lone surrogate
+        if (splitsSurrogatePair(str, cut)) {
+            cut--;
+        }
+        return str.substring(0, cut);
     }
 
     /**
@@ -5433,10 +5438,20 @@ public class StringUtils {
         if (pos < 0) {
             pos = 0;
         }
-        if (str.length() - pos <= len) {
-            return str.substring(pos);
+        int start = pos;
+        // keep the start off the middle of a surrogate pair so the result is never left holding a lone surrogate
+        if (splitsSurrogatePair(str, start)) {
+            start++;
         }
-        return str.substring(pos, pos + len);
+        if (str.length() - pos <= len) {
+            return str.substring(start);
+        }
+        int end = pos + len;
+        // keep both cuts off the middle of a surrogate pair so the result is never left holding a lone surrogate
+        if (splitsSurrogatePair(str, end)) {
+            end--;
+        }
+        return str.substring(start, Math.max(start, end));
     }
 
     /**
@@ -5660,6 +5675,13 @@ public class StringUtils {
             final int temp = start;
             start = end;
             end = temp;
+        }
+        // keep both cuts off the middle of a surrogate pair so the result is never left holding a lone surrogate
+        if (splitsSurrogatePair(str, start)) {
+            start--;
+        }
+        if (splitsSurrogatePair(str, end)) {
+            end++;
         }
         return str.substring(0, start) + overlay + str.substring(end);
     }
@@ -6955,7 +6977,12 @@ public class StringUtils {
         if (str.length() <= len) {
             return str;
         }
-        return str.substring(str.length() - len);
+        int start = str.length() - len;
+        // keep the cut off the middle of a surrogate pair so the result is never left holding a lone surrogate
+        if (splitsSurrogatePair(str, start)) {
+            start++;
+        }
+        return str.substring(start);
     }
 
     /**

--- a/src/test/java/org/apache/commons/lang3/StringUtilsSubstringTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringUtilsSubstringTest.java
@@ -17,8 +17,10 @@
 package org.apache.commons.lang3;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
@@ -398,5 +400,95 @@ class StringUtilsSubstringTest extends AbstractLangTest {
             results = StringUtils.substringsBetween("", "[", "]");
             assertEquals(0, results.length);
         }
+
+    @Test
+    void testLeftSurrogatePair() {
+        // U+1F600 GRINNING FACE is a supplementary code point stored as a surrogate pair
+        final String grin = "😀";
+        assertEquals("", StringUtils.left(grin, 0));
+        assertEquals("", StringUtils.left(grin, 1));
+        assertEquals(grin, StringUtils.left(grin, 2));
+        assertEquals(grin, StringUtils.left(grin, 3));
+
+        assertEquals("a", StringUtils.left("a" + grin, 1));
+        assertEquals("a", StringUtils.left("a" + grin, 2));
+        assertEquals("a" + grin, StringUtils.left("a" + grin, 3));
+
+        final String source = "a" + grin + "b" + grin + "cd" + grin + "ef";
+        for (int len = 0; len <= source.length(); len++) {
+            final String result = StringUtils.left(source, len);
+            assertTrue(result.length() <= len, () -> "result longer than len: " + result);
+            for (int i = 0; i < result.length(); i++) {
+                final char ch = result.charAt(i);
+                if (Character.isHighSurrogate(ch)) {
+                    assertTrue(i + 1 < result.length() && Character.isLowSurrogate(result.charAt(i + 1)), "lone high surrogate in: " + result);
+                    i++; // skip the paired low surrogate
+                } else {
+                    assertFalse(Character.isLowSurrogate(ch), "lone low surrogate in: " + result);
+                }
+            }
+        }
+    }
+
+    @Test
+    void testMidSurrogatePair() {
+        // U+1F600 GRINNING FACE is a supplementary code point stored as a surrogate pair
+        final String grin = "😀";
+        assertEquals("", StringUtils.mid(grin, 0, 0));
+        assertEquals("", StringUtils.mid(grin, 0, 1));
+        assertEquals(grin, StringUtils.mid(grin, 0, 2));
+        assertEquals(grin, StringUtils.mid(grin, 0, 3));
+        assertEquals("", StringUtils.mid(grin, 1, 1));
+        assertEquals("", StringUtils.mid(grin, 1, 2));
+
+        assertEquals("a", StringUtils.mid("a" + grin + "b", 0, 2));
+        assertEquals(grin, StringUtils.mid("a" + grin + "b", 1, 2));
+        assertEquals("b", StringUtils.mid("a" + grin + "b", 2, 2));
+
+        final String source = "a" + grin + "b" + grin + "cd" + grin + "ef";
+        for (int pos = 0; pos <= source.length(); pos++) {
+            for (int len = 0; len <= source.length(); len++) {
+                final String result = StringUtils.mid(source, pos, len);
+                for (int i = 0; i < result.length(); i++) {
+                    final char ch = result.charAt(i);
+                    if (Character.isHighSurrogate(ch)) {
+                        assertTrue(i + 1 < result.length() && Character.isLowSurrogate(result.charAt(i + 1)), "lone high surrogate in: " + result);
+                        i++; // skip the paired low surrogate
+                    } else {
+                        assertFalse(Character.isLowSurrogate(ch), "lone low surrogate in: " + result);
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    void testRightSurrogatePair() {
+        // U+1F600 GRINNING FACE is a supplementary code point stored as a surrogate pair
+        final String grin = "😀";
+        assertEquals("", StringUtils.right(grin, 0));
+        assertEquals("", StringUtils.right(grin, 1));
+        assertEquals(grin, StringUtils.right(grin, 2));
+        assertEquals(grin, StringUtils.right(grin, 3));
+
+        assertEquals("a", StringUtils.right(grin + "a", 1));
+        assertEquals("a", StringUtils.right(grin + "a", 2));
+        assertEquals(grin + "a", StringUtils.right(grin + "a", 3));
+
+        final String source = "a" + grin + "b" + grin + "cd" + grin + "ef";
+        for (int len = 0; len <= source.length(); len++) {
+            final String result = StringUtils.right(source, len);
+            assertTrue(result.length() <= len, () -> "result longer than len: " + result);
+            for (int i = 0; i < result.length(); i++) {
+                final char ch = result.charAt(i);
+                if (Character.isHighSurrogate(ch)) {
+                    assertTrue(i + 1 < result.length() && Character.isLowSurrogate(result.charAt(i + 1)), "lone high surrogate in: " + result);
+                    i++; // skip the paired low surrogate
+                } else {
+                    assertFalse(Character.isLowSurrogate(ch), "lone low surrogate in: " + result);
+                }
+            }
+        }
+    }
 
 }

--- a/src/test/java/org/apache/commons/lang3/StringUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/StringUtilsTest.java
@@ -1461,6 +1461,31 @@ class StringUtilsTest extends AbstractLangTest {
         assertEquals("abcdefzzzz", StringUtils.overlay("abcdef", "zzzz", 10, 8));
     }
 
+    @Test
+    void testOverlaySurrogatePair() {
+        final String grin = "😀";
+        // overlaying across surrogate pair boundary backs off start and advances end
+        assertEquals("X", StringUtils.overlay(grin, "X", 1, 1));
+        assertEquals("aXb", StringUtils.overlay("a" + grin + "b", "X", 1, 3));
+        assertEquals("aXb", StringUtils.overlay("a" + grin + "b", "X", 2, 2));
+
+        final String source = "a" + grin + "b" + grin + "cd" + grin + "ef";
+        for (int start = 0; start <= source.length(); start++) {
+            for (int end = 0; end <= source.length(); end++) {
+                final String result = StringUtils.overlay(source, "X", start, end);
+                for (int i = 0; i < result.length(); i++) {
+                    final char ch = result.charAt(i);
+                    if (Character.isHighSurrogate(ch)) {
+                        assertTrue(i + 1 < result.length() && Character.isLowSurrogate(result.charAt(i + 1)), "lone high surrogate in: " + result);
+                        i++; // skip the paired low surrogate
+                    } else {
+                        assertFalse(Character.isLowSurrogate(ch), "lone low surrogate in: " + result);
+                    }
+                }
+            }
+        }
+    }
+
     /**
      * Tests {@code prependIfMissing}.
      */


### PR DESCRIPTION
## Summary
Prevents `StringUtils.left`, `StringUtils.right`, `StringUtils.mid`, and `StringUtils.overlay` from splitting UTF-16 surrogate pairs into malformed lone surrogates.

## Details of Changes
- `StringUtils.left`: Backs off the cut by 1 when `splitsSurrogatePair` is true to avoid trailing lone high surrogates.
- `StringUtils.right`: Advances start by 1 when `splitsSurrogatePair` is true to avoid leading lone low surrogates.
- `StringUtils.mid`: Adjusts start and end boundaries to keep cuts off the middle of surrogate pairs.
- `StringUtils.overlay`: Adjusts replacement span boundaries off surrogate pairs.
- Added comprehensive unit tests in `StringUtilsSubstringTest` and `StringUtilsTest`.
- Added release notes entry in `src/changes/changes.xml`.