### PR TITLE
Fraction.add and subtract return the reduced form when an operand is zero

### DIFF
--- a/src/main/java/org/apache/commons/lang3/math/Fraction.java
+++ b/src/main/java/org/apache/commons/lang3/math/Fraction.java
@@ -551,10 +551,10 @@ public final class Fraction extends Number implements Comparable<Fraction> {
         Objects.requireNonNull(fraction, "fraction");
         // zero is identity for addition.
         if (numerator == 0) {
-            return isAdd ? fraction : fraction.negate();
+            return isAdd ? fraction.reduce() : fraction.reduce().negate();
         }
         if (fraction.numerator == 0) {
-            return this;
+            return reduce();
         }
         // Knuth 4.5.1 assumes operands in lowest terms and this class does not reduce on
         // construction, so reduce both first, as multiplyBy does.

--- a/src/test/java/org/apache/commons/lang3/math/FractionTest.java
+++ b/src/test/java/org/apache/commons/lang3/math/FractionTest.java
@@ -119,6 +119,34 @@ class FractionTest extends AbstractLangTest {
     }
 
     @Test
+    void testAddSubtractZeroOperand() {
+        // A zero operand returns the other operand in reduced form.
+        Fraction f = Fraction.ZERO.add(Fraction.getFraction(2, 4));
+        assertEquals(1, f.getNumerator());
+        assertEquals(2, f.getDenominator());
+
+        f = Fraction.getFraction(2, 4).add(Fraction.ZERO);
+        assertEquals(1, f.getNumerator());
+        assertEquals(2, f.getDenominator());
+
+        f = Fraction.ZERO.subtract(Fraction.getFraction(2, 4));
+        assertEquals(-1, f.getNumerator());
+        assertEquals(2, f.getDenominator());
+
+        f = Fraction.getFraction(2, 4).subtract(Fraction.ZERO);
+        assertEquals(1, f.getNumerator());
+        assertEquals(2, f.getDenominator());
+
+        // Integer.MIN_VALUE/2 reduces to -1073741824/1, whose negation fits an int.
+        f = Fraction.ZERO.subtract(Fraction.getFraction(Integer.MIN_VALUE, 2));
+        assertEquals(1073741824, f.getNumerator());
+        assertEquals(1, f.getDenominator());
+
+        // Integer.MIN_VALUE/1 is in lowest terms and still cannot be negated.
+        assertThrows(ArithmeticException.class, () -> Fraction.ZERO.subtract(Fraction.getFraction(Integer.MIN_VALUE, 1)));
+    }
+
+    @Test
     void testAdd() {
         Fraction f;
         Fraction f1;


### PR DESCRIPTION
Follow-up to #1784. The zero shortcuts in `addSub` returned the other operand as constructed, so `ZERO.add(2/4)` was `2/4` against the Javadoc's reduced-form promise, and `ZERO.subtract(Integer.MIN_VALUE/2)` threw although the reduced result `1073741824/1` fits, both noted in the #1784 review. The shortcuts now reduce before returning or negating. The new test covers both operations with zero on either side and the `Integer.MIN_VALUE` boundary; it fails on master and passes with the change. Default `mvn` goal green with `-Ddoclint=all`.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [x] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute? Claude (Anthropic) wrote the fix and the test from the #1784 review and ran the reproduction and the default Maven goal on a fresh clone; I directed and reviewed the work.
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
