### PR TITLE
Fix TypeUtils.isAssignable() for wildcards with multiple upper bounds

### DIFF
--- a/src/main/java/org/apache/commons/lang3/reflect/TypeUtils.java
+++ b/src/main/java/org/apache/commons/lang3/reflect/TypeUtils.java
@@ -1229,13 +1229,17 @@ public class TypeUtils {
                 // if there are assignments for unresolved type variables,
                 // now's the time to substitute them.
                 toBound = substituteTypeVariables(toBound, typeVarAssigns);
-                // each upper bound of the subject type has to be assignable to
-                // each
-                // upper bound of the target type
+                // at least one upper bound of the subject type has to be assignable to
+                // each upper bound of the target type
+                boolean satisfied = false;
                 for (final Type bound : upperBounds) {
-                    if (!isAssignable(bound, toBound, typeVarAssigns)) {
-                        return false;
+                    if (isAssignable(bound, toBound, typeVarAssigns)) {
+                        satisfied = true;
+                        break;
                     }
+                }
+                if (!satisfied) {
+                    return false;
                 }
             }
             for (Type toBound : toLowerBounds) {
@@ -1243,12 +1247,16 @@ public class TypeUtils {
                 // now's the time to substitute them.
                 toBound = substituteTypeVariables(toBound, typeVarAssigns);
                 // each lower bound of the target type has to be assignable to
-                // each
-                // lower bound of the subject type
+                // at least one lower bound of the subject type
+                boolean satisfied = false;
                 for (final Type bound : lowerBounds) {
-                    if (!isAssignable(toBound, bound, typeVarAssigns)) {
-                        return false;
+                    if (isAssignable(toBound, bound, typeVarAssigns)) {
+                        satisfied = true;
+                        break;
                     }
+                }
+                if (!satisfied) {
+                    return false;
                 }
             }
             return true;

--- a/src/main/java/org/apache/commons/lang3/reflect/TypeUtils.java
+++ b/src/main/java/org/apache/commons/lang3/reflect/TypeUtils.java
@@ -1247,16 +1247,11 @@ public class TypeUtils {
                 // now's the time to substitute them.
                 toBound = substituteTypeVariables(toBound, typeVarAssigns);
                 // each lower bound of the target type has to be assignable to
-                // at least one lower bound of the subject type
-                boolean satisfied = false;
+                // each lower bound of the subject type
                 for (final Type bound : lowerBounds) {
-                    if (isAssignable(toBound, bound, typeVarAssigns)) {
-                        satisfied = true;
-                        break;
+                    if (!isAssignable(toBound, bound, typeVarAssigns)) {
+                        return false;
                     }
-                }
-                if (!satisfied) {
-                    return false;
                 }
             }
             return true;

--- a/src/test/java/org/apache/commons/lang3/reflect/TypeUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/reflect/TypeUtilsTest.java
@@ -1246,4 +1246,32 @@ class TypeUtilsTest<B> extends AbstractLangTest {
         assertEquals(String.class, TypeUtils.wrap(String.class).getType());
     }
 
+    @Test
+    void testIsAssignableWildcardWithMultipleUpperBounds() {
+        // ? extends Serializable & Cloneable
+        final WildcardType subject = TypeUtils.wildcardType()
+                .withUpperBounds(Serializable.class, Cloneable.class)
+                .build();
+
+        // ? extends Serializable
+        final WildcardType targetSerializable = TypeUtils.wildcardType()
+                .withUpperBounds(Serializable.class)
+                .build();
+
+        // ? extends Cloneable
+        final WildcardType targetCloneable = TypeUtils.wildcardType()
+                .withUpperBounds(Cloneable.class)
+                .build();
+
+        // ? extends CharSequence
+        final WildcardType targetCharSequence = TypeUtils.wildcardType()
+                .withUpperBounds(CharSequence.class)
+                .build();
+
+        assertTrue(TypeUtils.isAssignable(subject, targetSerializable));
+        assertTrue(TypeUtils.isAssignable(subject, targetCloneable));
+        assertTrue(TypeUtils.isAssignable(subject, TypeUtils.wildcardType().withUpperBounds(Object.class).build()));
+        assertFalse(TypeUtils.isAssignable(subject, targetCharSequence));
+    }
+
 }

--- a/src/test/java/org/apache/commons/lang3/reflect/TypeUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/reflect/TypeUtilsTest.java
@@ -1268,10 +1268,32 @@ class TypeUtilsTest<B> extends AbstractLangTest {
                 .withUpperBounds(CharSequence.class)
                 .build();
 
+        // ? extends Serializable & Cloneable
+        final WildcardType targetSerializableAndCloneable = TypeUtils.wildcardType()
+                .withUpperBounds(Serializable.class, Cloneable.class)
+                .build();
+
+        // ? extends Serializable & CharSequence
+        final WildcardType targetSerializableAndCharSequence = TypeUtils.wildcardType()
+                .withUpperBounds(Serializable.class, CharSequence.class)
+                .build();
+
+        // Single target bound satisfied
         assertTrue(TypeUtils.isAssignable(subject, targetSerializable));
         assertTrue(TypeUtils.isAssignable(subject, targetCloneable));
         assertTrue(TypeUtils.isAssignable(subject, TypeUtils.wildcardType().withUpperBounds(Object.class).build()));
         assertFalse(TypeUtils.isAssignable(subject, targetCharSequence));
+
+        // Multiple target bounds where all are satisfied
+        assertTrue(TypeUtils.isAssignable(subject, targetSerializableAndCloneable));
+        assertTrue(TypeUtils.isAssignable(subject, TypeUtils.wildcardType().withUpperBounds(Object.class, Serializable.class).build()));
+
+        // Multiple target bounds where only one is satisfied
+        assertFalse(TypeUtils.isAssignable(subject, targetSerializableAndCharSequence));
+
+        // Reverse direction: single bound cannot satisfy multiple bounds
+        assertFalse(TypeUtils.isAssignable(targetSerializable, subject));
+        assertFalse(TypeUtils.isAssignable(targetCloneable, subject));
     }
 
 }


### PR DESCRIPTION
## Description
Fixes an issue in `TypeUtils.isAssignable(Type, WildcardType, Map)` where checking assignability of a `WildcardType` with multiple upper bounds (intersection types such as `? extends Serializable & Cloneable`) to another `WildcardType` (such as `? extends Serializable`) incorrectly returned `false`.

### Root Cause
When the subject `type` is a `WildcardType`, the upper bounds loop previously enforced that **every** upper bound in the subject wildcard had to be assignable to each target upper bound `toBound` (`forall bound in upperBounds: isAssignable(bound, toBound)`):

```java
for (Type toBound : toUpperBounds) {
    toBound = substituteTypeVariables(toBound, typeVarAssigns);
    for (final Type bound : upperBounds) {
        if (!isAssignable(bound, toBound, typeVarAssigns)) {
            return false;
        }
    }
}