### PR TITLE
Fix Fraction.add and subtract for operands not in lowest terms

### DIFF
--- a/src/main/java/org/apache/commons/lang3/math/Fraction.java
+++ b/src/main/java/org/apache/commons/lang3/math/Fraction.java
@@ -556,23 +556,31 @@ public final class Fraction extends Number implements Comparable<Fraction> {
         if (fraction.numerator == 0) {
             return this;
         }
+        // Knuth 4.5.1 assumes operands in lowest terms and this class does not reduce on
+        // construction, so reduce both first, as multiplyBy does.
+        final int thisGcd = greatestCommonDivisor(numerator, denominator);
+        final int thatGcd = greatestCommonDivisor(fraction.numerator, fraction.denominator);
+        final int thisNumerator = numerator / thisGcd;
+        final int thisDenominator = denominator / thisGcd;
+        final int thatNumerator = fraction.numerator / thatGcd;
+        final int thatDenominator = fraction.denominator / thatGcd;
         // if denominators are randomly distributed, d1 will be 1 about 61%
         // of the time.
-        final int d1 = greatestCommonDivisor(denominator, fraction.denominator);
+        final int d1 = greatestCommonDivisor(thisDenominator, thatDenominator);
         if (d1 == 1) {
             // result is ((u*v' +/- u'v) / u'v')
             // the int cross products u*v' and u'*v can overflow even when the reduced result
             // fits an int, so widen to long and let Math narrow the final numerator back.
-            final long uvp = (long) numerator * fraction.denominator;
-            final long upv = (long) fraction.numerator * denominator;
+            final long uvp = (long) thisNumerator * thatDenominator;
+            final long upv = (long) thatNumerator * thisDenominator;
             final long t = isAdd ? Math.addExact(uvp, upv) : Math.subtractExact(uvp, upv);
-            return new Fraction(Math.toIntExact(t), mulPosAndCheck(denominator, fraction.denominator));
+            return new Fraction(Math.toIntExact(t), mulPosAndCheck(thisDenominator, thatDenominator));
         }
         // the quantity 't' requires 65 bits of precision; see knuth 4.5.1
         // exercise 7. we're going to use a BigInteger.
         // t = u(v'/d1) +/- v(u'/d1)
-        final BigInteger uvp = BigInteger.valueOf(numerator).multiply(BigInteger.valueOf(fraction.denominator / d1));
-        final BigInteger upv = BigInteger.valueOf(fraction.numerator).multiply(BigInteger.valueOf(denominator / d1));
+        final BigInteger uvp = BigInteger.valueOf(thisNumerator).multiply(BigInteger.valueOf(thatDenominator / d1));
+        final BigInteger upv = BigInteger.valueOf(thatNumerator).multiply(BigInteger.valueOf(thisDenominator / d1));
         final BigInteger t = isAdd ? uvp.add(upv) : uvp.subtract(upv);
         // but d2 doesn't need extra precision because
         // d2 = gcd(t,d1) = gcd(t mod d1, d1)
@@ -584,7 +592,7 @@ public final class Fraction extends Number implements Comparable<Fraction> {
         if (w.bitLength() > 31) {
             throw new ArithmeticException("overflow: numerator too large after multiply");
         }
-        return new Fraction(w.intValue(), mulPosAndCheck(denominator / d1, fraction.denominator / d2));
+        return new Fraction(w.intValue(), mulPosAndCheck(thisDenominator / d1, thatDenominator / d2));
     }
 
     /**

--- a/src/test/java/org/apache/commons/lang3/math/FractionTest.java
+++ b/src/test/java/org/apache/commons/lang3/math/FractionTest.java
@@ -93,6 +93,26 @@ class FractionTest extends AbstractLangTest {
         assertEquals(Fraction.getFraction(7, 13).reduce().add(Fraction.getFraction(46341, 1073741823).reduce()),
                 Fraction.getFraction(7, 13).add(Fraction.getFraction(46341, 1073741823)));
 
+        // Both operands unreduced: 2/4 + 2/6 is 1/2 + 1/3.
+        f = Fraction.getFraction(2, 4).add(Fraction.getFraction(2, 6));
+        assertEquals(5, f.getNumerator());
+        assertEquals(6, f.getDenominator());
+
+        // Reduced denominators share a factor: 2/4 - 2/12 is 1/2 - 1/6.
+        f = Fraction.getFraction(2, 4).subtract(Fraction.getFraction(2, 12));
+        assertEquals(1, f.getNumerator());
+        assertEquals(3, f.getDenominator());
+
+        // Equal values cancel to 0/1.
+        f = Fraction.getFraction(2, 4).subtract(Fraction.getFraction(3, 6));
+        assertEquals(0, f.getNumerator());
+        assertEquals(1, f.getDenominator());
+
+        // Integer.MIN_VALUE/2 reduces to -1073741824/1 without overflowing.
+        f = Fraction.getFraction(Integer.MIN_VALUE, 2).add(Fraction.getFraction(2, 4));
+        assertEquals(-Integer.MAX_VALUE, f.getNumerator());
+        assertEquals(2, f.getDenominator());
+
         // A result that genuinely does not fit an int still overflows.
         final Fraction maxValue = Fraction.getFraction(-Integer.MAX_VALUE, 1);
         assertThrows(ArithmeticException.class, () -> maxValue.add(maxValue));

--- a/src/test/java/org/apache/commons/lang3/math/FractionTest.java
+++ b/src/test/java/org/apache/commons/lang3/math/FractionTest.java
@@ -65,6 +65,40 @@ class FractionTest extends AbstractLangTest {
     }
 
     @Test
+    void testAddSubtractUnreducedOperands() {
+        // 1073741823/2147483646 is 1/2, and 1/2 + 3/5 is 11/10.
+        Fraction f = Fraction.getFraction(1073741823, 2147483646).add(Fraction.getFraction(3, 5));
+        assertEquals(11, f.getNumerator());
+        assertEquals(10, f.getDenominator());
+
+        f = Fraction.getFraction(1073741823, 2147483646).subtract(Fraction.getFraction(3, 5));
+        assertEquals(-1, f.getNumerator());
+        assertEquals(10, f.getDenominator());
+
+        // 2147483646/2147483646 is 1, and 1 + -11 is -10.
+        f = Fraction.getFraction(2147483646, 2147483646).add(Fraction.getFraction(-11, 1));
+        assertEquals(-10, f.getNumerator());
+        assertEquals(1, f.getDenominator());
+
+        // add() returns the result in reduced form.
+        f = Fraction.getFraction(50, 100).add(Fraction.getFraction(1, 3));
+        assertEquals(5, f.getNumerator());
+        assertEquals(6, f.getDenominator());
+
+        f = Fraction.getFraction(2, 4).add(Fraction.getFraction(1, 2));
+        assertEquals(1, f.getNumerator());
+        assertEquals(1, f.getDenominator());
+
+        // Reducing the operands by hand must not change the answer.
+        assertEquals(Fraction.getFraction(7, 13).reduce().add(Fraction.getFraction(46341, 1073741823).reduce()),
+                Fraction.getFraction(7, 13).add(Fraction.getFraction(46341, 1073741823)));
+
+        // A result that genuinely does not fit an int still overflows.
+        final Fraction maxValue = Fraction.getFraction(-Integer.MAX_VALUE, 1);
+        assertThrows(ArithmeticException.class, () -> maxValue.add(maxValue));
+    }
+
+    @Test
     void testAdd() {
         Fraction f;
         Fraction f1;


### PR DESCRIPTION
`Fraction.addSub` runs Knuth 4.5.1 on the operands as given, but the algorithm assumes lowest terms and `getFraction(50, 100)` is stored as 50/100. A shared factor inside an operand survives into the common denominator, so `add` and `subtract` throw `ArithmeticException` while the exact result fits an int (1073741823/2147483646 plus 3/5 is 11/10) and return unreduced results against the reduced form the javadoc promises. #1769 fixed the same shape in `multiplyBy`.

Both operands are now reduced before the Knuth step, as `multiplyBy` does. Operands already in lowest terms take the identical path, so the existing overflow and identity assertions hold.

Test: `testAddSubtractUnreducedOperands`, red on master and green with the change. Default Maven goal green.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [x] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute? Claude (Anthropic) found the defect and drafted the fix and test; I reviewed them, reproduced the failure on a fresh clone of master, and ran the default Maven goal.
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
