### PR TITLE
Keep StopWatch.formatSplitTime from clamping splits to int millis

### DIFF
--- a/src/main/java/org/apache/commons/lang3/time/StopWatch.java
+++ b/src/main/java/org/apache/commons/lang3/time/StopWatch.java
@@ -327,7 +327,7 @@ public class StopWatch {
      * @since 3.10
      */
     public String formatSplitTime() {
-        return DurationFormatUtils.formatDurationHMS(DurationUtils.toMillisInt(getSplitDuration()));
+        return DurationFormatUtils.formatDurationHMS(DurationUtils.toMillisLong(getSplitDuration()));
     }
 
     /**

--- a/src/test/java/org/apache/commons/lang3/time/StopWatchTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/StopWatchTest.java
@@ -148,6 +148,17 @@ class StopWatchTest extends AbstractLangTest {
     }
 
     @Test
+    void testFormatSplitTimeExceedingIntMillis() throws Exception {
+        final StopWatch watch = StopWatch.createStarted();
+        // Backdate the start so the split spans more than Integer.MAX_VALUE milliseconds (about 24.86 days).
+        FieldUtils.writeField(watch, "startTimeNanos", System.nanoTime() - TimeUnit.DAYS.toNanos(30), true);
+        watch.split();
+        final long splitMillis = watch.getSplitDuration().toMillis();
+        assertTrue(splitMillis > Integer.MAX_VALUE, "precondition: split must exceed Integer.MAX_VALUE millis");
+        assertEquals(DurationFormatUtils.formatDurationHMS(splitMillis), watch.formatSplitTime(), "formatSplitTime");
+    }
+
+    @Test
     void testFormatSplitTimeWithMessage() {
         final StopWatch watch = new StopWatch(MESSAGE);
         watch.start();


### PR DESCRIPTION
`StopWatch.formatSplitTime()` feeds the split `Duration` through `DurationUtils.toMillisInt`, which clamps the millisecond value into `int` range. A split longer than `Integer.MAX_VALUE` ms (about 24.86 days) is capped, so `formatDurationHMS` renders the cap rather than the real elapsed time. Backdating the start by 30 days and calling `split()` gives `formatSplitTime()` = `596:31:23.647` while `getSplitDuration()` is `PT720H` (`720:00:00.008`).

`formatDurationHMS` already takes a `long`, and the sibling `formatTime()` hands it `getTime()` with no narrowing, so route the split path through `DurationUtils.toMillisLong` instead. Keeping the value a `long` up to the formatter is what drops the truncation, and normal-length splits are unchanged.