### PR TITLE
Return null for out-of-range offset in FastTimeZone.getGmtTimeZone

### DIFF
--- a/src/main/java/org/apache/commons/lang3/time/FastTimeZone.java
+++ b/src/main/java/org/apache/commons/lang3/time/FastTimeZone.java
@@ -48,13 +48,13 @@ public class FastTimeZone {
      * <p>
      * Note: the underlying regex is lenient — every capture group (sign, hours, minutes, and the {@code GMT} prefix) is optional. Inputs that lack any digit
      * group, such as the empty string, {@code "+"}, {@code "-"}, or {@code "GMT"} alone, still match and the method returns the GMT TimeZone with a raw offset
-     * of zero (mirroring {@link TimeZone#getTimeZone(String)} JDK-parity for unrecognized ids). Only inputs that fail the regex outright return
-     * {@code null}.
+     * of zero (mirroring {@link TimeZone#getTimeZone(String)} JDK-parity for unrecognized ids). Inputs that fail the regex outright, or that match but specify
+     * an out-of-range offset (24 hours or 60 minutes and above), return {@code null}.
      * </p>
      *
      * @param pattern The GMT offset.
      * @return A TimeZone matching the (possibly partial or empty) GMT offset pattern, defaulting to GMT for an unrecognized but parseable input, or
-     *         {@code null} if the pattern fails the regex.
+     *         {@code null} if the pattern fails the regex or specifies an out-of-range offset.
      */
     public static TimeZone getGmtTimeZone(final String pattern) {
         if ("Z".equals(pattern) || "UTC".equals(pattern)) {
@@ -66,6 +66,11 @@ public class FastTimeZone {
             final int minutes = parseInt(m.group(4));
             if (hours == 0 && minutes == 0) {
                 return GREENWICH;
+            }
+            if (hours >= 24 || minutes >= 60) {
+                // A matching but out-of-range offset is not a valid GMT id; report it the documented
+                // way instead of letting the GmtTimeZone constructor throw IllegalArgumentException.
+                return null;
             }
             return new GmtTimeZone(parseSign(m.group(1)), hours, minutes);
         }

--- a/src/test/java/org/apache/commons/lang3/time/FastTimeZoneTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/FastTimeZoneTest.java
@@ -118,6 +118,26 @@ class FastTimeZoneTest extends AbstractLangTest {
     }
 
     @Test
+    void testOutOfRangeOffsetReturnsNull() {
+        // A pattern that matches the regex but whose hours or minutes are out of range is not a valid GMT id.
+        // Before the fix these threw IllegalArgumentException from the GmtTimeZone constructor.
+        assertNull(FastTimeZone.getGmtTimeZone("GMT+24"));
+        assertNull(FastTimeZone.getGmtTimeZone("+24"));
+        assertNull(FastTimeZone.getGmtTimeZone("-24"));
+        assertNull(FastTimeZone.getGmtTimeZone("+99"));
+        assertNull(FastTimeZone.getGmtTimeZone("+12:60"));
+        assertNull(FastTimeZone.getGmtTimeZone("00:99"));
+    }
+
+    @Test
+    void testOutOfRangeOffsetViaGetTimeZoneFallsBack() {
+        // getTimeZone must not propagate the constructor exception; a null GMT result falls back to the JDK lookup.
+        final TimeZone tz = FastTimeZone.getTimeZone("GMT+24");
+        assertNotNull(tz);
+        assertEquals(0, tz.getRawOffset());
+    }
+
+    @Test
     void testPlusOnlyReturnsNonNull() {
         // Sign-only input still matches the regex; hours and minutes default to 0.
         final TimeZone tz = FastTimeZone.getGmtTimeZone("+");


### PR DESCRIPTION
`FastTimeZone.getGmtTimeZone(String)` is documented to return a `TimeZone` for any input matching its lenient GMT regex, and `null` only when the regex fails. It doesn't: a matching offset whose hours or minutes are out of range throws an undeclared `IllegalArgumentException` from the `GmtTimeZone` constructor.

Repro: `FastTimeZone.getGmtTimeZone("GMT+24")` (also `"+24"`, `"-24"`, `"+99"`, `"+12:60"`).
Expected: a `TimeZone`, or `null` (the documented failure signal).
Actual: `IllegalArgumentException: 24 hours out of range`. `getTimeZone("GMT+24")` inherits the throw, since it calls `getGmtTimeZone` before its Olson fallback.
Cause: the regex groups `(\d\d?)` accept `0`-`99`, but the parsed `hours`/`minutes` go straight into `new GmtTimeZone(...)`, which rejects `hours >= 24` / `minutes >= 60`.
Fix: return `null` for an out-of-range offset inside `getGmtTimeZone`, so `getTimeZone` falls back to the JDK lookup like any other unrecognised id. Valid offsets and the lenient partial-input cases (`""`, `"+"`, `"GMT"`) are unchanged; the `ISO8601` and named-zone strategies in `FastDateParser` already constrain or null-check the value, so this is the sole parse-driven site.

The added `FastTimeZoneTest` cases fail on the current source (both error with `IllegalArgumentException`) and pass after the change.

---

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [x] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute? Claude (Anthropic) helped locate the defect and draft the patch, tests and description; I reviewed the change and verified it locally (default `mvn` build and tests green).
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
