### PR TITLE
Fix check-then-act race in EventListenerSupport.addListener(L, boolean)

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -46,6 +46,7 @@ The <action> type attribute can be add,update,fix,remove.
   <body>
   <release version="3.21.0" date="YYY-MM-DD" description="This is a feature and maintenance release. Java 8 or later is required.">
     <!-- FIX -->
+    <action                   type="fix" dev="ggregory" due-to="Shreshth Kharbanda">Fix check-then-act race condition in EventListenerSupport.addListener(L, boolean) by using CopyOnWriteArrayList.addIfAbsent().</action>
     <action                   type="fix" dev="ggregory" due-to="Javid Khan, Gary Gregory">Stop ExtendedMessageFormat seekNonWs reading past the pattern end.</action>
     <action                   type="fix" dev="ggregory" due-to="ThrawnCA">Fix spelling and grammar in StringUtils #1486.</action>
     <action                   type="fix" dev="ggregory" due-to="Michael Hausegger, Gary Gregory">Add ConversionTest assertions to increase coverage #1489.</action>

--- a/src/main/java/org/apache/commons/lang3/event/EventListenerSupport.java
+++ b/src/main/java/org/apache/commons/lang3/event/EventListenerSupport.java
@@ -158,7 +158,7 @@ public class EventListenerSupport<L> implements Serializable {
     /**
      * Hold the registered listeners. This list is intentionally a thread-safe copy-on-write-array so that traversals over the list of listeners will be atomic.
      */
-    private List<L> listeners = new CopyOnWriteArrayList<>();
+    private CopyOnWriteArrayList<L> listeners = new CopyOnWriteArrayList<>();
 
     /**
      * The proxy representing the collection of listeners. Calls to this proxy object will be sent to all registered listeners.
@@ -242,8 +242,10 @@ public class EventListenerSupport<L> implements Serializable {
      */
     public void addListener(final L listener, final boolean allowDuplicate) {
         Objects.requireNonNull(listener, "listener");
-        if (allowDuplicate || !listeners.contains(listener)) {
+        if (allowDuplicate) {
             listeners.add(listener);
+        } else {
+            listeners.addIfAbsent(listener);
         }
     }
 

--- a/src/test/java/org/apache/commons/lang3/event/EventListenerSupportTest.java
+++ b/src/test/java/org/apache/commons/lang3/event/EventListenerSupportTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyVetoException;
@@ -39,6 +40,10 @@ import java.lang.reflect.UndeclaredThrowableException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
@@ -89,6 +94,32 @@ class EventListenerSupportTest extends AbstractLangTest {
         assertEquals(1, listenerSupport.getListeners().length);
         listenerSupport.removeListener(listener1);
         assertSame(empty, listenerSupport.getListeners());
+    }
+
+    @Test
+    void testAddListenerNoDuplicatesConcurrent() throws InterruptedException {
+        final EventListenerSupport<VetoableChangeListener> listenerSupport = EventListenerSupport.create(VetoableChangeListener.class);
+        final VetoableChangeListener listener = EasyMock.createNiceMock(VetoableChangeListener.class);
+        final int threadCount = 8;
+        final CountDownLatch startLatch = new CountDownLatch(1);
+        final ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        try {
+            for (int i = 0; i < threadCount; i++) {
+                executor.execute(() -> {
+                    try {
+                        startLatch.await();
+                    } catch (final InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                    listenerSupport.addListener(listener, false);
+                });
+            }
+            startLatch.countDown();
+        } finally {
+            executor.shutdown();
+            assertTrue(executor.awaitTermination(30, TimeUnit.SECONDS));
+        }
+        assertEquals(1, listenerSupport.getListeners().length);
     }
 
     @Test


### PR DESCRIPTION
## What

`EventListenerSupport.addListener(listener, false)` performs a non-atomic check-then-act on the shared listener list:

```java
if (allowDuplicate || !listeners.contains(listener)) {
    listeners.add(listener);
}
```

Two threads registering the same listener concurrently can both pass the `contains` check and both `add`, producing a duplicate registration even though `allowDuplicate` is `false`. Since this class is explicitly designed for multi-threaded use (the field Javadoc notes the list is "intentionally a thread-safe copy-on-write-array"), the compound operation should be atomic too.

## Fix

`CopyOnWriteArrayList` provides the atomic form of exactly this operation, so the change is minimal:

- narrow the private field's declared type from `List<L>` to `CopyOnWriteArrayList<L>` (already the documented, intentional implementation; `readObject` already assigns one), and
- use `addIfAbsent(listener)` when duplicates are disallowed.

Single-threaded behavior is unchanged and `testAddListenerNoDuplicates` passes as before.

## Testing

- Added `testAddListenerNoDuplicatesConcurrent`: eight threads released by a latch all register the same listener with `allowDuplicate = false`; exactly one registration must result. Deterministic under the fix.
- `mvn test -Dtest=EventListenerSupportTest`: 13/13 pass; `mvn checkstyle:check` passes.
- `src/changes/changes.xml` entry added under 3.21.0.

No JIRA issue filed for this one — happy to open one on LANG if preferred.

The race was flagged by a static-analysis tool I'm building (whole-program check-then-act detection on shared collection state); this PR is the manual verification and fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnA6jPsqhsGZ9idxJQi3ZG